### PR TITLE
Fix triple band SVG animation 

### DIFF
--- a/packages/micro-journeys/src/bolt-svg-animations/svg/tripleConnectionBand.js
+++ b/packages/micro-journeys/src/bolt-svg-animations/svg/tripleConnectionBand.js
@@ -75,7 +75,7 @@ export const tripleConnectionBand = ({ speed, direction, theme }) => {
 					transform: translate(126.5999984741211px, 46.5px) translate(-126.5999984741211px, -46.5px) translate(196px, 0px);
 			}
 			100% {
-					transform: translate(126.5999984741211px, 46.5px) translate(-126.5999984741211px, -46.5px) translate(196px, 0px);
+					transform: translate(126.5999984741211px, 46.5px) translate(-126.5999984741211px, -46.5px) translate(296px, 0px);
 			}
 	}
 
@@ -101,13 +101,13 @@ export const tripleConnectionBand = ({ speed, direction, theme }) => {
 					transform: translate(219.90000915527344px, 1.5px) translate(-219.90000915527344px, -1.5px) translate(-256px, 16px);
 			}
 			16.67% {
-					transform: translate(219.90000915527344px, 1.5px) translate(-219.90000915527344px, -1.5px) translate(-73px,  -2px);
+					transform: translate(219.90000915527344px, 1.5px) translate(-219.90000915527344px, -1.5px) translate(-73px,  -4px);
 			}
 			33.33% {
 					transform: translate(219.90000915527344px, 1.5px) translate(-219.90000915527344px, -1.5px) translate(100px, 7px);
 			}
 			100% {
-					transform: translate(219.90000915527344px, 1.5px) translate(-219.90000915527344px, -1.5px) translate(100px, 7px);
+					transform: translate(219.90000915527344px, 1.5px) translate(-219.90000915527344px, -1.5px) translate(560px, 27px);
 			}
 	}
 


### PR DESCRIPTION
## Jira

https://app.asana.com/0/1126340469288208/1139869914404437/f

## Summary
Refine  triple band SVG animation. 


## Details
TripleBandConnection SVG Animation has an issue where the first  arrow group hangs at the end of the animation.   this addresses that and improves the animation somewhat.  

## How to test

View/create a page with the triple band connection SVG, medium characters, and a darkbackground.   

Simplest method is to visit:  
/pattern-lab/?p=experiments-svg-animations and utilize the inspector to make the background dark.   Compare to [here](https://boltdesignsystem-epic-interactive-pathways.now.sh/pattern-lab/patterns/06-experiments-micro-journeys-combos--95-in-page-example/06-experiments-micro-journeys-combos--95-in-page-example.html     
Browser Name: chrome             ) where the arrows hang above the character.  
