### PR TITLE
feat(micro-journeys): forgo render on inactive content. 

### DIFF
--- a/packages/micro-journeys/src/interactive-pathway.js
+++ b/packages/micro-journeys/src/interactive-pathway.js
@@ -206,30 +206,35 @@ class BoltInteractivePathway extends withLitContext() {
     const navClasses = cx('c-bolt-interactive-pathway__nav');
     const itemClasses = cx('c-bolt-interactive-pathway__items');
 
-    return html`
-      ${this.addStyles([styles])}
-      <section class="${classes}">
-        <nav class="${navClasses}">
-          ${this.steps.map((step, stepIndex) => {
-            const isActiveItem = this.activeStep === stepIndex;
-            const navItemClasses = cx('c-bolt-interactive-pathway__nav-item', {
-              'c-bolt-interactive-pathway__nav-item--active': isActiveItem,
-            });
-            return html`
-              <div
-                class="${navItemClasses}"
-                @click=${() => this.setActiveStep(stepIndex)}
-              >
-                ${step.title}
-              </div>
-            `;
-          })}
-        </nav>
-        <div class="${itemClasses}">
-          ${this.slot('default')}
-        </div>
-      </section>
-    `;
+    return this.isActivePathway
+      ? html`
+          ${this.addStyles([styles])}
+          <section class="${classes}">
+            <nav class="${navClasses}">
+              ${this.steps.map((step, stepIndex) => {
+                const isActiveItem = this.activeStep === stepIndex;
+                const navItemClasses = cx(
+                  'c-bolt-interactive-pathway__nav-item',
+                  {
+                    'c-bolt-interactive-pathway__nav-item--active': isActiveItem,
+                  },
+                );
+                return html`
+                  <div
+                    class="${navItemClasses}"
+                    @click=${() => this.setActiveStep(stepIndex)}
+                  >
+                    ${step.title}
+                  </div>
+                `;
+              })}
+            </nav>
+            <div class="${itemClasses}">
+              ${this.slot('default')}
+            </div>
+          </section>
+        `
+      : '';
   }
 }
 

--- a/packages/micro-journeys/src/interactive-step.js
+++ b/packages/micro-journeys/src/interactive-step.js
@@ -155,12 +155,16 @@ class BoltInteractiveStep extends withLitContext() {
         </header>
         <div class="c-bolt-interactive-step__body">
           <div class="c-bolt-interactive-step__body-inner">
-            <div class="c-bolt-interactive-step__top-slot">
-              ${this.slot('top')}
-            </div>
-            <div class="c-bolt-interactive-step__bottom-slot">
-              ${this.slot('bottom')}
-            </div>
+            ${this._isActiveStep
+              ? html`
+                  <div class="c-bolt-interactive-step__top-slot">
+                    ${this.slot('top')}
+                  </div>
+                  <div class="c-bolt-interactive-step__bottom-slot">
+                    ${this.slot('bottom')}
+                  </div>
+                `
+              : ''}
           </div>
         </div>
       </article>


### PR DESCRIPTION
## Note:
This PR is also on hold. We should continue this conversation over at https://github.com/boltdesignsystem/bolt/pull/1528. This is a naive approach because of the way we are rendering and setting the active step/pathway.

## Jira

https://app.asana.com/0/1126340469288208/1144425881076982/f

## Summary

This avoids render on inactive pathways and steps.

However, this specifically is causing components w/o shadow dom to fail to render steps at all.

@sghoweri: do you have any insight into this?

## How to test

Visit /pattern-lab/?p=experiments-micro-journey, click around on steps and pathways.
