### PR TITLE
chore(button): add on_click and on_click_target to button schema

### DIFF
--- a/packages/components/bolt-button/button.schema.yml
+++ b/packages/components/bolt-button/button.schema.yml
@@ -69,6 +69,12 @@ properties:
     enum:
       - regular
       - full
+  on_click_target:
+    description: '`className` (e.g. "js-click-me") used in `querySelector` to reference a web component on the page. `onClick`, the `on_click` method name will be called on this element.'
+    type: string
+  on_click:
+    description: 'The name of a method on the `on_click_target`.'
+    type: string
   align:
     description: 'Horizontal alignment of items (text and icon) inside the button. Note: the values left and right are deprecated, use start and end instead.'
     type: string


### PR DESCRIPTION
## Summary

Adds `on_click` and `on_click_target` to Button schema.

## Details

While integrating the Button component into the Editor, we realized that Button extend BoltAction, which has `on_click` and `on_click_target` attributes. We need these attributes in the Editor, but we pull from Button schema, and `bolt-action` has no schema (so it wouldn't be possible to merge them).

Therefore, adding this to `bolt-button` the same way it's added to `bolt-trigger`'s schema.

Would be great to get this included in the upcoming release.