### PR TITLE
fix(micro-journeys): config for update of parents with event on edito…

### DIFF
--- a/packages/editor/src/setup-bolt.js
+++ b/packages/editor/src/setup-bolt.js
@@ -186,6 +186,12 @@ export function setupBolt(editor) {
    */
 
   /**
+   * @typedef removalEventsToFireOnParents
+   * @prop {string} parentSelector
+   * @prop {function} eventFactory
+   */
+
+  /**
    * @param {Object} opt
    * @param {string} opt.name i.e. `bolt-button`
    * @param {string} [opt.blockTitle] only used if `registerBlock` is `true`
@@ -205,6 +211,7 @@ export function setupBolt(editor) {
    * @param {(el: HTMLElement) => boolean} [opt.isComponent] - function to determine if an HTMLElement is this component. Defaults to seeing if tag name is component name
    * @param {Object.<string, boolean|string>} [opt.slots={ default: true }] - Which slots are available and what can go in them. For example `{ default: true, top: 'bolt-text, bolt-button' }` would let any element be placed as a direct child (the `default` slot) and the `top` slot would only accept `<bolt-text>` or `<bolt-button>`. Those values are passed right to Grape JS's `droppable`.
    * @param {SlotControl[]} [opt.slotControls]
+   * @param {removalEventsToFireOnParents[]} [opt.removalEventsToFireOnParents=[]]
    * @returns {{ component: Object, block: Object }} instances from registering @todo fill out types
    * @see {convertSchemaPropToTrait}
    */
@@ -227,6 +234,7 @@ export function setupBolt(editor) {
     isComponent,
     slots = { default: false },
     slotControls,
+    removalEventsToFireOnParents = [],
   }) {
     const { title, description, properties } = schema;
 
@@ -287,7 +295,7 @@ export function setupBolt(editor) {
       });
     });
 
-    const component = DomComponents.addType(name, {
+    const componentConfig = {
       isComponent: isComponent
         ? isComponent
         : el => el.tagName === name.toUpperCase(),
@@ -309,7 +317,22 @@ export function setupBolt(editor) {
           return slotControls;
         },
       },
-    });
+    };
+
+    if (removalEventsToFireOnParents.length) {
+      componentConfig.model.removed = function() {
+        removalEventsToFireOnParents.forEach(eventConfig => {
+          // this.closest(whatever) is always 0 so we use this.parent().closest(). Meaning immediate ancestors won't work.
+          const parent = this.parent().closest(eventConfig.parentSelector);
+          // parent is only found and dispatched once, because (my guess is that) nodes are removed from parent -> down.
+          if (parent) {
+            parent.view.el.dispatchEvent(eventConfig.eventFactory());
+          }
+        });
+      };
+    }
+
+    const component = DomComponents.addType(name, componentConfig);
 
     if (registerBlock) {
       const block = BlockManager.add(name, {
@@ -466,6 +489,16 @@ export function setupBolt(editor) {
     editable: true,
     highlightable: false,
     extraTraits: ['tab-title'],
+    removalEventsToFireOnParents: [
+      {
+        parentSelector: 'bolt-interactive-pathway',
+        eventFactory: () => {
+          return new CustomEvent('bolt-interactive-step:title-updated', {
+            bubbles: true,
+          });
+        },
+      },
+    ],
     slots: {
       top: true,
       bottom: true,
@@ -522,6 +555,16 @@ export function setupBolt(editor) {
     editable: false,
     highlightable: true,
     extraTraits: ['pathway-title'],
+    removalEventsToFireOnParents: [
+      {
+        parentSelector: 'bolt-interactive-pathways',
+        eventFactory: () => {
+          return new CustomEvent('bolt-interactive-pathway:title-updated', {
+            bubbles: true,
+          });
+        },
+      },
+    ],
     slots: {
       default: 'bolt-interactive-step',
     },


### PR DESCRIPTION
…r removal; add events for step and pathway removal

## Jira

https://app.asana.com/0/1126340469288208/1143556826115403/f

## Summary

Config for components to fire an event on parents upon removal; added events for step and pathway removal

## Details

Previously, when `bolt-interactive-pathway` or `bolt-interactive-step` was removed in the editor, parents did not update and it appeared to users that they were not removed.

## How to test

Go to editor, delete `bolt-interactive-pathway` and verify dropdown contains only one entry, delete `bolt-interactive-step` and verify nav no longer contains that item.
