### PR TITLE
Feature: Add Font Size, Line Height Utility Classes

### DIFF
--- a/packages/core/styles/01-settings/settings-font-size/_settings-font-size.scss
+++ b/packages/core/styles/01-settings/settings-font-size/_settings-font-size.scss
@@ -34,6 +34,10 @@ $bolt-line-height--xsmall: 1.45;
 $bolt-line-height--tight: 1.111;
 
 
+$bolt-global-line-heights: (
+  regular,
+  tight
+);
 
 
 /// Bolt's definition of all options of possible text sizes.
@@ -94,3 +98,5 @@ $bolt-font-sizes: (
     )
   )
 );
+
+$bolt-global-font-sizes: map-get($bolt-font-sizes, 'font-sizes');

--- a/packages/core/styles/02-tools/tools-font-size/_tools-font-size.scss
+++ b/packages/core/styles/02-tools/tools-font-size/_tools-font-size.scss
@@ -15,47 +15,26 @@
 /// @param {string} $leading
 ///   Defines the line-height of the text: regular or tight.
 ///
-@mixin bolt-font-size($size, $leading: regular) {
+@mixin bolt-font-size($size, $leading: regular, $important: null) {
+  @if $important == important {
+    $important: !important;
+  }
+
   $font-size: map-get-deep($bolt-font-sizes, 'font-sizes', $size, 'font-size');
 
   @if (type-of($font-size) == 'map') {
     $length: length(map-keys($font-size));
 
     @if ($length < 2) {
-      font-size: nth($font-size, 2);
+      font-size: nth($font-size, 2) $important;
     } @else {
-      @include bolt-poly-fluid-sizing('font-size', $font-size);
+      @include bolt-poly-fluid-sizing('font-size', $font-size, $important);
     }
   } @else {
-    font-size: $font-size;
+    font-size: $font-size $important;
   }
 
   @if ($leading != '' and  $leading != null) {
-    @if (type-of($leading) == number) {
-      $leading: $leading;
-    } @elseif (type-of($leading) == string) {
-      $leading: map-get-deep($bolt-font-sizes, 'font-sizes', $size, 'line-height', $leading);
-    }
-
-    @if (type-of($leading) == 'map') {
-      $length: length(map-keys($leading));
-
-      @if ($length < 2) {
-        line-height: nth($leading, 2);
-      } @else {
-        @debug $leading;
-        @include bolt-poly-fluid-sizing('line-height', $leading);
-      }
-    } @else {
-      line-height: $leading;
-    }
+    @include bolt-line-height($size, $leading, $important);
   }
 }
-
-/* stylelint-disable-next-line scss/at-mixin-pattern */
-@mixin font-size($args...) {
-  @warn 'PegaKit\'s `font-size` mixin is deprecated and will be removed in v1.0.0 of Bolt. Use the new @bolt-font-size mixin instead.';
-
-  @include bolt-font-size($args);
-}
-/* stylelint-enable */

--- a/packages/core/styles/02-tools/tools-line-height/_tools-line-height.scss
+++ b/packages/core/styles/02-tools/tools-line-height/_tools-line-height.scss
@@ -1,0 +1,39 @@
+/* ------------------------------------ *\
+  TOOLS - LINE HEIGHT
+\* ------------------------------------ */
+
+////
+/// @group Tools: Typography
+/// @author Salem Ghoweri
+////
+
+/// This returns the line-height for a specific element.
+///
+/// @param {string} $size
+///   Defines the size of the text: xsmall, small, base, medium, large, xlarge, or xxlarge.
+///
+/// @param {string} $leading
+///   Defines the line-height of the text: regular or tight.
+///
+@mixin bolt-line-height($size, $leading: regular, $important: null) {
+  @if $important == important {
+    $important: !important;
+  }
+  @if (type-of($leading) == number) {
+    $leading: $leading;
+  } @else if (type-of($leading) == string) {
+    $leading: map-get-deep($bolt-font-sizes, 'font-sizes', $size, 'line-height', $leading);
+  }
+
+  @if (type-of($leading) == 'map') {
+    $length: length(map-keys($leading));
+
+    @if ($length < 2) {
+      line-height: nth($leading, 2) $important;
+    } @else {
+      @include bolt-poly-fluid-sizing('line-height', $leading, $important);
+    }
+  } @else {
+    line-height: $leading $important;
+  }
+}

--- a/packages/core/styles/02-tools/tools-poly-fluid-sizing/_tools-poly-fluid-sizing.scss
+++ b/packages/core/styles/02-tools/tools-poly-fluid-sizing/_tools-poly-fluid-sizing.scss
@@ -10,7 +10,7 @@
 /// @requires bolt-map-sort
 /// @example
 ///   @include bolt-poly-fluid-sizing('font-size', (576px: 22px, 768px: 24px, 992px: 34px));
-@mixin bolt-poly-fluid-sizing($property, $map) {
+@mixin bolt-poly-fluid-sizing($property, $map, $important: null) {
   // Get the number of provided breakpoints
   $length: length(map-keys($map));
 

--- a/packages/global/styles/07-utilities/_utilities-colors.scss
+++ b/packages/global/styles/07-utilities/_utilities-colors.scss
@@ -19,6 +19,5 @@
         @include bolt-color($colorName, $colorShade, important);
       }
     }
-
   }
 }

--- a/packages/global/styles/07-utilities/_utilities-font-size.scss
+++ b/packages/global/styles/07-utilities/_utilities-font-size.scss
@@ -1,0 +1,11 @@
+/* ------------------------------------ *\
+  #FLEX UTILITIES
+\* ------------------------------------ */
+
+@import '@bolt/core';
+
+@each $name, $value in $bolt-global-font-sizes {
+  .u-bolt-font-size-#{$name} {
+    @include bolt-font-size($name, $leading: null, $important: important);
+  }
+}

--- a/packages/global/styles/07-utilities/_utilities-line-height.scss
+++ b/packages/global/styles/07-utilities/_utilities-line-height.scss
@@ -1,0 +1,18 @@
+/* ------------------------------------ *\
+  #FLEX UTILITIES
+\* ------------------------------------ */
+
+@import '@bolt/core';
+
+@each $fontSizeName, $value in $bolt-global-font-sizes {
+
+  .u-bolt-line-height-#{$fontSizeName} {
+    @include bolt-line-height($fontSizeName, $leading: 'regular', $important: important);
+  }
+
+  @each $lineHeightName in $bolt-global-line-heights {
+    .u-bolt-line-height-#{$fontSizeName}-#{$lineHeightName} {
+      @include bolt-line-height($fontSizeName, $leading: $lineHeightName, $important: important);
+    }
+  }
+}


### PR DESCRIPTION
- Updates our existing font size mixin to support an optional `important` parameter which is necessary to use this to power heavier handed utility classes which map to our global font sizes
- Breaks apart line-height specific logic into new standalone line-height Sass mixin
- Adds new utility classes for handling `font-size` and `line-height` respectfully
- Removes the old PegaKit `font-size` Sass mixin that was flagged for deprecation in Bolt v0.x