### PR TITLE
debug(micro-journeys): put console statement after polyfill load

### DIFF
--- a/packages/micro-journeys/index.js
+++ b/packages/micro-journeys/index.js
@@ -1,6 +1,7 @@
 import { polyfillLoader } from '@bolt/core/polyfills';
 
 polyfillLoader.then(res => {
+  console.debug('Bold polyfills and code have loaded, Micro Journey code is about to run.');
   import(
     /* webpackMode: 'eager', webpackChunkName: 'bolt-interactive-pathways' */ './src/interactive-pathways'
   );


### PR DESCRIPTION
## Jira

https://app.asana.com/0/1126340469288208/1144425881076982/f

## Summary

Debug branch, do not merged.

## Details

This adds a console.debug statement just after polyfills load.

## How to test

Wait for load in Edge. If console log  "Bolt polyfills and code have loaded, Micro Journey code is about to run." is seen after the delay, that is delay caused by Bolt itself, not Micro Journey code. If it is seen before the delay, then the delay is caused by Micro Journeys code.
