### PR TITLE
Image | JS | Fix images in tabs appearing fuzzy

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/tabs/30-tabs-content.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/tabs/30-tabs-content.twig
@@ -1,7 +1,7 @@
 {% set image_content %}
-  {% include "@bolt-components-image/image.twig" with {
-    src: "/images/placeholders/tout-4x3-climber.jpg",
-    alt: "A Rock Climber",
+  {% include '@bolt-components-image/image.twig' with {
+    src: "/images/placeholders/landscape-16x9-mountains.jpg",
+    alt: "Mountains",
   } only %}
 {% endset %}
 
@@ -169,16 +169,16 @@
       {% include "@bolt-components-tabs/tabs.twig" with {
         panels: [
           {
-            label: "An image",
-            content: image_content
+            label: "A teaser",
+            content: teaser_content
           },
           {
             label: "A table",
             content: table_content
           },
           {
-            label: "A teaser",
-            content: teaser_content
+            label: "An image",
+            content: image_content
           },
           {
             label: "A video",

--- a/packages/components/bolt-image/src/image.js
+++ b/packages/components/bolt-image/src/image.js
@@ -86,7 +86,8 @@ class BoltImage extends withLitHtml() {
   onResize() {
     if (
       this.isLoaded &&
-      (this.getAttribute('sizes') === 'auto' || !this.getAttribute('sizes'))
+      (this.getAttribute('sizes') === 'auto' || !this.getAttribute('sizes')) &&
+      this.offsetWidth > 0
     ) {
       this.sizes = `${this.offsetWidth}px`;
     }


### PR DESCRIPTION
## Jira

- http://vjira2:8080/browse/WWWD-4245

## Summary

Fix images in tabs appearing fuzzy.

## Details

Images that are in an inactive tab were not getting properly lazyloaded because they had no width.
We must check that an image has width before setting `sizes`.

## How to test

Run locally and view the Tabs Content page in an incognito window. Click on the "Image" tab and verify the image is not fuzzy.
