### PR TITLE
Bugfix/bds 1879 pass renderable content as list items

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/list/__tests__/-list-with-object-in-item.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/list/__tests__/-list-with-object-in-item.twig
@@ -1,0 +1,7 @@
+{% set item_1 = create_attribute({'test-attr': 'test-value'}) %}
+
+{% include "@bolt-components-list/list.twig" with {
+  items: [
+    item_1
+  ]
+} only %}

--- a/packages/components/bolt-list/__tests__/bolt-list.e2e.js
+++ b/packages/components/bolt-list/__tests__/bolt-list.e2e.js
@@ -1,0 +1,22 @@
+let currentBrowser;
+
+module.exports = {
+  tags: ['component', 'list'],
+
+  // This test would typically be more appropriate as a Jest test since it only
+  // requires simple rendering and testing the output, but Jest doesn't have an
+  // obvious way to pass along a twig object from javascript as a parameter to
+  // a twig template.
+  'Bolt List: items accept renderable objects as content': function(browser) {
+    const { testingUrl } = browser.globals;
+    currentBrowser = '--' + browser.currentEnv || 'chrome';
+
+    browser
+      .url(
+        `${testingUrl}/pattern-lab/patterns/02-components-list-__tests__--list-with-object-in-item/02-components-list-__tests__--list-with-object-in-item.html`,
+      )
+      .waitForElementVisible('bolt-list', 1000)
+      .assert.containsText('bolt-list', 'test-attr="test-value"')
+      .end();
+  },
+};

--- a/packages/components/bolt-list/list.schema.yml
+++ b/packages/components/bolt-list/list.schema.yml
@@ -10,14 +10,6 @@ properties:
   items:
     type: array
     description: Generates an array of items, each can contain renderable content (i.e. a string, render array, or included pattern).
-    properties:
-      items:
-        type: array
-        description: Renderable content for a single list item.
-        properties:
-          content:
-            type: string
-            description: Use this prop for an iterable item such as an array.
   tag:
     type: string
     description: 'Apply the semantic tag for the list.'

--- a/packages/components/bolt-list/src/_list-item.twig
+++ b/packages/components/bolt-list/src/_list-item.twig
@@ -19,7 +19,7 @@
 >
   <replace-with-grandchildren>
     <{{ tag }} {{ attributes.addClass(classes) }}>
-      {% if item is iterable %}
+      {% if item.content %}
         {{ item.content }}
       {% else %}
         {{ item }}

--- a/packages/components/bolt-table/src/table.twig
+++ b/packages/components/bolt-table/src/table.twig
@@ -50,7 +50,7 @@
               ]
             %}
             <th {{ cell_attributes.addClass(cell_classes) }} scope="col">
-              {% if cell is iterable %}
+              {% if cell.content %}
                 {{ cell.content }}
               {% else %}
                 {{ cell }}
@@ -75,7 +75,7 @@
               %}
               {% if cell is not empty %}
                 <th {{ cell_attributes.addClass(cell_classes) }} scope="row">
-                  {% if cell is iterable %}
+                  {% if cell.content %}
                     {{ cell.content }}
                   {% else %}
                     {{ cell }}
@@ -109,7 +109,7 @@
             {% for cell in side_headers.cells %}
               {% if loop.last %}
                 <th class="{{ "#{base_class}__cell #{base_class}__cell--header" }}">
-                  {% if cell is iterable %}
+                  {% if cell.content %}
                     {{ cell.content }}
                   {% else %}
                     {{ cell }}
@@ -126,7 +126,7 @@
               ]
             %}
             <td {{ cell_attributes.addClass(cell_classes) }}>
-              {% if cell is iterable %}
+              {% if cell.content %}
                 {{ cell.content }}
               {% else %}
                 {{ cell }}

--- a/packages/components/bolt-table/table.schema.yml
+++ b/packages/components/bolt-table/table.schema.yml
@@ -15,7 +15,7 @@ properties:
         type: object
         properties:
           cells:
-            description: Each item represents a cell in the top header.
+            description: Each item represents a cell in the top header.  Accepts either a renderable item (shorthand) or an item with 'content' and 'attributes' keys.
             type: array
             items:
               type: any
@@ -28,7 +28,7 @@ properties:
         type: object
         properties:
           cells:
-            description: Each item represents a cell in the side header.
+            description: Each item represents a cell in the side header.  Accepts either a renderable item (shorthand) or an item with 'content' and 'attributes' keys
             type: array
             items:
               type: any
@@ -42,7 +42,7 @@ properties:
     description: Generates an array of rows, each can contain an array of `cells`.
     properties:
       cells:
-        description: Each item represents a cell in a row.
+        description: Each item represents a cell in a row.  Accepts either a renderable item (shorthand) or an item with 'content' and 'attributes' keys
         type: array
         items:
           type: any
@@ -56,7 +56,7 @@ properties:
     description: Generates a table footer, can contain an array of `cells`.
     properties:
       cells:
-        description: Each item represents a cell in the footer.
+        description: Each item represents a cell in the footer.  Accepts either a renderable item (shorthand) or an item with 'content' and 'attributes' keys
         type: array
         items:
           type: any


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1879

## Summary

Allows render arrays to be used as items in list component

## Details

I think I figured out the reason for this "is iterable" pattern.  Specifically, for each cell in table, you might optionally want to specify some attributes for the cell itself, in which case `item` should be an array with both an `attributes` and a `content` key.  However, because that gets tedious if you _don't_ want to specify cell attributes, you can also just pass a string for each cell item as a shortcut.  As @charginghawk discovered though, this doesn't work if your item is a render array.

So, what's the upshot?
- For `bolt-list`, this pattern doesn't make sense because there's no support for separate `attributes` for each item.  Maybe there was and it got removed?  Maybe there's reason to believe we'll want it in the future?  In any case, I've updated the check to be `if item.content` instead of `if item is iterable` so that you can pass a render array for item (as long as it doesn't have a `content`) key.
- For `bolt-table`, I made the same change.  This allows you to use render arrays when using the shorthand and not specifying cell attributes.
- For `bolt-ul` and `bolt-ol`, it's basically impossible to pass a render array for an item because they interpret any array as a nested list.  I don't think there's really any good way out of this.

## How to test

- Go to `/pattern-lab/patterns/02-components-list-__tests__--list-with-object-in-item/02-components-list-__tests__--list-with-object-in-item.html` on this branch and confirm that you see the text `test-attr="test-value"`.  This indicates that something other than a string (in this case, an attributes object) can be passed as a renderable list item.
- You can also run automated nightwatch tests to confirm the same thing (I used `yarn test:e2e:quick-local`).  It should fail without the other commits on this branch and pass with them.
