### PR TITLE
Fix: List component's inline@breakpoint display options not aligning correctly in Firefox

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/list/40-list-align-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/list/40-list-align-variations.twig
@@ -25,15 +25,19 @@
 </p>
 
 {% for align in schema.properties.align.enum %}
-  <h3>Horizontally align inline items: {{ align }}</h3>
-  {% include "@bolt-components-list/list.twig" with {
-    display: "inline",
-    align: align,
-    items: [
-      placeholder_1,
-      placeholder_2,
-      placeholder_3,
-    ]
-  } only %}
+  {% for display in schema.properties.display.enum %}
+    {% if display != "block" and display != "flex" %}
+      <h3>Horizontally align {{ display }} items: {{ align }}</h3>
+      {% include "@bolt-components-list/list.twig" with {
+        display: display,
+        align: align,
+        items: [
+          placeholder_1,
+          placeholder_2,
+          placeholder_3,
+        ]
+      } only %}
+    {% endif %}
+  {% endfor %}
 {% endfor %}
 {# End component specific code #}

--- a/packages/components/bolt-list/list.schema.yml
+++ b/packages/components/bolt-list/list.schema.yml
@@ -9,10 +9,15 @@ properties:
     description: 'A Drupal-style attributes object with extra attributes to append to this component.'
   items:
     type: array
-    description: 'All items can be simple text or `items`.'
-    items:
-      type: [string, object, array]
-      description: Renderable content (i.e. a string, render array, or included pattern) for a single list item.
+    description: Generates an array of items, each can contain renderable content (i.e. a string, render array, or included pattern).
+    properties:
+      items:
+        type: array
+        description: Renderable content for a single list item.
+        properties:
+          content:
+            type: string
+            description: Use this prop for an iterable item such as an array.
   tag:
     type: string
     description: 'Apply the semantic tag for the list.'

--- a/packages/components/bolt-list/src/list.scss
+++ b/packages/components/bolt-list/src/list.scss
@@ -80,7 +80,7 @@
     // The inline here is talking about the items inside, the List component itself is still a block level element that would fill up the space of any container.
     &.c-bolt-list--display-inline,
     &.c-bolt-list--display-flex {
-      width: calc(100% + #{bolt-spacing($spacing-value-name)} + 1px); // Width must be defined in order for the list to dislay correctly in Firefox.
+      width: calc(100% + #{bolt-spacing($spacing-value-name)}); // Width must be defined in order for the list to dislay correctly in Firefox.
     }
 
     @each $breakpoint in $bolt-breakpoints {
@@ -89,7 +89,7 @@
       // The inline here is talking about the items inside, the List component itself is still a block level element that would fill up the space of any container.
       &.c-bolt-list--display-inline\@#{$breakpoint-name} {
         @include bolt-mq($breakpoint-name) {
-          width: calc(100% + #{bolt-spacing($spacing-value-name)} + 1px); // Width must be defined in order for the list to dislay correctly in Firefox.
+          width: calc(100% + #{bolt-spacing($spacing-value-name)}); // Width must be defined in order for the list to dislay correctly in Firefox.
         }
       }
     }

--- a/packages/components/bolt-list/src/list.scss
+++ b/packages/components/bolt-list/src/list.scss
@@ -77,9 +77,21 @@
     margin-bottom: bolt-v-spacing(#{$spacing-value-name}) * -1;
     margin-left: bolt-spacing(#{$spacing-value-name}) * -1;
 
+    // The inline here is talking about the items inside, the List component itself is still a block level element that would fill up the space of any container.
     &.c-bolt-list--display-inline,
     &.c-bolt-list--display-flex {
-      width: calc(100% + #{bolt-spacing($spacing-value-name)} + 1px); // The inline here is talking about the items inside, the List component itself is still a block level element that would fill up the space of any container.
+      width: calc(100% + #{bolt-spacing($spacing-value-name)} + 1px);
+    }
+
+    @each $breakpoint in $bolt-breakpoints {
+      $breakpoint-name: nth($breakpoint, 1);
+
+      // The inline here is talking about the items inside, the List component itself is still a block level element that would fill up the space of any container.
+      &.c-bolt-list--display-inline\@#{$breakpoint-name} {
+        @include bolt-mq($breakpoint-name) {
+          width: calc(100% + #{bolt-spacing($spacing-value-name)} + 1px);
+        }
+      }
     }
   }
 

--- a/packages/components/bolt-list/src/list.scss
+++ b/packages/components/bolt-list/src/list.scss
@@ -80,7 +80,7 @@
     // The inline here is talking about the items inside, the List component itself is still a block level element that would fill up the space of any container.
     &.c-bolt-list--display-inline,
     &.c-bolt-list--display-flex {
-      width: calc(100% + #{bolt-spacing($spacing-value-name)} + 1px);
+      width: calc(100% + #{bolt-spacing($spacing-value-name)} + 1px); // Width must be defined in order for the list to dislay correctly in Firefox.
     }
 
     @each $breakpoint in $bolt-breakpoints {
@@ -89,7 +89,7 @@
       // The inline here is talking about the items inside, the List component itself is still a block level element that would fill up the space of any container.
       &.c-bolt-list--display-inline\@#{$breakpoint-name} {
         @include bolt-mq($breakpoint-name) {
-          width: calc(100% + #{bolt-spacing($spacing-value-name)} + 1px);
+          width: calc(100% + #{bolt-spacing($spacing-value-name)} + 1px); // Width must be defined in order for the list to dislay correctly in Firefox.
         }
       }
     }


### PR DESCRIPTION
## Jira

Issue first raised in: http://vjira2:8080/browse/WWWD-4211?focusedCommentId=68872&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-68872

## Summary

Fixes an issue where the List component does not align correctly in Firefox when `display` is set to `inline@breakpoint`.

## Details

1. Added CSS to make sure `.c-bolt-list` container takes up full width of its parent.
2. Updated docs to demo the alignment when List is set to display inline@breakpoint.

## How to test

Run the branch locally and check the following:

- [ ] 1. Given I am viewing the align variations page (http://localhost:3000/pattern-lab/?p=components-list-align-variations)
- [ ] 2. Then I should see inline lists and inline@breakpoint lists
- [ ] 3. And each list's items are aligning correctly according to the align option specified
- [ ] 4. When I view the page in Chrome, FIrefox, Safari, and IE11
- [ ] 5. Then I should see that the alignments are identical across different browsers
