### PR TITLE
Tooltip | JS | Add possibility to add html or bolt component to tooltip content

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/tooltip/35-tooltip-content-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/tooltip/35-tooltip-content-variations.twig
@@ -1,0 +1,122 @@
+<div class="u-bolt-padding-top-large u-bolt-padding-bottom-large">
+  <p>Text</p>
+  {% grid "o-bolt-grid--center u-bolt-margin-bottom-medium" %}
+    {% cell "o-bolt-grid__cell" %}
+      {% include "@bolt-components-tooltip/tooltip.twig" with {
+        noWrap: true,
+        trigger: {
+          type: "text",
+          text: "Hover this text to show tooltip",
+          icon: {
+            name: "info-open",
+          }
+        },
+        content: "This is the tooltip content."
+      } only %}
+    {% endcell %}
+  {% endgrid %}
+
+  {% grid "o-bolt-grid--center u-bolt-margin-bottom-medium" %}
+    {% cell "o-bolt-grid__cell" %}
+      {% include "@bolt-components-tooltip/tooltip.twig" with {
+        noWrap: true,
+        trigger: {
+          type: "button",
+          text: "Press this button to show tooltip",
+          icon: {
+            name: "info-open",
+          },
+          toggle: {
+            text: "Hide tooltip",
+            name: "close-open"
+          }
+        },
+        content: "This tooltip activates when the trigger is pressed.",
+      } only %}
+    {% endcell %}
+  {% endgrid %}
+
+  <p>Bolt component</p>
+  {% grid "o-bolt-grid--center u-bolt-margin-bottom-medium" %}
+    {% cell "o-bolt-grid__cell" %}
+      {% include "@bolt-components-tooltip/tooltip.twig" with {
+        noWrap: true,
+        trigger: {
+          type: "text",
+          text: "Hover this text to show tooltip",
+          icon: {
+            name: "info-open",
+          }
+        },
+        content: "<bolt-ul>
+          <bolt-li>1</bolt-li>
+          <bolt-li>2</bolt-li>
+          <bolt-li>3</bolt-li>
+          <bolt-li>4</bolt-li>
+        <bolt-ul>"
+      } only %}
+    {% endcell %}
+  {% endgrid %}
+
+  {% grid "o-bolt-grid--center u-bolt-margin-bottom-medium" %}
+    {% cell "o-bolt-grid__cell" %}
+      {% include "@bolt-components-tooltip/tooltip.twig" with {
+        noWrap: true,
+        trigger: {
+          type: "button",
+          text: "Press this button to show tooltip",
+          icon: {
+            name: "info-open",
+          },
+          toggle: {
+            text: "Hide tooltip",
+            name: "close-open"
+          }
+        },
+        content: "<bolt-ul>
+          <bolt-li>1</bolt-li>
+          <bolt-li>2</bolt-li>
+          <bolt-li>3</bolt-li>
+          <bolt-li>4</bolt-li>
+        <bolt-ul>"
+      } only %}
+    {% endcell %}
+  {% endgrid %}
+
+  <p>HTML</p>
+  {% grid "o-bolt-grid--center u-bolt-margin-bottom-medium" %}
+    {% cell "o-bolt-grid__cell" %}
+      {% include "@bolt-components-tooltip/tooltip.twig" with {
+        noWrap: true,
+        trigger: {
+          type: "text",
+          text: "Hover this text to show tooltip",
+          icon: {
+            name: "info-open",
+          }
+        },
+        content: "This is the <strong>tooltip</strong> <i>content</i> with html."
+      } only %}
+    {% endcell %}
+  {% endgrid %}
+
+  {% grid "o-bolt-grid--center u-bolt-margin-bottom-medium" %}
+    {% cell "o-bolt-grid__cell" %}
+      {% include "@bolt-components-tooltip/tooltip.twig" with {
+        noWrap: true,
+        trigger: {
+          type: "button",
+          text: "Press this button to show tooltip",
+          icon: {
+            name: "info-open",
+          },
+          toggle: {
+            text: "Hide tooltip",
+            name: "close-open"
+          }
+        },
+        content: "This is the tooltip content with html <a href='example.com'>link</a>.",
+      } only %}
+    {% endcell %}
+  {% endgrid %}
+</div>

--- a/packages/components/bolt-tooltip/__tests__/__snapshots__/tooltip.js.snap
+++ b/packages/components/bolt-tooltip/__tests__/__snapshots__/tooltip.js.snap
@@ -9,6 +9,29 @@ exports[`<bolt-tooltip> Component Basic usage 1`] = `
 </bolt-tooltip>
 `;
 
+exports[`<bolt-tooltip> Component Bolt component content 1`] = `
+<bolt-tooltip trigger-type="text"
+              trigger-text="Trigger text"
+              trigger-icon-name="info-open"
+              content="&lt;bolt-ul&gt;
+        &lt;bolt-li&gt;1&lt;/bolt-li&gt;
+        &lt;bolt-li&gt;2&lt;/bolt-li&gt;
+        &lt;bolt-li&gt;3&lt;/bolt-li&gt;
+        &lt;bolt-li&gt;4&lt;/bolt-li&gt;
+      &lt;bolt-ul&gt;"
+>
+</bolt-tooltip>
+`;
+
+exports[`<bolt-tooltip> Component Bolt component content 2`] = `
+<bolt-tooltip trigger-type="text"
+              trigger-text="Trigger text"
+              trigger-icon-name="info-open"
+              content="This is the tooltip content with html &lt;a href=&quot;example.com&quot;&gt;link&lt;/a&gt;."
+>
+</bolt-tooltip>
+`;
+
 exports[`<bolt-tooltip> Component Direction of the tooltip bubble: down 1`] = `
 <bolt-tooltip trigger-type="button"
               trigger-text="Trigger text"

--- a/packages/components/bolt-tooltip/__tests__/tooltip.js
+++ b/packages/components/bolt-tooltip/__tests__/tooltip.js
@@ -32,6 +32,44 @@ describe('<bolt-tooltip> Component', () => {
     expect(results.html).toMatchSnapshot();
   });
 
+  // Bolt Component in content Usage
+  test('Bolt component content', async () => {
+    const results = await render('@bolt-components-tooltip/tooltip.twig', {
+      trigger: {
+        type: 'text',
+        text: 'Trigger text',
+        icon: {
+          name: 'info-open',
+        },
+      },
+      content: `<bolt-ul>
+        <bolt-li>1</bolt-li>
+        <bolt-li>2</bolt-li>
+        <bolt-li>3</bolt-li>
+        <bolt-li>4</bolt-li>
+      <bolt-ul>`,
+    });
+    expect(results.ok).toBe(true);
+    expect(results.html).toMatchSnapshot();
+  });
+
+  // HTML in content usage
+  test('Bolt component content', async () => {
+    const results = await render('@bolt-components-tooltip/tooltip.twig', {
+      trigger: {
+        type: 'text',
+        text: 'Trigger text',
+        icon: {
+          name: 'info-open',
+        },
+      },
+      content:
+        'This is the tooltip content with html <a href="example.com">link</a>.',
+    });
+    expect(results.ok).toBe(true);
+    expect(results.html).toMatchSnapshot();
+  });
+
   // Props
   direction.enum.forEach(async directionChoice => {
     test(`Direction of the tooltip bubble: ${directionChoice}`, async () => {

--- a/packages/components/bolt-tooltip/src/tooltip.js
+++ b/packages/components/bolt-tooltip/src/tooltip.js
@@ -2,6 +2,7 @@ import { define, props } from '@bolt/core/utils';
 import classNames from 'classnames/bind';
 import { html, withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 import { ifDefined } from 'lit-html/directives/if-defined';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 
 import styles from './tooltip.scss';
 
@@ -162,7 +163,9 @@ class BoltTooltip extends withLitHtml() {
           role="tooltip"
           aria-hidden="true"
         >
-          <span class="c-bolt-tooltip__content-bubble">${this.content}</span>
+          <span class="c-bolt-tooltip__content-bubble"
+            >${unsafeHTML(this.content)}</span
+          >
         </bolt-tooltip-content>
       </span>
     `;

--- a/packages/components/bolt-tooltip/tooltip.schema.yml
+++ b/packages/components/bolt-tooltip/tooltip.schema.yml
@@ -1,4 +1,3 @@
-$schema: http://json-schema.org/draft-04/schema#
 title: Tooltip
 type: object
 properties:
@@ -49,7 +48,7 @@ properties:
             description: The icon for our toggle
   content:
     type: any
-    description: This can be text OR an included bolt component (like Block List)
+    description: This can be text OR an included bolt component (like Block List) or html code
   direction:
     type: string
     description: Should tooltip push up or down?


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1820

## Summary

Update js version of tooltip and give a possibility to add HTML and bolt version to content. 

## How to test

Run this code locally. Check the tooltip example page and scroll down to see HTML 
![image](https://user-images.githubusercontent.com/16049049/64854947-12d83400-d61f-11e9-83f0-01d39d921740.png)
and Bolt Component examples. 
![image](https://user-images.githubusercontent.com/16049049/64854923-048a1800-d61f-11e9-8f82-4cd490e53911.png)
Check if all tests are passing.
