### PR TITLE
fix(micro-journeys): dot-and-line nav squished on mobile with overlon…

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/06-experiments/micro-journeys/billing-micro-journey-fragments/_micro-journey-demo-1.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/06-experiments/micro-journeys/billing-micro-journey-fragments/_micro-journey-demo-1.twig
@@ -1,7 +1,7 @@
 <bolt-interactive-pathways theme="{{ theme ? theme }}">
   <bolt-text subheadline font-size="xxlarge" slot="interactive-pathways-lead-text">How Pega technology resolves</bolt-text>
   <bolt-interactive-pathway pathway-title="Billing Inquires">
-    <bolt-interactive-step tab-title="Proactive service">
+    <bolt-interactive-step tab-title="Proactive service that meets or exeeds customer needs and offers a high return on investment to customers">
       {% include "./billing-micro-journey-fragments/_step-one.twig" %}
     </bolt-interactive-step>
 
@@ -35,7 +35,7 @@
       {% include "./billing-micro-journey-fragments/_step-five.twig" %}
     </bolt-interactive-step>
 
-    <bolt-interactive-step tab-title="Proactive service">
+    <bolt-interactive-step tab-title="Proactive service that meets or exeeds customer needs and offers a high return on investment to customers">
       {% include "./billing-micro-journey-fragments/_step-one.twig" %}
     </bolt-interactive-step>
 

--- a/packages/micro-journeys/src/nav-shared.scss
+++ b/packages/micro-journeys/src/nav-shared.scss
@@ -7,6 +7,7 @@ $nav-circle-border-size: 2px;
 @mixin bolt-micro-journeys-nav-dot($active: false) {
   @if $active {
     width: $nav-circle-size--active;
+    min-width: $nav-circle-size--active;
     height: $nav-circle-size--active;
     margin-left: -$nav-circle-size--active / 2 - $nav-circle-border-size;
     border: $nav-circle-border-size solid bolt-theme(primary);
@@ -19,6 +20,7 @@ $nav-circle-border-size: 2px;
     box-sizing: content-box;
     z-index: 1;
     width: $nav-circle-size;
+    min-width: $nav-circle-size;
     height: $nav-circle-size;
     margin-right: bolt-spacing(small);
     margin-left: -$nav-circle-size / 2;

--- a/packages/micro-journeys/src/nav-shared.scss
+++ b/packages/micro-journeys/src/nav-shared.scss
@@ -9,6 +9,8 @@ $nav-circle-border-size: 2px;
     width: $nav-circle-size--active;
     min-width: $nav-circle-size--active;
     height: $nav-circle-size--active;
+    // Center the dot vertical to the first line of text.
+    margin-top: calc(((#{$header-text-line-height} * #{$header-text-size}) - (#{$nav-circle-size--active} + (#{$nav-circle-border-size} * 2))) / 2);
     margin-left: -$nav-circle-size--active / 2 - $nav-circle-border-size;
     border: $nav-circle-border-size solid bolt-theme(primary);
     background-color: bolt-theme(secondary);
@@ -17,11 +19,14 @@ $nav-circle-border-size: 2px;
   @else {
     content: '';
     display: inline-block;
+    align-self: flex-start;
     box-sizing: content-box;
     z-index: 1;
     width: $nav-circle-size;
     min-width: $nav-circle-size;
     height: $nav-circle-size;
+    // Center the dot vertical to the first line of text.
+    margin-top: calc(((#{$header-text-line-height} * #{$header-text-size}) - #{$nav-circle-size}) / 2);
     margin-right: bolt-spacing(small);
     margin-left: -$nav-circle-size / 2;
     border-radius: 50%;
@@ -52,7 +57,6 @@ $nav-circle-border-size: 2px;
     display: flex;
     align-items: center;
     padding-bottom: 1.65rem;
-    white-space: nowrap;
     line-height: $header-text-line-height;
     font-size: $header-text-size;
     transition: color 0.5s ease, transform 0.5s ease;


### PR DESCRIPTION
…g text

## Jira

https://app.asana.com/0/1126340469288208/1145200998293129/f

## Summary

Fix dot-and-line nav squished on mobile with overlong text by allowing text wrapping

## Details

before:
<img width="403" alt="image" src="https://user-images.githubusercontent.com/1361104/66942420-aa5de780-f00e-11e9-8617-014a7089be8b.png">

after:
![image](https://user-images.githubusercontent.com/1361104/67414334-7e9bae00-f588-11e9-9ba3-8a59e3b57bbd.png)


## How to test

Visit microjourneys page, view wrapping on first Step: /pattern-lab/?p=experiments-micro-journeys
