### PR TITLE
(WIP/Debug) Debug/with without chrome fail

### DIFF
--- a/packages/with-without/index.js
+++ b/packages/with-without/index.js
@@ -1,6 +1,7 @@
 import { polyfillLoader } from '@bolt/core/polyfills';
 
 polyfillLoader.then(res => {
+  console.error('Polyfills just finished loading, kicking off w/wo.');
   import(/*
     webpackMode: 'eager',
   */ './js/accordion');

--- a/packages/with-without/js/handleActiveRegionChange.js
+++ b/packages/with-without/js/handleActiveRegionChange.js
@@ -20,6 +20,8 @@ const filterInvisibles = els => {
 
 const getCurriedPageLoadAnimation = mainWrapper => {
   return () => {
+    console.debug('w/wo firing getCurriedPageLoadAnimation');
+
     const animInitOutEls = Array.from(
       mainWrapper.querySelectorAll('bolt-animate[group="initial"][out]'),
     );
@@ -31,6 +33,7 @@ const getCurriedPageLoadAnimation = mainWrapper => {
     return triggerAnims({
       animEls: filterInvisibles(animInitEls),
       stage: 'IN',
+      debug: true,
     });
   };
 };
@@ -41,6 +44,8 @@ const getCurriedAnimateContentOut = (
   mainWrapper,
 ) => {
   return async () => {
+    console.debug('w/wo firing getCurriedAnimateContentOut');
+
     const animOutEls = Array.from(
       mainWrapper.querySelectorAll(
         `bolt-animate[group="${outGroupAttrVal}"][out]:not([type="in-effect-only"])`,
@@ -49,7 +54,7 @@ const getCurriedAnimateContentOut = (
     await triggerAnims({
       animEls: filterInvisibles(animOutEls),
       stage: 'OUT',
-      // debug: true,
+      debug: true,
     });
   };
 };
@@ -65,6 +70,8 @@ const getCurriedAnimateContentOut = (
  * @returns {void}
  */
 const triggerAnimateOutOnInOnlyContent = async (groupAttrVal, mainWrapper) => {
+  console.debug('w/wo firing triggerAnimateOutOnInOnlyContent');
+
   const animOutEls = Array.from(
     mainWrapper.querySelectorAll(
       `bolt-animate[group="${groupAttrVal}"][type="in-effect-only"]`,
@@ -83,11 +90,13 @@ const triggerAnimateOutOnInOnlyContent = async (groupAttrVal, mainWrapper) => {
   await triggerAnims({
     animEls: filterInvisibles(animOutEls),
     stage: 'OUT',
-    // debug: true,
+    debug: true,
   });
 };
 
 const triggerAnimateInOnInOnlyContent = async inGroupAttrVal => {
+  console.debug('w/wo firing triggerAnimateInOnInOnlyContent');
+
   const animOutEls = Array.from(
     document.querySelectorAll(
       `bolt-animate[group="${inGroupAttrVal}"][type="in-effect-only"]`,
@@ -97,7 +106,7 @@ const triggerAnimateInOnInOnlyContent = async inGroupAttrVal => {
   await triggerAnims({
     animEls: filterInvisibles(animOutEls),
     stage: 'IN',
-    // debug: true,
+    debug: true,
   });
 };
 
@@ -114,6 +123,8 @@ const triggerAnimateInOnInOnlyContent = async inGroupAttrVal => {
  * @returns {void}
  */
 const triggerAnimateInOnOutOnlyContent = async (groupAttrVal, mainWrapper) => {
+  console.debug('w/wo firing triggerAnimateInOnOutOnlyContent');
+
   const animOutEls = Array.from(
     mainWrapper.querySelectorAll(
       `bolt-animate[group="${groupAttrVal}"][type="out-effect-only"]`,
@@ -123,12 +134,14 @@ const triggerAnimateInOnOutOnlyContent = async (groupAttrVal, mainWrapper) => {
   await triggerAnims({
     animEls: filterInvisibles(animOutEls),
     stage: 'IN',
-    // debug: true,
+    debug: true,
   });
 };
 
 const getCurriedAnimateContentIn = (inGroupAttrVal, mainWrapper) => {
   return async () => {
+    console.debug('w/wo firing getCurriedAnimateContentIn');
+
     const animInEls = Array.from(
       mainWrapper.querySelectorAll(
         `bolt-animate[group="${inGroupAttrVal}"][in]:not([type="out-effect-only"])`,
@@ -191,7 +204,11 @@ const triggerActiveRegionChange = async (checked, wwoSwiper, init = false) => {
   if (init) {
     pierceShadowDomEls(mainWrapper);
 
+    console.debug('w/wo firing pageLoadAnimation');
+
     getCurriedPageLoadAnimation(mainWrapper)();
+
+    console.debug('w/wo fired pageLoadAnimation');
 
     if (withIsBecomingActive) {
       // In this case the checked button is With Pega, so transition to that slide first.

--- a/packages/with-without/js/with-without.js
+++ b/packages/with-without/js/with-without.js
@@ -11,6 +11,7 @@ const fireInitialAnimations = (toggleInputs, checkedValue, wwoSwiper) => {
   // Pushed to bottom of call stack b/c w/o shadowdom enabled it breaks if not.
   // Set up the resize listener which helps with some of the abs. pos. stuff.
   handleResize()();
+  console.debug('w/wo firing fireInitialAnimations');
   setTimeout(() => {
     // Initialize the page.
     triggerActiveRegionChange(
@@ -25,6 +26,7 @@ const fireInitialAnimations = (toggleInputs, checkedValue, wwoSwiper) => {
 };
 
 (() => {
+  console.debug('w/wo JS code has fired');
   const toggleInputsWrapper = document.getElementById('c-pega-wwo__toggle');
 
   // short-circuit all the things if no toggler is found.


### PR DESCRIPTION
## Summary

With/Without fails on Chrome in some contexts Mac and Windows, but specifically reproducible on Chrome 77 Windows 8.1 in Browserstack.

## Details

This is not a difference between triggerAnims and triggerAnimsOut. See link: https://develop.boltdesignsystem.com/pattern-lab/?p=experiments-with-without-overlay-animation-test

It is not a DomReady problem because IntersectionObserver also doesn't work: https://develop.boltdesignsystem.com/pattern-lab/?p=experiments-with-without-intersection-test

It _is_ a shadow dom problem, because w/wo works without the shadow dom enabled: https://develop.boltdesignsystem.com/pattern-lab/?p=experiments-with-without

Micro Journeys work fine.

## How to test

Load with/without on Chrome in Windows 8.1 in Browserstack.
