### PR TITLE
fix(editor): use package name for import

### DIFF
--- a/packages/editor/src/setup-bolt.js
+++ b/packages/editor/src/setup-bolt.js
@@ -18,7 +18,7 @@ import imageSchema from '@bolt/components-image/image.schema.yml';
 import animateSchema from '@bolt/components-animate/animate.schema';
 import * as starters from '@bolt/micro-journeys/starters';
 // @ts-ignore
-import linkSchema from '../../components/bolt-link/link.schema.yml'; // @todo figure out why the @bolt module name does not resolve for this
+import linkSchema from '@bolt/components-link/link.schema.yml';
 // import { animationNames } from '@bolt/components-animate/animation-meta';
 import { isChildOfEl, convertSchemaPropToTrait } from './utils';
 
@@ -499,7 +499,7 @@ export function setupBolt(editor) {
     initialContent: [
       `<bolt-text subheadline font-size="xxlarge" slot="interactive-pathways-lead-text">How Pega technology resolves</bolt-text>`,
       `<bolt-interactive-pathway pathway-title="New Title">
-        ${starters.stepOneCharacterLorem}        
+        ${starters.stepOneCharacterLorem}
         ${starters.stepTwoCharacterLorem}
       </bolt-interactive-pathway>`,
     ],


### PR DESCRIPTION
Packages shouldn't import other packages with relative paths; they should use package names. This fixes the editor importing the schema from the link component.