### PR TITLE
Update tooltip.js

### DIFF
--- a/packages/components/bolt-tooltip/src/tooltip.js
+++ b/packages/components/bolt-tooltip/src/tooltip.js
@@ -2,6 +2,7 @@ import { define, props } from '@bolt/core/utils';
 import classNames from 'classnames/bind';
 import { html, withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 import { ifDefined } from 'lit-html/directives/if-defined';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html';
 
 import styles from './tooltip.scss';
 
@@ -162,7 +163,7 @@ class BoltTooltip extends withLitHtml() {
           role="tooltip"
           aria-hidden="true"
         >
-          <span class="c-bolt-tooltip__content-bubble">${this.content}</span>
+          <span class="c-bolt-tooltip__content-bubble">${unsafeHTML(this.content || '')}</span>
         </bolt-tooltip-content>
       </span>
     `;


### PR DESCRIPTION
Fix for error with rendering HTML inside tooltip content (COMM-1413)

## Jira

http://vjira2:8080/browse/COMM-1413

## Summary

Fix for error with rendering HTML inside tooltip content 

## Details

HTML passed to tooltip is rendered as plain text

## How to test

Pass some HTML markup to the tooltip content. See how it's rendered.
