### PR TITLE
fix: z-index clash between dropdown menu and status bars

### DIFF
--- a/packages/micro-journeys/src/interactive-pathways.scss
+++ b/packages/micro-journeys/src/interactive-pathways.scss
@@ -109,7 +109,7 @@
 
     &.active {
       opacity: 1;
-      z-index: 1;
+      z-index: 2;
     }
 
     &__item {


### PR DESCRIPTION
## Asana

https://app.asana.com/0/1126340469288208/1142826690191123/f

## Summary

Quick fix for stacking conflict between the character's status/dialogue bar and the pathways dropdown menu.

## Details

Dropdown was behind the status bar text (see below). This PR puts it on top.

## How to test

Create a two character step layout with a dialogue above the left character. then open the dropdown menu. The status bar should be behind the dropdown menu now. 

![image](https://user-images.githubusercontent.com/16548879/66085027-f1cf7880-e524-11e9-86fd-4f40250685f5.png)

