### PR TITLE
Modal | FE | Fix modal video content shifting in IE Edge

### DIFF
--- a/packages/components/bolt-modal/src/modal.scss
+++ b/packages/components/bolt-modal/src/modal.scss
@@ -163,7 +163,8 @@ bolt-modal:not([ready]) {
     min-width: 200px; // Prevents content without defined width (such as image and video) from falling below 200px.
     max-width: calc(100% - #{bolt-spacing(medium) * 2});
     max-height: $bolt-modal-max-height;
-    transition: visibility $bolt-transition-timing $bolt-transition-ease $bolt-transition-timing;
+    transition: visibility $bolt-transition-timing $bolt-transition-ease
+      $bolt-transition-timing;
   }
 
   @at-root .c-bolt-modal.is-open #{&} {
@@ -193,6 +194,11 @@ bolt-modal:not([ready]) {
 
       .c-bolt-modal__content {
         transform: translateX(0) translateY(-50%) translateZ(0) perspective(1px); // The perspective hack here is to prevent the content from getting too blurry, a common CSS bug that happens to element with transform. Please note that this sub-pixel issue still persists at random breakpoints.
+        @supports (-ms-ime-align: auto) {
+          & {
+            transform: translateX(0) translateY(-50%) translateZ(0); // Remove perspective hack for ie-edge only, causes modal content to shift by 1px when modal contains video and user hovers over player
+          }
+        }
       }
     }
   }
@@ -206,7 +212,13 @@ bolt-modal:not([ready]) {
 
     &.is-open {
       .c-bolt-modal__content {
-        transform: translateX(-50%) translateY(-50%) translateZ(0) perspective(1px); // The perspective hack here is to prevent the content from getting too blurry, a common CSS bug that happens to element with transform. Please note that this sub-pixel issue still persists at random breakpoints.
+        transform: translateX(-50%) translateY(-50%) translateZ(0)
+          perspective(1px); // The perspective hack here is to prevent the content from getting too blurry, a common CSS bug that happens to element with transform. Please note that this sub-pixel issue still persists at random breakpoints.
+        @supports (-ms-ime-align: auto) {
+          & {
+            transform: translateX(-50%) translateY(-50%) translateZ(0); // Remove perspective hack for ie-edge only, causes modal content to shift by 1px when modal contains video and user hovers over player
+          }
+        }
       }
     }
 


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1699

## Summary

Fix modal video content shifting on hover in IE Edge.

## Details

To prevent blurry text we're using a CSS hack that involves the "perspective" property. In Edge only, this hack is causing modal content to shift when you hover over it, as it interacts with some default Brightcove styles. As a compromise, we're simply removing the hack from IE Edge. The blurry text is not very noticeable but the content shifting bug is.

## How to test

1. Reproduce the bug by checking out `master`.

2. Open the Modal Usage Video page in a text editor (`/docs-site/src/pages/pattern-lab/_patterns/02-components/modal/45-modal-usage-video.twig`).

3. Add this code to the top of the file:
```
{% embed "@bolt-components-sticky/sticky.twig" %}
  {% block sticky_content %}
    <div style="color:white;background-color:red">
      First sticky item
    </div>
  {% endblock %}
{% endembed %}
```

Note: a position "sticky" element elsewhere on the page seems to contribute to the bug ^.

4. Go to the [Modal Usage Video page](http://localhost:3000/pattern-lab/patterns/02-components-modal-45-modal-usage-video/02-components-modal-45-modal-usage-video.html) locally in Edge.

5. Note that when you hover over the paused video the control bar shifts left-right by one pixel. If you don't see it immediately, resize the browser and try again. The bug on QA is more severe, but I suspect there are other factors making that one worse. This isolated case is a proxy for the underlying issue.

6. Checkout feature branch `fix/modal-content-shifting-in-edge` locally and repeat the above steps.

7. Notice that the control bar does not shift left-right at all on hover.
