### PR TITLE
Feat/micro journey little fixes

### DIFF
--- a/packages/components/bolt-animate/animate.schema.js
+++ b/packages/components/bolt-animate/animate.schema.js
@@ -19,13 +19,13 @@ module.exports = {
     },
     inDuration: {
       type: 'number',
-      title: 'Build In Duration',
+      title: 'Build In Duration (ms)',
       description: 'Set in milliseconds',
       default: 500,
     },
     inDelay: {
       type: 'number',
-      title: 'Build In Delay',
+      title: 'Build In Delay (ms)',
       description: 'Set in milliseconds',
       default: 0,
     },
@@ -48,13 +48,13 @@ module.exports = {
     },
     idleDuration: {
       type: 'number',
-      title: 'Idle Animation Duration (before repeating)',
+      title: 'Idle Animation Duration (before repeating; ms)',
       description: 'Set in milliseconds',
       default: 500,
     },
     idleDelay: {
       type: 'number',
-      title: 'Idle Delay',
+      title: 'Idle Delay (ms)',
       description: 'Set in milliseconds',
       default: 0,
     },
@@ -67,13 +67,13 @@ module.exports = {
     },
     outDuration: {
       type: 'number',
-      title: 'Build Out Duration',
+      title: 'Build Out Duration (ms)',
       description: 'Set in milliseconds',
       default: 350,
     },
     outDelay: {
       type: 'number',
-      title: 'Build Out Delay',
+      title: 'Build Out Delay (ms)',
       description: 'Set in milliseconds',
       default: 0,
     },

--- a/packages/editor/src/index.js
+++ b/packages/editor/src/index.js
@@ -218,7 +218,7 @@ function init() {
           const html = editor.getHtml();
           const unsavedChanges = editor.getDirtyCount();
           if (unsavedChanges) {
-            console.log(
+            console.warn(
               'There were unsaved changes we will lose on next page reload...',
             );
           }

--- a/packages/editor/src/setup-bolt.js
+++ b/packages/editor/src/setup-bolt.js
@@ -234,7 +234,6 @@ export function setupBolt(editor) {
       const prop = properties[propName];
 
       if (!prop) {
-        console.log({ schema });
         throw new EditorRegisterBoltError(
           `Prop "${propName} does not exist on schema for "${name}"`,
         );
@@ -499,7 +498,7 @@ export function setupBolt(editor) {
     initialContent: [
       `<bolt-text subheadline font-size="xxlarge" slot="interactive-pathways-lead-text">How Pega technology resolves</bolt-text>`,
       `<bolt-interactive-pathway pathway-title="New Title">
-        ${starters.stepOneCharacterLorem}        
+        ${starters.stepOneCharacterLorem}
         ${starters.stepTwoCharacterLorem}
       </bolt-interactive-pathway>`,
     ],

--- a/packages/editor/src/setup-bolt.js
+++ b/packages/editor/src/setup-bolt.js
@@ -485,7 +485,7 @@ export function setupBolt(editor) {
   registerBoltComponent({
     name: 'bolt-interactive-pathways',
     schema: pathwaysSchema,
-    propsToTraits: ['customImageSrc', 'imageAlt', 'theme'],
+    propsToTraits: ['customImageSrc', 'imageAlt', 'theme', 'hidePathwaysImage'],
     category: 'Starters',
     blockTitle: 'Pathways',
     draggable: true,

--- a/packages/micro-journeys/src/interactive-pathways.js
+++ b/packages/micro-journeys/src/interactive-pathways.js
@@ -181,7 +181,6 @@ class BoltInteractivePathways extends withLitContext() {
 
   render() {
     const props = this.validateProps(this.props);
-    // @TODO fix https://github.com/bolt-design-system/bolt/issues/1460
 
     const classes = cx('c-bolt-interactive-pathways', {
       [`t-bolt-${props.theme}`]: !!props.theme,
@@ -285,12 +284,17 @@ class BoltInteractivePathways extends withLitContext() {
       ${this.addStyles([styles, themes])}
       <div class="${classes}">
         <div class="c-bolt-interactive-pathways__header">
-          <bolt-image
-            no-lazy
-            sizes="auto"
-            src="${props.customImageSrc || pathwaysLogo}"
-            alt="${props.imageAlt}"
-          ></bolt-image>
+          ${props.hidePathwaysImage
+            ? ''
+            : html`
+                <bolt-image
+                  no-lazy
+                  sizes="auto"
+                  src="${props.customImageSrc || pathwaysLogo}"
+                  alt="${props.imageAlt}"
+                ></bolt-image>
+              `}
+
           <div class="c-bolt-interactive-pathways__nav">
             <div class="c-bolt-interactive-pathways__nav--inner">
               <span class="c-bolt-interactive-pathways__nav-text"

--- a/packages/micro-journeys/src/interactive-pathways.schema.js
+++ b/packages/micro-journeys/src/interactive-pathways.schema.js
@@ -21,5 +21,11 @@ module.exports = {
       description: 'Alt attribute for the image at the top of the pathway',
       default: 'Pega logo',
     },
+    hidePathwaysImage: {
+      title: 'Hide Pathways Image',
+      type: 'boolean',
+      description: 'Do not show the image at the top of the patheay',
+      default: false,
+    },
   },
 };


### PR DESCRIPTION
## Jira

Add MS hint to `bolt-animate` https://app.asana.com/0/1126340469288208/1143556826115401/f
Remove console logs: https://app.asana.com/0/1126340469288208/1143553749250536/f
Hide pathways image: https://app.asana.com/0/1126340469288208/1143553749250544/f


## Summary

Add ms hint to `bolt-animate`; Remove console logs; Hide pathways image

## Detail

This is several small fixes rolled into one branch.

## How to test

Test `bolt-animate` in editor has a MS hint: https://app.asana.com/0/1126340469288208/1143556826115401/f
Open editor page, verify no console logs: https://app.asana.com/0/1126340469288208/1143553749250536/f
Verify in editor that pathways image can be hidden: https://app.asana.com/0/1126340469288208/1143553749250544/f
