### PR TITLE
Hotfix: Tooltip Refactor + Updates

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/tooltip/05-tooltip.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/tooltip/05-tooltip.twig
@@ -1,3 +1,49 @@
+{% set content %}
+<ul class="c-bolt-block-list">
+  <li class="c-bolt-block-list__item">
+    <bolt-link display="inline" valign="center" url="" target="_blank" class="js-bolt-share__facebook">
+      <bolt-icon slot="before" name="facebook-solid" size="medium"></bolt-icon>Facebook</bolt-link>
+  </li>
+  <li class="c-bolt-block-list__item">
+    <bolt-link display="inline" valign="center" url="" target="_blank" class="js-bolt-share__twitter">
+      <bolt-icon slot="before" name="twitter" size="medium"></bolt-icon>Twitter</bolt-link>
+  </li>
+  <li class="c-bolt-block-list__item">
+    <bolt-link display="inline" valign="center" url="" target="_blank" class="js-bolt-share__linkedin">
+      <bolt-icon slot="before" name="linkedin" size="medium"></bolt-icon>LinkedIn</bolt-link>
+  </li>
+  <li class="c-bolt-block-list__item">
+    <bolt-link display="inline" valign="center" url="" target="_self" class="js-bolt-share__email">
+      <bolt-icon slot="before" name="email" size="medium"></bolt-icon>Email</bolt-link>
+  </li>
+  <li class="c-bolt-block-list__item">
+    <bolt-copy-to-clipboard>
+      <span class="c-bolt-copy-to-clipboard js-bolt-copy-to-clipboard">
+        <button class="c-bolt-copy-to-clipboard__trigger" data-clipboard-text="https://community.pega.com/knowledgebase/articles/documents-api-pega-infinity-mobile-client">
+          <div class="c-bolt-copy-to-clipboard__action">
+            <bolt-icon name="asset-link" size="medium"></bolt-icon>
+            <span class="c-bolt-copy-to-clipboard__action-text">
+              Copy Link
+            </span>
+          </div>
+        </button>
+        <span class="c-bolt-copy-to-clipboard__transition">
+          <span class="c-bolt-copy-to-clipboard__transition-animation">
+            <bolt-icon name="refresh" size="medium"></bolt-icon>
+          </span>
+        </span>
+        <span class="c-bolt-copy-to-clipboard__confirmation">
+          <div class="c-bolt-copy-to-clipboard__info js-bolt-copy-to-clipboard__trigger">
+            <bolt-icon name="check" size="medium"></bolt-icon>
+            Copied!
+          </div>
+        </span>
+      </span>
+    </bolt-copy-to-clipboard>
+  </li>
+</ul>
+{% endset %}
+
 <div class="u-bolt-padding-top-large u-bolt-padding-bottom-large">
   {% grid "o-bolt-grid--center" %}
     {% cell "o-bolt-grid__cell" %}
@@ -6,7 +52,7 @@
           type: "text",
           text: "This is the tooltip trigger"
         },
-        content: "This is the tooltip content."
+        content: content
       } only %}
     {% endcell %}
   {% endgrid %}

--- a/packages/components/bolt-tooltip/__tests__/__snapshots__/tooltip.js.snap
+++ b/packages/components/bolt-tooltip/__tests__/__snapshots__/tooltip.js.snap
@@ -4,8 +4,8 @@ exports[`<bolt-tooltip> Component Basic usage 1`] = `
 <bolt-tooltip trigger-type="text"
               trigger-text="Trigger text"
               trigger-icon-name="info-open"
-              content="Tooltip content."
 >
+  Tooltip content.
 </bolt-tooltip>
 `;
 
@@ -13,9 +13,9 @@ exports[`<bolt-tooltip> Component Direction of the tooltip bubble: down 1`] = `
 <bolt-tooltip trigger-type="button"
               trigger-text="Trigger text"
               trigger-icon-name="info-open"
-              position-vert="down"
-              content="Tooltip content."
+              direction="down"
 >
+  Tooltip content.
 </bolt-tooltip>
 `;
 
@@ -24,8 +24,8 @@ exports[`<bolt-tooltip> Component Direction of the tooltip bubble: medium 1`] = 
               trigger-text="Trigger text"
               trigger-icon-name="info-open"
               spacing="medium"
-              content="Tooltip content."
 >
+  Tooltip content.
 </bolt-tooltip>
 `;
 
@@ -34,8 +34,8 @@ exports[`<bolt-tooltip> Component Direction of the tooltip bubble: none 1`] = `
               trigger-text="Trigger text"
               trigger-icon-name="info-open"
               spacing="none"
-              content="Tooltip content."
 >
+  Tooltip content.
 </bolt-tooltip>
 `;
 
@@ -44,8 +44,8 @@ exports[`<bolt-tooltip> Component Direction of the tooltip bubble: small 1`] = `
               trigger-text="Trigger text"
               trigger-icon-name="info-open"
               spacing="small"
-              content="Tooltip content."
 >
+  Tooltip content.
 </bolt-tooltip>
 `;
 
@@ -53,9 +53,9 @@ exports[`<bolt-tooltip> Component Direction of the tooltip bubble: up 1`] = `
 <bolt-tooltip trigger-type="button"
               trigger-text="Trigger text"
               trigger-icon-name="info-open"
-              position-vert="up"
-              content="Tooltip content."
+              direction="up"
 >
+  Tooltip content.
 </bolt-tooltip>
 `;
 
@@ -64,8 +64,8 @@ exports[`<bolt-tooltip> Component Direction of the tooltip bubble: xsmall 1`] = 
               trigger-text="Trigger text"
               trigger-icon-name="info-open"
               spacing="xsmall"
-              content="Tooltip content."
 >
+  Tooltip content.
 </bolt-tooltip>
 `;
 
@@ -73,8 +73,8 @@ exports[`<bolt-tooltip> Component No wrapping for tooltip content: false 1`] = `
 <bolt-tooltip trigger-type="text"
               trigger-text="Trigger text"
               trigger-icon-name="info-open"
-              content="Tooltip content. This text should wrap if noWrap is set to false, otherwise it should not wrap."
 >
+  Tooltip content. This text should wrap if noWrap is set to false, otherwise it should not wrap.
 </bolt-tooltip>
 `;
 
@@ -83,7 +83,7 @@ exports[`<bolt-tooltip> Component No wrapping for tooltip content: true 1`] = `
               trigger-text="Trigger text"
               trigger-icon-name="info-open"
               no-wrap
-              content="Tooltip content. This text should wrap if noWrap is set to false, otherwise it should not wrap."
 >
+  Tooltip content. This text should wrap if noWrap is set to false, otherwise it should not wrap.
 </bolt-tooltip>
 `;

--- a/packages/components/bolt-tooltip/index.js
+++ b/packages/components/bolt-tooltip/index.js
@@ -1,5 +1,7 @@
 import { polyfillLoader } from '@bolt/core/polyfills';
 
 polyfillLoader.then(res => {
-  import('./src/tooltip.js');
+  import(
+    /* webpackMode: 'eager', webpackChunkName: 'bolt-tooltip' */ './src/tooltip'
+  );
 });

--- a/packages/components/bolt-tooltip/src/tooltip.js
+++ b/packages/components/bolt-tooltip/src/tooltip.js
@@ -47,7 +47,7 @@ class BoltTooltip extends withLitHtml() {
       ...{ default: 'small' },
     },
     triggerID: props.string,
-    positionVert: {
+    direction: {
       ...props.string,
       ...{ default: 'up' },
     },
@@ -141,8 +141,8 @@ class BoltTooltip extends withLitHtml() {
       [`c-bolt-tooltip${
         this.triggerType === 'button' ? `--action` : `--help`
       }`]: this.triggerType,
-      [`is-push-${this.positionVert}`]: this.positionVert,
       [`is-open`]: this.isOpen,
+      [`is-push-${this.direction}`]: this.direction,
       [`c-bolt-tooltip--nowrap`]: this.noWrap,
       [`c-bolt-tooltip--spacing-${this.spacing}`]: this.spacing,
     });

--- a/packages/components/bolt-tooltip/src/tooltip.js
+++ b/packages/components/bolt-tooltip/src/tooltip.js
@@ -2,7 +2,6 @@ import { define, props } from '@bolt/core/utils';
 import classNames from 'classnames/bind';
 import { html, withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 import { ifDefined } from 'lit-html/directives/if-defined';
-
 import styles from './tooltip.scss';
 
 let cx = classNames.bind(styles);
@@ -84,11 +83,25 @@ class BoltTooltip extends withLitHtml() {
     this.addEventListener('mouseleave', this.handleMovingOutOfTrigger);
   }
 
-  rendered(){
+  rendered() {
     super.rendered && super.rendered();
-    this.setAttribute('ready', '');
-    this.renderRoot.querySelector('.c-bolt-tooltip__content').addEventListener('mouseover', this.handleMovingOverContent);
-    this.renderRoot.querySelector('.c-bolt-tooltip__content').addEventListener('mouseleave', this.handleMovingOutOfContent);
+    if (!this.hasAttribute('ready')) {
+      this.setAttribute('ready', '');
+    }
+    this.tooltipContentElem = this.renderRoot.querySelector(
+      '.c-bolt-tooltip__content',
+    );
+
+    if (this.tooltipContentElem) {
+      this.tooltipContentElem.addEventListener(
+        'mouseover',
+        this.handleMovingOverContent,
+      );
+      this.tooltipContentElem.addEventListener(
+        'mouseleave',
+        this.handleMovingOutOfContent,
+      );
+    }
 
     if (
       this.triggerType === 'button' &&
@@ -105,13 +118,22 @@ class BoltTooltip extends withLitHtml() {
     }
   }
 
-  disconnected(){
+  disconnected() {
     super.disconnected && super.disconnected();
 
     this.removeEventListener('mouseover', this.handleMovingOverTrigger);
     this.removeEventListener('mouseleave', this.handleMovingOutOfTrigger);
-    this.renderRoot.querySelector('.c-bolt-tooltip__content').removeEventListener('mouseover', this.handleMovingOverContent);
-    this.renderRoot.querySelector('.c-bolt-tooltip__content').removeEventListener('mouseleave', this.handleMovingOutOfContent);
+
+    if (this.tooltipContentElem) {
+      this.tooltipContentElem.removeEventListener(
+        'mouseover',
+        this.handleMovingOverContent,
+      );
+      this.tooltipContentElem.removeEventListener(
+        'mouseleave',
+        this.handleMovingOutOfContent,
+      );
+    }
 
     if (this.isWatchingForExternalClicks === true) {
       document.removeEventListener('click', this.handleExternalClick);

--- a/packages/components/bolt-tooltip/src/tooltip.js
+++ b/packages/components/bolt-tooltip/src/tooltip.js
@@ -55,7 +55,7 @@ class BoltTooltip extends withLitHtml() {
       ...props.string,
       ...{ default: undefined },
     }, // For use ONLY with share
-    active: {
+    isOpen: {
       ...props.boolean,
       ...{ default: false },
     },
@@ -72,17 +72,16 @@ class BoltTooltip extends withLitHtml() {
   }
 
   clickHandler() {
-    this.active = !this.active;
-    this.renderRoot
-      .querySelector('bolt-tooltip-trigger')
-      .classList.toggle('is-active');
+    this.isOpen = !this.isOpen;
+  }
+
   }
 
   setClick() {
     if (this.triggerType === 'button') {
       return html`
         <bolt-tooltip-trigger
-          class="c-bolt-tooltip__trigger"
+          class="${this.isOpen ? 'is-active' : ''} c-bolt-tooltip__trigger"
           aria-describedby=${this.triggerID}
           @click=${this.clickHandler}
         >
@@ -92,7 +91,7 @@ class BoltTooltip extends withLitHtml() {
     } else {
       return html`
         <bolt-tooltip-trigger
-          class="c-bolt-tooltip__trigger"
+          class="${this.isOpen ? 'is-active' : ''} c-bolt-tooltip__trigger"
           aria-describedby=${this.triggerID}
         >
           ${this.setTrigger()}
@@ -110,14 +109,14 @@ class BoltTooltip extends withLitHtml() {
           >${this.triggerIconName &&
             html`
               <bolt-icon
-                name="${this.active
+                name="${this.isOpen
                   ? this.triggerToggleIcon
                   : this.triggerIconName}"
                 size="${this.triggerIconSize}"
                 slot="before"
               ></bolt-icon>
             `}
-          ${this.active
+          ${this.isOpen
             ? this.triggerToggleText
             : this.triggerText}</bolt-button
         >
@@ -138,11 +137,12 @@ class BoltTooltip extends withLitHtml() {
   }
 
   render() {
-    const classes = cx('c-bolt-tooltip is-align-center', {
+    const classes = cx('c-bolt-tooltip is-align-center is-rendered', {
       [`c-bolt-tooltip${
         this.triggerType === 'button' ? `--action` : `--help`
       }`]: this.triggerType,
       [`is-push-${this.positionVert}`]: this.positionVert,
+      [`is-open`]: this.isOpen,
       [`c-bolt-tooltip--nowrap`]: this.noWrap,
       [`c-bolt-tooltip--spacing-${this.spacing}`]: this.spacing,
     });
@@ -162,7 +162,9 @@ class BoltTooltip extends withLitHtml() {
           role="tooltip"
           aria-hidden="true"
         >
-          <span class="c-bolt-tooltip__content-bubble">${this.content}</span>
+          <span class="c-bolt-tooltip__content-bubble"
+            >${this.slot('default')}</span
+          >
         </bolt-tooltip-content>
       </span>
     `;

--- a/packages/components/bolt-tooltip/src/tooltip.scss
+++ b/packages/components/bolt-tooltip/src/tooltip.scss
@@ -44,6 +44,21 @@ $bolt-tooltip-transition: $bolt-transition;
   100% { transform: translate(-50%, -110%) scale(1); }
 }
 
+:host {
+  display: inline-block;
+}
+
+// display the initial text for simple text-based Tooltips
+bolt-tooltip:not([ready]):not([trigger-type="button"]):before {
+  content: attr(trigger-text);
+}
+
+// hide the initial tooltip content before the JS is ready
+// @todo: refactor + replace when restoring tooltips that work w/o JS
+bolt-tooltip:not([ready]) > * {
+  display: none;
+}
+
 // Tooltip positioning
 .c-bolt-tooltip {
   display: inline-block;

--- a/packages/components/bolt-tooltip/src/tooltip.scss
+++ b/packages/components/bolt-tooltip/src/tooltip.scss
@@ -181,7 +181,7 @@ $bolt-tooltip-transition: $bolt-transition;
         }
       }
 
-      .is-active+.c-bolt-tooltip__content--button {
+      .is-open+.c-bolt-tooltip__content--button {
         animation: bounceUp 500ms ease forwards;
 
         &.c-bolt-tooltip__content--count-5 {
@@ -215,7 +215,7 @@ $bolt-tooltip-transition: $bolt-transition;
         }
       }
 
-      .is-active+.c-bolt-tooltip__content--button {
+      .is-open+.c-bolt-tooltip__content--button {
         animation: bounceDown 500ms ease forwards;
       }
 
@@ -404,7 +404,7 @@ $bolt-tooltip-transition: $bolt-transition;
     opacity: 0 !important; // We need this to override the hover functionality
     pointer-events: none;
 
-    .is-active+& {
+    .is-open+& {
       opacity: bolt-opacity(100) !important; // Brings us back only when active
       pointer-events: auto !important; // Brings back the ability to click links within the tooltip only when active
     }
@@ -436,14 +436,15 @@ $bolt-tooltip-transition: $bolt-transition;
 
 
 // Show and hide effects
-.c-bolt-tooltip:not(:hover) > .c-bolt-tooltip__content,
+.c-bolt-tooltip:not(:hover):not(.is-open) > .c-bolt-tooltip__content,
 .c-bolt-tooltip__trigger + .c-bolt-tooltip__content {
   opacity: bolt-opacity(0);
   pointer-events: none;
 }
 
-.c-bolt-tooltip:hover > .c-bolt-tooltip__content,
-.c-bolt-tooltip__trigger.is-active + .c-bolt-tooltip__content {
+.c-bolt-tooltip:hover:not(.is-rendered) > .c-bolt-tooltip__content,
+.c-bolt-tooltip.is-open > .c-bolt-tooltip__content,
+.c-bolt-tooltip__trigger.is-open + .c-bolt-tooltip__content {
   opacity: bolt-opacity(100);
   pointer-events: auto;
 }
@@ -455,7 +456,7 @@ $bolt-tooltip-transition: $bolt-transition;
   }
 
   &:hover > .c-bolt-tooltip__content,
-  .c-bolt-tooltip__trigger.is-active + .c-bolt-tooltip__content {
+  .c-bolt-tooltip__trigger.is-open + .c-bolt-tooltip__content {
     //padding-bottom: 0.25em; // Extra spacing between the bubble and the trigger
   }
 }
@@ -467,7 +468,7 @@ $bolt-tooltip-transition: $bolt-transition;
   }
 
   &:hover > .c-bolt-tooltip__content,
-  .c-bolt-tooltip__trigger.is-active + .c-bolt-tooltip__content {
+  .c-bolt-tooltip__trigger.is-open + .c-bolt-tooltip__content {
     padding-left: $bolt-tooltip-bubble-triangle-width * 1.5; // Extra spacing between the bubble and the trigger
   }
 }
@@ -479,7 +480,7 @@ $bolt-tooltip-transition: $bolt-transition;
   }
 
   &:hover > .c-bolt-tooltip__content,
-  .c-bolt-tooltip__trigger.is-active + .c-bolt-tooltip__content {
+  .c-bolt-tooltip__trigger.is-open + .c-bolt-tooltip__content {
     //padding-top: 0.25em; // Extra spacing between the bubble and the trigger
   }
 }
@@ -491,7 +492,7 @@ $bolt-tooltip-transition: $bolt-transition;
   }
 
   &:hover > .c-bolt-tooltip__content,
-  .c-bolt-tooltip__trigger.is-active + .c-bolt-tooltip__content {
+  .c-bolt-tooltip__trigger.is-open + .c-bolt-tooltip__content {
     padding-right: $bolt-tooltip-bubble-triangle-width * 1.5; // Extra spacing between the bubble and the trigger
   }
 }

--- a/packages/components/bolt-tooltip/src/tooltip.scss
+++ b/packages/components/bolt-tooltip/src/tooltip.scss
@@ -161,7 +161,7 @@ $bolt-tooltip-transition: $bolt-transition;
 
     &.is-push-up {
       .c-bolt-tooltip__content {
-        transform: translate(-50%, calc(-100% - #{$bolt-tooltip-bubble-triangle-width}));
+        transform: translate(-50%, calc(-100%));
 
         &--button {
           transform: translate(-50%, -115%) scale(1);
@@ -208,7 +208,7 @@ $bolt-tooltip-transition: $bolt-transition;
 
     &.is-push-down {
       .c-bolt-tooltip__content {
-        transform: translate(-50%, #{$bolt-tooltip-bubble-triangle-width});
+        transform: translate(-50%);
 
         &--button {
           transform: translate(-50%, 15%) scale(1);
@@ -398,6 +398,7 @@ $bolt-tooltip-transition: $bolt-transition;
   display: block;
   position: absolute;
   z-index: bolt-z-index('tooltip');
+  cursor: default;
   transition: all $bolt-tooltip-transition;
 
   &--button {
@@ -452,7 +453,7 @@ $bolt-tooltip-transition: $bolt-transition;
 .c-bolt-tooltip.is-push-up {
   &:not(:hover) > .c-bolt-tooltip__content,
   .c-bolt-tooltip__trigger + .c-bolt-tooltip__content {
-    padding-bottom: 0;
+    padding-bottom: $bolt-tooltip-bubble-triangle-width;
   }
 
   &:hover > .c-bolt-tooltip__content,
@@ -476,7 +477,7 @@ $bolt-tooltip-transition: $bolt-transition;
 .c-bolt-tooltip.is-push-down {
   &:not(:hover) > .c-bolt-tooltip__content,
   .c-bolt-tooltip__trigger + .c-bolt-tooltip__content {
-    padding-top: 0;
+    padding-top: $bolt-tooltip-bubble-triangle-width;
   }
 
   &:hover > .c-bolt-tooltip__content,

--- a/packages/components/bolt-tooltip/src/tooltip.twig
+++ b/packages/components/bolt-tooltip/src/tooltip.twig
@@ -40,13 +40,11 @@
 {% endif %}
 
 {% if direction %}
-  {% set attributes = attributes.setAttribute("position-vert", direction) %}
-{% endif %}
-
-{% if content %}
-  {% set attributes = attributes.setAttribute("content", content) %}
+  {% set attributes = attributes.setAttribute("direction", direction) %}
 {% endif %}
 
 {% set customElementName = customElementName | default('bolt-' ~ componentName) %}
 
-<{{ customElementName }} {{ attributes }}></{{ customElementName }}>
+<{{ customElementName }} {{ attributes }}>
+  {{ content | default("") }}
+</{{ customElementName }}>


### PR DESCRIPTION
## Jira
TBD

## Summary
Internal refactoring + fixes to the current Tooltip component to address rendering issues when passing along complex content (HTML vs only simple text content). These updates should also address the main problem that #1484 is solving (albeit, just with a different approach).

## Details
- Switches from copying over content via the `content` prop to instead render the content in the Web Component's default slot
- Fixes an issue with the Tooltip prematurely closing when hovering from the Tooltip's trigger to content container
- Addresses a problem with the `direction` prop documented in the component's schema not matching up with the prop name used in the Web Component internally
- Updated the component's internal logic to now open / close based on JS logic vs CSS logic (which didn't account for content rendering inside of slots)
- Fixed another issue with the current Tooltip component stripping out many of the styles of nested content due to not previously using `<slot>`s
- Added the ability to now automatically close open Tooltips (in particular, tooltips that open via clicks vs just hovers) when clicking outside of the Tooltip's content / trigger area.

## How to Test
- Confirm tests passing as expected
- Test out Tooltip component in Pattern Lab (basic cross browser smoke tests) — in particular, comparing this branch with the version up on the live site: https://boltdesignsystem.com/pattern-lab/patterns/02-components-tooltip/index.html
- Confirm working as expected on touch devices (both the link and button variations) 