### PR TITLE
Fix: Backport Upstream Pattern Lab UIKit Bug Fixes

### DIFF
--- a/docs-site/config/config.yml
+++ b/docs-site/config/config.yml
@@ -41,6 +41,8 @@ ishControlsHide:
     - hay
     - disco
     - random
+    - all
+    - views-all
 styleguideKit: bolt-design-system/styleguidekit-twig-default
 styleguideKitPath: vendor/bolt-design-system/styleguidekit-twig-default
 lineageMatch: >-

--- a/packages/uikit-workshop/src/scripts/components/pl-nav/pl-nav.js
+++ b/packages/uikit-workshop/src/scripts/components/pl-nav/pl-nav.js
@@ -534,16 +534,23 @@ class Nav extends BaseComponent {
           );
         })}
 
-        {/* <li class="pl-c-nav__item">
-          <a
-            href="styleguide/html/styleguide.html"
-            class="pl-c-nav__link pl-c-nav__link--pattern"
-            data-patternpartial="all"
-            tabindex="0"
-          >
-            All
-          </a>
-        </li> */}
+        {/* display the All link if window.ishControlsHide is undefined (for some reason) OR window.ishControls.ishControlsHide doesn't have `views-all` and/or `all` set to true */}
+
+        {(window.ishControls === undefined ||
+          window.ishControls.ishControlsHide === undefined ||
+          (window.ishControls.ishControlsHide['views-all'] !== true &&
+            window.ishControls.ishControlsHide['all'] !== true)) && (
+          <li class="pl-c-nav__item">
+            <a
+              onClick={e => this.handleClick(e, 'all')}
+              href="styleguide/html/styleguide.html"
+              class="pl-c-nav__link pl-c-nav__link--pattern"
+              data-patternpartial="all"
+              tabindex="0">
+              All
+            </a>
+          </li>
+        )}
       </ol>
     );
   }

--- a/packages/uikit-workshop/src/scripts/components/pl-nav/pl-nav.js
+++ b/packages/uikit-workshop/src/scripts/components/pl-nav/pl-nav.js
@@ -8,104 +8,103 @@ import ArrowIcon from '../../../icons/arrow-down.svg';
 import { BaseComponent } from '../base-component.js';
 import 'url-search-params-polyfill';
 
-const SubSubList = (props) => {
+const SubSubList = props => {
   const { children, category, elem } = props;
   const reorderedChildren = [];
 
-  const nonViewAllItems = children.filter((item => (item.patternName !== 'View All' && !item.patternName.includes(' Docs'))));
+  const nonViewAllItems = children.filter(
+    item =>
+      item.patternName !== 'View All' && !item.patternName.includes(' Docs'),
+  );
   // const nonViewAllItems = children.filter((item => (item.patternName !== 'View All')));
-  const viewAllItems = children.filter((item => item.patternName === 'View All'));
+  const viewAllItems = children.filter(item => item.patternName === 'View All');
 
   reorderedChildren.push(...viewAllItems, ...nonViewAllItems);
 
   return (
-    <li
-      className={`pl-c-nav__item pl-c-nav__item--${
-        category.toLowerCase()
-      }`}
-    >
-
-      {
-        viewAllItems.length > 0 ?
-          viewAllItems.map((patternSubtypeItem) =>
-            <div class="pl-c-nav__link--overview-wrapper">
-              <a href={`patterns/${patternSubtypeItem.patternPath}`}
-                className={`pl-c-nav__link pl-c-nav__link--sublink
-                ${patternSubtypeItem.patternName === 'View All' ? 'pl-c-nav__link--overview pl-js-link-overview' : 'pl-c-nav__link--subsublink'}
-                `}
-                onClick={(e) => elem.handleClick(e, patternSubtypeItem.patternPartial)}
-                data-patternpartial={patternSubtypeItem.patternPartial}>
-                  {
-                    patternSubtypeItem.patternName === 'View All' ?
-                    `${category}` :
-                    patternSubtypeItem.patternName
-                  }
-                  { patternSubtypeItem.patternState && (
-                    <span
-                      class={`pl-c-pattern-state pl-c-pattern-state--${
-                        patternSubtypeItem.patternState
-                      }`}
-                      title={patternSubtypeItem.patternState}
-                    />
-                  )}
-                </a>
-
-                {
-                  nonViewAllItems.length > 1 && elem.layoutMode && (
-                    <SpecialButton
-                      aria-controls={category}
-                      onClick={elem.toggleSpecialNavPanel}
-                      isOpen={false}
-                      isOpenClass={elem.isOpenClass}
-                    >
-                      {category}
-                    </SpecialButton>
-                  )
+    <li className={`pl-c-nav__item pl-c-nav__item--${category.toLowerCase()}`}>
+      {viewAllItems.length > 0 ? (
+        viewAllItems.map(patternSubtypeItem => (
+          <div class="pl-c-nav__link--overview-wrapper">
+            <a
+              href={`patterns/${patternSubtypeItem.patternPath}`}
+              className={`pl-c-nav__link pl-c-nav__link--sublink
+                ${
+                  patternSubtypeItem.patternName === 'View All'
+                    ? 'pl-c-nav__link--overview pl-js-link-overview'
+                    : 'pl-c-nav__link--subsublink'
                 }
-          </div>) :
-            (<Button
-              aria-controls={category}
-              onClick={elem.toggleNavPanel}
-              isOpen={false}
-              isOpenClass={elem.isOpenClass}
-            >
-              {category}
-            </Button>)
-      }
+                `}
+              onClick={e =>
+                elem.handleClick(e, patternSubtypeItem.patternPartial)
+              }
+              data-patternpartial={patternSubtypeItem.patternPartial}>
+              {patternSubtypeItem.patternName === 'View All'
+                ? `${category}`
+                : patternSubtypeItem.patternName}
+              {patternSubtypeItem.patternState && (
+                <span
+                  class={`pl-c-pattern-state pl-c-pattern-state--${patternSubtypeItem.patternState}`}
+                  title={patternSubtypeItem.patternState}
+                />
+              )}
+            </a>
 
-      {
-        ((viewAllItems.length > 0 && nonViewAllItems.length > 1) || (viewAllItems.length === 0)) && (
-          <ol id={category}
+            {nonViewAllItems.length > 1 && elem.layoutMode && (
+              <SpecialButton
+                aria-controls={category}
+                onClick={elem.toggleSpecialNavPanel}
+                isOpen={false}
+                isOpenClass={elem.isOpenClass}>
+                {category}
+              </SpecialButton>
+            )}
+          </div>
+        ))
+      ) : (
+        <Button
+          aria-controls={category}
+          onClick={elem.toggleNavPanel}
+          isOpen={false}
+          isOpenClass={elem.isOpenClass}>
+          {category}
+        </Button>
+      )}
+
+      {((viewAllItems.length > 0 && nonViewAllItems.length > 1) ||
+        viewAllItems.length === 0) && (
+        <ol
+          id={category}
           className={`pl-c-nav__subsublist pl-c-nav__subsublist--dropdown pl-js-acc-panel`}>
-            {
-              nonViewAllItems.map((patternSubtypeItem) =>
-                <li class="pl-c-nav__item">
-                  <a href={`patterns/${patternSubtypeItem.patternPath}`}
-                    className={`pl-c-nav__link pl-c-nav__link--sublink
-                      ${patternSubtypeItem.patternName === 'View All' ? 'pl-c-nav__link--overview' : 'pl-c-nav__link--subsublink'}
-                    `}
-                    onClick={(e) => elem.handleClick(e, patternSubtypeItem.patternPartial)}
-                    data-patternpartial={patternSubtypeItem.patternPartial}>
-                      {
-                        patternSubtypeItem.patternName === 'View All' ?
-                        `${category} Overview` :
-                        patternSubtypeItem.patternName
+          {nonViewAllItems.map(patternSubtypeItem => (
+            <li class="pl-c-nav__item">
+              <a
+                href={`patterns/${patternSubtypeItem.patternPath}`}
+                className={`pl-c-nav__link pl-c-nav__link--sublink
+                      ${
+                        patternSubtypeItem.patternName === 'View All'
+                          ? 'pl-c-nav__link--overview'
+                          : 'pl-c-nav__link--subsublink'
                       }
-                      { patternSubtypeItem.patternState && (
-                        <span
-                          class={`pl-c-pattern-state pl-c-pattern-state--${
-                            patternSubtypeItem.patternState
-                          }`}
-                          title={patternSubtypeItem.patternState}
-                        />
-                      )}
-                    </a>
-                </li>
-              )
-            }
-          </ol>
-        )
-      }
+                    `}
+                onClick={e =>
+                  elem.handleClick(e, patternSubtypeItem.patternPartial)
+                }
+                data-patternpartial={patternSubtypeItem.patternPartial}>
+                {patternSubtypeItem.patternName === 'View All'
+                  ? `${category} Overview`
+                  : patternSubtypeItem.patternName}
+                {patternSubtypeItem.patternState && (
+                  <span
+                    class={`pl-c-pattern-state pl-c-pattern-state--${patternSubtypeItem.patternState}`}
+                    title={patternSubtypeItem.patternState}
+                  />
+                )}
+              </a>
+            </li>
+          ))}
+        </ol>
+      )}
     </li>
   );
 };
@@ -113,10 +112,11 @@ const SubSubList = (props) => {
 const SpecialButton = props => {
   return (
     <button
-      className={`pl-c-nav__link pl-c-nav__link--section-dropdown pl-js-acc-handle ${props.isOpen ? props.isOpenClass : ''}`}
+      className={`pl-c-nav__link pl-c-nav__link--section-dropdown pl-js-acc-handle ${
+        props.isOpen ? props.isOpenClass : ''
+      }`}
       role="tab"
-      {...props}
-    >
+      {...props}>
       {props.children}
       <span class="pl-c-nav__link-icon">
         <ArrowIcon
@@ -133,13 +133,12 @@ const SpecialButton = props => {
 const Button = props => {
   return (
     <button
-      className={`pl-c-nav__link pl-c-nav__link--dropdown pl-js-acc-handle ${props.isOpen ? props.isOpenClass : ''}`}
+      className={`pl-c-nav__link pl-c-nav__link--dropdown pl-js-acc-handle ${
+        props.isOpen ? props.isOpenClass : ''
+      }`}
       role="tab"
-      {...props}
-    >
-      <span className={`pl-c-nav__link-text`}>
-        {props.children}
-      </span>
+      {...props}>
+      <span className={`pl-c-nav__link-text`}>{props.children}</span>
       <span class="pl-c-nav__link-icon">
         <ArrowIcon
           height={24}
@@ -155,12 +154,19 @@ const Button = props => {
 const ButtonTitle = props => {
   return (
     <button
-      className={`pl-c-nav__link pl-c-nav__link--title pl-js-acc-handle ${props.isOpen ? props.isOpenClass : ''}`}
+      className={`pl-c-nav__link pl-c-nav__link--title pl-js-acc-handle ${
+        props.isOpen ? props.isOpenClass : ''
+      }`}
       role="tab"
-      style={`${props.layoutMode === 'vertical' ? 'pointer-events: none; font-weight: 700; cursor: pointer;' : ''}`}
-      {...props}
-    >
-      <span class="pl-c-nav__link-icon" style={`${props.layoutMode === 'vertical' ? 'display: none;' : ''}`}>
+      style={`${
+        props.layoutMode === 'vertical'
+          ? 'pointer-events: none; font-weight: 700; cursor: pointer;'
+          : ''
+      }`}
+      {...props}>
+      <span
+        class="pl-c-nav__link-icon"
+        style={`${props.layoutMode === 'vertical' ? 'display: none;' : ''}`}>
         <ArrowIcon
           height={24}
           width={16}
@@ -168,9 +174,7 @@ const ButtonTitle = props => {
           fill="currentColor"
         />
       </span>
-      <span className={`pl-c-nav__link-text`}>
-        {props.children}
-      </span>
+      <span className={`pl-c-nav__link-text`}>{props.children}</span>
     </button>
   );
 };
@@ -203,11 +207,11 @@ class Nav extends BaseComponent {
     this.iframeElem = document.querySelector('pl-iframe');
     window.addEventListener('message', this.receiveIframeMessage, false);
 
-    document.body.addEventListener('click', function(e){
+    document.body.addEventListener('click', function(e) {
       if (
         e.target.closest('pl-header') === null &&
         e.target.closest('svg') === null
-      ){
+      ) {
         self.cleanupActiveNav();
       }
     });
@@ -216,7 +220,7 @@ class Nav extends BaseComponent {
   _stateChanged(state) {
     this.layoutMode = state.app.layoutMode || '';
 
-    if (this.currentPattern !== state.app.currentPattern){
+    if (this.currentPattern !== state.app.currentPattern) {
       this.currentPattern = state.app.currentPattern;
     }
 
@@ -244,34 +248,41 @@ class Nav extends BaseComponent {
 
     if (data.event !== undefined && data.event === 'patternLab.pageClick') {
       try {
-        if (window.matchMedia("(min-width: calc(42em))").matches && self.layoutMode !== 'vertical'){
+        if (
+          window.matchMedia('(min-width: calc(42em))').matches &&
+          self.layoutMode !== 'vertical'
+        ) {
           self.cleanupActiveNav();
         }
-      } catch(error){
-
+      } catch (error) {
         console.log(error);
       }
     }
   }
 
-  cleanupActiveNav(topLevelOnly){
+  cleanupActiveNav(topLevelOnly) {
     this.navContainer = document.querySelector('.pl-js-nav-container');
     this.navAccordionTriggers = document.querySelectorAll('.pl-js-acc-handle');
     this.navAccordionPanels = document.querySelectorAll('.pl-js-acc-panel');
-    this.topLevelTriggers = document.querySelectorAll('.pl-c-nav__link--title.pl-is-active');
+    this.topLevelTriggers = document.querySelectorAll(
+      '.pl-c-nav__link--title.pl-is-active',
+    );
 
     if (topLevelOnly === true) {
       this.navContainer.classList.remove('pl-is-active');
-      this.topLevelTriggers.forEach((trigger) => {
+      this.topLevelTriggers.forEach(trigger => {
         trigger.classList.remove('pl-is-active');
       });
     } else {
-      if (window.matchMedia("(max-width: calc(42em - 1px))").matches || this.layoutMode !== 'vertical'){
+      if (
+        window.matchMedia('(max-width: calc(42em - 1px))').matches ||
+        this.layoutMode !== 'vertical'
+      ) {
         this.navContainer.classList.remove('pl-is-active');
-        this.navAccordionTriggers.forEach((trigger) => {
+        this.navAccordionTriggers.forEach(trigger => {
           trigger.classList.remove('pl-is-active');
         });
-        this.navAccordionPanels.forEach((panel) => {
+        this.navAccordionPanels.forEach(panel => {
           panel.classList.remove('pl-is-active');
         });
       } else {
@@ -287,42 +298,46 @@ class Nav extends BaseComponent {
   }
 
   handleURLChange() {
-    if (!this._hasInitiallyRendered){
+    if (!this._hasInitiallyRendered) {
       this.handleURLChangeOnRender = true;
       return;
     }
 
-    const shouldAutoOpenNav = window.matchMedia("(min-width: calc(42em))").matches && this.layoutMode === 'vertical';
+    const shouldAutoOpenNav =
+      window.matchMedia('(min-width: calc(42em))').matches &&
+      this.layoutMode === 'vertical';
 
     const currentPattern = this.currentPattern;
-    const activeLink = document.querySelector(`[data-patternpartial="${currentPattern}"]`);
+    const activeLink = document.querySelector(
+      `[data-patternpartial="${currentPattern}"]`,
+    );
     const self = this;
 
-    if (this.previousActiveLinks){
-      this.previousActiveLinks.forEach(function(link, index){
+    if (this.previousActiveLinks) {
+      this.previousActiveLinks.forEach(function(link, index) {
         self.previousActiveLinks[index].classList.remove('pl-is-active');
       });
     }
     this.previousActiveLinks = [];
 
-    if (activeLink){
+    if (activeLink) {
       activeLink.classList.add('pl-is-active');
       this.previousActiveLinks.push(activeLink);
 
       // handle overview links vs nested links
-      if (activeLink.classList.contains('pl-js-link-overview')){
+      if (activeLink.classList.contains('pl-js-link-overview')) {
         const childDropdownTrigger = activeLink.nextSibling;
         const childDropdown = activeLink.parentNode.nextSibling;
 
-        if (childDropdown && shouldAutoOpenNav){
-          if (childDropdown.tagName){
+        if (childDropdown && shouldAutoOpenNav) {
+          if (childDropdown.tagName) {
             childDropdown.classList.add('pl-is-active');
             this.previousActiveLinks.push(childDropdown);
           }
         }
 
-        if (childDropdownTrigger && shouldAutoOpenNav){
-          if (childDropdownTrigger.tagName){
+        if (childDropdownTrigger && shouldAutoOpenNav) {
+          if (childDropdownTrigger.tagName) {
             childDropdownTrigger.classList.add('pl-is-active');
             this.previousActiveLinks.push(childDropdownTrigger);
           }
@@ -332,48 +347,62 @@ class Nav extends BaseComponent {
       const parentDropdown = activeLink.closest('.pl-js-acc-panel');
       let parentDropdownTrigger;
 
-      if (parentDropdown){
-        if (parentDropdown.previousSibling){
+      if (parentDropdown) {
+        if (parentDropdown.previousSibling) {
           parentDropdownTrigger = parentDropdown.previousSibling;
 
-          if (parentDropdown.previousSibling.classList.contains('pl-c-nav__link--overview-wrapper') && shouldAutoOpenNav){
+          if (
+            parentDropdown.previousSibling.classList.contains(
+              'pl-c-nav__link--overview-wrapper',
+            ) &&
+            shouldAutoOpenNav
+          ) {
             this.previousActiveLinks.push(parentDropdown.previousSibling);
             parentDropdown.previousSibling.classList.add('pl-is-active');
-            parentDropdownTrigger = parentDropdown.previousSibling.querySelector('.pl-js-acc-handle');
+            parentDropdownTrigger = parentDropdown.previousSibling.querySelector(
+              '.pl-js-acc-handle',
+            );
           }
 
-          const grandparentDropdown = parentDropdown.closest('.pl-c-nav__sublist--dropdown');
-          const grandparentDropdownTrigger = grandparentDropdown.previousSibling;
+          const grandparentDropdown = parentDropdown.closest(
+            '.pl-c-nav__sublist--dropdown',
+          );
+          const grandparentDropdownTrigger =
+            grandparentDropdown.previousSibling;
 
-          if (parentDropdown && shouldAutoOpenNav){
+          if (parentDropdown && shouldAutoOpenNav) {
             parentDropdown.classList.add('pl-is-active');
             this.previousActiveLinks.push(parentDropdown);
           }
 
           // don't auto-open
-          if (parentDropdownTrigger){
-            if (shouldAutoOpenNav === true || parentDropdownTrigger.classList.contains('pl-c-nav__link--title') === false) {
+          if (parentDropdownTrigger) {
+            if (
+              shouldAutoOpenNav === true ||
+              parentDropdownTrigger.classList.contains(
+                'pl-c-nav__link--title',
+              ) === false
+            ) {
               parentDropdownTrigger.classList.add('pl-is-active');
               this.previousActiveLinks.push(parentDropdownTrigger);
             }
           }
 
-          if (grandparentDropdown && shouldAutoOpenNav){
-            if (shouldAutoOpenNav){
+          if (grandparentDropdown && shouldAutoOpenNav) {
+            if (shouldAutoOpenNav) {
               grandparentDropdown.classList.add('pl-is-active');
             }
             this.previousActiveLinks.push(grandparentDropdown);
           }
 
-          if (grandparentDropdownTrigger && shouldAutoOpenNav){
-            if (shouldAutoOpenNav){
+          if (grandparentDropdownTrigger && shouldAutoOpenNav) {
+            if (shouldAutoOpenNav) {
               grandparentDropdownTrigger.classList.add('pl-is-active');
             }
             this.previousActiveLinks.push(grandparentDropdownTrigger);
           }
         }
       }
-
     } else {
       this.cleanupActiveNav();
     }
@@ -394,26 +423,32 @@ class Nav extends BaseComponent {
   toggleSpecialNavPanel(e) {
     const target = e.target;
     const panel = target.parentNode.nextSibling;
-    const subnav = panel.parentNode.parentNode.classList.contains('pl-js-acc-panel');
+    const subnav = panel.parentNode.parentNode.classList.contains(
+      'pl-js-acc-panel',
+    );
 
     if (!subnav) {
-      const navTriggers = document.querySelectorAll(`.pl-js-acc-handle.pl-is-active`);
-      const navPanels = document.querySelectorAll(`.pl-js-acc-panel.pl-is-active`);
+      const navTriggers = document.querySelectorAll(
+        `.pl-js-acc-handle.pl-is-active`,
+      );
+      const navPanels = document.querySelectorAll(
+        `.pl-js-acc-panel.pl-is-active`,
+      );
 
-      navTriggers.forEach((navTrigger) => {
-        if(navTrigger !== target) {
+      navTriggers.forEach(navTrigger => {
+        if (navTrigger !== target) {
           navTrigger.classList.remove('pl-is-active');
         }
       });
 
-      navPanels.forEach((navPanel) => {
-        if(navPanel !== target) {
+      navPanels.forEach(navPanel => {
+        if (navPanel !== target) {
           navPanel.classList.remove('pl-is-active');
         }
       });
     }
 
-    if (target.classList.contains('pl-is-active')){
+    if (target.classList.contains('pl-is-active')) {
       target.classList.remove('pl-is-active');
       panel.classList.remove('pl-is-active');
     } else {
@@ -425,26 +460,28 @@ class Nav extends BaseComponent {
   toggleNavPanel(e) {
     const target = e.target;
     const panel = target.nextSibling;
-    const subnav = target.parentNode.parentNode.classList.contains('pl-js-acc-panel');
+    const subnav = target.parentNode.parentNode.classList.contains(
+      'pl-js-acc-panel',
+    );
 
     if (!subnav) {
       const navTriggers = document.querySelectorAll('.pl-js-acc-handle');
       const navPanels = document.querySelectorAll('.pl-js-acc-panel');
 
-      navTriggers.forEach((navTrigger) => {
-        if(navTrigger !== target) {
+      navTriggers.forEach(navTrigger => {
+        if (navTrigger !== target) {
           navTrigger.classList.remove('pl-is-active');
         }
       });
 
-      navPanels.forEach((navPanel) => {
-        if(navPanel !== target) {
+      navPanels.forEach(navPanel => {
+        if (navPanel !== target) {
           navPanel.classList.remove('pl-is-active');
         }
       });
     }
 
-    if (target.classList.contains('pl-is-active')){
+    if (target.classList.contains('pl-is-active')) {
       target.classList.remove('pl-is-active');
       panel.classList.remove('pl-is-active');
     } else {
@@ -453,12 +490,12 @@ class Nav extends BaseComponent {
     }
   }
 
-  rendered(){
-    if (this._hasInitiallyRendered === false){
+  rendered() {
+    if (this._hasInitiallyRendered === false) {
       this._hasInitiallyRendered = true;
     }
 
-    if (this.handleURLChangeOnRender === true){
+    if (this.handleURLChangeOnRender === true) {
       this.handleURLChangeOnRender = false;
       this.handleURLChange();
     }
@@ -479,25 +516,28 @@ class Nav extends BaseComponent {
 
           return (
             <li className={classes}>
-
               <ButtonTitle
                 aria-controls={item.patternTypeLC}
                 onClick={this.toggleNavPanel}
                 isOpen={false}
                 isOpenClass={this.isOpenClass}
-                layoutMode={this.layoutMode}
-              >
+                layoutMode={this.layoutMode}>
                 {item.patternTypeUC}
               </ButtonTitle>
 
               <ol
                 id={item.patternSubtypeUC}
                 className={`pl-c-nav__sublist pl-c-nav__sublist--dropdown pl-js-acc-panel`}
-                style={`${self.layoutMode === 'vertical' ? 'visibility: visible; max-height: 9999px;' : ''}`}
-              >
+                style={`${
+                  self.layoutMode === 'vertical'
+                    ? 'visibility: visible; max-height: 9999px;'
+                    : ''
+                }`}>
                 {item.patternTypeItems.map((patternSubtype, i) => {
                   return (
-                    <SubSubList elem={this.elem} category={patternSubtype.patternSubtypeUC}>
+                    <SubSubList
+                      elem={this.elem}
+                      category={patternSubtype.patternSubtypeUC}>
                       {patternSubtype.patternSubtypeItems}
                     </SubSubList>
                   );
@@ -510,18 +550,17 @@ class Nav extends BaseComponent {
                         <a
                           href={`patterns/${patternItem.patternPath}`}
                           class="pl-c-nav__link pl-c-nav__link--pattern"
-                          onClick={(e) => this.handleClick(e, patternItem.patternPartial)}
+                          onClick={e =>
+                            this.handleClick(e, patternItem.patternPartial)
+                          }
                           data-patternpartial={patternItem.patternPartial}
-                          tabindex="0"
-                        >
+                          tabindex="0">
                           {patternItem.patternName === 'View All'
                             ? patternItem.patternName + ' ' + item.patternTypeUC
                             : patternItem.patternName}
                           {patternItem.patternState && (
                             <span
-                              class={`pl-c-pattern-state pl-c-pattern-state--${
-                                patternItem.patternState
-                              }`}
+                              class={`pl-c-pattern-state pl-c-pattern-state--${patternItem.patternState}`}
                               title={patternItem.patternState}
                             />
                           )}

--- a/packages/uikit-workshop/src/scripts/components/pl-viewport/pl-viewport.js
+++ b/packages/uikit-workshop/src/scripts/components/pl-viewport/pl-viewport.js
@@ -347,7 +347,10 @@ class IFrame extends BaseComponent {
       if (window.patternData) {
         patternParam = window.patternData.patternPartial;
       } else {
-        patternParam = 'components-overview';
+        patternParam =
+          window.config && window.config.defaultPattern
+            ? window.config.defaultPattern
+            : 'all';
       }
     }
 

--- a/packages/uikit-workshop/src/scripts/components/pl-viewport/pl-viewport.js
+++ b/packages/uikit-workshop/src/scripts/components/pl-viewport/pl-viewport.js
@@ -56,8 +56,11 @@ class IFrame extends BaseComponent {
     const urlParams = new URLSearchParams(queryString);
     let patternParam = urlParams.get('p');
 
-    if (e.detail.pattern) {
-      document.title = 'Pattern Lab - ' + e.detail.pattern;
+    let currentPattern =
+      e.detail.pattern || window.config.defaultPattern || 'all';
+
+    if (currentPattern) {
+      document.title = 'Pattern Lab - ' + currentPattern;
 
       const addressReplacement =
         window.location.protocol === 'file:'
@@ -67,13 +70,13 @@ class IFrame extends BaseComponent {
             window.location.host +
             window.location.pathname.replace('index.html', '') +
             '?p=' +
-            e.detail.pattern;
+            currentPattern;
 
       // first time hitting a PL page -- no query string on the current page
       if (patternParam === null) {
         window.history.replaceState(
           {
-            currentPattern: e.detail.pattern,
+            currentPattern: currentPattern,
           },
           null,
           addressReplacement,
@@ -81,7 +84,7 @@ class IFrame extends BaseComponent {
       } else {
         window.history.replaceState(
           {
-            currentPattern: e.detail.pattern,
+            currentPattern: currentPattern,
           },
           null,
           addressReplacement,
@@ -404,9 +407,7 @@ class IFrame extends BaseComponent {
           class="pl-c-viewport__iframe-wrapper pl-js-vp-iframe-container"
           style={`width: ${initialWidth}`}>
           <iframe
-            className={`pl-c-viewport__iframe pl-js-iframe pl-c-body--theme-${
-              this.themeMode
-            }`}
+            className={`pl-c-viewport__iframe pl-js-iframe pl-c-body--theme-${this.themeMode}`}
             sandbox="allow-same-origin allow-scripts allow-popups allow-forms allow-modals"
             // srcdoc={render(<IframeInner />)}
             src={url}


### PR DESCRIPTION
## Jira
N/A

## Summary
Adds upstream Pattern Lab UIKit fixes PR'd in https://github.com/pattern-lab/patternlab-node/pull/1053

## Details
- Updates the Viewport component to use the Pattern Lab `defaultPattern` config (if it exists) when setting up the iframe URL that initially loads.
- Updates the Nav component to re-enable displaying the top level `All` link by default unless the `ishControlsHide['views-all]` config option is enabled.
- Fixes an unreported Pattern query string-related issue I noticed when testing out the All link updates. Basically the top most `All` page doesn't seem to emit the name of that page's "pattern" which the iframe emits the patternLoad event. 
- Minor code formatting based on our Prettier rules

## How to test
- Confirm Travis build passes as expected (which already includes some basic UI checks for Pattern Lab, including that the PL JavaScript compiled and renders as expected).