### PR TITLE
Accordion | Dev | Add custom accordion spacing option

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/accordion/45-accordion-trigger-and-content-spacing-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/accordion/45-accordion-trigger-and-content-spacing-variations.twig
@@ -1,0 +1,123 @@
+<p>
+  By setting the <code>content_spacing</code> or <code>trigger_spacing</code> prop to an Accordion Item, the default spacing value inherited from the parent Accordion can be optionally overridden.
+</p>
+
+{% set spacing_item %}
+  <div class="t-bolt-xlight">
+    This entire accordion has the <code>spacing</code> prop defined.
+  </div>
+{% endset %}
+
+{% set content_spacing_item %}
+  <div class="t-bolt-xlight">
+    This item has the <code>content_spacing</code> prop defined.
+  </div>
+{% endset %}
+
+{% set trigger_spacing_item %}
+  This item has the <code>trigger_spacing</code> prop defined.
+{% endset %}
+
+{% grid "o-bolt-grid--flex o-bolt-grid--matrix" %}
+  {% cell "u-bolt-width-12/12 u-bolt-width-6/12@medium" %}
+    <h3>Basic usage: spacing</h3>
+    <p>
+      Using <code>spacing</code> will uniformly set the same spacing on both the trigger and the content.
+    </p>
+    <div class="t-bolt-light u-bolt-padding-small">
+      {% include "@bolt-components-accordion/accordion.twig" with {
+        spacing: "none",
+        items: [
+          {
+            trigger: "<div class='t-bolt-xlight'>Spacing: none</div>",
+            content: spacing_item,
+            open: true,
+          },
+        ]
+      } only %}
+      {% include "@bolt-components-accordion/accordion.twig" with {
+        spacing: "small",
+        items: [
+          {
+            trigger: "<div class='t-bolt-xlight'>Spacing: small</div>",
+            content: spacing_item,
+            open: true,
+          },
+        ]
+      } only %}
+      {% include "@bolt-components-accordion/accordion.twig" with {
+        spacing: "medium",
+        items: [
+          {
+            trigger: "<div class='t-bolt-xlight'>Spacing: medium</div>",
+            content: spacing_item,
+            open: true,
+          },
+        ]
+      } only %}
+    </div>
+  {% endcell %}
+  {% cell "u-bolt-width-12/12 u-bolt-width-6/12@medium" %}
+    {# Empty white space #}
+  {% endcell %}
+  {% cell "u-bolt-width-12/12 u-bolt-width-6/12@medium" %}
+    <h3>Advanced usage: content spacing</h3>
+    <p>
+      Using <code>content_spacing</code> will only set the spacing on the content container. This should only be used if you don't want the same spacing on both the trigger and the content.
+    </p>
+    <div class="t-bolt-light u-bolt-padding-small">
+      {% include "@bolt-components-accordion/accordion.twig" with {
+        items: [
+          {
+            trigger: "Content spacing: none",
+            content_spacing: "none",
+            content: content_spacing_item,
+            open: true,
+          },
+          {
+            trigger: "Content spacing: small",
+            content_spacing: "small",
+            content: content_spacing_item,
+            open: true,
+          },
+          {
+            trigger: "Content spacing: medium",
+            content_spacing: "medium",
+            content: content_spacing_item,
+            open: true,
+          },
+        ]
+      } only %}
+    </div>
+  {% endcell %}
+  {% cell "u-bolt-width-12/12 u-bolt-width-6/12@medium" %}
+    <h3>Advanced usage: trigger spacing</h3>
+    <p>
+      Using <code>trigger_spacing</code> will only set the spacing on the trigger container. This should only be used if you don't want the same spacing on both the trigger and the content.
+    </p>
+    <div class="t-bolt-light u-bolt-padding-small">
+      {% include "@bolt-components-accordion/accordion.twig" with {
+        items: [
+          {
+            trigger: "<div class='t-bolt-xlight'>Trigger spacing: none</div>",
+            trigger_spacing: "none",
+            content: trigger_spacing_item,
+            open: true,
+          },
+          {
+            trigger: "<div class='t-bolt-xlight'>Trigger spacing: small</div>",
+            trigger_spacing: "small",
+            content: trigger_spacing_item,
+            open: true,
+          },
+          {
+            trigger: "<div class='t-bolt-xlight'>Trigger spacing: medium</div>",
+            trigger_spacing: "medium",
+            content: trigger_spacing_item,
+            open: true,
+          },
+        ]
+      } only %}
+    </div>
+  {% endcell %}
+{% endgrid %}

--- a/packages/components/bolt-accordion/__tests__/__snapshots__/accordion.js.snap
+++ b/packages/components/bolt-accordion/__tests__/__snapshots__/accordion.js.snap
@@ -801,6 +801,261 @@ exports[`<bolt-accordion> Component basic usage 1`] = `
 </bolt-accordion>
 `;
 
+exports[`<bolt-accordion> Component content spacing: large 1`] = `
+<bolt-accordion>
+  <replace-with-children class="c-bolt-accordion">
+    <bolt-accordion-item content-spacing="large">
+      <input class="c-bolt-accordion-item__state"
+             type="checkbox"
+             id="c-bolt-accordion-item-12345"
+      >
+      <div class="c-bolt-accordion-item c-bolt-accordion-item--separator c-bolt-accordion-item--first-item c-bolt-accordion-item--last-item"
+           id="c-bolt-accordion-item-inner-12345"
+      >
+        <div class="c-bolt-accordion-item__trigger">
+          <label for="c-bolt-accordion-item-12345"
+                 class="c-bolt-accordion-item__trigger-label c-bolt-accordion-item__trigger-label--offset c-bolt-accordion-spacing--medium"
+          >
+            <div class="c-bolt-accordion-item__trigger-content">
+              <ssr-keep for="bolt-accordion-item">
+                <div slot="trigger">
+                  Accordion item 1
+                </div>
+              </ssr-keep>
+            </div>
+          </label>
+          <a href="#c-bolt-accordion-item-12345"
+             class="c-bolt-accordion-item__trigger-link c-bolt-accordion-item__trigger-link--open c-bolt-accordion-spacing--medium"
+          >
+            <span class="c-bolt-accordion-item__toggle-text">
+              Open Accordion
+            </span>
+          </a>
+          <a href="#c-bolt-accordion-item-inner-12345"
+             class="c-bolt-accordion-item__trigger-link c-bolt-accordion-item__trigger-link--close c-bolt-accordion-spacing--medium"
+          >
+            <span class="c-bolt-accordion-item__toggle-text">
+              Close Accordion
+            </span>
+          </a>
+        </div>
+        <div class="c-bolt-accordion-item__content">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--large">
+            <ssr-keep for="bolt-accordion-item">
+              This is the accordion content.
+            </ssr-keep>
+          </div>
+        </div>
+      </div>
+    </bolt-accordion-item>
+  </replace-with-children>
+</bolt-accordion>
+`;
+
+exports[`<bolt-accordion> Component content spacing: medium 1`] = `
+<bolt-accordion>
+  <replace-with-children class="c-bolt-accordion">
+    <bolt-accordion-item content-spacing="medium">
+      <input class="c-bolt-accordion-item__state"
+             type="checkbox"
+             id="c-bolt-accordion-item-12345"
+      >
+      <div class="c-bolt-accordion-item c-bolt-accordion-item--separator c-bolt-accordion-item--first-item c-bolt-accordion-item--last-item"
+           id="c-bolt-accordion-item-inner-12345"
+      >
+        <div class="c-bolt-accordion-item__trigger">
+          <label for="c-bolt-accordion-item-12345"
+                 class="c-bolt-accordion-item__trigger-label c-bolt-accordion-item__trigger-label--offset c-bolt-accordion-spacing--medium"
+          >
+            <div class="c-bolt-accordion-item__trigger-content">
+              <ssr-keep for="bolt-accordion-item">
+                <div slot="trigger">
+                  Accordion item 1
+                </div>
+              </ssr-keep>
+            </div>
+          </label>
+          <a href="#c-bolt-accordion-item-12345"
+             class="c-bolt-accordion-item__trigger-link c-bolt-accordion-item__trigger-link--open c-bolt-accordion-spacing--medium"
+          >
+            <span class="c-bolt-accordion-item__toggle-text">
+              Open Accordion
+            </span>
+          </a>
+          <a href="#c-bolt-accordion-item-inner-12345"
+             class="c-bolt-accordion-item__trigger-link c-bolt-accordion-item__trigger-link--close c-bolt-accordion-spacing--medium"
+          >
+            <span class="c-bolt-accordion-item__toggle-text">
+              Close Accordion
+            </span>
+          </a>
+        </div>
+        <div class="c-bolt-accordion-item__content">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--medium">
+            <ssr-keep for="bolt-accordion-item">
+              This is the accordion content.
+            </ssr-keep>
+          </div>
+        </div>
+      </div>
+    </bolt-accordion-item>
+  </replace-with-children>
+</bolt-accordion>
+`;
+
+exports[`<bolt-accordion> Component content spacing: none 1`] = `
+<bolt-accordion>
+  <replace-with-children class="c-bolt-accordion">
+    <bolt-accordion-item content-spacing="none">
+      <input class="c-bolt-accordion-item__state"
+             type="checkbox"
+             id="c-bolt-accordion-item-12345"
+      >
+      <div class="c-bolt-accordion-item c-bolt-accordion-item--separator c-bolt-accordion-item--first-item c-bolt-accordion-item--last-item"
+           id="c-bolt-accordion-item-inner-12345"
+      >
+        <div class="c-bolt-accordion-item__trigger">
+          <label for="c-bolt-accordion-item-12345"
+                 class="c-bolt-accordion-item__trigger-label c-bolt-accordion-item__trigger-label--offset c-bolt-accordion-spacing--medium"
+          >
+            <div class="c-bolt-accordion-item__trigger-content">
+              <ssr-keep for="bolt-accordion-item">
+                <div slot="trigger">
+                  Accordion item 1
+                </div>
+              </ssr-keep>
+            </div>
+          </label>
+          <a href="#c-bolt-accordion-item-12345"
+             class="c-bolt-accordion-item__trigger-link c-bolt-accordion-item__trigger-link--open c-bolt-accordion-spacing--medium"
+          >
+            <span class="c-bolt-accordion-item__toggle-text">
+              Open Accordion
+            </span>
+          </a>
+          <a href="#c-bolt-accordion-item-inner-12345"
+             class="c-bolt-accordion-item__trigger-link c-bolt-accordion-item__trigger-link--close c-bolt-accordion-spacing--medium"
+          >
+            <span class="c-bolt-accordion-item__toggle-text">
+              Close Accordion
+            </span>
+          </a>
+        </div>
+        <div class="c-bolt-accordion-item__content">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--none">
+            <ssr-keep for="bolt-accordion-item">
+              This is the accordion content.
+            </ssr-keep>
+          </div>
+        </div>
+      </div>
+    </bolt-accordion-item>
+  </replace-with-children>
+</bolt-accordion>
+`;
+
+exports[`<bolt-accordion> Component content spacing: small 1`] = `
+<bolt-accordion>
+  <replace-with-children class="c-bolt-accordion">
+    <bolt-accordion-item content-spacing="small">
+      <input class="c-bolt-accordion-item__state"
+             type="checkbox"
+             id="c-bolt-accordion-item-12345"
+      >
+      <div class="c-bolt-accordion-item c-bolt-accordion-item--separator c-bolt-accordion-item--first-item c-bolt-accordion-item--last-item"
+           id="c-bolt-accordion-item-inner-12345"
+      >
+        <div class="c-bolt-accordion-item__trigger">
+          <label for="c-bolt-accordion-item-12345"
+                 class="c-bolt-accordion-item__trigger-label c-bolt-accordion-item__trigger-label--offset c-bolt-accordion-spacing--medium"
+          >
+            <div class="c-bolt-accordion-item__trigger-content">
+              <ssr-keep for="bolt-accordion-item">
+                <div slot="trigger">
+                  Accordion item 1
+                </div>
+              </ssr-keep>
+            </div>
+          </label>
+          <a href="#c-bolt-accordion-item-12345"
+             class="c-bolt-accordion-item__trigger-link c-bolt-accordion-item__trigger-link--open c-bolt-accordion-spacing--medium"
+          >
+            <span class="c-bolt-accordion-item__toggle-text">
+              Open Accordion
+            </span>
+          </a>
+          <a href="#c-bolt-accordion-item-inner-12345"
+             class="c-bolt-accordion-item__trigger-link c-bolt-accordion-item__trigger-link--close c-bolt-accordion-spacing--medium"
+          >
+            <span class="c-bolt-accordion-item__toggle-text">
+              Close Accordion
+            </span>
+          </a>
+        </div>
+        <div class="c-bolt-accordion-item__content">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--small">
+            <ssr-keep for="bolt-accordion-item">
+              This is the accordion content.
+            </ssr-keep>
+          </div>
+        </div>
+      </div>
+    </bolt-accordion-item>
+  </replace-with-children>
+</bolt-accordion>
+`;
+
+exports[`<bolt-accordion> Component content spacing: xsmall 1`] = `
+<bolt-accordion>
+  <replace-with-children class="c-bolt-accordion">
+    <bolt-accordion-item content-spacing="xsmall">
+      <input class="c-bolt-accordion-item__state"
+             type="checkbox"
+             id="c-bolt-accordion-item-12345"
+      >
+      <div class="c-bolt-accordion-item c-bolt-accordion-item--separator c-bolt-accordion-item--first-item c-bolt-accordion-item--last-item"
+           id="c-bolt-accordion-item-inner-12345"
+      >
+        <div class="c-bolt-accordion-item__trigger">
+          <label for="c-bolt-accordion-item-12345"
+                 class="c-bolt-accordion-item__trigger-label c-bolt-accordion-item__trigger-label--offset c-bolt-accordion-spacing--medium"
+          >
+            <div class="c-bolt-accordion-item__trigger-content">
+              <ssr-keep for="bolt-accordion-item">
+                <div slot="trigger">
+                  Accordion item 1
+                </div>
+              </ssr-keep>
+            </div>
+          </label>
+          <a href="#c-bolt-accordion-item-12345"
+             class="c-bolt-accordion-item__trigger-link c-bolt-accordion-item__trigger-link--open c-bolt-accordion-spacing--medium"
+          >
+            <span class="c-bolt-accordion-item__toggle-text">
+              Open Accordion
+            </span>
+          </a>
+          <a href="#c-bolt-accordion-item-inner-12345"
+             class="c-bolt-accordion-item__trigger-link c-bolt-accordion-item__trigger-link--close c-bolt-accordion-spacing--medium"
+          >
+            <span class="c-bolt-accordion-item__toggle-text">
+              Close Accordion
+            </span>
+          </a>
+        </div>
+        <div class="c-bolt-accordion-item__content">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--xsmall">
+            <ssr-keep for="bolt-accordion-item">
+              This is the accordion content.
+            </ssr-keep>
+          </div>
+        </div>
+      </div>
+    </bolt-accordion-item>
+  </replace-with-children>
+</bolt-accordion>
+`;
+
 exports[`<bolt-accordion> Component expand single items: false 1`] = `
 <bolt-accordion>
   <replace-with-children class="c-bolt-accordion">
@@ -1763,6 +2018,261 @@ exports[`<bolt-accordion> Component spacing: xsmall 1`] = `
         </div>
         <div class="c-bolt-accordion-item__content">
           <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-item__content-inner--offset c-bolt-accordion-spacing--xsmall">
+            <ssr-keep for="bolt-accordion-item">
+              This is the accordion content.
+            </ssr-keep>
+          </div>
+        </div>
+      </div>
+    </bolt-accordion-item>
+  </replace-with-children>
+</bolt-accordion>
+`;
+
+exports[`<bolt-accordion> Component trigger spacing: large 1`] = `
+<bolt-accordion>
+  <replace-with-children class="c-bolt-accordion">
+    <bolt-accordion-item trigger-spacing="large">
+      <input class="c-bolt-accordion-item__state"
+             type="checkbox"
+             id="c-bolt-accordion-item-12345"
+      >
+      <div class="c-bolt-accordion-item c-bolt-accordion-item--separator c-bolt-accordion-item--first-item c-bolt-accordion-item--last-item"
+           id="c-bolt-accordion-item-inner-12345"
+      >
+        <div class="c-bolt-accordion-item__trigger">
+          <label for="c-bolt-accordion-item-12345"
+                 class="c-bolt-accordion-item__trigger-label c-bolt-accordion-item__trigger-label--offset c-bolt-accordion-spacing--large"
+          >
+            <div class="c-bolt-accordion-item__trigger-content">
+              <ssr-keep for="bolt-accordion-item">
+                <div slot="trigger">
+                  Accordion item 1
+                </div>
+              </ssr-keep>
+            </div>
+          </label>
+          <a href="#c-bolt-accordion-item-12345"
+             class="c-bolt-accordion-item__trigger-link c-bolt-accordion-item__trigger-link--open c-bolt-accordion-spacing--large"
+          >
+            <span class="c-bolt-accordion-item__toggle-text">
+              Open Accordion
+            </span>
+          </a>
+          <a href="#c-bolt-accordion-item-inner-12345"
+             class="c-bolt-accordion-item__trigger-link c-bolt-accordion-item__trigger-link--close c-bolt-accordion-spacing--large"
+          >
+            <span class="c-bolt-accordion-item__toggle-text">
+              Close Accordion
+            </span>
+          </a>
+        </div>
+        <div class="c-bolt-accordion-item__content">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--medium">
+            <ssr-keep for="bolt-accordion-item">
+              This is the accordion content.
+            </ssr-keep>
+          </div>
+        </div>
+      </div>
+    </bolt-accordion-item>
+  </replace-with-children>
+</bolt-accordion>
+`;
+
+exports[`<bolt-accordion> Component trigger spacing: medium 1`] = `
+<bolt-accordion>
+  <replace-with-children class="c-bolt-accordion">
+    <bolt-accordion-item trigger-spacing="medium">
+      <input class="c-bolt-accordion-item__state"
+             type="checkbox"
+             id="c-bolt-accordion-item-12345"
+      >
+      <div class="c-bolt-accordion-item c-bolt-accordion-item--separator c-bolt-accordion-item--first-item c-bolt-accordion-item--last-item"
+           id="c-bolt-accordion-item-inner-12345"
+      >
+        <div class="c-bolt-accordion-item__trigger">
+          <label for="c-bolt-accordion-item-12345"
+                 class="c-bolt-accordion-item__trigger-label c-bolt-accordion-item__trigger-label--offset c-bolt-accordion-spacing--medium"
+          >
+            <div class="c-bolt-accordion-item__trigger-content">
+              <ssr-keep for="bolt-accordion-item">
+                <div slot="trigger">
+                  Accordion item 1
+                </div>
+              </ssr-keep>
+            </div>
+          </label>
+          <a href="#c-bolt-accordion-item-12345"
+             class="c-bolt-accordion-item__trigger-link c-bolt-accordion-item__trigger-link--open c-bolt-accordion-spacing--medium"
+          >
+            <span class="c-bolt-accordion-item__toggle-text">
+              Open Accordion
+            </span>
+          </a>
+          <a href="#c-bolt-accordion-item-inner-12345"
+             class="c-bolt-accordion-item__trigger-link c-bolt-accordion-item__trigger-link--close c-bolt-accordion-spacing--medium"
+          >
+            <span class="c-bolt-accordion-item__toggle-text">
+              Close Accordion
+            </span>
+          </a>
+        </div>
+        <div class="c-bolt-accordion-item__content">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--medium">
+            <ssr-keep for="bolt-accordion-item">
+              This is the accordion content.
+            </ssr-keep>
+          </div>
+        </div>
+      </div>
+    </bolt-accordion-item>
+  </replace-with-children>
+</bolt-accordion>
+`;
+
+exports[`<bolt-accordion> Component trigger spacing: none 1`] = `
+<bolt-accordion>
+  <replace-with-children class="c-bolt-accordion">
+    <bolt-accordion-item trigger-spacing="none">
+      <input class="c-bolt-accordion-item__state"
+             type="checkbox"
+             id="c-bolt-accordion-item-12345"
+      >
+      <div class="c-bolt-accordion-item c-bolt-accordion-item--separator c-bolt-accordion-item--first-item c-bolt-accordion-item--last-item"
+           id="c-bolt-accordion-item-inner-12345"
+      >
+        <div class="c-bolt-accordion-item__trigger">
+          <label for="c-bolt-accordion-item-12345"
+                 class="c-bolt-accordion-item__trigger-label c-bolt-accordion-item__trigger-label--offset c-bolt-accordion-spacing--none"
+          >
+            <div class="c-bolt-accordion-item__trigger-content">
+              <ssr-keep for="bolt-accordion-item">
+                <div slot="trigger">
+                  Accordion item 1
+                </div>
+              </ssr-keep>
+            </div>
+          </label>
+          <a href="#c-bolt-accordion-item-12345"
+             class="c-bolt-accordion-item__trigger-link c-bolt-accordion-item__trigger-link--open c-bolt-accordion-spacing--none"
+          >
+            <span class="c-bolt-accordion-item__toggle-text">
+              Open Accordion
+            </span>
+          </a>
+          <a href="#c-bolt-accordion-item-inner-12345"
+             class="c-bolt-accordion-item__trigger-link c-bolt-accordion-item__trigger-link--close c-bolt-accordion-spacing--none"
+          >
+            <span class="c-bolt-accordion-item__toggle-text">
+              Close Accordion
+            </span>
+          </a>
+        </div>
+        <div class="c-bolt-accordion-item__content">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--medium">
+            <ssr-keep for="bolt-accordion-item">
+              This is the accordion content.
+            </ssr-keep>
+          </div>
+        </div>
+      </div>
+    </bolt-accordion-item>
+  </replace-with-children>
+</bolt-accordion>
+`;
+
+exports[`<bolt-accordion> Component trigger spacing: small 1`] = `
+<bolt-accordion>
+  <replace-with-children class="c-bolt-accordion">
+    <bolt-accordion-item trigger-spacing="small">
+      <input class="c-bolt-accordion-item__state"
+             type="checkbox"
+             id="c-bolt-accordion-item-12345"
+      >
+      <div class="c-bolt-accordion-item c-bolt-accordion-item--separator c-bolt-accordion-item--first-item c-bolt-accordion-item--last-item"
+           id="c-bolt-accordion-item-inner-12345"
+      >
+        <div class="c-bolt-accordion-item__trigger">
+          <label for="c-bolt-accordion-item-12345"
+                 class="c-bolt-accordion-item__trigger-label c-bolt-accordion-item__trigger-label--offset c-bolt-accordion-spacing--small"
+          >
+            <div class="c-bolt-accordion-item__trigger-content">
+              <ssr-keep for="bolt-accordion-item">
+                <div slot="trigger">
+                  Accordion item 1
+                </div>
+              </ssr-keep>
+            </div>
+          </label>
+          <a href="#c-bolt-accordion-item-12345"
+             class="c-bolt-accordion-item__trigger-link c-bolt-accordion-item__trigger-link--open c-bolt-accordion-spacing--small"
+          >
+            <span class="c-bolt-accordion-item__toggle-text">
+              Open Accordion
+            </span>
+          </a>
+          <a href="#c-bolt-accordion-item-inner-12345"
+             class="c-bolt-accordion-item__trigger-link c-bolt-accordion-item__trigger-link--close c-bolt-accordion-spacing--small"
+          >
+            <span class="c-bolt-accordion-item__toggle-text">
+              Close Accordion
+            </span>
+          </a>
+        </div>
+        <div class="c-bolt-accordion-item__content">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--medium">
+            <ssr-keep for="bolt-accordion-item">
+              This is the accordion content.
+            </ssr-keep>
+          </div>
+        </div>
+      </div>
+    </bolt-accordion-item>
+  </replace-with-children>
+</bolt-accordion>
+`;
+
+exports[`<bolt-accordion> Component trigger spacing: xsmall 1`] = `
+<bolt-accordion>
+  <replace-with-children class="c-bolt-accordion">
+    <bolt-accordion-item trigger-spacing="xsmall">
+      <input class="c-bolt-accordion-item__state"
+             type="checkbox"
+             id="c-bolt-accordion-item-12345"
+      >
+      <div class="c-bolt-accordion-item c-bolt-accordion-item--separator c-bolt-accordion-item--first-item c-bolt-accordion-item--last-item"
+           id="c-bolt-accordion-item-inner-12345"
+      >
+        <div class="c-bolt-accordion-item__trigger">
+          <label for="c-bolt-accordion-item-12345"
+                 class="c-bolt-accordion-item__trigger-label c-bolt-accordion-item__trigger-label--offset c-bolt-accordion-spacing--xsmall"
+          >
+            <div class="c-bolt-accordion-item__trigger-content">
+              <ssr-keep for="bolt-accordion-item">
+                <div slot="trigger">
+                  Accordion item 1
+                </div>
+              </ssr-keep>
+            </div>
+          </label>
+          <a href="#c-bolt-accordion-item-12345"
+             class="c-bolt-accordion-item__trigger-link c-bolt-accordion-item__trigger-link--open c-bolt-accordion-spacing--xsmall"
+          >
+            <span class="c-bolt-accordion-item__toggle-text">
+              Open Accordion
+            </span>
+          </a>
+          <a href="#c-bolt-accordion-item-inner-12345"
+             class="c-bolt-accordion-item__trigger-link c-bolt-accordion-item__trigger-link--close c-bolt-accordion-spacing--xsmall"
+          >
+            <span class="c-bolt-accordion-item__toggle-text">
+              Close Accordion
+            </span>
+          </a>
+        </div>
+        <div class="c-bolt-accordion-item__content">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--medium">
             <ssr-keep for="bolt-accordion-item">
               This is the accordion content.
             </ssr-keep>

--- a/packages/components/bolt-accordion/__tests__/__snapshots__/accordion.js.snap
+++ b/packages/components/bolt-accordion/__tests__/__snapshots__/accordion.js.snap
@@ -126,7 +126,7 @@ exports[`<bolt-accordion> Component Default <bolt-accordion> w/o Shadow DOM rend
           
         
           <div
-            class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--medium"
+            class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--medium c-bolt-accordion-item__content-inner--offset"
             style=""
           >
             
@@ -274,7 +274,7 @@ exports[`<bolt-accordion> Component Default <bolt-accordion> w/o Shadow DOM rend
           
         
           <div
-            class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--medium"
+            class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--medium c-bolt-accordion-item__content-inner--offset"
             style=""
           >
             
@@ -422,7 +422,7 @@ exports[`<bolt-accordion> Component Default <bolt-accordion> w/o Shadow DOM rend
           
         
           <div
-            class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--medium"
+            class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--medium c-bolt-accordion-item__content-inner--offset"
             style=""
           >
             
@@ -492,7 +492,7 @@ exports[`<bolt-accordion> Component Default <bolt-accordion> with Shadow DOM ren
 
 exports[`<bolt-accordion> Component Default <bolt-accordion> with Shadow DOM renders 2`] = `
 <style>
-  bolt-accordion-item{display:block}bolt-accordion-item replace-with-children,bolt-accordion-item replace-with-grandchildren{display:block;-webkit-box-flex:1;flex-grow:1}.c-bolt-accordion-item ::slotted(.is-last-child),.c-bolt-accordion-item ::slotted(:last-child){margin-bottom:0!important}.c-bolt-accordion-item__state{display:none}.c-bolt-accordion-item--box-shadow .c-bolt-accordion-item__content{background-color:rgba(224,226,235,.1)}.c-bolt-accordion-item--box-shadow .c-bolt-accordion-item__content:after,.c-bolt-accordion-item--box-shadow .c-bolt-accordion-item__content:before{content:'';display:block;opacity:1;position:absolute;right:0;left:0;height:.206rem;pointer-events:none;will-change:opacity;-webkit-transition:opacity .1s ease-in-out;transition:opacity .1s ease-in-out}.c-bolt-accordion-item--box-shadow .c-bolt-accordion-item__content:before{top:0;background:-webkit-gradient(linear,left top, left bottom,color-stop(0, rgba(141,142,153,.1)),to(transparent));background:linear-gradient(to bottom,rgba(141,142,153,.1) 0,transparent 100%)}.c-bolt-accordion-item--box-shadow .c-bolt-accordion-item__content:after{bottom:0;background:-webkit-gradient(linear,left top, left bottom,color-stop(0, transparent),to(rgba(141,142,153,.1)));background:linear-gradient(to bottom,transparent 0,rgba(141,142,153,.1) 100%)}.c-bolt-accordion-item--box-shadow.c-bolt-accordion-item--first-item .c-bolt-accordion-item__trigger,.c-bolt-accordion-item--box-shadow.c-bolt-accordion-item--first-item .c-bolt-accordion-item__trigger-label{border-top-right-radius:3px;border-top-left-radius:3px}.c-bolt-accordion-item--box-shadow.c-bolt-accordion-item--last-item .c-bolt-accordion-item__content,.c-bolt-accordion-item--box-shadow.c-bolt-accordion-item--last-item .c-bolt-accordion-item__trigger-label,.c-bolt-accordion-item--box-shadow.c-bolt-accordion-item--last-item .c-bolt-accordion-item__trigger:not(.c-bolt-accordion-item__trigger--open){border-bottom-right-radius:3px;border-bottom-left-radius:3px}.c-bolt-accordion-item--box-shadow.c-bolt-accordion-item--last-item .c-bolt-accordion-item__content:after{display:none}.c-bolt-accordion-item__trigger{display:-webkit-box;display:flex;position:relative;margin:0}.c-bolt-accordion-item__trigger-label{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Fira Sans","Droid Sans","Helvetica Neue",sans-serif;font-family:var(--bolt-font-family-heading);font-size:1rem;line-height:1.65;display:-webkit-box;display:flex;-webkit-box-pack:justify;justify-content:space-between;-webkit-box-align:center;align-items:center;-webkit-appearance:none;-moz-appearance:none;appearance:none;position:relative;width:100%;margin:0;padding:0;color:inherit;text-align:left;text-align:start;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;outline-offset:-4px;border:none;background-color:rgba(var(--bolt-theme-background), 1)}.js-fonts-loaded .c-bolt-accordion-item__trigger-label{font-family:"Open Sans","Helvetica Neue",sans-serif;font-family:var(--bolt-font-family-heading)}.c-bolt-accordion-item--icon-valign-top .c-bolt-accordion-item__trigger-label{-webkit-box-align:start;align-items:flex-start}.c-bolt-accordion-item__trigger-label:-moz-focusring{outline:0}.c-bolt-accordion-item__trigger-label:before{content:'';display:block;opacity:0;position:absolute;top:0;right:0;bottom:0;left:0;pointer-events:none;background-color:rgba(var(--bolt-theme-primary), 0.15);will-change:opacity;-webkit-transition:opacity .1s ease-in-out;transition:opacity .1s ease-in-out}.c-bolt-accordion-item__trigger-label:not(.c-bolt-accordion-item__trigger-label--inactive){cursor:pointer}.c-bolt-accordion-item__trigger-label:not(.c-bolt-accordion-item__trigger-label--inactive):hover:before{opacity:.2}.c-bolt-accordion-item__trigger-label:not(.c-bolt-accordion-item__trigger-label--inactive):active:before{opacity:1}.c-bolt-accordion-item__trigger-link{display:block;position:absolute;top:0;right:0;width:.311rem;height:100%;outline-offset:-4px}.c-bolt-accordion-item__trigger-link:after{content:'';display:block;position:absolute;top:50%;right:50%;width:.622rem;height:.622rem;border-radius:1px;border-width:3px 3px 0 0;border-style:solid;border-color:rgba(var(--bolt-theme-link), 1);-webkit-transform-origin:50% 50%;transform-origin:50% 50%}.c-bolt-accordion-item__trigger-label--inactive~.c-bolt-accordion-item__trigger-link{visibility:hidden}.c-bolt-accordion-item__trigger-link--open:after{-webkit-transform:rotate(135deg) translateX(-50%) translateY(50%);transform:rotate(135deg) translateX(-50%) translateY(50%)}.c-bolt-accordion-item__trigger-link--close:after{-webkit-transform:rotate(-45deg);transform:rotate(-45deg)}.c-bolt-accordion-item__toggle-text{position:absolute;width:1px;height:1px;overflow:hidden;margin:-1px;padding:0;border:0;clip:rect(0 0 0 0);-webkit-clip-path:inset(50%);clip-path:inset(50%);white-space:nowrap}.c-bolt-accordion-item__state:checked+.c-bolt-accordion-item .c-bolt-accordion-item__trigger-link--open,.c-bolt-accordion-item__state:target+.c-bolt-accordion-item .c-bolt-accordion-item__trigger-link--open,.c-bolt-accordion-item__trigger-link--close{display:none}.c-bolt-accordion-item__state:checked+.c-bolt-accordion-item .c-bolt-accordion-item__trigger-link--close,.c-bolt-accordion-item__state:target+.c-bolt-accordion-item .c-bolt-accordion-item__trigger-link--close{display:block}.c-bolt-accordion-item__trigger--open{z-index:1}.c-bolt-accordion-item__trigger-icons{display:-webkit-box;display:flex;flex-shrink:0;position:relative;-webkit-transform:translateX(.25rem);transform:translateX(.25rem);overflow:hidden;color:rgba(var(--bolt-theme-link), 1);line-height:0;font-size:1.4rem}.c-bolt-accordion-item__trigger-label--inactive .c-bolt-accordion-item__trigger-icons{visibility:hidden}.c-bolt-accordion-item__trigger-icons-inner{padding:.206rem 0;display:block;-webkit-transform:rotate(0);transform:rotate(0);-webkit-transform-origin:50% 50%;transform-origin:50% 50%;will-change:transform;-webkit-transition:-webkit-transform .2s ease-in-out;transition:-webkit-transform .2s ease-in-out;transition:transform .2s ease-in-out;transition:transform .2s ease-in-out, -webkit-transform .2s ease-in-out}[aria-expanded=false] .c-bolt-accordion-item__trigger-icons-inner{-webkit-transform:rotate(0);transform:rotate(0)}[aria-expanded=true] .c-bolt-accordion-item__trigger-icons-inner{-webkit-transform:rotate(180deg);transform:rotate(180deg)}.c-bolt-accordion-item__trigger-content{-webkit-box-flex:1;flex-grow:1;margin-bottom:0}.c-bolt-accordion-item__content{display:none;position:relative;-webkit-transform:translateY(-1rem);transform:translateY(-1rem);width:100%;height:0;will-change:transform;-webkit-transition:-webkit-transform .2s cubic-bezier(0,0,.3,1) .1s;transition:-webkit-transform .2s cubic-bezier(0,0,.3,1) .1s;transition:transform .2s cubic-bezier(0,0,.3,1) .1s;transition:transform .2s cubic-bezier(0,0,.3,1) .1s, -webkit-transform .2s cubic-bezier(0,0,.3,1) .1s}.c-bolt-accordion-item__content[data-open]:not([style*=height]){visibility:visible;height:auto;-webkit-transition:none;transition:none}.c-bolt-accordion-item__content:not([role=region]){display:block;visibility:hidden;height:auto;max-height:0}.c-bolt-accordion-item__state:checked+.c-bolt-accordion-item .c-bolt-accordion-item__content,.c-bolt-accordion-item__state:target+.c-bolt-accordion-item .c-bolt-accordion-item__content{visibility:visible;-webkit-transform:translate3d(0,0,0);transform:translate3d(0,0,0);max-height:none;will-change:transform,height;-webkit-transition:height .2s ease-in-out,-webkit-transform .2s ease-in-out;transition:height .2s ease-in-out,-webkit-transform .2s ease-in-out;transition:transform .2s ease-in-out,height .2s ease-in-out;transition:transform .2s ease-in-out,height .2s ease-in-out,-webkit-transform .2s ease-in-out}.c-bolt-accordion-item__content--open{display:block;-webkit-transform:translate3d(0,0,0);transform:translate3d(0,0,0);-webkit-transition:height .2s ease-in-out;transition:height .2s ease-in-out}.c-bolt-accordion-item__content-inner{opacity:0;position:relative;overflow:auto;will-change:opacity;-webkit-transition:opacity .1s ease-in-out;transition:opacity .1s ease-in-out;-webkit-overflow-scrolling:touch}.c-bolt-accordion-item__content--opened .c-bolt-accordion-item__content-inner,.c-bolt-accordion-item__state:checked+.c-bolt-accordion-item .c-bolt-accordion-item__content-inner,.c-bolt-accordion-item__state:target+.c-bolt-accordion-item .c-bolt-accordion-item__content-inner{opacity:1;will-change:opacity;-webkit-transition:opacity .2s ease-in-out;transition:opacity .2s ease-in-out}.c-bolt-accordion-item__state+.c-bolt-accordion-item .c-bolt-accordion-item__trigger{z-index:1}.c-bolt-accordion-item--separator{border-top-color:rgba(var(--bolt-theme-text), 0.15);border-top-style:solid;border-top-width:1px}.c-bolt-accordion-item--separator.c-bolt-accordion-item--last-item{border-bottom-color:rgba(var(--bolt-theme-text), 0.15);border-bottom-style:solid;border-bottom-width:1px}.c-bolt-accordion-item--separator.c-bolt-accordion-item--box-shadow.c-bolt-accordion-item--first-item{border-top:none}.c-bolt-accordion-item--separator.c-bolt-accordion-item--box-shadow.c-bolt-accordion-item--last-item{border-bottom:none}.c-bolt-accordion-spacing--xsmall{padding:.206rem .5rem}.c-bolt-accordion-spacing--xsmall.c-bolt-accordion-item__content-inner,.c-bolt-accordion-spacing--xsmall.c-bolt-accordion-item__trigger-label.c-bolt-accordion-item__trigger-label--offset{padding-right:calc(1.9rem)}.c-bolt-accordion-spacing--xsmall.c-bolt-accordion-item__content-inner{padding-bottom:.412rem}.c-bolt-accordion-spacing--small{padding:.412rem 1rem}.c-bolt-accordion-spacing--small.c-bolt-accordion-item__content-inner,.c-bolt-accordion-spacing--small.c-bolt-accordion-item__trigger-label.c-bolt-accordion-item__trigger-label--offset{padding-right:calc(2.4rem)}.c-bolt-accordion-spacing--small.c-bolt-accordion-item__content-inner{padding-bottom:.825rem}.c-bolt-accordion-spacing--medium{padding:.825rem 2rem}.c-bolt-accordion-spacing--medium.c-bolt-accordion-item__content-inner,.c-bolt-accordion-spacing--medium.c-bolt-accordion-item__trigger-label.c-bolt-accordion-item__trigger-label--offset{padding-right:calc(3.4rem)}.c-bolt-accordion-spacing--medium.c-bolt-accordion-item__content-inner{padding-bottom:1.65rem}.c-bolt-accordion-spacing--large{padding:1.65rem 4rem}.c-bolt-accordion-spacing--large.c-bolt-accordion-item__content-inner,.c-bolt-accordion-spacing--large.c-bolt-accordion-item__trigger-label.c-bolt-accordion-item__trigger-label--offset{padding-right:calc(5.4rem)}.c-bolt-accordion-spacing--large.c-bolt-accordion-item__content-inner{padding-bottom:3.3rem}
+  bolt-accordion-item{display:block}bolt-accordion-item replace-with-children,bolt-accordion-item replace-with-grandchildren,bolt-accordion-item ssr-keep{display:block;-webkit-box-flex:1;flex-grow:1}.c-bolt-accordion-item ::slotted(.is-last-child),.c-bolt-accordion-item ::slotted(:last-child){margin-bottom:0!important}.c-bolt-accordion-item__state{display:none}.c-bolt-accordion-item--box-shadow .c-bolt-accordion-item__content{background-color:rgba(224,226,235,.1)}.c-bolt-accordion-item--box-shadow .c-bolt-accordion-item__content:after,.c-bolt-accordion-item--box-shadow .c-bolt-accordion-item__content:before{content:'';display:block;opacity:1;position:absolute;right:0;left:0;height:.206rem;pointer-events:none;will-change:opacity;-webkit-transition:opacity .1s ease-in-out;transition:opacity .1s ease-in-out}.c-bolt-accordion-item--box-shadow .c-bolt-accordion-item__content:before{top:0;background:-webkit-gradient(linear,left top, left bottom,color-stop(0, rgba(141,142,153,.1)),to(transparent));background:linear-gradient(to bottom,rgba(141,142,153,.1) 0,transparent 100%)}.c-bolt-accordion-item--box-shadow .c-bolt-accordion-item__content:after{bottom:0;background:-webkit-gradient(linear,left top, left bottom,color-stop(0, transparent),to(rgba(141,142,153,.1)));background:linear-gradient(to bottom,transparent 0,rgba(141,142,153,.1) 100%)}.c-bolt-accordion-item--box-shadow.c-bolt-accordion-item--first-item .c-bolt-accordion-item__trigger,.c-bolt-accordion-item--box-shadow.c-bolt-accordion-item--first-item .c-bolt-accordion-item__trigger-label{border-top-right-radius:3px;border-top-left-radius:3px}.c-bolt-accordion-item--box-shadow.c-bolt-accordion-item--last-item .c-bolt-accordion-item__content,.c-bolt-accordion-item--box-shadow.c-bolt-accordion-item--last-item .c-bolt-accordion-item__trigger-label,.c-bolt-accordion-item--box-shadow.c-bolt-accordion-item--last-item .c-bolt-accordion-item__trigger:not(.c-bolt-accordion-item__trigger--open){border-bottom-right-radius:3px;border-bottom-left-radius:3px}.c-bolt-accordion-item--box-shadow.c-bolt-accordion-item--last-item .c-bolt-accordion-item__content:after{display:none}.c-bolt-accordion-item__trigger{display:-webkit-box;display:flex;position:relative;margin:0}.c-bolt-accordion-item__trigger-label{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Fira Sans","Droid Sans","Helvetica Neue",sans-serif;font-family:var(--bolt-font-family-heading);font-size:1rem;line-height:1.65;display:-webkit-box;display:flex;-webkit-box-pack:justify;justify-content:space-between;-webkit-box-align:center;align-items:center;-webkit-appearance:none;-moz-appearance:none;appearance:none;position:relative;width:100%;margin:0;padding:0;color:inherit;text-align:left;text-align:start;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;outline-offset:-4px;border:none;background-color:rgba(var(--bolt-theme-background), 1)}.js-fonts-loaded .c-bolt-accordion-item__trigger-label{font-family:"Open Sans","Helvetica Neue",sans-serif;font-family:var(--bolt-font-family-heading)}.c-bolt-accordion-item--icon-valign-top .c-bolt-accordion-item__trigger-label{-webkit-box-align:start;align-items:flex-start}.c-bolt-accordion-item__trigger-label:-moz-focusring{outline:0}.c-bolt-accordion-item__trigger-label:before{content:'';display:block;opacity:0;position:absolute;top:0;right:0;bottom:0;left:0;pointer-events:none;background-color:rgba(var(--bolt-theme-primary), 0.15);will-change:opacity;-webkit-transition:opacity .1s ease-in-out;transition:opacity .1s ease-in-out}.c-bolt-accordion-item__trigger-label:not(.c-bolt-accordion-item__trigger-label--inactive){cursor:pointer}.c-bolt-accordion-item__trigger-label:not(.c-bolt-accordion-item__trigger-label--inactive):hover:before{opacity:.2}.c-bolt-accordion-item__trigger-label:not(.c-bolt-accordion-item__trigger-label--inactive):active:before{opacity:1}.c-bolt-accordion-item__trigger-link{display:block;position:absolute;top:0;right:0;width:.311rem;height:100%;outline-offset:-4px}.c-bolt-accordion-item__trigger-link:after{content:'';display:block;position:absolute;top:50%;right:50%;width:.622rem;height:.622rem;border-radius:1px;border-width:3px 3px 0 0;border-style:solid;border-color:rgba(var(--bolt-theme-link), 1);-webkit-transform-origin:50% 50%;transform-origin:50% 50%}.c-bolt-accordion-item__trigger-label--inactive~.c-bolt-accordion-item__trigger-link{visibility:hidden}.c-bolt-accordion-item__trigger-link--open:after{-webkit-transform:rotate(135deg) translateX(-50%) translateY(50%);transform:rotate(135deg) translateX(-50%) translateY(50%)}.c-bolt-accordion-item__trigger-link--close:after{-webkit-transform:rotate(-45deg);transform:rotate(-45deg)}.c-bolt-accordion-item__toggle-text{position:absolute;width:1px;height:1px;overflow:hidden;margin:-1px;padding:0;border:0;clip:rect(0 0 0 0);-webkit-clip-path:inset(50%);clip-path:inset(50%);white-space:nowrap}.c-bolt-accordion-item__state:checked+.c-bolt-accordion-item .c-bolt-accordion-item__trigger-link--open,.c-bolt-accordion-item__state:target+.c-bolt-accordion-item .c-bolt-accordion-item__trigger-link--open,.c-bolt-accordion-item__trigger-link--close{display:none}.c-bolt-accordion-item__state:checked+.c-bolt-accordion-item .c-bolt-accordion-item__trigger-link--close,.c-bolt-accordion-item__state:target+.c-bolt-accordion-item .c-bolt-accordion-item__trigger-link--close{display:block}.c-bolt-accordion-item__trigger--open{z-index:1}.c-bolt-accordion-item__trigger-icons{display:-webkit-box;display:flex;flex-shrink:0;position:relative;-webkit-transform:translateX(.25rem);transform:translateX(.25rem);overflow:hidden;color:rgba(var(--bolt-theme-link), 1);line-height:0;font-size:1.4rem}.c-bolt-accordion-item__trigger-label--inactive .c-bolt-accordion-item__trigger-icons{visibility:hidden}.c-bolt-accordion-item__trigger-icons-inner{padding:.206rem 0;display:block;-webkit-transform:rotate(0);transform:rotate(0);-webkit-transform-origin:50% 50%;transform-origin:50% 50%;will-change:transform;-webkit-transition:-webkit-transform .2s ease-in-out;transition:-webkit-transform .2s ease-in-out;transition:transform .2s ease-in-out;transition:transform .2s ease-in-out, -webkit-transform .2s ease-in-out}[aria-expanded=false] .c-bolt-accordion-item__trigger-icons-inner{-webkit-transform:rotate(0);transform:rotate(0)}[aria-expanded=true] .c-bolt-accordion-item__trigger-icons-inner{-webkit-transform:rotate(180deg);transform:rotate(180deg)}.c-bolt-accordion-item__trigger-content{-webkit-box-flex:1;flex-grow:1;margin-bottom:0}.c-bolt-accordion-item__content{display:none;position:relative;-webkit-transform:translateY(-1rem);transform:translateY(-1rem);width:100%;height:0;will-change:transform;-webkit-transition:-webkit-transform .2s cubic-bezier(0,0,.3,1) .1s;transition:-webkit-transform .2s cubic-bezier(0,0,.3,1) .1s;transition:transform .2s cubic-bezier(0,0,.3,1) .1s;transition:transform .2s cubic-bezier(0,0,.3,1) .1s, -webkit-transform .2s cubic-bezier(0,0,.3,1) .1s}.c-bolt-accordion-item__content[data-open]:not([style*=height]){visibility:visible;height:auto;-webkit-transition:none;transition:none}.c-bolt-accordion-item__content:not([role=region]){display:block;visibility:hidden;height:auto;max-height:0}.c-bolt-accordion-item__state:checked+.c-bolt-accordion-item .c-bolt-accordion-item__content,.c-bolt-accordion-item__state:target+.c-bolt-accordion-item .c-bolt-accordion-item__content{visibility:visible;-webkit-transform:translate3d(0,0,0);transform:translate3d(0,0,0);max-height:none;will-change:transform,height;-webkit-transition:height .2s ease-in-out,-webkit-transform .2s ease-in-out;transition:height .2s ease-in-out,-webkit-transform .2s ease-in-out;transition:transform .2s ease-in-out,height .2s ease-in-out;transition:transform .2s ease-in-out,height .2s ease-in-out,-webkit-transform .2s ease-in-out}.c-bolt-accordion-item__content--open{display:block;-webkit-transform:translate3d(0,0,0);transform:translate3d(0,0,0);-webkit-transition:height .2s ease-in-out;transition:height .2s ease-in-out}.c-bolt-accordion-item__content-inner{opacity:0;position:relative;overflow:auto;will-change:opacity;-webkit-transition:opacity .1s ease-in-out;transition:opacity .1s ease-in-out;-webkit-overflow-scrolling:touch}.c-bolt-accordion-item__content--opened .c-bolt-accordion-item__content-inner,.c-bolt-accordion-item__state:checked+.c-bolt-accordion-item .c-bolt-accordion-item__content-inner,.c-bolt-accordion-item__state:target+.c-bolt-accordion-item .c-bolt-accordion-item__content-inner{opacity:1;will-change:opacity;-webkit-transition:opacity .2s ease-in-out;transition:opacity .2s ease-in-out}.c-bolt-accordion-item__state+.c-bolt-accordion-item .c-bolt-accordion-item__trigger{z-index:1}.c-bolt-accordion-item--separator{border-top-color:rgba(var(--bolt-theme-text), 0.15);border-top-style:solid;border-top-width:1px}.c-bolt-accordion-item--separator.c-bolt-accordion-item--last-item{border-bottom-color:rgba(var(--bolt-theme-text), 0.15);border-bottom-style:solid;border-bottom-width:1px}.c-bolt-accordion-item--separator.c-bolt-accordion-item--box-shadow.c-bolt-accordion-item--first-item{border-top:none}.c-bolt-accordion-item--separator.c-bolt-accordion-item--box-shadow.c-bolt-accordion-item--last-item{border-bottom:none}.c-bolt-accordion-spacing--xsmall{padding:.206rem .5rem}.c-bolt-accordion-spacing--xsmall.c-bolt-accordion-item__content-inner.c-bolt-accordion-item__content-inner--offset,.c-bolt-accordion-spacing--xsmall.c-bolt-accordion-item__trigger-label.c-bolt-accordion-item__trigger-label--offset{padding-right:calc(1.9rem)}.c-bolt-accordion-spacing--xsmall.c-bolt-accordion-item__content-inner{padding-bottom:.412rem}.c-bolt-accordion-spacing--small{padding:.412rem 1rem}.c-bolt-accordion-spacing--small.c-bolt-accordion-item__content-inner.c-bolt-accordion-item__content-inner--offset,.c-bolt-accordion-spacing--small.c-bolt-accordion-item__trigger-label.c-bolt-accordion-item__trigger-label--offset{padding-right:calc(2.4rem)}.c-bolt-accordion-spacing--small.c-bolt-accordion-item__content-inner{padding-bottom:.825rem}.c-bolt-accordion-spacing--medium{padding:.825rem 2rem}.c-bolt-accordion-spacing--medium.c-bolt-accordion-item__content-inner.c-bolt-accordion-item__content-inner--offset,.c-bolt-accordion-spacing--medium.c-bolt-accordion-item__trigger-label.c-bolt-accordion-item__trigger-label--offset{padding-right:calc(3.4rem)}.c-bolt-accordion-spacing--medium.c-bolt-accordion-item__content-inner{padding-bottom:1.65rem}.c-bolt-accordion-spacing--large{padding:1.65rem 4rem}.c-bolt-accordion-spacing--large.c-bolt-accordion-item__content-inner.c-bolt-accordion-item__content-inner--offset,.c-bolt-accordion-spacing--large.c-bolt-accordion-item__trigger-label.c-bolt-accordion-item__trigger-label--offset{padding-right:calc(5.4rem)}.c-bolt-accordion-spacing--large.c-bolt-accordion-item__content-inner{padding-bottom:3.3rem}
 </style>
 <div class="c-bolt-accordion-item c-bolt-accordion-item--separator c-bolt-accordion-item--first-item">
   <div class="c-bolt-accordion-item__trigger"
@@ -521,7 +521,7 @@ exports[`<bolt-accordion> Component Default <bolt-accordion> with Shadow DOM ren
        role="region"
        aria-labelledby="handorgel1-fold1-header"
   >
-    <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--medium">
+    <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--medium c-bolt-accordion-item__content-inner--offset">
       <slot>
       </slot>
     </div>
@@ -568,7 +568,7 @@ exports[`<bolt-accordion> Component Inactive item 1`] = `
           </a>
         </div>
         <div class="c-bolt-accordion-item__content">
-          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--medium">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-item__content-inner--offset c-bolt-accordion-spacing--medium">
             <ssr-keep for="bolt-accordion-item">
               This is the accordion content.
             </ssr-keep>
@@ -606,7 +606,7 @@ exports[`<bolt-accordion> Component Inactive item 1`] = `
           </a>
         </div>
         <div class="c-bolt-accordion-item__content">
-          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--medium">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-item__content-inner--offset c-bolt-accordion-spacing--medium">
             <ssr-keep for="bolt-accordion-item">
               This is the accordion content.
             </ssr-keep>
@@ -650,7 +650,7 @@ exports[`<bolt-accordion> Component Inactive item 1`] = `
           </a>
         </div>
         <div class="c-bolt-accordion-item__content">
-          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--medium">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-item__content-inner--offset c-bolt-accordion-spacing--medium">
             <ssr-keep for="bolt-accordion-item">
               This is the accordion content.
             </ssr-keep>
@@ -701,7 +701,7 @@ exports[`<bolt-accordion> Component basic usage 1`] = `
           </a>
         </div>
         <div class="c-bolt-accordion-item__content">
-          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--medium">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-item__content-inner--offset c-bolt-accordion-spacing--medium">
             <ssr-keep for="bolt-accordion-item">
               This is the accordion content.
             </ssr-keep>
@@ -745,7 +745,7 @@ exports[`<bolt-accordion> Component basic usage 1`] = `
           </a>
         </div>
         <div class="c-bolt-accordion-item__content">
-          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--medium">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-item__content-inner--offset c-bolt-accordion-spacing--medium">
             <ssr-keep for="bolt-accordion-item">
               This is the accordion content.
             </ssr-keep>
@@ -789,7 +789,7 @@ exports[`<bolt-accordion> Component basic usage 1`] = `
           </a>
         </div>
         <div class="c-bolt-accordion-item__content">
-          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--medium">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-item__content-inner--offset c-bolt-accordion-spacing--medium">
             <ssr-keep for="bolt-accordion-item">
               This is the accordion content.
             </ssr-keep>
@@ -840,7 +840,7 @@ exports[`<bolt-accordion> Component expand single items: false 1`] = `
           </a>
         </div>
         <div class="c-bolt-accordion-item__content">
-          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--medium">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-item__content-inner--offset c-bolt-accordion-spacing--medium">
             <ssr-keep for="bolt-accordion-item">
               This is the accordion content.
             </ssr-keep>
@@ -884,7 +884,7 @@ exports[`<bolt-accordion> Component expand single items: false 1`] = `
           </a>
         </div>
         <div class="c-bolt-accordion-item__content">
-          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--medium">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-item__content-inner--offset c-bolt-accordion-spacing--medium">
             <ssr-keep for="bolt-accordion-item">
               This is the accordion content.
             </ssr-keep>
@@ -928,7 +928,7 @@ exports[`<bolt-accordion> Component expand single items: false 1`] = `
           </a>
         </div>
         <div class="c-bolt-accordion-item__content">
-          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--medium">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-item__content-inner--offset c-bolt-accordion-spacing--medium">
             <ssr-keep for="bolt-accordion-item">
               This is the accordion content.
             </ssr-keep>
@@ -979,7 +979,7 @@ exports[`<bolt-accordion> Component expand single items: true 1`] = `
           </a>
         </div>
         <div class="c-bolt-accordion-item__content">
-          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--medium">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-item__content-inner--offset c-bolt-accordion-spacing--medium">
             <ssr-keep for="bolt-accordion-item">
               This is the accordion content.
             </ssr-keep>
@@ -1023,7 +1023,7 @@ exports[`<bolt-accordion> Component expand single items: true 1`] = `
           </a>
         </div>
         <div class="c-bolt-accordion-item__content">
-          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--medium">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-item__content-inner--offset c-bolt-accordion-spacing--medium">
             <ssr-keep for="bolt-accordion-item">
               This is the accordion content.
             </ssr-keep>
@@ -1067,7 +1067,7 @@ exports[`<bolt-accordion> Component expand single items: true 1`] = `
           </a>
         </div>
         <div class="c-bolt-accordion-item__content">
-          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--medium">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-item__content-inner--offset c-bolt-accordion-spacing--medium">
             <ssr-keep for="bolt-accordion-item">
               This is the accordion content.
             </ssr-keep>
@@ -1118,7 +1118,7 @@ exports[`<bolt-accordion> Component spacing: large 1`] = `
           </a>
         </div>
         <div class="c-bolt-accordion-item__content">
-          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--large">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-item__content-inner--offset c-bolt-accordion-spacing--large">
             <ssr-keep for="bolt-accordion-item">
               This is the accordion content.
             </ssr-keep>
@@ -1162,7 +1162,7 @@ exports[`<bolt-accordion> Component spacing: large 1`] = `
           </a>
         </div>
         <div class="c-bolt-accordion-item__content">
-          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--large">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-item__content-inner--offset c-bolt-accordion-spacing--large">
             <ssr-keep for="bolt-accordion-item">
               This is the accordion content.
             </ssr-keep>
@@ -1206,7 +1206,7 @@ exports[`<bolt-accordion> Component spacing: large 1`] = `
           </a>
         </div>
         <div class="c-bolt-accordion-item__content">
-          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--large">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-item__content-inner--offset c-bolt-accordion-spacing--large">
             <ssr-keep for="bolt-accordion-item">
               This is the accordion content.
             </ssr-keep>
@@ -1257,7 +1257,7 @@ exports[`<bolt-accordion> Component spacing: medium 1`] = `
           </a>
         </div>
         <div class="c-bolt-accordion-item__content">
-          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--medium">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-item__content-inner--offset c-bolt-accordion-spacing--medium">
             <ssr-keep for="bolt-accordion-item">
               This is the accordion content.
             </ssr-keep>
@@ -1301,7 +1301,7 @@ exports[`<bolt-accordion> Component spacing: medium 1`] = `
           </a>
         </div>
         <div class="c-bolt-accordion-item__content">
-          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--medium">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-item__content-inner--offset c-bolt-accordion-spacing--medium">
             <ssr-keep for="bolt-accordion-item">
               This is the accordion content.
             </ssr-keep>
@@ -1345,7 +1345,7 @@ exports[`<bolt-accordion> Component spacing: medium 1`] = `
           </a>
         </div>
         <div class="c-bolt-accordion-item__content">
-          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--medium">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-item__content-inner--offset c-bolt-accordion-spacing--medium">
             <ssr-keep for="bolt-accordion-item">
               This is the accordion content.
             </ssr-keep>
@@ -1396,7 +1396,7 @@ exports[`<bolt-accordion> Component spacing: none 1`] = `
           </a>
         </div>
         <div class="c-bolt-accordion-item__content">
-          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--none">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-item__content-inner--offset c-bolt-accordion-spacing--none">
             <ssr-keep for="bolt-accordion-item">
               This is the accordion content.
             </ssr-keep>
@@ -1440,7 +1440,7 @@ exports[`<bolt-accordion> Component spacing: none 1`] = `
           </a>
         </div>
         <div class="c-bolt-accordion-item__content">
-          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--none">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-item__content-inner--offset c-bolt-accordion-spacing--none">
             <ssr-keep for="bolt-accordion-item">
               This is the accordion content.
             </ssr-keep>
@@ -1484,7 +1484,7 @@ exports[`<bolt-accordion> Component spacing: none 1`] = `
           </a>
         </div>
         <div class="c-bolt-accordion-item__content">
-          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--none">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-item__content-inner--offset c-bolt-accordion-spacing--none">
             <ssr-keep for="bolt-accordion-item">
               This is the accordion content.
             </ssr-keep>
@@ -1535,7 +1535,7 @@ exports[`<bolt-accordion> Component spacing: small 1`] = `
           </a>
         </div>
         <div class="c-bolt-accordion-item__content">
-          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--small">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-item__content-inner--offset c-bolt-accordion-spacing--small">
             <ssr-keep for="bolt-accordion-item">
               This is the accordion content.
             </ssr-keep>
@@ -1579,7 +1579,7 @@ exports[`<bolt-accordion> Component spacing: small 1`] = `
           </a>
         </div>
         <div class="c-bolt-accordion-item__content">
-          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--small">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-item__content-inner--offset c-bolt-accordion-spacing--small">
             <ssr-keep for="bolt-accordion-item">
               This is the accordion content.
             </ssr-keep>
@@ -1623,7 +1623,7 @@ exports[`<bolt-accordion> Component spacing: small 1`] = `
           </a>
         </div>
         <div class="c-bolt-accordion-item__content">
-          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--small">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-item__content-inner--offset c-bolt-accordion-spacing--small">
             <ssr-keep for="bolt-accordion-item">
               This is the accordion content.
             </ssr-keep>
@@ -1674,7 +1674,7 @@ exports[`<bolt-accordion> Component spacing: xsmall 1`] = `
           </a>
         </div>
         <div class="c-bolt-accordion-item__content">
-          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--xsmall">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-item__content-inner--offset c-bolt-accordion-spacing--xsmall">
             <ssr-keep for="bolt-accordion-item">
               This is the accordion content.
             </ssr-keep>
@@ -1718,7 +1718,7 @@ exports[`<bolt-accordion> Component spacing: xsmall 1`] = `
           </a>
         </div>
         <div class="c-bolt-accordion-item__content">
-          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--xsmall">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-item__content-inner--offset c-bolt-accordion-spacing--xsmall">
             <ssr-keep for="bolt-accordion-item">
               This is the accordion content.
             </ssr-keep>
@@ -1762,7 +1762,7 @@ exports[`<bolt-accordion> Component spacing: xsmall 1`] = `
           </a>
         </div>
         <div class="c-bolt-accordion-item__content">
-          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-spacing--xsmall">
+          <div class="c-bolt-accordion-item__content-inner c-bolt-accordion-item__content-inner--offset c-bolt-accordion-spacing--xsmall">
             <ssr-keep for="bolt-accordion-item">
               This is the accordion content.
             </ssr-keep>

--- a/packages/components/bolt-accordion/__tests__/accordion.js
+++ b/packages/components/bolt-accordion/__tests__/accordion.js
@@ -118,6 +118,42 @@ describe('<bolt-accordion> Component', () => {
     });
   });
 
+  spacing.enum.forEach(async spacingChoice => {
+    test(`trigger spacing: ${spacingChoice}`, async () => {
+      const results = await render(
+        '@bolt-components-accordion/accordion.twig',
+        {
+          items: [
+            {
+              trigger: 'Accordion item 1',
+              content: 'This is the accordion content.',
+              trigger_spacing: spacingChoice,
+            },
+          ],
+        },
+      );
+      expect(results.ok).toBe(true);
+      expect(results.html).toMatchSnapshot();
+    });
+    test(`content spacing: ${spacingChoice}`, async () => {
+      const results = await render(
+        '@bolt-components-accordion/accordion.twig',
+        {
+          content_spacing: spacingChoice,
+          items: [
+            {
+              trigger: 'Accordion item 1',
+              content: 'This is the accordion content.',
+              content_spacing: spacingChoice,
+            },
+          ],
+        },
+      );
+      expect(results.ok).toBe(true);
+      expect(results.html).toMatchSnapshot();
+    });
+  });
+
   test(`Inactive item`, async () => {
     const results = await render('@bolt-components-accordion/accordion.twig', {
       items: [

--- a/packages/components/bolt-accordion/__tests__/accordion.js
+++ b/packages/components/bolt-accordion/__tests__/accordion.js
@@ -1,21 +1,14 @@
 import {
   render,
-  renderString,
-  stop as stopTwigRenderer,
-} from '@bolt/twig-renderer';
-import { fixture as html } from '@open-wc/testing-helpers';
+  stopServer,
+  html,
+  vrtDefaultConfig as vrtConfig,
+} from '../../../testing/testing-helpers';
 const { readYamlFileSync } = require('@bolt/build-tools/utils/yaml');
 const { join } = require('path');
 const schema = readYamlFileSync(join(__dirname, '../accordion.schema.yml'));
-const { single, spacing } = schema.properties;
-
-async function renderTwig(template, data) {
-  return await render(template, data, true);
-}
-
-async function renderTwigString(template, data) {
-  return await renderString(template, data, true);
-}
+const { single } = schema.properties;
+const { spacing } = schema.definitions;
 
 const timeout = 120000;
 
@@ -85,24 +78,21 @@ describe('<bolt-accordion> Component', () => {
   }, timeout);
 
   afterAll(async () => {
-    await stopTwigRenderer();
+    await stopServer();
     await page.close();
   }, timeout);
 
   test('basic usage', async () => {
-    const results = await renderTwig(
-      '@bolt-components-accordion/accordion.twig',
-      {
-        items: accordionTwigItems,
-      },
-    );
+    const results = await render('@bolt-components-accordion/accordion.twig', {
+      items: accordionTwigItems,
+    });
     expect(results.ok).toBe(true);
     expect(results.html).toMatchSnapshot();
   });
 
   single.enum.forEach(async singleChoice => {
     test(`expand single items: ${singleChoice}`, async () => {
-      const results = await renderTwig(
+      const results = await render(
         '@bolt-components-accordion/accordion.twig',
         {
           single: singleChoice,
@@ -116,7 +106,7 @@ describe('<bolt-accordion> Component', () => {
 
   spacing.enum.forEach(async spacingChoice => {
     test(`spacing: ${spacingChoice}`, async () => {
-      const results = await renderTwig(
+      const results = await render(
         '@bolt-components-accordion/accordion.twig',
         {
           spacing: spacingChoice,
@@ -129,26 +119,23 @@ describe('<bolt-accordion> Component', () => {
   });
 
   test(`Inactive item`, async () => {
-    const results = await renderTwig(
-      '@bolt-components-accordion/accordion.twig',
-      {
-        items: [
-          {
-            trigger: 'Active accordion item',
-            content: 'This is the accordion content.',
-          },
-          {
-            trigger: 'Inactive accordion item',
-            content: 'This is the accordion content.',
-            inactive: true,
-          },
-          {
-            trigger: 'Active accordion item',
-            content: 'This is the accordion content.',
-          },
-        ],
-      },
-    );
+    const results = await render('@bolt-components-accordion/accordion.twig', {
+      items: [
+        {
+          trigger: 'Active accordion item',
+          content: 'This is the accordion content.',
+        },
+        {
+          trigger: 'Inactive accordion item',
+          content: 'This is the accordion content.',
+          inactive: true,
+        },
+        {
+          trigger: 'Active accordion item',
+          content: 'This is the accordion content.',
+        },
+      ],
+    });
     expect(results.ok).toBe(true);
     expect(results.html).toMatchSnapshot();
   });

--- a/packages/components/bolt-accordion/accordion.schema.yml
+++ b/packages/components/bolt-accordion/accordion.schema.yml
@@ -36,6 +36,16 @@ properties:
           type: string
           description: Accessible label for the close trigger to collapse an item.
           default: Close Accordion
+        trigger_spacing:
+          type: string
+          hidden: true
+          description: Overrides the default trigger spacing (by default, inherited from the parent bolt-accordion)
+          $ref: "#/definitions/spacing"
+        content_spacing:
+          type: string
+          hidden: true
+          description: Overrides the default content spacing (by default, inherited from the parent bolt-accordion)
+          $ref: "#/definitions/spacing"
   single:
     type: boolean
     description: Allow only one section to open at a time.
@@ -60,15 +70,10 @@ properties:
       - true
       - false
   spacing:
+    $ref: "#/definitions/spacing"
     type: string
     description: Controls the inset spacing of each item.
     default: medium
-    enum:
-      - none
-      - xsmall
-      - small
-      - medium
-      - large
   icon_valign:
     type: string
     title: icon_valign (twig) / icon-valign (web component)
@@ -77,3 +82,11 @@ properties:
     enum:
       - top
       - center
+definitions:
+  spacing:
+    enum:
+      - none
+      - xsmall
+      - small
+      - medium
+      - large

--- a/packages/components/bolt-accordion/src/AccordionItem/AccordionItemContent.js
+++ b/packages/components/bolt-accordion/src/AccordionItem/AccordionItemContent.js
@@ -4,7 +4,10 @@ import { html } from '@bolt/core/renderers/renderer-lit-html';
 export const AccordionItemContent = (children, props, context) => {
   const contentInnerClasses = css(
     'c-bolt-accordion-item__content-inner',
-    context.spacing ? `c-bolt-accordion-spacing--${context.spacing}` : '',
+    props.contentSpacing || context.spacing
+      ? `c-bolt-accordion-spacing--${props.contentSpacing || context.spacing}`
+      : '',
+    !props.contentSpacing ? 'c-bolt-accordion-item__content-inner--offset' : '',
   );
 
   const contentTemplate = children => {

--- a/packages/components/bolt-accordion/src/AccordionItem/AccordionItemTrigger.js
+++ b/packages/components/bolt-accordion/src/AccordionItem/AccordionItemTrigger.js
@@ -7,7 +7,9 @@ export const AccordionItemTrigger = (children, props, context) => {
   const labelClasses = css(
     'c-bolt-accordion-item__trigger-label',
     props.inactive ? `c-bolt-accordion-item__trigger-label--inactive` : '',
-    context.spacing ? `c-bolt-accordion-spacing--${context.spacing}` : '',
+    props.triggerSpacing || context.spacing
+      ? `c-bolt-accordion-spacing--${props.triggerSpacing || context.spacing}`
+      : '',
   );
 
   const labelInner = children => {

--- a/packages/components/bolt-accordion/src/AccordionItem/accordion-item.scss
+++ b/packages/components/bolt-accordion/src/AccordionItem/accordion-item.scss
@@ -10,7 +10,8 @@ bolt-accordion-item {
 
   // Required for no-JS styles to display properly
   replace-with-children,
-  replace-with-grandchildren {
+  replace-with-grandchildren,
+  ssr-keep {
     display: block;
     flex-grow: 1;
   }
@@ -395,7 +396,8 @@ bolt-accordion-item {
     .c-bolt-accordion-spacing--#{$spacing-value-name} {
       @include bolt-padding(#{$spacing-value-name}, squished);
 
-      &.c-bolt-accordion-item__content-inner,
+      // Applies only to js content
+      &.c-bolt-accordion-item__content-inner.c-bolt-accordion-item__content-inner--offset,
       // Applies only to no-js trigger
       &.c-bolt-accordion-item__trigger-label.c-bolt-accordion-item__trigger-label--offset {
         padding-right: calc(

--- a/packages/components/bolt-accordion/src/AccordionItem/accordion-item.twig
+++ b/packages/components/bolt-accordion/src/AccordionItem/accordion-item.twig
@@ -9,13 +9,16 @@
 {% set this = init(schema.properties.items.items) %}
 {% set inner_attributes = create_attribute({}) %}
 {% set label_attributes = create_attribute({}) %}
+{% set content_attributes = create_attribute({}) %}
 
 {% set _uuid = this.data.uuid.value|default(bolt.data.config.env == "test" ? "12345" : random()) %}
 {% set primary_uuid = base_class ~ "-#{_uuid}" %}
 {% set secondary_uuid = base_class ~ "-inner-#{_uuid}" %}
 
 {% set inactive = this.data.inactive.value %}
-{% set spacing_class = spacing ? "c-bolt-accordion-spacing--" ~ spacing : "" %}
+{% set trigger_spacing_class = "c-bolt-accordion-spacing--" ~ trigger_spacing|default(spacing) %}
+{% set content_spacing_class = "c-bolt-accordion-spacing--" ~ content_spacing|default(spacing) %}
+
 {% set trigger_tag = inactive ? "div" : "label" %}
 
 {# init() will not return "trigger" because "trigger" can be an object or array #}
@@ -35,7 +38,13 @@
   "c-bolt-accordion-item__trigger-label",
   "c-bolt-accordion-item__trigger-label--offset",
   inactive ? "c-bolt-accordion-item__trigger-label--inactive" : "",
-  spacing_class
+  trigger_spacing_class
+] %}
+
+{% set content_classes = [
+  "c-bolt-accordion-item__content-inner",
+  trigger_spacing or content_spacing ? "" : "c-bolt-accordion-item__content-inner--offset",
+  content_spacing_class
 ] %}
 
 {% if not inactive %}
@@ -79,17 +88,17 @@
         </div>
       </{{ trigger_tag }}>
 
-      <a href="#{{ primary_uuid }}" class="c-bolt-accordion-item__trigger-link c-bolt-accordion-item__trigger-link--open {{ spacing_class }}">
+      <a href="#{{ primary_uuid }}" class="c-bolt-accordion-item__trigger-link c-bolt-accordion-item__trigger-link--open {{ trigger_spacing_class }}">
         <span class="c-bolt-accordion-item__toggle-text">{{ this.data.open_label.value }}</span>
       </a>
 
-      <a href="#{{ secondary_uuid }}" class="c-bolt-accordion-item__trigger-link c-bolt-accordion-item__trigger-link--close {{ spacing_class }}">
+      <a href="#{{ secondary_uuid }}" class="c-bolt-accordion-item__trigger-link c-bolt-accordion-item__trigger-link--close {{ trigger_spacing_class }}">
         <span class="c-bolt-accordion-item__toggle-text">{{ this.data.close_label.value }}</span>
       </a>
     </div>
 
     <div class="c-bolt-accordion-item__content">
-      <div class="c-bolt-accordion-item__content-inner {{ spacing_class }}">
+      <div {{ content_attributes.addClass(content_classes) }}>
         <ssr-keep for="bolt-accordion-item">
           {{ content }}
         </ssr-keep>

--- a/packages/components/bolt-accordion/src/AccordionItem/index.js
+++ b/packages/components/bolt-accordion/src/AccordionItem/index.js
@@ -12,6 +12,8 @@ class AccordionItem extends withContext(withLitHtml()) {
 
   static props = {
     open: props.boolean,
+    contentSpacing: props.string,
+    triggerSpacing: props.string,
     inactive: props.boolean,
     uuid: props.string,
   };


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/BDS-1664

## Summary
Adds two new spacing configuration options for `<bolt-accordion-item>`s, `content-spacing` and `trigger-spacing` to allow the default spacing inherited from the parent `<bolt-accordion>` to get customized in certain situations.

## Details
> Note: this breaks out the Accordion work from #1286 into its own PR and omits the docs-site changes that were a part of the original PR. Those will be added separately.

Nested content that already contains internal space doesn't work well with our current accordion implementation as I quickly found out when I tried to put a Table component in the accordion's content and noticed that our current config options didn't allow me to line up the Table component in my accordion with other tables already on the page.

This update adds a small configuration addition to allow the accordion's default space to get used on the parent container while still being able to override the space for a particular accordion item's content and/or trigger.

## How to test
- [ ] Review code updates
- [ ] Check out the updated demo on the docs site
