### PR TITLE
Tabs | JS | Close dropdown menu after selecting tab item

### DIFF
--- a/packages/components/bolt-tabs/src/tabs.js
+++ b/packages/components/bolt-tabs/src/tabs.js
@@ -130,6 +130,13 @@ class BoltTabs extends withContext(withLitHtml()) {
     );
   }
 
+  // Get tab labels in the "show more" menu
+  get dropdownTabLabels() {
+    return this.renderRoot.querySelectorAll(
+      '.c-bolt-tabs__label.c-bolt-tabs__label--is-duplicate',
+    );
+  }
+
   validateIndex(index) {
     const panels = this.tabPanels;
 
@@ -228,12 +235,9 @@ class BoltTabs extends withContext(withLitHtml()) {
         break;
     }
 
-    // If any of the above keys were pressed, update selected tab and set focus
+    // If any of the above keys were pressed, toggle the menu (if needed), update selected tab, and set focus.
     if (newIndex !== undefined) {
-      this.renderRoot.querySelectorAll('[role="tab"]')[newIndex].focus();
-      this.setSelectedTab(newIndex);
-
-      // If menu button is displayed, handle keying in and out of the dropdown
+      // If menu button is displayed, handle keying in and out of the dropdown. Do this before setting focus, or target will be hidden and focus may not be set.
       if (!this.menuButtonIsHidden) {
         if (this.tabLabels[newIndex].classList.contains('is-hidden')) {
           !this.menuIsOpen && this.openDropdown();
@@ -241,6 +245,12 @@ class BoltTabs extends withContext(withLitHtml()) {
           this.menuIsOpen && this.closeDropdown();
         }
       }
+
+      this.tabLabels[newIndex].classList.contains('is-hidden')
+        ? this.dropdownTabLabels[newIndex].focus()
+        : this.tabLabels[newIndex].focus();
+
+      this.setSelectedTab(newIndex);
     }
   }
 

--- a/packages/components/bolt-tabs/src/tabs.js
+++ b/packages/components/bolt-tabs/src/tabs.js
@@ -259,6 +259,11 @@ class BoltTabs extends withContext(withLitHtml()) {
     const listClasses = cx('c-bolt-tabs__nav', {});
     const panelsClasses = cx('c-bolt-tabs__panels-container');
 
+    const handleLabelClick = (e, index) => {
+      this.setSelectedTab(index);
+      this.menuIsOpen && this.closeDropdown();
+    };
+
     const tabButtons = isDropdown => {
       let buttons = [];
 
@@ -286,7 +291,7 @@ class BoltTabs extends withContext(withLitHtml()) {
             aria-controls="${panelId}"
             id="${labelId}"
             tabindex="${isSelected ? 0 : -1}"
-            @click=${e => this.setSelectedTab(index)}
+            @click=${e => handleLabelClick(e, index)}
             @keydown=${e => this.handleOnKeydown(e)}
             @keyup=${e => this.handleOnKeyup(e)}
           >

--- a/packages/components/bolt-tabs/src/tabs.js
+++ b/packages/components/bolt-tabs/src/tabs.js
@@ -325,6 +325,8 @@ class BoltTabs extends withContext(withLitHtml()) {
             aria-haspopup="true"
             aria-expanded="${this.menuIsOpen}"
             class="${cx('c-bolt-tabs__button', 'c-bolt-tabs__show-button')}"
+            @keydown=${e => this.handleOnKeydown(e)}
+            @keyup=${e => this.handleOnKeyup(e)}
           >
             <span class="${cx('c-bolt-tabs__show-text')}">
               ${this.props.moreText ? this.props.moreText : 'More'}


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/WWWD-4244

## Summary

Close "More" menu when a menu item is selected.

## Details

Also includes related accessibility fixes to handle focus when menu closes.

## How to test

- Check out branch and test locally in Chrome and IE.
- Verify that the More menu closes after selecting a Tab item from the menu.