### PR TITLE
feat: speed up default exit animation to create a smoother experience

### DIFF
--- a/packages/components/bolt-animate/animate.schema.js
+++ b/packages/components/bolt-animate/animate.schema.js
@@ -69,7 +69,7 @@ module.exports = {
       type: 'number',
       title: 'Build Out Duration',
       description: 'Set in milliseconds',
-      default: 500,
+      default: 350,
     },
     outDelay: {
       type: 'number',


### PR DESCRIPTION
## Asana

https://app.asana.com/0/1126340469288208/1140951723352001/f

## Summary

Reduces the default exit animation from 500ms to 350ms for UX reasons. When clicking on an inactive step, this will decrease the default time to that step being "active" and thus making the application feel more responsive to user interactions. 

See the Doherty Threshold principle for background on this: https://lawsofux.com/doherty-threshold.html

## How to test

Click through steps. It should feel a bit more responsive than before.
