### PR TITLE
Fix/micro journey mobile styles

### DIFF
--- a/packages/micro-journeys/src/interactive-pathways.scss
+++ b/packages/micro-journeys/src/interactive-pathways.scss
@@ -30,18 +30,19 @@
     padding: 1.65rem 0;
 
     &--inner {
+      align-items: center;
       display: flex;
       flex-direction: column;
       flex-wrap: nowrap;
-      align-items: center;
-      z-index: 999;
       max-width: 100%;
-      white-space: nowrap;
+      text-align: center;
+      z-index: 999;
 
       @include bolt-mq(medium) {
+        align-items: baseline;
         flex-direction: row;
         justify-content: center;
-        align-items: baseline;
+        white-space: nowrap;
       }
     }
   }

--- a/packages/micro-journeys/src/interactive-pathways.scss
+++ b/packages/micro-journeys/src/interactive-pathways.scss
@@ -30,18 +30,18 @@
     padding: 1.65rem 0;
 
     &--inner {
-      align-items: center;
       display: flex;
       flex-direction: column;
       flex-wrap: nowrap;
+      align-items: center;
+      z-index: 999;
       max-width: 100%;
       text-align: center;
-      z-index: 999;
 
       @include bolt-mq(medium) {
-        align-items: baseline;
         flex-direction: row;
         justify-content: center;
+        align-items: baseline;
         white-space: nowrap;
       }
     }

--- a/packages/micro-journeys/src/interactive-step.scss
+++ b/packages/micro-journeys/src/interactive-step.scss
@@ -59,9 +59,9 @@ bolt-interactive-step {
   }
 
   &__body {
-    align-items: flex-start;
     display: flex;
     flex-direction: column;
+    align-items: flex-start;
     position: absolute;
     left: -9999px;
     padding-bottom: bolt-spacing(medium);

--- a/packages/micro-journeys/src/interactive-step.scss
+++ b/packages/micro-journeys/src/interactive-step.scss
@@ -59,13 +59,17 @@ bolt-interactive-step {
   }
 
   &__body {
+    align-items: flex-start;
     display: flex;
     flex-direction: column;
-    align-items: center;
     position: absolute;
     left: -9999px;
     padding-bottom: bolt-spacing(medium);
     padding-left: bolt-spacing(medium);
+
+    @include bolt-mq(medium) {
+      align-items: center;
+    }
 
     .c-bolt-interactive-step--active & {
       position: static;
@@ -87,10 +91,11 @@ bolt-interactive-step {
     display: flex;
     flex-direction: column;
     justify-content: center;
-    align-items: center;
+    align-items: flex-start;
     max-width: 100%;
 
     @include bolt-mq(medium) {
+      align-items: center;
       max-width: 700px;
     }
 

--- a/packages/micro-journeys/src/status-dialogue-bar.scss
+++ b/packages/micro-journeys/src/status-dialogue-bar.scss
@@ -10,7 +10,7 @@ $bolt-tooltip-bubble-triangle-width: 8px;
 .c-bolt-status-dialogue-bar {
   display: flex;
   align-items: center;
-  max-width: 110px;
+  max-width: 170px;
   padding: bolt-spacing(xsmall) bolt-spacing(small);
   color: bolt-color(black);
   border-radius: $bolt-border-radius;

--- a/packages/micro-journeys/src/status-dialogue-bar.scss
+++ b/packages/micro-journeys/src/status-dialogue-bar.scss
@@ -10,7 +10,7 @@ $bolt-tooltip-bubble-triangle-width: 8px;
 .c-bolt-status-dialogue-bar {
   display: flex;
   align-items: center;
-  max-width: 170px;
+  max-width: 110px;
   padding: bolt-spacing(xsmall) bolt-spacing(small);
   color: bolt-color(black);
   border-radius: $bolt-border-radius;
@@ -19,6 +19,10 @@ $bolt-tooltip-bubble-triangle-width: 8px;
 
   @include bolt-mq(small) {
     max-width: 300px;
+  }
+  
+  @include bolt-mq($from: medium, $until: large) {
+    transform: translateX(-2rem);
   }
 
   &--alert {

--- a/packages/micro-journeys/src/two-character-layout.scss
+++ b/packages/micro-journeys/src/two-character-layout.scss
@@ -1,11 +1,18 @@
 @import '@bolt/core';
 
 .c-bolt-two-character-layout {
+
+  @include bolt-mq($until: xsmall) {
+    transform: translateX(-2rem);
+  }
+
   &__character-row {
     display: inline-flex;
     justify-content: center;
     align-items: center;
     margin: 90px 0; // This margin is needed to accommodate speech bubbles that are absolute positioned around characters
+
+
 
     @include bolt-mq(small) {
       margin: 110px 0; // This margin is needed to accommodate speech bubbles that are absolute positioned around characters


### PR DESCRIPTION
## Jira

https://app.asana.com/0/1126340469288208/1142087816592431/f

## Summary

Micro Journeys had a few visual issues at mobile/tablet and extremely small desktop sizes.   This PR updates those.   The two-character layout with dialogue bar was particularly problematic, as it simply requires more space than often available within interactive step.     

Given the extremely small user share of the problematic resolutions, it seemed a few quick-fix transformXs to clean that up felt more prudent than refactoring or spending too many hours troubleshooting.  


## How to test

View the Micro Journeys page in pattern lab at 320px or ~900px screen resolution.   
