### PR TITLE
Update Bolt Grid System

### DIFF
--- a/apps/pattern-lab/src/_patterns/02-components/icon/20-icon-name-variations.twig
+++ b/apps/pattern-lab/src/_patterns/02-components/icon/20-icon-name-variations.twig
@@ -1,15 +1,37 @@
 {% set schema = bolt.data.components['@bolt-components-icon'].schema %}
 
 {# loop through icons referenced in schema #}
-<ul class="bolt-icon-list-demo">
-{% for name in schema.properties.name.enum %}
-  <li>
-    {% include "@bolt-components-icon/icon.twig" with {
-      name: name,
-      background: "circle",
-      size: "large",
-    }%}
-    <br />{{ name }}
-  </li>
-{% endfor %}
-</ul>
+<ul class="o-bolt-bare-list">
+{% grid with {
+  tag: "ul",
+  attributes: {
+    class: [
+      "o-bolt-grid--flex",
+      "o-bolt-grid--center",
+      "o-bolt-grid--middle"
+    ]
+  }
+} %}
+  {% for name in schema.properties.name.enum %}
+    {% cell with {
+      tag: "li",
+      widths: [
+        "1/2",
+        "1/3@small",
+        "1/5@medium",
+        "1/8@xlarge",
+      ]
+    } %}
+      <div class="o-bolt-island o-bolt-island--small o-bolt-block o-bolt-block--center o-bolt-block--small">
+        <div class="o-bolt-block__image">
+          {% include "@bolt-components-icon/icon.twig" with {
+            name: name,
+            background: "circle",
+            size: "large",
+          }%}
+        </div>
+        <div class="o-bolt-block__body u-bolt-font-size-small u-bolt-line-height-small">{{ name }}</div>
+      </div>
+    {% endcell %}
+  {% endfor %}
+{% endgrid %}

--- a/apps/pattern-lab/src/styles/pl.scss
+++ b/apps/pattern-lab/src/styles/pl.scss
@@ -42,26 +42,6 @@ bolt-demo {
   max-height: 0px; // prevent background from showing up
 }
 
-ul.bolt-icon-list-demo {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-start;
-  list-style-type: none;
-  margin: 0;
-
-  li {
-    margin: 25px 0;
-    text-align: center;
-    width: 25%;
-    @media (max-width: 768px) {
-      width: 33%;
-    }
-    @media (max-width: 575px) {
-      margin: 15px 0;
-      width: 50%;
-    }
-  }
-}
 
 .bolt-z-index-demo {
   display: inline-block;

--- a/packages/core-php/src/Layout/GridCellNode.php
+++ b/packages/core-php/src/Layout/GridCellNode.php
@@ -31,9 +31,9 @@ class GridCellNode extends \Twig_Node {
         $GLOBALS['cell_attributes_custom'][ $GLOBALS['cell_counter'] ] = array_merge_recursive($GLOBALS['cell_attributes_custom'][ $GLOBALS['cell_counter'] ], $value);
 
       } elseif (is_array($value)) {
-        self::displayCellRecursiveResults($value);
+        $GLOBALS['cell_props'][ $GLOBALS['cell_counter'] ][$key] = $value;
       } elseif(is_object($value)) {
-        self::displayCellRecursiveResults($value);
+        $GLOBALS['cell_props'][ $GLOBALS['cell_counter'] ][$key] = $value;
       } else {
         $GLOBALS['cell_props'][ $GLOBALS['cell_counter'] ] = array_merge_recursive($GLOBALS['cell_props'][ $GLOBALS['cell_counter'] ], array($key => $value));
       }
@@ -111,10 +111,19 @@ class GridCellNode extends \Twig_Node {
     //@TODO: pull in template logic used here from external Twig file.
     $string       = "
       {% set classes = [] %}
+      {% set cellTag = cell.tag ? cell.tag : 'div' %}
 
-      <div {{ attributes.addClass(classes) | raw }}>
-      $contents
-      </div>
+      {% if cell.widths %}
+        {% for width in cell.widths %}
+          {% set classes = classes | merge(
+            ['u-bolt-width-' ~ width]
+          ) %}
+        {% endfor %}
+      {% endif %}
+
+      <{{ cellTag }} {{ attributes.addClass(classes) | raw }}>
+        $contents
+      </{{ cellTag }}>
     ";
 
     // Pre-render the inline Twig template + the data we've merged and normalized

--- a/packages/core-php/src/Layout/GridTagNode.php
+++ b/packages/core-php/src/Layout/GridTagNode.php
@@ -25,9 +25,9 @@ class GridTagNode extends \Twig_Node {
       if(is_array($value) && $key == 'attributes') {
         $GLOBALS['grid_attributes_custom'][ $GLOBALS['counter'] ] = array_merge_recursive($GLOBALS['grid_attributes_custom'][ $GLOBALS['counter'] ], $value);
       } elseif (is_array($value)) {
-        self::displayRecursiveResults($value);
+        $GLOBALS['grid_props'][ $GLOBALS['counter'] ][$key] = $value;
       } elseif(is_object($value)) {
-        self::displayRecursiveResults($value);
+        $GLOBALS['grid_props'][ $GLOBALS['counter'] ][$key] = $value;
       } else {
           $GLOBALS['grid_props'][ $GLOBALS['counter'] ] = array_merge_recursive($GLOBALS['grid_props'][ $GLOBALS['counter'] ], array($key => $value));
       }
@@ -96,9 +96,12 @@ class GridTagNode extends \Twig_Node {
         grid.center ? 'o-grid--center' : '',
         grid.reverse == 'true' ? 'o-grid--rev' : ''
       ] %}
-      <div {{ attributes.addClass(classes) | raw }}>
-      $contents
-      </div>
+
+      {% set gridTag = grid.tag ? grid.tag : 'div' %}
+
+      <{{ gridTag }} {{ attributes.addClass(classes) | raw }}>
+        $contents
+      </{{ gridTag }}>
     ";
     // Pre-render the inline Twig template + the data we've merged and normalized
     $rendered = $stringLoader->render(array("string" => $string, "data" => $data));


### PR DESCRIPTION
#- Updates the grid system in Bolt to correctly expose extra params that get passed along (arrays and object params that weren't the `attributes` object were getting messed up previously -- this update fixes this)
- Adds new `widths` param to the Grid system's `{% cell %}` tags to more clearly specify width behavior
- Also adds a new 'tag' param to the `{% grid %}` and `{% cell %}` tags to optionally allow us to specify which HTML tag should get used. 
- Updates the existing Icon component demo in Pattern Lab to use these updates (note: this depends on the work included in #669 and #672); removes docs site-specific CSS no longer required as a result

CC @mikemai2awesome @EvanLovely @joekarasek @rockymountainhigh1943 