### PR TITLE
Add 'playsinline' to video player

### DIFF
--- a/packages/components/bolt-video/src/video.standalone.js
+++ b/packages/components/bolt-video/src/video.standalone.js
@@ -672,6 +672,7 @@ class BoltVideo extends withPreact() {
           loop={this.props.loop}
           className="video-js"
           controls={this.props.controls === false ? false : true}
+          playsinline
         />
         {this.props.showMeta && h(videoMetaTag)}
         {this.props.isBackgroundVideo && (


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1404

## Summary

On iOS playing a video automatically switches to full-screen native video player, unless (since iOS v10.0) the `playsinline` attribute is present.

## Details

tbd

## How to test

tbd