### PR TITLE
Fix: Update Nightwatch Config for Local Testing

### DIFF
--- a/packages/testing/testing-nightwatch/nightwatch.local.js
+++ b/packages/testing/testing-nightwatch/nightwatch.local.js
@@ -29,7 +29,7 @@ module.exports = {
   selenium: {
     start_process: true,
     server_path: seleniumServer.path,
-    port: 4444, // Standard selenium port
+    // port: 4444, // Standard selenium port -- commenting this out to try and allow selenium to auto-assign
     cli_args: {
       'webdriver.chrome.driver': chromeDriver.path,
       // 'webdriver.gecko.driver': geckoDriver.path, // temporarily disabling FF testing till self-signed cert issue (when installing geckodriver) is debugged

--- a/packages/testing/testing-nightwatch/package.json
+++ b/packages/testing/testing-nightwatch/package.json
@@ -18,7 +18,7 @@
   "main": "nightwatch.js",
   "dependencies": {
     "@zeit/fetch-retry": "^4.0.1",
-    "chromedriver": "^76.0.1",
+    "chromedriver": "^78.0.1",
     "ci-utils": "^0.6.0",
     "geckodriver": "^1.16.2",
     "globby": "^10.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5055,10 +5055,10 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@^76.0.1:
-  version "76.0.1"
-  resolved "https://registry.npmjs.org/chromedriver/-/chromedriver-76.0.1.tgz#65283299c3b34b1212eef272c32bd826c6bdebd3"
-  integrity sha512-+8BCemJLKPF2w/UpzA1uNgLWQrg1IgIO4ZYcsAjYYgqD8zUcvQ+RfwA/0TR1Zwv9Mkd8fdzTe21eZ2FyZ83DAg==
+chromedriver@^78.0.1:
+  version "78.0.1"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-78.0.1.tgz#2db3425a2cba6fcaf1a41d9538b16c3d06fa74a8"
+  integrity sha512-eOsyFk4xb9EECs1VMrDbxO713qN+Bu1XUE8K9AuePc3839TPdAegg72kpXSzkeNqRNZiHbnJUItIVCLFkDqceA==
   dependencies:
     del "^4.1.1"
     extract-zip "^1.6.7"


### PR DESCRIPTION
## Jira
N/A

## Summary
Fixes to the Nightwatch Updates the Chrome Driver version to the latest version of Chrome (used when running Nightwatch tests locally) + disables assigning a port to Selenium Server to help prevent issues if port `4444` is unavailable.

## How to test
Try running Nightwatch tests locally to confirm everything is working as expected.
