### PR TITLE
feat(micro-journeys): starter templates for one and two character

### DIFF
--- a/packages/editor/src/setup-bolt.js
+++ b/packages/editor/src/setup-bolt.js
@@ -20,7 +20,7 @@ import * as starters from '@bolt/micro-journeys/starters';
 // @ts-ignore
 import linkSchema from '@bolt/components-link/link.schema.yml';
 // import { animationNames } from '@bolt/components-animate/animation-meta';
-import { isChildOfEl, convertSchemaPropToTrait } from './utils';
+import { isChildOfEl, convertSchemaPropToTrait, getStepsLorem } from './utils';
 
 class EditorRegisterBoltError extends Error {}
 
@@ -515,86 +515,26 @@ export function setupBolt(editor) {
     ],
   });
 
-  registerBoltComponent({
-    name: 'bolt-interactive-pathways',
-    schema: pathwaysSchema,
-    propsToTraits: ['customImageSrc', 'imageAlt', 'theme', 'hidePathwaysImage'],
-    category: 'Starters',
-    blockTitle: 'Single Pathways',
-    draggable: true,
-    editable: false,
-    highlightable: false,
-    registerBlock: true,
-    slots: {
-      default: 'bolt-interactive-pathway',
-    },
-    initialContent: [
-      `<bolt-text subheadline font-size="xxlarge" slot="interactive-pathways-lead-text">How Pega technology resolves</bolt-text>`,
-      `<bolt-interactive-pathway pathway-title="First Title">
-        ${starters.stepOneCharacterLorem}
-        ${starters.stepTwoCharacterLorem}
-      </bolt-interactive-pathway>`,
-    ],
-    slotControls: [
-      {
-        slotName: 'default',
-        components: [
-          {
-            id: 'pathway',
-            title: 'Pathway',
-            content: starters.pathwayLorem,
-          },
-        ],
-      },
-    ],
-  });
-
-  BlockManager.add('One-Char Pathways', {
-    label: `<span title="">One-char Multiple Pathways</span>`,
+  BlockManager.add('One-Char Pathway', {
+    label: `<span title="">One-character Pathway</span>`,
     category: 'Starters',
     select: true,
     content: `<bolt-interactive-pathways>
       <bolt-text subheadline font-size="xxlarge" slot="interactive-pathways-lead-text">How Pega technology resolves</bolt-text>
-      <bolt-interactive-pathway pathway-title="One-character starter pathway 1">
-        ${starters.stepOneCharacterStarter}
-        ${starters.stepOneCharacterStarter}
-        ${starters.stepOneCharacterStarter}
-        ${starters.stepOneCharacterStarter}
-        ${starters.stepOneCharacterStarter}
-        ${starters.stepOneCharacterStarter}
-      </bolt-interactive-pathway>
-      <bolt-interactive-pathway pathway-title="One-character starter pathway 2">
-        ${starters.stepOneCharacterStarter}
-        ${starters.stepOneCharacterStarter}
-        ${starters.stepOneCharacterStarter}
-        ${starters.stepOneCharacterStarter}
-        ${starters.stepOneCharacterStarter}
-        ${starters.stepOneCharacterStarter}
+      <bolt-interactive-pathway pathway-title="Billing Inquiries">
+        ${getStepsLorem(starters.stepOneCharacterStarter, 6)}
       </bolt-interactive-pathway>
     </bolt-interactive-pathways>`,
   });
 
-  BlockManager.add('Two-Char Pathways', {
-    label: `<span title="">Two-char multiple Pathways</span>`,
+  BlockManager.add('Two-Char Pathway', {
+    label: `<span title="">Two-character Pathway</span>`,
     category: 'Starters',
     select: true,
     content: `<bolt-interactive-pathways>
       <bolt-text subheadline font-size="xxlarge" slot="interactive-pathways-lead-text">How Pega technology resolves</bolt-text>
-      <bolt-interactive-pathway pathway-title="Two-character starter pathway 1">
-        ${starters.stepTwoCharacterStarter}
-        ${starters.stepTwoCharacterStarter}
-        ${starters.stepTwoCharacterStarter}
-        ${starters.stepTwoCharacterStarter}
-        ${starters.stepTwoCharacterStarter}
-        ${starters.stepTwoCharacterStarter}
-      </bolt-interactive-pathway>
-      <bolt-interactive-pathway pathway-title="Two-character starter pathway 2">
-        ${starters.stepTwoCharacterStarter}
-        ${starters.stepTwoCharacterStarter}
-        ${starters.stepTwoCharacterStarter}
-        ${starters.stepTwoCharacterStarter}
-        ${starters.stepTwoCharacterStarter}
-        ${starters.stepTwoCharacterStarter}
+      <bolt-interactive-pathway pathway-title="Billing Inquiries">
+        ${getStepsLorem(starters.stepTwoCharacterStarter, 6)}
       </bolt-interactive-pathway>
     </bolt-interactive-pathways>`,
   });
@@ -631,6 +571,44 @@ export function setupBolt(editor) {
             id: 'stepTwoCharacterLorem',
             title: 'Step - Two-Character Starter',
             content: starters.stepTwoCharacterLorem,
+          },
+        ],
+      },
+    ],
+  });
+
+  registerBoltComponent({
+    name: 'bolt-interactive-pathways',
+    schema: pathwaysSchema,
+    propsToTraits: ['customImageSrc', 'imageAlt', 'theme', 'hidePathwaysImage'],
+    category: 'Starters',
+    blockTitle: 'Multiple Pathways',
+    draggable: true,
+    editable: false,
+    highlightable: false,
+    registerBlock: true,
+    slots: {
+      default: 'bolt-interactive-pathway',
+    },
+    initialContent: [
+      `<bolt-text subheadline font-size="xxlarge" slot="interactive-pathways-lead-text">How Pega technology resolves</bolt-text>`,
+      `<bolt-interactive-pathway pathway-title="First Title">
+        ${starters.stepOneCharacterLorem}
+        ${starters.stepTwoCharacterLorem}
+      </bolt-interactive-pathway>`,
+      `<bolt-interactive-pathway pathway-title="Second Title">
+        ${starters.stepOneCharacterLorem}
+        ${starters.stepTwoCharacterLorem}
+      </bolt-interactive-pathway>`,
+    ],
+    slotControls: [
+      {
+        slotName: 'default',
+        components: [
+          {
+            id: 'pathways',
+            title: 'Pathways',
+            content: starters.pathwayLorem,
           },
         ],
       },

--- a/packages/editor/src/setup-bolt.js
+++ b/packages/editor/src/setup-bolt.js
@@ -539,6 +539,21 @@ export function setupBolt(editor) {
     </bolt-interactive-pathways>`,
   });
 
+  BlockManager.add('Multiple Two-Character Pathways', {
+    label: `<span title="">Multiple Two-character Pathways</span>`,
+    category: 'Starters',
+    select: true,
+    content: `<bolt-interactive-pathways>
+      <bolt-text subheadline font-size="xxlarge" slot="interactive-pathways-lead-text">How Pega technology resolves</bolt-text>
+      <bolt-interactive-pathway pathway-title="Billing Inquiries">
+        ${getStepsLorem(starters.stepTwoCharacterStarter, 6)}
+      </bolt-interactive-pathway>
+      <bolt-interactive-pathway pathway-title="Another story">
+        ${getStepsLorem(starters.stepTwoCharacterStarter, 6)}
+      </bolt-interactive-pathway>
+    </bolt-interactive-pathways>`,
+  });
+
   registerBoltComponent({
     name: 'bolt-interactive-pathway',
     draggable: false,

--- a/packages/editor/src/setup-bolt.js
+++ b/packages/editor/src/setup-bolt.js
@@ -566,7 +566,7 @@ export function setupBolt(editor) {
     </bolt-interactive-pathways>`,
   });
 
-  // Commented this out because this work was superceded by above starters. But leaving because they're simpler and client may want to reinstate.
+  // Commented this out because this was superceded by above starters. But leaving because they're simpler and client may want to reinstate.
   // registerBoltComponent({
   //   name: 'bolt-interactive-pathways',
   //   schema: pathwaysSchema,

--- a/packages/editor/src/setup-bolt.js
+++ b/packages/editor/src/setup-bolt.js
@@ -539,21 +539,6 @@ export function setupBolt(editor) {
     </bolt-interactive-pathways>`,
   });
 
-  BlockManager.add('Multiple One-Character Pathways', {
-    label: `<span title="">One-Character Pathways</span>`,
-    category: 'Starters',
-    select: true,
-    content: `<bolt-interactive-pathways>
-      <bolt-text subheadline font-size="xxlarge" slot="interactive-pathways-lead-text">How Pega technology resolves</bolt-text>
-      <bolt-interactive-pathway pathway-title="Billing Inquiries">
-        ${getStepsLorem(starters.stepOneCharacterStarter, 6)}
-      </bolt-interactive-pathway>
-      <bolt-interactive-pathway pathway-title="Another story">
-        ${getStepsLorem(starters.stepOneCharacterStarter, 6)}
-      </bolt-interactive-pathway>
-    </bolt-interactive-pathways>`,
-  });
-
   BlockManager.add('Multiple Two-Character Pathways', {
     label: `<span title="">Two-character Pathways</span>`,
     category: 'Starters',

--- a/packages/editor/src/setup-bolt.js
+++ b/packages/editor/src/setup-bolt.js
@@ -549,14 +549,13 @@ export function setupBolt(editor) {
     ],
   });
 
-  // Just adding a second starter GrapesJS "Block" in addition to one above
-  BlockManager.add('Multiple Pathways', {
-    label: `<span title="">Multiple Pathways</span>`,
+  BlockManager.add('One-Char Pathways', {
+    label: `<span title="">One-char Multiple Pathways</span>`,
     category: 'Starters',
     select: true,
     content: `<bolt-interactive-pathways>
       <bolt-text subheadline font-size="xxlarge" slot="interactive-pathways-lead-text">How Pega technology resolves</bolt-text>
-      <bolt-interactive-pathway pathway-title="One-character starter">
+      <bolt-interactive-pathway pathway-title="One-character starter pathway 1">
         ${starters.stepOneCharacterStarter}
         ${starters.stepOneCharacterStarter}
         ${starters.stepOneCharacterStarter}
@@ -564,13 +563,38 @@ export function setupBolt(editor) {
         ${starters.stepOneCharacterStarter}
         ${starters.stepOneCharacterStarter}
       </bolt-interactive-pathway>
-      <bolt-interactive-pathway pathway-title="Two-character starter">
-       ${starters.stepTwoCharacterStarter}
-       ${starters.stepTwoCharacterStarter}
-       ${starters.stepTwoCharacterStarter}
-       ${starters.stepTwoCharacterStarter}
-       ${starters.stepTwoCharacterStarter}
-       ${starters.stepTwoCharacterStarter}
+      <bolt-interactive-pathway pathway-title="One-character starter pathway 2">
+        ${starters.stepOneCharacterStarter}
+        ${starters.stepOneCharacterStarter}
+        ${starters.stepOneCharacterStarter}
+        ${starters.stepOneCharacterStarter}
+        ${starters.stepOneCharacterStarter}
+        ${starters.stepOneCharacterStarter}
+      </bolt-interactive-pathway>
+    </bolt-interactive-pathways>`,
+  });
+
+  BlockManager.add('Two-Char Pathways', {
+    label: `<span title="">Two-char multiple Pathways</span>`,
+    category: 'Starters',
+    select: true,
+    content: `<bolt-interactive-pathways>
+      <bolt-text subheadline font-size="xxlarge" slot="interactive-pathways-lead-text">How Pega technology resolves</bolt-text>
+      <bolt-interactive-pathway pathway-title="Two-character starter pathway 1">
+        ${starters.stepTwoCharacterStarter}
+        ${starters.stepTwoCharacterStarter}
+        ${starters.stepTwoCharacterStarter}
+        ${starters.stepTwoCharacterStarter}
+        ${starters.stepTwoCharacterStarter}
+        ${starters.stepTwoCharacterStarter}
+      </bolt-interactive-pathway>
+      <bolt-interactive-pathway pathway-title="Two-character starter pathway 2">
+        ${starters.stepTwoCharacterStarter}
+        ${starters.stepTwoCharacterStarter}
+        ${starters.stepTwoCharacterStarter}
+        ${starters.stepTwoCharacterStarter}
+        ${starters.stepTwoCharacterStarter}
+        ${starters.stepTwoCharacterStarter}
       </bolt-interactive-pathway>
     </bolt-interactive-pathways>`,
   });

--- a/packages/editor/src/setup-bolt.js
+++ b/packages/editor/src/setup-bolt.js
@@ -545,10 +545,22 @@ export function setupBolt(editor) {
     select: true,
     content: `<bolt-interactive-pathways>
       <bolt-text subheadline font-size="xxlarge" slot="interactive-pathways-lead-text">How Pega technology resolves</bolt-text>
-      <bolt-interactive-pathway pathway-title="Billing Inquiries">
+      <bolt-interactive-pathway pathway-title="Pathway 1">
         ${getStepsLorem(starters.stepTwoCharacterStarter, 6)}
       </bolt-interactive-pathway>
-       <bolt-interactive-pathway pathway-title="Another story">
+      <bolt-interactive-pathway pathway-title="Pathway 2">
+        ${getStepsLorem(starters.stepTwoCharacterStarter, 6)}
+      </bolt-interactive-pathway>
+      <bolt-interactive-pathway pathway-title="Pathway 3">
+        ${getStepsLorem(starters.stepTwoCharacterStarter, 6)}
+      </bolt-interactive-pathway>
+      <bolt-interactive-pathway pathway-title="Pathway 4">
+        ${getStepsLorem(starters.stepTwoCharacterStarter, 6)}
+      </bolt-interactive-pathway>
+      <bolt-interactive-pathway pathway-title="Pathway 5">
+        ${getStepsLorem(starters.stepTwoCharacterStarter, 6)}
+      </bolt-interactive-pathway>
+      <bolt-interactive-pathway pathway-title="Pathway 6">
         ${getStepsLorem(starters.stepTwoCharacterStarter, 6)}
       </bolt-interactive-pathway>
     </bolt-interactive-pathways>`,

--- a/packages/editor/src/setup-bolt.js
+++ b/packages/editor/src/setup-bolt.js
@@ -120,7 +120,7 @@ const iconGroupHorizontal = {
 
 const svgAnimations = {
   id: 'bolt-svg-animations',
-  title: 'Svg Animtions',
+  title: 'Svg Animations',
   content: `<bolt-svg-animations anim-type="orbit"></bolt-svg-animations>`,
 };
 
@@ -520,7 +520,7 @@ export function setupBolt(editor) {
     schema: pathwaysSchema,
     propsToTraits: ['customImageSrc', 'imageAlt', 'theme', 'hidePathwaysImage'],
     category: 'Starters',
-    blockTitle: 'Pathways',
+    blockTitle: 'Single Pathways',
     draggable: true,
     editable: false,
     highlightable: false,
@@ -549,6 +549,32 @@ export function setupBolt(editor) {
     ],
   });
 
+  // Just adding a second starter GrapesJS "Block" in addition to one above
+  BlockManager.add('Multiple Pathways', {
+    label: `<span title="">Multiple Pathways</span>`,
+    category: 'Starters',
+    select: true,
+    content: `<bolt-interactive-pathways>
+      <bolt-text subheadline font-size="xxlarge" slot="interactive-pathways-lead-text">How Pega technology resolves</bolt-text>
+      <bolt-interactive-pathway pathway-title="One-character starter">
+        ${starters.stepOneCharacterStarter}
+        ${starters.stepOneCharacterStarter}
+        ${starters.stepOneCharacterStarter}
+        ${starters.stepOneCharacterStarter}
+        ${starters.stepOneCharacterStarter}
+        ${starters.stepOneCharacterStarter}
+      </bolt-interactive-pathway>
+      <bolt-interactive-pathway pathway-title="Two-character starter">
+       ${starters.stepTwoCharacterStarter}
+       ${starters.stepTwoCharacterStarter}
+       ${starters.stepTwoCharacterStarter}
+       ${starters.stepTwoCharacterStarter}
+       ${starters.stepTwoCharacterStarter}
+       ${starters.stepTwoCharacterStarter}
+      </bolt-interactive-pathway>
+    </bolt-interactive-pathways>`,
+  });
+
   registerBoltComponent({
     name: 'bolt-interactive-pathway',
     draggable: false,
@@ -574,12 +600,12 @@ export function setupBolt(editor) {
         components: [
           {
             id: 'stepOneCharacterLorem',
-            title: 'Step - One Character Lorem',
+            title: 'Step - One-Character Starter',
             content: starters.stepOneCharacterLorem,
           },
           {
             id: 'stepTwoCharacterLorem',
-            title: 'Step - Two Character Lorem',
+            title: 'Step - Two-Character Starter',
             content: starters.stepTwoCharacterLorem,
           },
         ],

--- a/packages/editor/src/setup-bolt.js
+++ b/packages/editor/src/setup-bolt.js
@@ -592,43 +592,44 @@ export function setupBolt(editor) {
     ],
   });
 
-  registerBoltComponent({
-    name: 'bolt-interactive-pathways',
-    schema: pathwaysSchema,
-    propsToTraits: ['customImageSrc', 'imageAlt', 'theme', 'hidePathwaysImage'],
-    category: 'Starters',
-    blockTitle: 'Multiple Pathways',
-    draggable: true,
-    editable: false,
-    highlightable: false,
-    registerBlock: true,
-    slots: {
-      default: 'bolt-interactive-pathway',
-    },
-    initialContent: [
-      `<bolt-text subheadline font-size="xxlarge" slot="interactive-pathways-lead-text">How Pega technology resolves</bolt-text>`,
-      `<bolt-interactive-pathway pathway-title="First Title">
-        ${starters.stepOneCharacterLorem}
-        ${starters.stepTwoCharacterLorem}
-      </bolt-interactive-pathway>`,
-      `<bolt-interactive-pathway pathway-title="Second Title">
-        ${starters.stepOneCharacterLorem}
-        ${starters.stepTwoCharacterLorem}
-      </bolt-interactive-pathway>`,
-    ],
-    slotControls: [
-      {
-        slotName: 'default',
-        components: [
-          {
-            id: 'pathways',
-            title: 'Pathways',
-            content: starters.pathwayLorem,
-          },
-        ],
-      },
-    ],
-  });
+  // Commented out because this work was superceded by above starters. But leaving because they're simpler and client may want to reinstate.
+  // registerBoltComponent({
+  //   name: 'bolt-interactive-pathways',
+  //   schema: pathwaysSchema,
+  //   propsToTraits: ['customImageSrc', 'imageAlt', 'theme', 'hidePathwaysImage'],
+  //   category: 'Starters',
+  //   blockTitle: 'Multiple Pathways',
+  //   draggable: true,
+  //   editable: false,
+  //   highlightable: false,
+  //   registerBlock: true,
+  //   slots: {
+  //     default: 'bolt-interactive-pathway',
+  //   },
+  //   initialContent: [
+  //     `<bolt-text subheadline font-size="xxlarge" slot="interactive-pathways-lead-text">How Pega technology resolves</bolt-text>`,
+  //     `<bolt-interactive-pathway pathway-title="First Title">
+  //       ${starters.stepOneCharacterLorem}
+  //       ${starters.stepTwoCharacterLorem}
+  //     </bolt-interactive-pathway>`,
+  //     `<bolt-interactive-pathway pathway-title="Second Title">
+  //       ${starters.stepOneCharacterLorem}
+  //       ${starters.stepTwoCharacterLorem}
+  //     </bolt-interactive-pathway>`,
+  //   ],
+  //   slotControls: [
+  //     {
+  //       slotName: 'default',
+  //       components: [
+  //         {
+  //           id: 'pathways',
+  //           title: 'Pathways',
+  //           content: starters.pathwayLorem,
+  //         },
+  //       ],
+  //     },
+  //   ],
+  // });
 
   registerBoltComponent({
     name: 'bolt-animate',

--- a/packages/editor/src/setup-bolt.js
+++ b/packages/editor/src/setup-bolt.js
@@ -515,8 +515,8 @@ export function setupBolt(editor) {
     ],
   });
 
-  BlockManager.add('One-Char Pathway', {
-    label: `<span title="">One-character Pathway</span>`,
+  BlockManager.add('One-Character Pathway', {
+    label: `<span title="">One-Character Pathway</span>`,
     category: 'Starters',
     select: true,
     content: `<bolt-interactive-pathways>
@@ -527,20 +527,35 @@ export function setupBolt(editor) {
     </bolt-interactive-pathways>`,
   });
 
-  BlockManager.add('Two-Char Pathway', {
-    label: `<span title="">Two-character Pathway</span>`,
+  BlockManager.add('Two-Character Pathway', {
+    label: `<span title="">Two-Character Pathway</span>`,
     category: 'Starters',
     select: true,
     content: `<bolt-interactive-pathways>
       <bolt-text subheadline font-size="xxlarge" slot="interactive-pathways-lead-text">How Pega technology resolves</bolt-text>
       <bolt-interactive-pathway pathway-title="Billing Inquiries">
         ${getStepsLorem(starters.stepTwoCharacterStarter, 6)}
+      </bolt-interactive-pathway>
+    </bolt-interactive-pathways>`,
+  });
+
+  BlockManager.add('Multiple One-Character Pathways', {
+    label: `<span title="">One-Character Pathways</span>`,
+    category: 'Starters',
+    select: true,
+    content: `<bolt-interactive-pathways>
+      <bolt-text subheadline font-size="xxlarge" slot="interactive-pathways-lead-text">How Pega technology resolves</bolt-text>
+      <bolt-interactive-pathway pathway-title="Billing Inquiries">
+        ${getStepsLorem(starters.stepOneCharacterStarter, 6)}
+      </bolt-interactive-pathway>
+      <bolt-interactive-pathway pathway-title="Another story">
+        ${getStepsLorem(starters.stepOneCharacterStarter, 6)}
       </bolt-interactive-pathway>
     </bolt-interactive-pathways>`,
   });
 
   BlockManager.add('Multiple Two-Character Pathways', {
-    label: `<span title="">Multiple Two-character Pathways</span>`,
+    label: `<span title="">Two-character Pathways</span>`,
     category: 'Starters',
     select: true,
     content: `<bolt-interactive-pathways>
@@ -548,48 +563,10 @@ export function setupBolt(editor) {
       <bolt-interactive-pathway pathway-title="Billing Inquiries">
         ${getStepsLorem(starters.stepTwoCharacterStarter, 6)}
       </bolt-interactive-pathway>
-      <bolt-interactive-pathway pathway-title="Another story">
+       <bolt-interactive-pathway pathway-title="Another story">
         ${getStepsLorem(starters.stepTwoCharacterStarter, 6)}
       </bolt-interactive-pathway>
     </bolt-interactive-pathways>`,
-  });
-
-  registerBoltComponent({
-    name: 'bolt-interactive-pathway',
-    draggable: false,
-    editable: false,
-    highlightable: true,
-    extraTraits: ['pathway-title'],
-    removalEventsToFireOnParents: [
-      {
-        parentSelector: 'bolt-interactive-pathways',
-        eventFactory: () => {
-          return new CustomEvent('bolt-interactive-pathway:title-updated', {
-            bubbles: true,
-          });
-        },
-      },
-    ],
-    slots: {
-      default: 'bolt-interactive-step',
-    },
-    slotControls: [
-      {
-        slotName: 'default',
-        components: [
-          {
-            id: 'stepOneCharacterLorem',
-            title: 'Step - One-Character Starter',
-            content: starters.stepOneCharacterLorem,
-          },
-          {
-            id: 'stepTwoCharacterLorem',
-            title: 'Step - Two-Character Starter',
-            content: starters.stepTwoCharacterLorem,
-          },
-        ],
-      },
-    ],
   });
 
   // Commented out because this work was superceded by above starters. But leaving because they're simpler and client may want to reinstate.
@@ -630,6 +607,44 @@ export function setupBolt(editor) {
   //     },
   //   ],
   // });
+
+  registerBoltComponent({
+    name: 'bolt-interactive-pathway',
+    draggable: false,
+    editable: false,
+    highlightable: true,
+    extraTraits: ['pathway-title'],
+    removalEventsToFireOnParents: [
+      {
+        parentSelector: 'bolt-interactive-pathways',
+        eventFactory: () => {
+          return new CustomEvent('bolt-interactive-pathway:title-updated', {
+            bubbles: true,
+          });
+        },
+      },
+    ],
+    slots: {
+      default: 'bolt-interactive-step',
+    },
+    slotControls: [
+      {
+        slotName: 'default',
+        components: [
+          {
+            id: 'stepOneCharacterLorem',
+            title: 'Step - One-Character Starter',
+            content: starters.stepOneCharacterLorem,
+          },
+          {
+            id: 'stepTwoCharacterLorem',
+            title: 'Step - Two-Character Starter',
+            content: starters.stepTwoCharacterLorem,
+          },
+        ],
+      },
+    ],
+  });
 
   registerBoltComponent({
     name: 'bolt-animate',

--- a/packages/editor/src/setup-bolt.js
+++ b/packages/editor/src/setup-bolt.js
@@ -554,7 +554,7 @@ export function setupBolt(editor) {
     </bolt-interactive-pathways>`,
   });
 
-  // Commented out because this work was superceded by above starters. But leaving because they're simpler and client may want to reinstate.
+  // Commented this out because this work was superceded by above starters. But leaving because they're simpler and client may want to reinstate.
   // registerBoltComponent({
   //   name: 'bolt-interactive-pathways',
   //   schema: pathwaysSchema,

--- a/packages/editor/src/utils.js
+++ b/packages/editor/src/utils.js
@@ -98,3 +98,22 @@ export function addThemeContextClasses({ space, canvasWrapper }) {
   }
   return themeClass;
 }
+
+/**
+ * Wrap a component in a numbered `bolt-interactive-step`.
+ *
+ * @param {string} starter: The starter HTML to wrap. Should not include bolt-interactive-step
+ * @param {number} numberOfSteps The quantity of numbered steps to get.
+ * @returns {string}
+ */
+export function getStepsLorem(starter, numberOfSteps) {
+  let returnVal = '';
+  for (let i = 1; i <= numberOfSteps; i++) {
+    returnVal = `${returnVal}
+    <bolt-interactive-step tab-title="Lorem ipsum step ${i}">
+      ${starter}
+    </bolt-interactive-step>
+  `;
+  }
+  return returnVal;
+}

--- a/packages/micro-journeys/starters/index.js
+++ b/packages/micro-journeys/starters/index.js
@@ -13,6 +13,8 @@ import oneCharacterLorem from './one-character-lorem.html';
 import oneCharacter1 from './one-character-1.html';
 import stepOneCharacterLorem from './step-one-character-lorem.html';
 import stepTwoCharacterLorem from './step-two-character-lorem.html';
+import stepOneCharacterStarter from './step-one-character-starter.html';
+import stepTwoCharacterStarter from './step-two-character-starter.html';
 import pathwayLorem from './pathwayLorem';
 
 export {
@@ -31,5 +33,7 @@ export {
   oneCharacterLorem,
   stepOneCharacterLorem,
   stepTwoCharacterLorem,
+  stepOneCharacterStarter,
+  stepTwoCharacterStarter,
   pathwayLorem,
 };

--- a/packages/micro-journeys/starters/step-one-character-starter.html
+++ b/packages/micro-journeys/starters/step-one-character-starter.html
@@ -1,0 +1,65 @@
+<bolt-interactive-step tab-title="Starter step: one character">
+  <!--  Step Top-->
+  <bolt-animate slot="top" in-order="1" in="fade-in" out="fade-out" out-order="1" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out-duration="350" out-easing="ease">
+    <bolt-one-character-layout>
+      <bolt-character size="medium" character-image="customer-surprise" character-custom-url="https://www.fillmurray.com/g/200/200">
+        <bolt-animate in="fade-in" in-order="1" out="fade-out" slot="top" out-order="1" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out-duration="350" out-easing="ease">
+          <bolt-status-dialogue-bar icon-name="mobility" dialogue-arrow-direction="down">
+            <p data-highlightable="1" slot="text" class="gjs-comp-selected">
+              Why is my bill so high? Let me check.
+            </p>
+          </bolt-status-dialogue-bar>
+        </bolt-animate>
+        <bolt-animate slot="bottom" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+          <bolt-cta>
+            <bolt-animate slot="icon" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+              <bolt-icon name="eye">
+              </bolt-icon>
+            </bolt-animate>
+            <bolt-animate slot="link" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+              <bolt-link display="inline" valign="center" on-click="none" class="gjs-comp-selected">
+                Customer billing view
+                <bolt-icon name="chevron-right">
+                </bolt-icon>
+              </bolt-link>
+            </bolt-animate>
+          </bolt-cta>
+          <bolt-text font-size="xsmall" align="inherit" color="theme-body" display="block" font-family="body" font-style="regular" font-weight="regular" letter-spacing="regular" line-height="regular" tag="p" text-transform="regular">I am text
+          </bolt-text>
+        </bolt-animate>
+        <bolt-animate slot="right" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+          <bolt-status-dialogue-bar dialogue-arrow-direction="none" is-alert-message="" icon-name="exclamation">
+            <p slot="text"> Uh oh!
+            </p>
+          </bolt-status-dialogue-bar>
+        </bolt-animate>
+        <bolt-animate slot="left" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+          <bolt-icon size="xlarge" name="calendar" background="square" color="blue">
+          </bolt-icon>
+        </bolt-animate>
+        <bolt-animate slot="background" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+          <bolt-svg-animations anim-type="orbit" direction="left" speed="4000">
+          </bolt-svg-animations>
+        </bolt-animate>
+      </bolt-character>
+    </bolt-one-character-layout>
+  </bolt-animate>
+  <!--  Step Bottom-->
+  <bolt-animate slot="bottom" in-order="5" in="fade-in" out="fade-out" out-order="5" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out-duration="350" out-easing="ease">
+    <bolt-text align="inherit" color="theme-body" display="block" font-family="body" font-size="medium" font-style="regular" font-weight="regular" letter-spacing="regular" line-height="regular" tag="p" text-transform="regular">
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ab animi atque consectetur delectus deserunt eaque exercitationem fugiat mollitia nobis nostrum, odit placeat, quae repudiandae, saepe sequi sint tempore ut velit.
+    </bolt-text>
+    <bolt-cta>
+      <bolt-animate slot="icon" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+        <bolt-icon size="medium" name="video">
+        </bolt-icon>
+      </bolt-animate>
+      <bolt-animate slot="link" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+        <bolt-link display="inline" valign="center" on-click="none">CTA text 
+          <bolt-icon name="chevron-right">
+          </bolt-icon>
+        </bolt-link>
+      </bolt-animate>
+    </bolt-cta>
+  </bolt-animate>
+</bolt-interactive-step>

--- a/packages/micro-journeys/starters/step-one-character-starter.html
+++ b/packages/micro-journeys/starters/step-one-character-starter.html
@@ -1,65 +1,63 @@
-<bolt-interactive-step tab-title="Starter step: one character">
-  <!--  Step Top-->
-  <bolt-animate slot="top" in-order="1" in="fade-in" out="fade-out" out-order="1" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out-duration="350" out-easing="ease">
-    <bolt-one-character-layout>
-      <bolt-character size="medium" character-image="customer-surprise" character-custom-url="https://www.fillmurray.com/g/200/200">
-        <bolt-animate in="fade-in" in-order="1" out="fade-out" slot="top" out-order="1" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out-duration="350" out-easing="ease">
-          <bolt-status-dialogue-bar icon-name="mobility" dialogue-arrow-direction="down">
-            <p data-highlightable="1" slot="text" class="gjs-comp-selected">
-              Why is my bill so high? Let me check.
-            </p>
-          </bolt-status-dialogue-bar>
-        </bolt-animate>
-        <bolt-animate slot="bottom" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
-          <bolt-cta>
-            <bolt-animate slot="icon" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
-              <bolt-icon name="eye">
+<!--  Step Top-->
+<bolt-animate slot="top" in-order="1" in="fade-in" out="fade-out" out-order="1" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out-duration="350" out-easing="ease">
+  <bolt-one-character-layout>
+    <bolt-character size="medium" character-image="customer-surprise" character-custom-url="https://www.fillmurray.com/g/200/200">
+      <bolt-animate in="fade-in" in-order="1" out="fade-out" slot="top" out-order="1" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out-duration="350" out-easing="ease">
+        <bolt-status-dialogue-bar icon-name="mobility" dialogue-arrow-direction="down">
+          <p data-highlightable="1" slot="text" class="gjs-comp-selected">
+            Why is my bill so high? Let me check.
+          </p>
+        </bolt-status-dialogue-bar>
+      </bolt-animate>
+      <bolt-animate slot="bottom" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+        <bolt-cta>
+          <bolt-animate slot="icon" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+            <bolt-icon name="eye">
+            </bolt-icon>
+          </bolt-animate>
+          <bolt-animate slot="link" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+            <bolt-link display="inline" valign="center" on-click="none" class="gjs-comp-selected">
+              Customer billing view
+              <bolt-icon name="chevron-right">
               </bolt-icon>
-            </bolt-animate>
-            <bolt-animate slot="link" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
-              <bolt-link display="inline" valign="center" on-click="none" class="gjs-comp-selected">
-                Customer billing view
-                <bolt-icon name="chevron-right">
-                </bolt-icon>
-              </bolt-link>
-            </bolt-animate>
-          </bolt-cta>
-          <bolt-text font-size="xsmall" align="inherit" color="theme-body" display="block" font-family="body" font-style="regular" font-weight="regular" letter-spacing="regular" line-height="regular" tag="p" text-transform="regular">I am text
-          </bolt-text>
-        </bolt-animate>
-        <bolt-animate slot="right" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
-          <bolt-status-dialogue-bar dialogue-arrow-direction="none" is-alert-message="" icon-name="exclamation">
-            <p slot="text"> Uh oh!
-            </p>
-          </bolt-status-dialogue-bar>
-        </bolt-animate>
-        <bolt-animate slot="left" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
-          <bolt-icon size="xlarge" name="calendar" background="square" color="blue">
-          </bolt-icon>
-        </bolt-animate>
-        <bolt-animate slot="background" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
-          <bolt-svg-animations anim-type="orbit" direction="left" speed="4000">
-          </bolt-svg-animations>
-        </bolt-animate>
-      </bolt-character>
-    </bolt-one-character-layout>
-  </bolt-animate>
-  <!--  Step Bottom-->
-  <bolt-animate slot="bottom" in-order="5" in="fade-in" out="fade-out" out-order="5" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out-duration="350" out-easing="ease">
-    <bolt-text align="inherit" color="theme-body" display="block" font-family="body" font-size="medium" font-style="regular" font-weight="regular" letter-spacing="regular" line-height="regular" tag="p" text-transform="regular">
-      Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ab animi atque consectetur delectus deserunt eaque exercitationem fugiat mollitia nobis nostrum, odit placeat, quae repudiandae, saepe sequi sint tempore ut velit.
-    </bolt-text>
-    <bolt-cta>
-      <bolt-animate slot="icon" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
-        <bolt-icon size="medium" name="video">
+            </bolt-link>
+          </bolt-animate>
+        </bolt-cta>
+        <bolt-text font-size="xsmall" align="inherit" color="theme-body" display="block" font-family="body" font-style="regular" font-weight="regular" letter-spacing="regular" line-height="regular" tag="p" text-transform="regular">I am text
+        </bolt-text>
+      </bolt-animate>
+      <bolt-animate slot="right" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+        <bolt-status-dialogue-bar dialogue-arrow-direction="none" is-alert-message="" icon-name="exclamation">
+          <p slot="text"> Uh oh!
+          </p>
+        </bolt-status-dialogue-bar>
+      </bolt-animate>
+      <bolt-animate slot="left" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+        <bolt-icon size="large" name="user-interface" color="blue">
         </bolt-icon>
       </bolt-animate>
-      <bolt-animate slot="link" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
-        <bolt-link display="inline" valign="center" on-click="none">CTA text 
-          <bolt-icon name="chevron-right">
-          </bolt-icon>
-        </bolt-link>
+      <bolt-animate slot="background" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+        <bolt-svg-animations anim-type="orbit" direction="left" speed="4000">
+        </bolt-svg-animations>
       </bolt-animate>
-    </bolt-cta>
-  </bolt-animate>
-</bolt-interactive-step>
+    </bolt-character>
+  </bolt-one-character-layout>
+</bolt-animate>
+<!--  Step Bottom-->
+<bolt-animate slot="bottom" in-order="5" in="fade-in" out="fade-out" out-order="5" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out-duration="350" out-easing="ease">
+  <bolt-text align="inherit" color="theme-body" display="block" font-family="body" font-size="medium" font-style="regular" font-weight="regular" letter-spacing="regular" line-height="regular" tag="p" text-transform="regular">
+    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ab animi atque consectetur delectus deserunt eaque exercitationem fugiat mollitia nobis nostrum, odit placeat, quae repudiandae, saepe sequi sint tempore ut velit.
+  </bolt-text>
+  <bolt-cta>
+    <bolt-animate slot="icon" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+      <bolt-icon size="medium" name="video">
+      </bolt-icon>
+    </bolt-animate>
+    <bolt-animate slot="link" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+      <bolt-link display="inline" valign="center" on-click="none">CTA text 
+        <bolt-icon name="chevron-right">
+        </bolt-icon>
+      </bolt-link>
+    </bolt-animate>
+  </bolt-cta>
+</bolt-animate>

--- a/packages/micro-journeys/starters/step-two-character-starter.html
+++ b/packages/micro-journeys/starters/step-two-character-starter.html
@@ -1,0 +1,89 @@
+<bolt-interactive-step tab-title="Starter step: Two character">
+  <!--  Step Top-->
+  <bolt-animate slot="top" in-order="1" in="fade-in" out="fade-out" out-order="1" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out-duration="350" out-easing="ease">
+    <bolt-two-character-layout>
+      <bolt-animate slot="character--left" in-order="1" in="fade-in" out="fade-out" out-order="1" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out-duration="350" out-easing="ease">
+        <bolt-character size="medium" character-image="customer-surprise" character-custom-url="https://www.fillmurray.com/g/200/200">
+          <bolt-animate slot="bottom" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+            <bolt-text font-size="xsmall" align="inherit" color="theme-body" display="block" font-family="body" font-style="regular" font-weight="regular" letter-spacing="regular" line-height="regular" tag="p" text-transform="regular">lorem
+            </bolt-text>
+            <bolt-cta>
+              <bolt-icon size="medium" slot="icon" name="asset-presentation">
+              </bolt-icon>
+              <bolt-link slot="link" display="inline" valign="center" on-click="none">
+                CTA Text
+                <bolt-icon name="chevron-right">
+                </bolt-icon>
+              </bolt-link>
+            </bolt-cta>
+          </bolt-animate>
+          <bolt-animate slot="background" in="fade-in" in-order="1" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+            <bolt-svg-animations speed="4000" anim-type="radar" theme="dark" direction="left">
+            </bolt-svg-animations>
+          </bolt-animate>
+          <bolt-animate slot="left" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+            <bolt-list display="block" spacing="small">
+              <bolt-list-item>
+                <bolt-icon name="mobility" size="large">
+                </bolt-icon>
+              </bolt-list-item>
+              <bolt-list-item>
+                <bolt-icon name="documentation" size="large">
+                </bolt-icon>
+              </bolt-list-item>
+              <bolt-list-item last="">
+                <bolt-icon name="print" size="large">
+                </bolt-icon>
+              </bolt-list-item>
+            </bolt-list>
+          </bolt-animate>
+        </bolt-character>
+      </bolt-animate>
+      <bolt-animate slot="connection" in="fade-in" in-order="1" out="fade-out" out-order="1" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out-duration="350" out-easing="ease">
+        <bolt-connection anim-type="connectionBand" direction="left">
+        </bolt-connection>
+      </bolt-animate>
+      <bolt-animate slot="character--right" in="fade-in" in-order="1" out="fade-out" out-order="1" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out-duration="350" out-easing="ease">
+        <bolt-character size="medium" character-image="customer-surprise" character-custom-url="https://www.fillmurray.com/g/200/200">
+          <bolt-animate in="fade-in" in-order="1" out="fade-out" slot="top" out-order="1" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out-duration="350" out-easing="ease">
+            <bolt-status-dialogue-bar icon-name="mobility" dialogue-arrow-direction="none">
+              <p slot="text">
+                Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+              </p>
+            </bolt-status-dialogue-bar>
+          </bolt-animate>
+          <bolt-animate slot="bottom" idle="none" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+            <bolt-text font-size="xsmall" align="inherit" color="theme-body" display="block" font-family="body" font-style="regular" font-weight="regular" letter-spacing="regular" line-height="regular" tag="p" text-transform="regular">Customer
+            </bolt-text>
+          </bolt-animate>
+          <bolt-animate slot="left" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+          </bolt-animate>
+          <bolt-animate slot="right" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+            <bolt-status-dialogue-bar dialogue-arrow-direction="none" is-alert-message="" icon-name="exclamation">
+              <p slot="text"> Uh oh!
+              </p>
+            </bolt-status-dialogue-bar>
+          </bolt-animate>
+        </bolt-character>
+      </bolt-animate>
+    </bolt-two-character-layout>
+  </bolt-animate>
+  <!--  Step Bottom-->
+  <bolt-animate slot="bottom" in-order="5" in="fade-in" out="fade-out" out-order="5" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out-duration="350" out-easing="ease">
+    <bolt-text align="inherit" color="theme-body" display="block" font-family="body" font-size="medium" font-style="regular" font-weight="regular" letter-spacing="regular" line-height="regular" tag="p" text-transform="regular">
+      To avoid costly calls to your service center (and keeping customers happy), you ned to stay one step ahead. That's why Pega's real-time monitoring and pattern detection lets you sense a potential billing issue, then send your customer a proactive notification
+    </bolt-text>
+    <bolt-cta>
+      <bolt-animate slot="icon" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+        <bolt-icon size="medium" name="video">
+        </bolt-icon>
+      </bolt-animate>
+      <bolt-animate slot="link" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+        <bolt-link display="inline" valign="center" on-click="none">It's not mind-reading. It's signals 
+          <bolt-icon name="chevron-right">
+          </bolt-icon>
+        </bolt-link>
+      </bolt-animate>
+    </bolt-cta>
+  </bolt-animate>
+</bolt-interactive-step>

--- a/packages/micro-journeys/starters/step-two-character-starter.html
+++ b/packages/micro-journeys/starters/step-two-character-starter.html
@@ -1,89 +1,87 @@
-<bolt-interactive-step tab-title="Starter step: Two character">
-  <!--  Step Top-->
-  <bolt-animate slot="top" in-order="1" in="fade-in" out="fade-out" out-order="1" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out-duration="350" out-easing="ease">
-    <bolt-two-character-layout>
-      <bolt-animate slot="character--left" in-order="1" in="fade-in" out="fade-out" out-order="1" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out-duration="350" out-easing="ease">
-        <bolt-character size="medium" character-image="customer-surprise" character-custom-url="https://www.fillmurray.com/g/200/200">
-          <bolt-animate slot="bottom" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
-            <bolt-text font-size="xsmall" align="inherit" color="theme-body" display="block" font-family="body" font-style="regular" font-weight="regular" letter-spacing="regular" line-height="regular" tag="p" text-transform="regular">lorem
-            </bolt-text>
-            <bolt-cta>
-              <bolt-icon size="medium" slot="icon" name="asset-presentation">
+<!--  Step Top-->
+<bolt-animate slot="top" in-order="1" in="fade-in" out="fade-out" out-order="1" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out-duration="350" out-easing="ease">
+  <bolt-two-character-layout>
+    <bolt-animate slot="character--left" in-order="1" in="fade-in" out="fade-out" out-order="1" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out-duration="350" out-easing="ease">
+      <bolt-character size="medium" character-image="customer-surprise" character-custom-url="https://www.fillmurray.com/g/200/200">
+        <bolt-animate slot="bottom" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+          <bolt-text font-size="xsmall" align="inherit" color="theme-body" display="block" font-family="body" font-style="regular" font-weight="regular" letter-spacing="regular" line-height="regular" tag="p" text-transform="regular">Company
+          </bolt-text>
+          <bolt-cta>
+            <bolt-icon size="medium" slot="icon" name="asset-presentation">
+            </bolt-icon>
+            <bolt-link slot="link" display="inline" valign="center" on-click="none">
+              CTA Text
+              <bolt-icon name="chevron-right">
               </bolt-icon>
-              <bolt-link slot="link" display="inline" valign="center" on-click="none">
-                CTA Text
-                <bolt-icon name="chevron-right">
-                </bolt-icon>
-              </bolt-link>
-            </bolt-cta>
-          </bolt-animate>
-          <bolt-animate slot="background" in="fade-in" in-order="1" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
-            <bolt-svg-animations speed="4000" anim-type="radar" theme="dark" direction="left">
-            </bolt-svg-animations>
-          </bolt-animate>
-          <bolt-animate slot="left" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
-            <bolt-list display="block" spacing="small">
-              <bolt-list-item>
-                <bolt-icon name="mobility" size="large">
-                </bolt-icon>
-              </bolt-list-item>
-              <bolt-list-item>
-                <bolt-icon name="documentation" size="large">
-                </bolt-icon>
-              </bolt-list-item>
-              <bolt-list-item last="">
-                <bolt-icon name="print" size="large">
-                </bolt-icon>
-              </bolt-list-item>
-            </bolt-list>
-          </bolt-animate>
-        </bolt-character>
-      </bolt-animate>
-      <bolt-animate slot="connection" in="fade-in" in-order="1" out="fade-out" out-order="1" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out-duration="350" out-easing="ease">
-        <bolt-connection anim-type="connectionBand" direction="left">
-        </bolt-connection>
-      </bolt-animate>
-      <bolt-animate slot="character--right" in="fade-in" in-order="1" out="fade-out" out-order="1" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out-duration="350" out-easing="ease">
-        <bolt-character size="medium" character-image="customer-surprise" character-custom-url="https://www.fillmurray.com/g/200/200">
-          <bolt-animate in="fade-in" in-order="1" out="fade-out" slot="top" out-order="1" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out-duration="350" out-easing="ease">
-            <bolt-status-dialogue-bar icon-name="mobility" dialogue-arrow-direction="none">
-              <p slot="text">
-                Lorem ipsum dolor sit amet, consectetur adipisicing elit.
-              </p>
-            </bolt-status-dialogue-bar>
-          </bolt-animate>
-          <bolt-animate slot="bottom" idle="none" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
-            <bolt-text font-size="xsmall" align="inherit" color="theme-body" display="block" font-family="body" font-style="regular" font-weight="regular" letter-spacing="regular" line-height="regular" tag="p" text-transform="regular">Customer
-            </bolt-text>
-          </bolt-animate>
-          <bolt-animate slot="left" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
-          </bolt-animate>
-          <bolt-animate slot="right" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
-            <bolt-status-dialogue-bar dialogue-arrow-direction="none" is-alert-message="" icon-name="exclamation">
-              <p slot="text"> Uh oh!
-              </p>
-            </bolt-status-dialogue-bar>
-          </bolt-animate>
-        </bolt-character>
-      </bolt-animate>
-    </bolt-two-character-layout>
-  </bolt-animate>
-  <!--  Step Bottom-->
-  <bolt-animate slot="bottom" in-order="5" in="fade-in" out="fade-out" out-order="5" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out-duration="350" out-easing="ease">
-    <bolt-text align="inherit" color="theme-body" display="block" font-family="body" font-size="medium" font-style="regular" font-weight="regular" letter-spacing="regular" line-height="regular" tag="p" text-transform="regular">
-      To avoid costly calls to your service center (and keeping customers happy), you ned to stay one step ahead. That's why Pega's real-time monitoring and pattern detection lets you sense a potential billing issue, then send your customer a proactive notification
-    </bolt-text>
-    <bolt-cta>
-      <bolt-animate slot="icon" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
-        <bolt-icon size="medium" name="video">
+            </bolt-link>
+          </bolt-cta>
+        </bolt-animate>
+        <bolt-animate slot="background" in="fade-in" in-order="1" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+          <bolt-svg-animations speed="4000" anim-type="radar" theme="dark" direction="left">
+          </bolt-svg-animations>
+        </bolt-animate>
+        <bolt-animate slot="left" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+          <bolt-list display="block" spacing="small">
+            <bolt-list-item>
+              <bolt-icon name="mobility" size="large">
+              </bolt-icon>
+            </bolt-list-item>
+            <bolt-list-item>
+              <bolt-icon name="documentation" size="large">
+              </bolt-icon>
+            </bolt-list-item>
+            <bolt-list-item last="">
+              <bolt-icon name="print" size="large">
+              </bolt-icon>
+            </bolt-list-item>
+          </bolt-list>
+        </bolt-animate>
+      </bolt-character>
+    </bolt-animate>
+    <bolt-animate slot="connection" in="fade-in" in-order="1" out="fade-out" out-order="1" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out-duration="350" out-easing="ease">
+      <bolt-connection anim-type="connectionBand" direction="left">
+      </bolt-connection>
+    </bolt-animate>
+    <bolt-animate slot="character--right" in="fade-in" in-order="1" out="fade-out" out-order="1" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out-duration="350" out-easing="ease">
+      <bolt-character size="medium" character-image="customer-surprise" character-custom-url="https://www.fillmurray.com/g/200/200">
+        <bolt-animate in="fade-in" in-order="1" out="fade-out" slot="top" out-order="1" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out-duration="350" out-easing="ease">
+          <bolt-status-dialogue-bar icon-name="mobility" dialogue-arrow-direction="none">
+            <p slot="text">
+              Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+            </p>
+          </bolt-status-dialogue-bar>
+        </bolt-animate>
+        <bolt-animate slot="bottom" idle="none" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+          <bolt-text font-size="xsmall" align="inherit" color="theme-body" display="block" font-family="body" font-style="regular" font-weight="regular" letter-spacing="regular" line-height="regular" tag="p" text-transform="regular">Customer
+          </bolt-text>
+        </bolt-animate>
+        <bolt-animate slot="left" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+        </bolt-animate>
+        <bolt-animate slot="right" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+          <bolt-status-dialogue-bar dialogue-arrow-direction="none" is-alert-message="" icon-name="exclamation">
+            <p slot="text"> Uh oh!
+            </p>
+          </bolt-status-dialogue-bar>
+        </bolt-animate>
+      </bolt-character>
+    </bolt-animate>
+  </bolt-two-character-layout>
+</bolt-animate>
+<!--  Step Bottom-->
+<bolt-animate slot="bottom" in-order="5" in="fade-in" out="fade-out" out-order="5" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out-duration="350" out-easing="ease">
+  <bolt-text align="inherit" color="theme-body" display="block" font-family="body" font-size="medium" font-style="regular" font-weight="regular" letter-spacing="regular" line-height="regular" tag="p" text-transform="regular">
+    To avoid costly calls to your service center (and keeping customers happy), you ned to stay one step ahead. That's why Pega's real-time monitoring and pattern detection lets you sense a potential billing issue, then send your customer a proactive notification.
+  </bolt-text>
+  <bolt-cta>
+    <bolt-animate slot="icon" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+      <bolt-icon size="medium" name="video">
+      </bolt-icon>
+    </bolt-animate>
+    <bolt-animate slot="link" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
+      <bolt-link display="inline" valign="center" on-click="none">It's not mind-reading. It's signals 
+        <bolt-icon name="chevron-right">
         </bolt-icon>
-      </bolt-animate>
-      <bolt-animate slot="link" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
-        <bolt-link display="inline" valign="center" on-click="none">It's not mind-reading. It's signals 
-          <bolt-icon name="chevron-right">
-          </bolt-icon>
-        </bolt-link>
-      </bolt-animate>
-    </bolt-cta>
-  </bolt-animate>
-</bolt-interactive-step>
+      </bolt-link>
+    </bolt-animate>
+  </bolt-cta>
+</bolt-animate>


### PR DESCRIPTION
## Jira

https://app.asana.com/0/1126340469288208/1146085721698826/f

## Summary

Add Single and Multiple Pathways starters, add specific One and Two Character layouts from starter docs from Ross.

## Details

The PDF describing these specific layouts can be found on the asana task.

## How to test

This button is added, with two pathways representing one and two character layouts respectively from the PDF:

![image](https://user-images.githubusercontent.com/1361104/67602386-11307e80-f73c-11e9-9780-9610eb2efee2.png)

One char: 
![image](https://user-images.githubusercontent.com/1361104/67602472-46d56780-f73c-11e9-832b-4c90088037a2.png)

Two char:
![image](https://user-images.githubusercontent.com/1361104/67602518-65d3f980-f73c-11e9-8964-41814748f72a.png)
