### PR TITLE
Fix/context js error on svg animations

### DIFF
--- a/packages/core/utils/context/with-context.js
+++ b/packages/core/utils/context/with-context.js
@@ -34,7 +34,10 @@ export class ContextGetter {
         }
       } while ((node = node.parentNode || node.host));
 
-      throw new Error('Context not found');
+      // Special prop `contextIsOptional` prevents error if node.parentNode w/context is not found.
+      if (!Context.contextIsOptional) {
+        throw new Error('Context not found');
+      }
     } else throw new Error('Not consuming or providing the specified context');
   }
 

--- a/packages/micro-journeys/src/bolt-svg-animations/svg-animations.schema.js
+++ b/packages/micro-journeys/src/bolt-svg-animations/svg-animations.schema.js
@@ -31,7 +31,7 @@ module.exports = {
       enum: ['light', 'dark'],
       default: '',
       description:
-        'control color scheme of component, not applicable to all animTypes',
+        'Sets the theme context of the animation manually, if applicable.',
     },
   },
 };

--- a/packages/micro-journeys/src/interactive-pathways.js
+++ b/packages/micro-journeys/src/interactive-pathways.js
@@ -17,6 +17,7 @@ let cx = classNames.bind(styles);
 
 export const BoltInteractivePathwaysContext = defineContext({
   theme: schema.properties.theme.default,
+  contextIsOptional: true,
 });
 
 @define


### PR DESCRIPTION
## Jira

https://app.asana.com/0/1126340469288208/1142725462089537/f

## Summary

Add a `contextIsOptional` prop and check in `with-context.js` to prevent error throwing for optional contexts.

## Details

Our SVG animations appear without the Interactive Pathways context that provides a theme context in demos, and since they don’t have a parent bolt-interactive-pathways node that provides context when they’re isolated, they throw an error.

This adds a `contextIsOptional` prop and check in `with-context.js` to prevent error throwing for optional contexts, and then adds this prop to the theme context.

@sghoweri please let me know if this solution is preferred from an architectural standpoint. I also considered an optional `contextIsOptional` argument to the `Context` constructor that sets `Context.contextIsOptional`, but this seemed cleaner.

## How to test
Visit http://localhost:3000/pattern-lab/?p=viewall-experiments-micro-journeys or http://localhost:3000/pattern-lab/?p=experiments-character-kitchen-sink, confirm no Context errors in the console.
