### PR TITLE
Tabs | Bug | Fix tabs inside band IE/Edge bug

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/tabs/30-tabs-content.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/tabs/30-tabs-content.twig
@@ -232,3 +232,38 @@
     {% endcell %}
   {% endgrid %}
 </div>
+
+{% set basic_tabs %}
+  {% include "@bolt-components-tabs/tabs.twig" with {
+    panels: [
+      {
+        label: "Tab label 1",
+        content: placeholder_content
+      },
+      {
+        label: "Tab label 2",
+        content: placeholder_content
+      },
+      {
+        label: "Tab label 3",
+        content: placeholder_content
+      },
+      {
+        label: "Tab label 4",
+        content: placeholder_content
+      },
+      {
+        label: "Tab label 5",
+        content: placeholder_content
+      },
+      {
+        label: "Tab label 6",
+        content: placeholder_content
+      },
+    ]
+  } only %}
+{% endset %}
+
+{% include "@bolt-components-band/band.twig" with {
+  content: basic_tabs,
+} only %}

--- a/packages/components/bolt-tabs/src/tabs.js
+++ b/packages/components/bolt-tabs/src/tabs.js
@@ -577,12 +577,16 @@ class BoltTabs extends withContext(withLitHtml()) {
   disconnected() {
     super.disconnected && super.disconnected();
 
+    this.ready = false;
+    this.removeAttribute('ready');
+
     window.removeEventListener('optimizedResize', this._resizeMenu);
     document.removeEventListener('click', this._handleExternalClicks);
-    this.dropdownButton.removeEventListener(
-      'click',
-      this._handleDropdownToggle,
-    );
+    this.dropdownButton &&
+      this.dropdownButton.removeEventListener(
+        'click',
+        this._handleDropdownToggle,
+      );
 
     // remove MutationObserver if supported + exists
     if (window.MutationObserver && this.observer) {


### PR DESCRIPTION
## Jira

- http://vjira2:8080/browse/WWWD-4173

## Summary
Fix IE/Edge bug that breaks dropdown menu when Tabs are nested inside a Band.

## Details
In IE/Edge Tabs are disconnected and reconnected when placed inside a band. After disconnecting, certain event handlers were not getting re-added and breaking the dropdown menu.

To fix, I made sure the `ready` flag was unset on disconnect so that the component will properly setup the next time it connects.

## How to test

- View Tab Content page in IE and Edge. There is a new example of a Tab inside a Band. Make sure the dropdown works properly. Resize the window and test.
