### PR TITLE
chore(micro-journeys): remove destructured assignment to prevent trut…

### DIFF
--- a/packages/micro-journeys/src/character.js
+++ b/packages/micro-journeys/src/character.js
@@ -50,18 +50,13 @@ class BoltCharacter extends withLitHtml() {
   }
 
   render() {
-    const {
-      characterImage,
-      characterCustomUrl,
-      size,
-      useIcon,
-    } = this.validateProps(this.props);
-    const classes = cx('c-bolt-character', `c-bolt-character--${size}`);
+    const props = this.validateProps(this.props);
+    const classes = cx('c-bolt-character', `c-bolt-character--${props.size}`);
 
     const image =
-      characterImage === 'custom'
-        ? characterCustomUrl
-        : resolveCharacterImage(characterImage);
+      props.characterImage === 'custom'
+        ? props.characterCustomUrl
+        : resolveCharacterImage(props.characterImage);
 
     return html`
       ${this.addStyles([styles])}
@@ -87,7 +82,7 @@ class BoltCharacter extends withLitHtml() {
           ${this.slot('right')}
         </span>
         <div class="c-bolt-character__main-image-wrapper">
-          ${useIcon
+          ${props.useIcon
             ? html`
                 <span
                   class="c-bolt-character__slot c-bolt-character__slot--icon--wrapper"

--- a/packages/micro-journeys/src/character.schema.js
+++ b/packages/micro-journeys/src/character.schema.js
@@ -46,7 +46,7 @@ module.exports = {
     useIcon: {
       type: 'boolean',
       description: 'Use a bolt-icon in place of an image Url.',
-      default: true,
+      default: false,
     },
   },
 };

--- a/packages/micro-journeys/src/character.schema.js
+++ b/packages/micro-journeys/src/character.schema.js
@@ -46,6 +46,7 @@ module.exports = {
     useIcon: {
       type: 'boolean',
       description: 'Use a bolt-icon in place of an image Url.',
+      default: true,
     },
   },
 };

--- a/packages/micro-journeys/src/connection.js
+++ b/packages/micro-journeys/src/connection.js
@@ -25,7 +25,7 @@ class BoltConnection extends withLitHtml() {
   }
 
   render() {
-    const { direction, animType, speed } = this.validateProps(this.props);
+    const props = this.validateProps(this.props);
     const classes = cx('c-bolt-connection');
     return html`
       ${this.addStyles([styles])}
@@ -38,9 +38,9 @@ class BoltConnection extends withLitHtml() {
           `}
         <bolt-svg-animations
           class="c-bolt-connection__main-image"
-          speed="${speed}"
-          anim-type="${animType}"
-          direction="${direction}"
+          speed="${props.speed}"
+          anim-type="${props.animType}"
+          direction="${props.direction}"
         />
         ${this.slots.bottom &&
           html`

--- a/packages/micro-journeys/src/interactive-pathways.js
+++ b/packages/micro-journeys/src/interactive-pathways.js
@@ -10,8 +10,9 @@ import classNames from 'classnames/bind';
 import debounce from 'lodash.debounce';
 import themes from '@bolt/global/styles/06-themes/_themes.all.scss';
 import styles from './interactive-pathways.scss';
-import pathwaysLogo from './images/interactive-pathways-logo.png';
 import schema from './interactive-pathways.schema';
+// @TODO this default image should be located in schema
+import pathwaysLogo from './images/interactive-pathways-logo.png';
 
 let cx = classNames.bind(styles);
 
@@ -189,16 +190,13 @@ class BoltInteractivePathways extends withContext(withLitHtml()) {
   }
 
   render() {
-    const {
-      customImageSrc = pathwaysLogo,
-      imageAlt,
-      theme,
-    } = this.validateProps(this.props);
-
-    this.contexts.get(BoltInteractivePathwaysContext).theme = theme;
+    const props = this.validateProps(this.props);
+    // @TODO fix https://github.com/bolt-design-system/bolt/issues/1460
+    this.contexts.get(BoltInteractivePathwaysContext).theme =
+      props.theme || schema.properties.theme.default;
 
     const classes = cx('c-bolt-interactive-pathways', {
-      [`t-bolt-${theme}`]: theme,
+      [`t-bolt-${props.theme}`]: !!props.theme,
     });
 
     const titles = this.pathways.map((pathway, i) => pathway.getTitle());
@@ -277,8 +275,8 @@ class BoltInteractivePathways extends withContext(withLitHtml()) {
           <bolt-image
             no-lazy
             sizes="auto"
-            src="${customImageSrc}"
-            alt="${imageAlt}"
+            src="${props.customImageSrc || pathwaysLogo}"
+            alt="${props.imageAlt}"
           ></bolt-image>
           <div class="c-bolt-interactive-pathways__nav">
             <div class="c-bolt-interactive-pathways__nav--inner">

--- a/packages/micro-journeys/src/interactive-pathways.schema.js
+++ b/packages/micro-journeys/src/interactive-pathways.schema.js
@@ -13,6 +13,7 @@ module.exports = {
       type: 'string',
       description:
         'URL source for the image at the top of the pathway. Fallback is the two diamond logo.',
+      // @TODO the default image should be located here.
       default: '',
     },
     imageAlt: {

--- a/packages/micro-journeys/src/interactive-step.js
+++ b/packages/micro-journeys/src/interactive-step.js
@@ -45,9 +45,7 @@ class BoltInteractiveStep extends withContext(withLitHtml()) {
   /**
    * @param {Event} event
    */
-  handleAnimationEnd(event) {
-    console.debug('bolt:transitionend', event);
-  }
+  handleAnimationEnd(event) {}
 
   connectedCallback() {
     super.connectedCallback();
@@ -131,7 +129,7 @@ class BoltInteractiveStep extends withContext(withLitHtml()) {
 
   render() {
     // validate the original prop data passed along -- returns back the validated data w/ added default values
-    const { tabTitle } = this.validateProps(this.props);
+    const props = this.validateProps(this.props);
     this.theme = this.context.theme;
     const isLastStep = !(
       this.nextElementSibling &&
@@ -159,7 +157,7 @@ class BoltInteractiveStep extends withContext(withLitHtml()) {
           class="${titleClasses}"
           @click=${() => this.triggerStepChange()}
         >
-          ${tabTitle}
+          ${props.tabTitle}
         </header>
         <div class="c-bolt-interactive-step__body">
           <div class="c-bolt-interactive-step__body-inner">

--- a/packages/micro-journeys/src/status-dialogue-bar.js
+++ b/packages/micro-journeys/src/status-dialogue-bar.js
@@ -26,26 +26,22 @@ class BoltStatusDialogueBar extends withLitHtml() {
   }
 
   render() {
-    const {
-      iconName,
-      isAlertMessage,
-      dialogueArrowDirection,
-    } = this.validateProps(this.props);
+    const props = this.validateProps(this.props);
     const classes = cx('c-bolt-status-dialogue-bar', {
-      [`c-bolt-status-dialogue-bar--alert`]: isAlertMessage,
-      [`c-bolt-status-dialogue-bar--include-${dialogueArrowDirection}-arrow`]: !!(
-        dialogueArrowDirection && dialogueArrowDirection !== 'none'
+      [`c-bolt-status-dialogue-bar--alert`]: props.isAlertMessage,
+      [`c-bolt-status-dialogue-bar--include-${props.dialogueArrowDirection}-arrow`]: !!(
+        props.dialogueArrowDirection && props.dialogueArrowDirection !== 'none'
       ),
     });
 
     return html`
       ${this.addStyles([styles])}
       <div class="${classes}">
-        ${iconName
+        ${props.iconName
           ? html`
               <bolt-icon
                 size="medium"
-                name="${iconName}"
+                name="${props.iconName}"
                 class="c-bolt-status-dialogue-bar__icon"
               />
             `


### PR DESCRIPTION
…hy undefined string when default is empty string

## Jira

https://app.asana.com/0/1126340469288208/1142567203125433/f

## Summary

chore(micro-journeys): remove destructured assignment to prevent truthy undefined string when default is empty string

## Details

In several places, we used destructred assignment to pull values from validateProps. We should not do this because it leads to inconsistent results as per: https://github.com/boltdesignsystem/bolt/issues/1460

Remove all uses of destructured assignment to prevent false printing.

## How to test

Check out files changed, and verify that things are working properly in this components.
