### PR TITLE
Fix/nav theme colors

### DIFF
--- a/packages/micro-journeys/src/interactive-pathways.js
+++ b/packages/micro-journeys/src/interactive-pathways.js
@@ -5,6 +5,7 @@ import debounce from 'lodash.debounce';
 import styles from './interactive-pathways.scss';
 import pathwaysLogo from './images/interactive-pathways-logo.png';
 import schema from './interactive-pathways.schema';
+import { getClosestTheme, themeMutationObserver } from './util';
 
 let cx = classNames.bind(styles);
 
@@ -137,11 +138,20 @@ class BoltInteractivePathways extends withLitHtml() {
     this.triggerUpdate();
   }
 
+  connected() {
+    themeMutationObserver();
+    document.body.addEventListener('boltThemeHasChanged', e => {
+      console.log('theme changed');
+      this.triggerUpdate();
+    });
+  }
+
   render() {
+    const closestTheme = getClosestTheme({ space: this });
     const { customImageSrc = pathwaysLogo, imageAlt } = this.validateProps(
       this.props,
     );
-    const classes = cx('c-bolt-interactive-pathways');
+    const classes = cx('c-bolt-interactive-pathways', closestTheme);
 
     const titles = this.pathways.map((pathway, i) => pathway.getTitle());
 

--- a/packages/micro-journeys/src/nav-shared.scss
+++ b/packages/micro-journeys/src/nav-shared.scss
@@ -11,7 +11,14 @@ $nav-circle-border-size: 2px;
     margin-left: -$nav-circle-size--active / 2 - $nav-circle-border-size;
     border: $nav-circle-border-size solid bolt-theme(primary);
     // @TODO there's no good way to match the comps here given we can't know what theme we're in b/c shadow dom.
-    background-color: bolt-theme(secondary);
+    background-color: bolt-theme(
+      (
+        xdark: primary 1,
+        dark: primary 1,
+        light: secondary 1,
+        xlight: secondary 1
+      )
+    );
   }
 
   @else {

--- a/packages/micro-journeys/src/util.js
+++ b/packages/micro-journeys/src/util.js
@@ -1,0 +1,63 @@
+const themeClasses = [
+  't-bolt-xlight',
+  't-bolt-light',
+  't-bolt-medium',
+  't-bolt-dark',
+  't-bolt-xdark',
+];
+
+/**
+ * @param {Object} opt
+ * @param {HTMLElement} opt.space
+ * @return {string} class name added
+ */
+export const getClosestTheme = ({ space }) => {
+  const defaultTheme = 't-bolt-light';
+  let themeClass = defaultTheme;
+  const themeContextEl = space.closest(`.${themeClasses.join(', .')}`);
+  if (themeContextEl) {
+    themeContextEl.classList.forEach(className => {
+      if (themeClasses.includes(`${className}`)) {
+        themeClass = className;
+      }
+    });
+  }
+  return themeClass;
+};
+
+/**
+ * Watch for class changes to body or child of body found to contain any of the the bolt theme class, fire event if so.
+ *
+ * @return {void}
+ */
+export const themeMutationObserver = () => {
+  // Make sure there's only one observer, and it exists as class in this browser. Yes, it works on IE 11.
+  if (!MutationObserver || window.boltThemeMutationObserver) {
+    return;
+  }
+
+  const observerConfig = { attributes: true, childList: true, subtree: true };
+
+  const observerCallback = function(mutationsList, observer) {
+    for (let mutation of mutationsList) {
+      if (
+        mutation.type === 'attributes' &&
+        mutation.attributeName === 'class'
+      ) {
+        const changedTheme = themeClasses.find(className =>
+          mutation.target.classList.contains(className),
+        );
+        if (changedTheme) {
+          const event = new CustomEvent('boltThemeHasChanged', {
+            detail: changedTheme,
+          });
+          document.body.dispatchEvent(event);
+        }
+      }
+    }
+  };
+
+  window.boltThemeMutationObserver = new MutationObserver(observerCallback);
+  const targetNode = document.body;
+  window.boltThemeMutationObserver.observe(targetNode, observerConfig);
+};


### PR DESCRIPTION
## Jira

https://app.asana.com/0/0/1140762213210489/f

## Summary

Example of currently broken `bolt-theme(`) usage. 

## Details

`bolt-theme` is used with an object argument, as detailed here: https://www.notion.so/basaltinc/bolt-theme-and-bolt-color-979d447ef1914b868703c5b5a8863abc.    Currently it does not work, or there is an issue with this implementation.  

## How to test

Visit /pattern-lab/?p=experiments-micro-journeys  and change the theme to dark.  Note that the  active dot on the lefthand nav always has a white background, regardless of theme.
