### PR TITLE
fix(micro-journeys): tighten dialog icon spacing

### DIFF
--- a/packages/micro-journeys/src/status-dialogue-bar.scss
+++ b/packages/micro-journeys/src/status-dialogue-bar.scss
@@ -11,7 +11,7 @@ $bolt-tooltip-bubble-triangle-width: 8px;
   display: flex;
   align-items: center;
   max-width: 120px;
-  padding: bolt-spacing(xsmall) bolt-spacing(small);
+  padding: bolt-spacing(xsmall) bolt-spacing(xsmall);
   color: bolt-color(black);
   border-radius: $bolt-border-radius;
   background-color: bolt-color(white);
@@ -31,7 +31,7 @@ $bolt-tooltip-bubble-triangle-width: 8px;
   }
 
   &__icon{
-    @include bolt-padding-right(small);
+    @include bolt-padding-right(xsmall);
     box-sizing: content-box;
   }
 


### PR DESCRIPTION
## Jira

https://app.asana.com/0/1126340469288208/1146062428777064/f

## Summary

Tighten spacing around icon in dialog bar.

## Details
Before
![image](https://user-images.githubusercontent.com/1361104/67587307-32cc3e80-f719-11e9-9bda-d4e6cdee2f82.png)

After
![image](https://user-images.githubusercontent.com/1361104/67589055-3235a700-f71d-11e9-9580-1d03fca7540c.png)



## How to test

/?p=experiments-micro-journeys

Note: there are other dialog bar tickets, this is just a low-hanging fruit ticket.