### PR TITLE
fix(micro-journeys): move link component to use slot-after for icon

### DIFF
--- a/packages/micro-journeys/starters/cta-text-1.html
+++ b/packages/micro-journeys/starters/cta-text-1.html
@@ -6,7 +6,6 @@
     <bolt-icon size="medium" name="asset-presentation"></bolt-icon>
   </bolt-animate>
   <bolt-animate slot="link">
-    <bolt-link url="#">It’s not mind-reading. It’s signals<bolt-icon name="chevron-right" slot="after"></bolt-icon>
-    </bolt-link>
+    <bolt-link url="#">It’s not mind-reading. It’s signals<bolt-icon name="chevron-right" slot="after"></bolt-icon></bolt-link>
   </bolt-animate>
 </bolt-cta>

--- a/packages/micro-journeys/starters/cta-text-1.html
+++ b/packages/micro-journeys/starters/cta-text-1.html
@@ -6,9 +6,7 @@
     <bolt-icon size="medium" name="asset-presentation"></bolt-icon>
   </bolt-animate>
   <bolt-animate slot="link">
-    <bolt-link url="#">
-      It’s not mind-reading. It’s signals
-      <bolt-icon name="chevron-right"></bolt-icon>
+    <bolt-link url="#">It’s not mind-reading. It’s signals<bolt-icon name="chevron-right" slot="after"></bolt-icon>
     </bolt-link>
   </bolt-animate>
 </bolt-cta>

--- a/packages/micro-journeys/starters/cta-text-2.html
+++ b/packages/micro-journeys/starters/cta-text-2.html
@@ -6,9 +6,6 @@
     <bolt-icon name="asset-presentation"></bolt-icon>
   </bolt-animate>
   <bolt-animate slot="link">
-    <bolt-link display="inline">
-      See this in action
-      <bolt-icon name="chevron-right"></bolt-icon>
-    </bolt-link>
+    <bolt-link display="inline">See this in action<bolt-icon name="chevron-right" slot="after"></bolt-icon></bolt-link>
   </bolt-animate>
 </bolt-cta>

--- a/packages/micro-journeys/starters/cta-text-3.html
+++ b/packages/micro-journeys/starters/cta-text-3.html
@@ -3,9 +3,7 @@
 </bolt-text>
 <bolt-cta>
   <bolt-animate slot="link">
-    <bolt-link display="inline">
-      What do we mean by “next best action”?
-      <bolt-icon name="chevron-right"></bolt-icon>
+    <bolt-link display="inline">What do we mean by “next best action”?<bolt-icon name="chevron-right" slot="after"></bolt-icon>
     </bolt-link>
   </bolt-animate>
 </bolt-cta>

--- a/packages/micro-journeys/starters/cta-text-4.html
+++ b/packages/micro-journeys/starters/cta-text-4.html
@@ -3,9 +3,6 @@
 </bolt-text>
 <bolt-cta>
   <bolt-animate slot="link">
-    <bolt-link display="inline">
-      Find out how Cisco cut AHT in half
-      <bolt-icon name="chevron-right"></bolt-icon>
-    </bolt-link>
+    <bolt-link display="inline">Find out how Cisco cut AHT in half<bolt-icon name="chevron-right" slot="after"></bolt-icon></bolt-link>
   </bolt-animate>
 </bolt-cta>

--- a/packages/micro-journeys/starters/cta-text-5.html
+++ b/packages/micro-journeys/starters/cta-text-5.html
@@ -7,10 +7,7 @@
     <bolt-icon size="medium" name="co-browse"></bolt-icon>
   </bolt-animate>
   <bolt-animate slot="link">
-    <bolt-link display="inline">
-    Explore our industry-leading software
-    <bolt-icon name="chevron-right"></bolt-icon>
-  </bolt-link>
+    <bolt-link display="inline">Explore our industry-leading software<bolt-icon name="chevron-right" slot="after"></bolt-icon></bolt-link>
   </bolt-animate>
 </bolt-cta>
 <br>
@@ -19,10 +16,7 @@
     <bolt-icon size="medium" name="customer-service"></bolt-icon>
   </bolt-animate>
   <bolt-animate slot="link">
-    <bolt-link display="inline">
-    Learn more about intelligent guidance
-    <bolt-icon name="chevron-right"></bolt-icon>
-  </bolt-link>
+    <bolt-link display="inline">Learn more about intelligent guidance<bolt-icon name="chevron-right" slot="after"></bolt-icon></bolt-link>
   </bolt-animate>
 </bolt-cta>
 <br>
@@ -31,9 +25,6 @@
     <bolt-icon size="medium" name="eye"></bolt-icon>
   </bolt-animate>
   <bolt-animate slot="link">
-    <bolt-link display="inline">
-    Sign up for an upcoming demo
-    <bolt-icon name="chevron-right"></bolt-icon>
-  </bolt-link>
+    <bolt-link display="inline">Sign up for an upcoming demo<bolt-icon name="chevron-right" slot="after"></bolt-icon></bolt-link>
   </bolt-animate>
 </bolt-cta>

--- a/packages/micro-journeys/starters/cta-text-lorem.html
+++ b/packages/micro-journeys/starters/cta-text-lorem.html
@@ -6,9 +6,6 @@
     <bolt-icon size="medium" name="asset-presentation"></bolt-icon>
   </bolt-animate>
   <bolt-animate slot="link">
-    <bolt-link display="inline">
-      Ab animi atque consectetur
-      <bolt-icon name="chevron-right"></bolt-icon>
-    </bolt-link>
+    <bolt-link display="inline">Ab animi atque consectetur<bolt-icon name="chevron-right" slot="after"></bolt-icon></bolt-link>
   </bolt-animate>
 </bolt-cta>

--- a/packages/micro-journeys/starters/one-character-1.html
+++ b/packages/micro-journeys/starters/one-character-1.html
@@ -13,10 +13,7 @@
               <bolt-icon name="eye"></bolt-icon>
             </bolt-animate>
             <bolt-animate slot="link">
-              <bolt-link display="inline">
-                Customer billing view
-                <bolt-icon name="chevron-right"></bolt-icon>
-              </bolt-link>
+              <bolt-link display="inline">Customer billing view<bolt-icon name="chevron-right" slot="after"></bolt-icon></bolt-link>
             </bolt-animate>
           </bolt-cta>
         </bolt-animate>

--- a/packages/micro-journeys/starters/one-character-lorem.html
+++ b/packages/micro-journeys/starters/one-character-lorem.html
@@ -13,10 +13,7 @@
               <bolt-icon name="eye"></bolt-icon>
             </bolt-animate>
             <bolt-animate slot="link">
-              <bolt-link font-size="xsmall" display="inline">
-                Lorem ipsum dolor sit amet
-                <bolt-icon name="chevron-right"></bolt-icon>
-              </bolt-link>
+              <bolt-link font-size="xsmall" display="inline">Lorem ipsum dolor sit amet<bolt-icon name="chevron-right" slot="after"></bolt-icon></bolt-link>
             </bolt-animate>
           </bolt-cta>
         </bolt-animate>

--- a/packages/micro-journeys/starters/step-one-character-lorem.html
+++ b/packages/micro-journeys/starters/step-one-character-lorem.html
@@ -16,10 +16,7 @@
               <bolt-icon name="eye"></bolt-icon>
             </bolt-animate>
             <bolt-animate slot="link">
-              <bolt-link display="inline">
-                Lorem ipsum dolor sit amet
-                <bolt-icon name="chevron-right"></bolt-icon>
-              </bolt-link>
+              <bolt-link display="inline">Lorem ipsum dolor sit amet<bolt-icon name="chevron-right" slot="after"></bolt-icon></bolt-link>
             </bolt-animate>
           </bolt-cta>
         </bolt-animate>
@@ -36,10 +33,7 @@
         <bolt-icon size="medium" name="asset-presentation"></bolt-icon>
       </bolt-animate>
       <bolt-animate slot="link">
-        <bolt-link display="inline">
-          Ab animi atque consectetur
-          <bolt-icon name="chevron-right"></bolt-icon>
-        </bolt-link>
+        <bolt-link display="inline" slot="after">Ab animi atque consectetur<bolt-icon name="chevron-right"></bolt-icon></bolt-link>
       </bolt-animate>
     </bolt-cta>
   </bolt-animate>

--- a/packages/micro-journeys/starters/step-one-character-starter.html
+++ b/packages/micro-journeys/starters/step-one-character-starter.html
@@ -16,11 +16,7 @@
             </bolt-icon>
           </bolt-animate>
           <bolt-animate slot="link" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
-            <bolt-link display="inline" valign="center" on-click="none" class="gjs-comp-selected">
-              Customer billing view
-              <bolt-icon name="chevron-right">
-              </bolt-icon>
-            </bolt-link>
+            <bolt-link display="inline" valign="center" on-click="none" class="gjs-comp-selected">Customer billing view<bolt-icon name="chevron-right" slot="after"></bolt-icon></bolt-link>
           </bolt-animate>
         </bolt-cta>
         <bolt-text font-size="xsmall" align="inherit" color="theme-body" display="block" font-family="body" font-style="regular" font-weight="regular" letter-spacing="regular" line-height="regular" tag="p" text-transform="regular">I am text
@@ -54,9 +50,7 @@
       </bolt-icon>
     </bolt-animate>
     <bolt-animate slot="link" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
-      <bolt-link display="inline" valign="center" on-click="none">CTA text 
-        <bolt-icon name="chevron-right">
-        </bolt-icon>
+      <bolt-link display="inline" valign="center" on-click="none">CTA text<bolt-icon name="chevron-right" slot="after"></bolt-icon>
       </bolt-link>
     </bolt-animate>
   </bolt-cta>

--- a/packages/micro-journeys/starters/step-two-character-lorem.html
+++ b/packages/micro-journeys/starters/step-two-character-lorem.html
@@ -41,10 +41,7 @@
         <bolt-icon size="medium" name="asset-presentation"></bolt-icon>
       </bolt-animate>
       <bolt-animate slot="link">
-        <bolt-link display="inline">
-          Ab animi atque consectetur
-          <bolt-icon name="chevron-right"></bolt-icon>
-        </bolt-link>
+        <bolt-link display="inline">Ab animi atque consectetur<bolt-icon name="chevron-right"></bolt-icon></bolt-link>
       </bolt-animate>
     </bolt-cta>
   </bolt-animate>

--- a/packages/micro-journeys/starters/step-two-character-starter.html
+++ b/packages/micro-journeys/starters/step-two-character-starter.html
@@ -78,9 +78,7 @@
       </bolt-icon>
     </bolt-animate>
     <bolt-animate slot="link" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
-      <bolt-link display="inline" valign="center" on-click="none">It's not mind-reading. It's signals 
-        <bolt-icon name="chevron-right">
-        </bolt-icon>
+      <bolt-link display="inline" valign="center" on-click="none">It's not mind-reading. It's signals<bolt-icon name="chevron-right" slot="after"></bolt-icon>
       </bolt-link>
     </bolt-animate>
   </bolt-cta>

--- a/packages/micro-journeys/starters/step-two-character-starter.html
+++ b/packages/micro-journeys/starters/step-two-character-starter.html
@@ -9,11 +9,7 @@
           <bolt-cta>
             <bolt-icon size="medium" slot="icon" name="asset-presentation">
             </bolt-icon>
-            <bolt-link slot="link" display="inline" valign="center" on-click="none">
-              CTA Text
-              <bolt-icon name="chevron-right">
-              </bolt-icon>
-            </bolt-link>
+            <bolt-link slot="link" display="inline" valign="center" on-click="none">CTA Text<bolt-icon name="chevron-right" slot="after"></bolt-icon></bolt-link>
           </bolt-cta>
         </bolt-animate>
         <bolt-animate slot="background" in="fade-in" in-order="1" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
@@ -78,8 +74,7 @@
       </bolt-icon>
     </bolt-animate>
     <bolt-animate slot="link" initial-appearance="hidden" in="none" in-duration="500" in-easing="ease" in-order="1" idle="none" idle-duration="500" out="none" out-duration="350" out-easing="ease" out-order="1">
-      <bolt-link display="inline" valign="center" on-click="none">It's not mind-reading. It's signals<bolt-icon name="chevron-right" slot="after"></bolt-icon>
-      </bolt-link>
+      <bolt-link display="inline" valign="center" on-click="none">It's not mind-reading. It's signals<bolt-icon name="chevron-right" slot="after"></bolt-icon></bolt-link>
     </bolt-animate>
   </bolt-cta>
 </bolt-animate>

--- a/packages/micro-journeys/starters/two-characters-3.html
+++ b/packages/micro-journeys/starters/two-characters-3.html
@@ -14,10 +14,7 @@
             <bolt-icon name="eye"></bolt-icon>
           </bolt-animate>
           <bolt-animate slot="link">
-            <bolt-link display="inline">
-              Agent view of billing charges
-              <bolt-icon name="chevron-right"></bolt-icon>
-            </bolt-link>
+            <bolt-link display="inline">Agent view of billing charges<bolt-icon name="chevron-right" slot="after"></bolt-icon></bolt-link>
           </bolt-animate>
         </bolt-cta>
       </bolt-animate>


### PR DESCRIPTION
## Jira

https://app.asana.com/0/1126340469288208/1146297619076806

## Summary

Make link component to use `slot-after` for `bolt-icon` in `bolt-cta`, remove whitespace

## Details

![image](https://user-images.githubusercontent.com/1361104/68513138-e36d2e80-023f-11ea-9600-a4dad12ee938.png)


## How to test
See screenshot.

Visit patterns/06-experiments-micro-journeys-90-micro-journeys/06-experiments-micro-journeys-90-micro-journeys.html and shrink until chevron widows.
