### PR TITLE
Accordion | JS | Fix nested accordion bug

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/accordion/40-accordion-content-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/accordion/40-accordion-content-variations.twig
@@ -265,6 +265,25 @@
   } only %}
 {% endset %}
 
+{% set accordion_content %}
+  {% include "@bolt-components-accordion/accordion.twig" with {
+    items: [
+      {
+        trigger: "Accordion item 1",
+        content: "This is the accordion content.",
+      },
+      {
+        trigger: "Accordion item 2",
+        content: "This is the accordion content.",
+      },
+      {
+        trigger: "Accordion item 3",
+        content: "This is the accordion content.",
+      }
+    ]
+  } only %}
+{% endset %}
+
 <h3>Pass various components into the content</h3>
 {% include "@bolt-components-accordion/accordion.twig" with {
   box_shadow: true,
@@ -284,6 +303,10 @@
     {
       trigger: "Expand this to see a video",
       content: video_content
+    },
+    {
+      trigger: "Expand this to see a nested accordion",
+      content: accordion_content
     },
     {
       trigger: "Expand this to see tabs",

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/tabs/30-tabs-content.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/tabs/30-tabs-content.twig
@@ -163,6 +163,44 @@
   } only %}
 {% endset %}
 
+{% set tab_content_1 %}
+  {% include "@bolt-components-placeholder/placeholder.twig" with {
+      text: "Tab panel 1",
+      size: "large",
+    } only %}
+{% endset %}
+{% set tab_content_2 %}
+  {% include "@bolt-components-placeholder/placeholder.twig" with {
+      text: "Tab panel 2",
+      size: "large",
+    } only %}
+{% endset %}
+{% set tab_content_3 %}
+  {% include "@bolt-components-placeholder/placeholder.twig" with {
+      text: "Tab panel 3",
+      size: "large",
+    } only %}
+{% endset %}
+
+{% set tabs_content %}
+  {% include "@bolt-components-tabs/tabs.twig" with {
+    panels: [
+      {
+        label: "Tab label 1",
+        content: tab_content_1,
+      },
+      {
+        label: "Tab label 2",
+        content: tab_content_2,
+      },
+      {
+        label: "Tab label 3",
+        content: tab_content_3,
+      }
+    ]
+  } only %}
+{% endset %}
+
 <div class="u-bolt-margin-bottom-small">
   {% grid "o-bolt-grid--flex o-bolt-grid--middle o-bolt-grid--center" %}
     {% cell "u-bolt-width-12/12 u-bolt-width-9/12@small" %}
@@ -183,6 +221,10 @@
           {
             label: "A video",
             content: video_content,
+          },
+          {
+            label: "Tabs",
+            content: tabs_content,
           },
           {
             label: "An accordion",

--- a/packages/components/bolt-accordion/__tests__/accordion.js
+++ b/packages/components/bolt-accordion/__tests__/accordion.js
@@ -154,7 +154,7 @@ describe('<bolt-accordion> Component', () => {
   });
 
   test('Default <bolt-accordion> with Shadow DOM renders', async function() {
-    const accordionShadowRoot = await page.evaluate(async accordionHTML => {
+    await page.evaluate(async accordionHTML => {
       const wrapper = document.createElement('div');
       wrapper.innerHTML = accordionHTML;
       document.body.appendChild(wrapper);
@@ -173,10 +173,15 @@ describe('<bolt-accordion> Component', () => {
             element.addEventListener('error', reject);
           });
         }),
-      ).then(() => {
-        return accordion.renderRoot.innerHTML;
-      });
+      );
     }, accordionHTML);
+
+    // Wait for Handorgel to run, starts after component 'ready' event
+    await page.waitFor(250);
+
+    const accordionShadowRoot = await page.evaluate(async () => {
+      return document.querySelector('bolt-accordion').renderRoot.innerHTML;
+    });
 
     const accordionItemShadowRoot = await page.evaluate(async () => {
       const item = document.querySelector('bolt-accordion-item');
@@ -191,7 +196,6 @@ describe('<bolt-accordion> Component', () => {
     expect(renderedShadowRoot.innerHTML).toMatchSnapshot();
     expect(renderedItemShadowRoot.innerHTML).toMatchSnapshot();
 
-    await page.waitFor(500);
     const image = await page.screenshot();
 
     expect(image).toMatchImageSnapshot({
@@ -201,32 +205,34 @@ describe('<bolt-accordion> Component', () => {
   });
 
   test('Default <bolt-accordion> w/o Shadow DOM renders', async function() {
-    const accordionOuterHTML = await page.evaluate(
-      async accordionNoShadowHTML => {
-        const wrapper = document.createElement('div');
-        wrapper.innerHTML = accordionNoShadowHTML;
-        document.body.appendChild(wrapper);
+    await page.evaluate(async accordionNoShadowHTML => {
+      const wrapper = document.createElement('div');
+      wrapper.innerHTML = accordionNoShadowHTML;
+      document.body.appendChild(wrapper);
 
-        const accordion = document.querySelector('bolt-accordion');
-        const accordionItems = Array.from(
-          document.querySelectorAll('bolt-accordion-item'),
-        );
-        const allElements = [accordion, ...accordionItems];
+      const accordion = document.querySelector('bolt-accordion');
+      const accordionItems = Array.from(
+        document.querySelectorAll('bolt-accordion-item'),
+      );
+      const allElements = [accordion, ...accordionItems];
 
-        return await Promise.all(
-          allElements.map(element => {
-            if (element._wasInitiallyRendered) return;
-            return new Promise((resolve, reject) => {
-              element.addEventListener('ready', resolve);
-              element.addEventListener('error', reject);
-            });
-          }),
-        ).then(() => {
-          return accordion.outerHTML;
-        });
-      },
-      accordionNoShadowHTML,
-    );
+      return await Promise.all(
+        allElements.map(element => {
+          if (element._wasInitiallyRendered) return;
+          return new Promise((resolve, reject) => {
+            element.addEventListener('ready', resolve);
+            element.addEventListener('error', reject);
+          });
+        }),
+      );
+    }, accordionNoShadowHTML);
+
+    // Wait for Handorgel to run, starts after component 'ready' event
+    await page.waitFor(250);
+
+    const accordionOuterHTML = await page.evaluate(async () => {
+      return document.querySelector('bolt-accordion').outerHTML;
+    });
 
     const accordionRenderedHTML = await html(accordionOuterHTML);
     expect(accordionRenderedHTML).toMatchSnapshot();

--- a/packages/components/bolt-accordion/src/AccordionItem/index.js
+++ b/packages/components/bolt-accordion/src/AccordionItem/index.js
@@ -117,14 +117,6 @@ class AccordionItem extends withContext(withLitHtml()) {
     `;
   }
 
-  rendered() {
-    super.rendered && super.rendered();
-
-    this.contentElem = this.renderRoot.querySelector(
-      '.c-bolt-accordion-item__content',
-    );
-  }
-
   render() {
     this.addClassesToSlottedChildren(['default', 'trigger']);
 

--- a/packages/components/bolt-accordion/src/accordion.js
+++ b/packages/components/bolt-accordion/src/accordion.js
@@ -204,19 +204,21 @@ class BoltAccordion extends withContext(withLitHtml()) {
     // Array passed to the Accordion plugin, a series of trigger/content pairs
     this.accordionItems = [];
 
-    this.accordionItemElements.forEach(item => {
-      const onItemReady = e => {
-        if (e.detail.name !== 'bolt-accordion-item') return;
+    Promise.all(
+      this.accordionItemElements.map(item => {
+        if (item._wasInitiallyRendered || this._wasMutated) return;
+        return new Promise((resolve, reject) => {
+          item.addEventListener('ready', e => {
+            return item === e.target && resolve();
+          });
+          item.addEventListener('error', reject);
+        });
+      }),
+    ).then(() => {
+      this.accordionItemElements.forEach(item => {
         this.handleAccordionItemReady(item);
-        item.removeEventListener('rendered', onItemReady);
-      };
-
-      if (item._wasInitiallyRendered || this._wasMutated) {
-        this.handleAccordionItemReady(item);
-        this._wasMutated = false;
-      } else {
-        item.addEventListener('rendered', onItemReady);
-      }
+      });
+      this._wasMutated = false;
     });
   }
 


### PR DESCRIPTION
## Jira

- http://vjira2:8080/browse/BDS-1870

## Summary

Fix bug where an accordion inside an accordion does not render properly.

## Details

It appears that changing when `ssrHydrationPrep` gets called resolves this issue on its own ([see commit](https://github.com/boltdesignsystem/bolt/commit/b7f14efa74e778f888e9c122882929869fc03105#diff-d45fd62db4da766d397ba2b3eaae5990)). Still, the changes here make the component more resilient. Before, accordion items were initialized on 'rendered', which could be unpredictable as components may render multiple times, and on certain renders we got different results when we queried the 'renderRoot`. Now, we're initializing on 'ready', inside a `Promise`, which waits for all accordion items to finish before setting up the Accordion.

## How to test

- Check out `fix/nested-accordion-bug` branch locally.
- Go to the [Accordion content page](http://localhost:3000/pattern-lab/patterns/02-components-accordion-40-accordion-content-variations/02-components-accordion-40-accordion-content-variations.html
) locally.
- Verify the nested accordion in the second example properly renders and functions as expected.
- For good measure, also check the Accordion tab on the [Tabs Content page](http://localhost:3000/pattern-lab/patterns/02-components-tabs-30-tabs-content/02-components-tabs-30-tabs-content.html) locally.
- Test in Chrome, IE11, and Edge