### PR TITLE
Figure | Twig | Add media content prop

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/carousel/00-carousel-docs.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/carousel/00-carousel-docs.twig
@@ -51,55 +51,55 @@
       slides: [
         include("@bolt-components-figure/figure.twig", {
           media: {
-            image: {
+            content: include("@bolt-components-image/image.twig", {
               src: "/images/placeholders/landscape-16x9-mountains.jpg",
               alt: "Image caption",
-            },
+            }),
           },
           caption: "This is caption for image figure slide 1."
         }, with_context = false),
         include("@bolt-components-figure/figure.twig", {
           media: {
-            image: {
+            content: include("@bolt-components-image/image.twig", {
               src: "/images/placeholders/landscape-16x9-mountains.jpg",
               alt: "Image caption",
-            },
+            }),
           },
           caption: "This is caption for image figure slide 2."
         }, with_context = false),
         include("@bolt-components-figure/figure.twig", {
           media: {
-            image: {
+            content: include("@bolt-components-image/image.twig", {
               src: "/images/placeholders/landscape-16x9-mountains.jpg",
               alt: "Image caption",
-            },
+            }),
           },
           caption: "This is caption for image figure slide 3."
         }, with_context = false),
         include("@bolt-components-figure/figure.twig", {
           media: {
-            image: {
+            content: include("@bolt-components-image/image.twig", {
               src: "/images/placeholders/landscape-16x9-mountains.jpg",
               alt: "Image caption",
-            },
+            }),
           },
           caption: "This is caption for image figure slide 4."
         }, with_context = false),
         include("@bolt-components-figure/figure.twig", {
           media: {
-            image: {
+            content: include("@bolt-components-image/image.twig", {
               src: "/images/placeholders/landscape-16x9-mountains.jpg",
               alt: "Image caption",
-            },
+            }),
           },
           caption: "This is caption for image figure slide 5."
         }, with_context = false),
         include("@bolt-components-figure/figure.twig", {
           media: {
-            image: {
+            content: include("@bolt-components-image/image.twig", {
               src: "/images/placeholders/landscape-16x9-mountains.jpg",
               alt: "Image caption",
-            },
+            }),
           },
           caption: "This is caption for image figure slide 6."
         }, with_context = false),

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/carousel/25-carousel-basic-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/carousel/25-carousel-basic-variations.twig
@@ -245,13 +245,24 @@
   } only %}
 {% endset %}
 
+{% set figure_image_1 %}
+  {% include "@bolt-components-image/image.twig" with {
+    src: "/images/placeholders/landscape-16x9-mountains.jpg",
+    alt: "Image caption",
+  } only %}
+{% endset %}
+
+{% set figure_image_2 %}
+  {% include "@bolt-components-image/image.twig" with {
+    src: "/images/placeholders/landscape-16x9-skyline.jpg",
+    alt: "Image caption",
+  } only %}
+{% endset %}
+
 {% set image_slide_1 %}
   {% include "@bolt-components-figure/figure.twig" with {
     media: {
-      content: include("@bolt-components-image/image.twig", {
-        src: "/images/placeholders/landscape-16x9-mountains.jpg",
-        alt: "Image caption",
-      }),
+      content: figure_image_1
     },
     caption: "This is caption for image figure slide 1."
   } only %}
@@ -259,10 +270,7 @@
 {% set image_slide_2 %}
   {% include "@bolt-components-figure/figure.twig" with {
     media: {
-      content: include("@bolt-components-image/image.twig", {
-        src: "/images/placeholders/landscape-16x9-skyline.jpg",
-        alt: "Image caption",
-      }),
+      content: figure_image_2
     },
     caption: "This is caption for image figure slide 2."
   } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/carousel/25-carousel-basic-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/carousel/25-carousel-basic-variations.twig
@@ -248,10 +248,10 @@
 {% set image_slide_1 %}
   {% include "@bolt-components-figure/figure.twig" with {
     media: {
-      image: {
+      content: include("@bolt-components-image/image.twig", {
         src: "/images/placeholders/landscape-16x9-mountains.jpg",
         alt: "Image caption",
-      },
+      }),
     },
     caption: "This is caption for image figure slide 1."
   } only %}
@@ -259,10 +259,10 @@
 {% set image_slide_2 %}
   {% include "@bolt-components-figure/figure.twig" with {
     media: {
-      image: {
+      content: include("@bolt-components-image/image.twig", {
         src: "/images/placeholders/landscape-16x9-skyline.jpg",
         alt: "Image caption",
-      },
+      }),
     },
     caption: "This is caption for image figure slide 2."
   } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/figure/00-figure-docs.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/figure/00-figure-docs.twig
@@ -1,10 +1,13 @@
 {% set usage %}{% verbatim %}
+{% set image %}
+  {% include '@bolt-components-image/image.twig' with {
+    src: "/images/placeholders/500x500.jpg"
+  } only %}
+{% endset %}
+
 {% include "@bolt-components-figure/figure.twig" with {
   media: {
-    image: {
-      src: "/images/placeholders/500x500.jpg",
-      lazyload: false
-    },
+    content: image
   },
   caption: "Figure caption."
 } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/figure/00-figure-docs.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/figure/00-figure-docs.twig
@@ -1,13 +1,9 @@
 {% set usage %}{% verbatim %}
-{% set image %}
-  {% include '@bolt-components-image/image.twig' with {
-    src: "/images/placeholders/500x500.jpg"
-  } only %}
-{% endset %}
-
 {% include "@bolt-components-figure/figure.twig" with {
   media: {
-    content: image
+    content: include("@bolt-components-image/image.twig", {
+      src: "/images/placeholders/500x500.jpg"
+    }),
   },
   caption: "Figure caption."
 } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/figure/00-figure-docs.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/figure/00-figure-docs.twig
@@ -1,9 +1,14 @@
 {% set usage %}{% verbatim %}
+
+{% set image %}
+  {% include "@bolt-components-image/image.twig" with {
+    src: "/images/placeholders/500x500.jpg"
+  } only %}
+{% endset %}
+
 {% include "@bolt-components-figure/figure.twig" with {
   media: {
-    content: include("@bolt-components-image/image.twig", {
-      src: "/images/placeholders/500x500.jpg"
-    }),
+    content: image
   },
   caption: "Figure caption."
 } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/figure/05-figure.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/figure/05-figure.twig
@@ -1,9 +1,12 @@
+{% set image %}
+  {% include '@bolt-components-image/image.twig' with {
+    src: "/images/placeholders/500x500.jpg"
+  } only %}
+{% endset %}
+
 {% include "@bolt-components-figure/figure.twig" with {
   media: {
-    image: {
-      src: "/images/placeholders/500x500.jpg",
-      lazyload: false
-    },
+    content: image
   },
   caption: "Fig. 1: This is Bill. He is awesome."
 } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/figure/05-figure.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/figure/05-figure.twig
@@ -1,8 +1,12 @@
+{% set image %}
+  {% include "@bolt-components-image/image.twig" with {
+    src: "/images/placeholders/500x500.jpg"
+  } only %}
+{% endset %}
+
 {% include "@bolt-components-figure/figure.twig" with {
   media: {
-    content: include("@bolt-components-image/image.twig", {
-      src: "/images/placeholders/500x500.jpg"
-    }),
+    content: image
   },
   caption: "Fig. 1: This is Bill. He is awesome."
 } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/figure/05-figure.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/figure/05-figure.twig
@@ -1,12 +1,8 @@
-{% set image %}
-  {% include '@bolt-components-image/image.twig' with {
-    src: "/images/placeholders/500x500.jpg"
-  } only %}
-{% endset %}
-
 {% include "@bolt-components-figure/figure.twig" with {
   media: {
-    content: image
+    content: include("@bolt-components-image/image.twig", {
+      src: "/images/placeholders/500x500.jpg"
+    }),
   },
   caption: "Fig. 1: This is Bill. He is awesome."
 } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/figure/10-figure-media-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/figure/10-figure-media-variations.twig
@@ -1,9 +1,82 @@
+{% set image %}
+  {% include "@bolt-components-image/image.twig" with {
+    src: "/images/placeholders/landscape-16x9-mountains.jpg",
+  } only %}
+{% endset %}
+
+{% set icon %}
+  {% include "@bolt-components-icon/icon.twig" with {
+    name: "add-open",
+    size: "large",
+  } only %}
+{% endset %}
+
+{% set video %}
+  {% include "@bolt-components-video/video.twig" with {
+    "videoId": "4892122320001",
+    "accountId": "1900410236",
+    "playerId": "r1CAdLzTW",
+    "showMeta": true,
+    "showMetaTitle": true,
+  } only %}
+{% endset %}
+
+{% set table %}
+  {% include "@bolt-components-table/table.twig" with {
+    headers: {
+      top: {
+        cells: [
+          "Column 1",
+          "Column 2",
+          "Column 3",
+        ]
+      },
+      side: {
+        cells: [
+          "Row 1",
+          "Row 2",
+          "Row 3",
+          "Footer",
+        ]
+      }
+    },
+    rows: [
+      {
+        cells: [
+          "R1C1",
+          "R1C2",
+          "R1C3",
+        ]
+      },
+      {
+        cells: [
+          "R2C1",
+          "R2C2",
+          "R2C3",
+        ]
+      },
+      {
+        cells: [
+          "R3C1",
+          "R3C2",
+          "R3C3",
+        ]
+      }
+    ],
+    footer: {
+      cells: [
+        "FC1",
+        "FC2",
+        "FC3",
+      ]
+    }
+  } only %}
+{% endset %}
+
 <h3>Image Figure</h3>
 {% include "@bolt-components-figure/figure.twig" with {
   media: {
-    content: include("@bolt-components-image/image.twig", {
-      src: "/images/placeholders/landscape-16x9-mountains.jpg",
-    }),
+    content: image
   },
   caption: "Fig. 1: This is an image."
 } only %}
@@ -11,10 +84,7 @@
 <h3>Icon Figure</h3>
 {% include "@bolt-components-figure/figure.twig" with {
   media: {
-    content: include("@bolt-components-icon/icon.twig", {
-      name: "add-open",
-      size: "large",
-    }),
+    content: icon
   },
   caption: "Fig. 2: This is an icon."
 } only %}
@@ -22,13 +92,7 @@
 <h3>Video Figure</h3>
 {% include "@bolt-components-figure/figure.twig" with {
   media: {
-    content: include("@bolt-components-video/video.twig", {
-      "videoId": "4892122320001",
-      "accountId": "1900410236",
-      "playerId": "r1CAdLzTW",
-      "showMeta": true,
-      "showMetaTitle": true,
-    }),
+    content: figure
   },
   caption: "Fig. 3: This is a video."
 } only %}
@@ -36,55 +100,7 @@
 <h3>Table Figure</h3>
 {% include "@bolt-components-figure/figure.twig" with {
   media: {
-    content: include("@bolt-components-table/table.twig", {
-      headers: {
-        top: {
-          cells: [
-            "Column 1",
-            "Column 2",
-            "Column 3",
-          ]
-        },
-        side: {
-          cells: [
-            "Row 1",
-            "Row 2",
-            "Row 3",
-            "Footer",
-          ]
-        }
-      },
-      rows: [
-        {
-          cells: [
-            "R1C1",
-            "R1C2",
-            "R1C3",
-          ]
-        },
-        {
-          cells: [
-            "R2C1",
-            "R2C2",
-            "R2C3",
-          ]
-        },
-        {
-          cells: [
-            "R3C1",
-            "R3C2",
-            "R3C3",
-          ]
-        }
-      ],
-      footer: {
-        cells: [
-          "FC1",
-          "FC2",
-          "FC3",
-        ]
-      }
-    }),
+    content: table
   },
   caption: "Fig. 4: This is a table."
 } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/figure/10-figure-media-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/figure/10-figure-media-variations.twig
@@ -1,82 +1,9 @@
-{% set image %}
-  {% include '@bolt-components-image/image.twig' with {
-    src: "/images/placeholders/landscape-16x9-mountains.jpg",
-  } only %}
-{% endset %}
-
-{% set icon %}
-  {% include "@bolt-components-icon/icon.twig" with {
-    name: "add-open",
-    size: "large",
-  }%}
-{% endset %}
-
-{% set video %}
-  {% include "@bolt/video.twig" with {
-    "videoId": "4892122320001",
-    "accountId": "1900410236",
-    "playerId": "r1CAdLzTW",
-    "showMeta": true,
-    "showMetaTitle": true,
-  } only %}
-{% endset %}
-
-{% set table %}
-  {% include "@bolt-components-table/table.twig" with {
-    headers: {
-      top: {
-        cells: [
-          "Column 1",
-          "Column 2",
-          "Column 3",
-        ]
-      },
-      side: {
-        cells: [
-          "Row 1",
-          "Row 2",
-          "Row 3",
-          "Footer",
-        ]
-      }
-    },
-    rows: [
-      {
-        cells: [
-          "R1C1",
-          "R1C2",
-          "R1C3",
-        ]
-      },
-      {
-        cells: [
-          "R2C1",
-          "R2C2",
-          "R2C3",
-        ]
-      },
-      {
-        cells: [
-          "R3C1",
-          "R3C2",
-          "R3C3",
-        ]
-      }
-    ],
-    footer: {
-      cells: [
-        "FC1",
-        "FC2",
-        "FC3",
-      ]
-    }
-  } only %}
-{% endset %}
-
 <h3>Image Figure</h3>
 {% include "@bolt-components-figure/figure.twig" with {
   media: {
-    content: image
+    content: include("@bolt-components-image/image.twig", {
+      src: "/images/placeholders/landscape-16x9-mountains.jpg",
+    }),
   },
   caption: "Fig. 1: This is an image."
 } only %}
@@ -84,7 +11,10 @@
 <h3>Icon Figure</h3>
 {% include "@bolt-components-figure/figure.twig" with {
   media: {
-    content: icon
+    content: include("@bolt-components-icon/icon.twig", {
+      name: "add-open",
+      size: "large",
+    }),
   },
   caption: "Fig. 2: This is an icon."
 } only %}
@@ -92,7 +22,13 @@
 <h3>Video Figure</h3>
 {% include "@bolt-components-figure/figure.twig" with {
   media: {
-    content: video
+    content: include("@bolt-components-video/video.twig", {
+      "videoId": "4892122320001",
+      "accountId": "1900410236",
+      "playerId": "r1CAdLzTW",
+      "showMeta": true,
+      "showMetaTitle": true,
+    }),
   },
   caption: "Fig. 3: This is a video."
 } only %}
@@ -100,7 +36,55 @@
 <h3>Table Figure</h3>
 {% include "@bolt-components-figure/figure.twig" with {
   media: {
-    content: table
+    content: include("@bolt-components-table/table.twig", {
+      headers: {
+        top: {
+          cells: [
+            "Column 1",
+            "Column 2",
+            "Column 3",
+          ]
+        },
+        side: {
+          cells: [
+            "Row 1",
+            "Row 2",
+            "Row 3",
+            "Footer",
+          ]
+        }
+      },
+      rows: [
+        {
+          cells: [
+            "R1C1",
+            "R1C2",
+            "R1C3",
+          ]
+        },
+        {
+          cells: [
+            "R2C1",
+            "R2C2",
+            "R2C3",
+          ]
+        },
+        {
+          cells: [
+            "R3C1",
+            "R3C2",
+            "R3C3",
+          ]
+        }
+      ],
+      footer: {
+        cells: [
+          "FC1",
+          "FC2",
+          "FC3",
+        ]
+      }
+    }),
   },
   caption: "Fig. 4: This is a table."
 } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/figure/10-figure-media-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/figure/10-figure-media-variations.twig
@@ -1,10 +1,82 @@
+{% set image %}
+  {% include '@bolt-components-image/image.twig' with {
+    src: "/images/placeholders/landscape-16x9-mountains.jpg",
+  } only %}
+{% endset %}
+
+{% set icon %}
+  {% include "@bolt-components-icon/icon.twig" with {
+    name: "add-open",
+    size: "large",
+  }%}
+{% endset %}
+
+{% set video %}
+  {% include "@bolt/video.twig" with {
+    "videoId": "4892122320001",
+    "accountId": "1900410236",
+    "playerId": "r1CAdLzTW",
+    "showMeta": true,
+    "showMetaTitle": true,
+  } only %}
+{% endset %}
+
+{% set table %}
+  {% include "@bolt-components-table/table.twig" with {
+    headers: {
+      top: {
+        cells: [
+          "Column 1",
+          "Column 2",
+          "Column 3",
+        ]
+      },
+      side: {
+        cells: [
+          "Row 1",
+          "Row 2",
+          "Row 3",
+          "Footer",
+        ]
+      }
+    },
+    rows: [
+      {
+        cells: [
+          "R1C1",
+          "R1C2",
+          "R1C3",
+        ]
+      },
+      {
+        cells: [
+          "R2C1",
+          "R2C2",
+          "R2C3",
+        ]
+      },
+      {
+        cells: [
+          "R3C1",
+          "R3C2",
+          "R3C3",
+        ]
+      }
+    ],
+    footer: {
+      cells: [
+        "FC1",
+        "FC2",
+        "FC3",
+      ]
+    }
+  } only %}
+{% endset %}
+
 <h3>Image Figure</h3>
 {% include "@bolt-components-figure/figure.twig" with {
   media: {
-    image: {
-      src: "/images/placeholders/landscape-16x9-mountains.jpg",
-      lazyload: false,
-    },
+    content: image
   },
   caption: "Fig. 1: This is an image."
 } only %}
@@ -12,10 +84,7 @@
 <h3>Icon Figure</h3>
 {% include "@bolt-components-figure/figure.twig" with {
   media: {
-    icon: {
-      name: "add-open",
-      size: "large",
-    }
+    content: icon
   },
   caption: "Fig. 2: This is an icon."
 } only %}
@@ -23,13 +92,7 @@
 <h3>Video Figure</h3>
 {% include "@bolt-components-figure/figure.twig" with {
   media: {
-    video: {
-      "videoId": "4892122320001",
-      "accountId": "1900410236",
-      "playerId": "r1CAdLzTW",
-      "showMeta": true,
-      "showMetaTitle": true,
-    }
+    content: video
   },
   caption: "Fig. 3: This is a video."
 } only %}
@@ -37,55 +100,7 @@
 <h3>Table Figure</h3>
 {% include "@bolt-components-figure/figure.twig" with {
   media: {
-    table: {
-      headers: {
-        top: {
-          cells: [
-            "Column 1",
-            "Column 2",
-            "Column 3",
-          ]
-        },
-        side: {
-          cells: [
-            "Row 1",
-            "Row 2",
-            "Row 3",
-            "Footer",
-          ]
-        }
-      },
-      rows: [
-        {
-          cells: [
-            "R1C1",
-            "R1C2",
-            "R1C3",
-          ]
-        },
-        {
-          cells: [
-            "R2C1",
-            "R2C2",
-            "R2C3",
-          ]
-        },
-        {
-          cells: [
-            "R3C1",
-            "R3C2",
-            "R3C3",
-          ]
-        }
-      ],
-      footer: {
-        cells: [
-          "FC1",
-          "FC2",
-          "FC3",
-        ]
-      }
-    }
+    content: table
   },
   caption: "Fig. 4: This is a table."
 } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/modal/40-modal-usage-image-and-caption.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/modal/40-modal-usage-image-and-caption.twig
@@ -20,11 +20,11 @@
   {% set modal_content %}
     {% include "@bolt-components-figure/figure.twig" with {
       media: {
-        image: {
+        content: include("@bolt-components-image/image.twig", {
           src: "/images/placeholders/tout-4x3-climber.jpg",
           alt: "Image description.",
           max_width: "1000px",
-        },
+        }),
       },
       caption: caption,
     } only %}
@@ -96,10 +96,10 @@
   {% set modal_content %}
     {% include "@bolt-components-figure/figure.twig" with {
       media: {
-        image: {
+        content: include("@bolt-components-image/image.twig", {
           src: "/images/content/screenshots/device-screenshot--desktop.jpg",
           alt: "Image description.",
-        },
+        }),
       },
       caption: caption,
     } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/modal/40-modal-usage-image-and-caption.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/modal/40-modal-usage-image-and-caption.twig
@@ -17,14 +17,17 @@
       } only %}
     </div>
   {% endset %}
+  {% set modal_image_1 %}
+    {% include "@bolt-components-image/image.twig" with {
+      src: "/images/placeholders/tout-4x3-climber.jpg",
+      alt: "Image description.",
+      max_width: "1000px",
+    } only %}
+  {% endset %}
   {% set modal_content %}
     {% include "@bolt-components-figure/figure.twig" with {
       media: {
-        content: include("@bolt-components-image/image.twig", {
-          src: "/images/placeholders/tout-4x3-climber.jpg",
-          alt: "Image description.",
-          max_width: "1000px",
-        }),
+        content: modal_image_1
       },
       caption: caption,
     } only %}
@@ -93,13 +96,16 @@
       } only %}
     </div>
   {% endset %}
+  {% set modal_image_2 %}
+    {% include "@bolt-components-image/image.twig" with {
+      src: "/images/content/screenshots/device-screenshot--desktop.jpg",
+      alt: "Image description.",
+    } only %}
+  {% endset %}
   {% set modal_content %}
     {% include "@bolt-components-figure/figure.twig" with {
       media: {
-        content: include("@bolt-components-image/image.twig", {
-          src: "/images/content/screenshots/device-screenshot--desktop.jpg",
-          alt: "Image description.",
-        }),
+        content: modal_image_2
       },
       caption: caption,
     } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/04-pages/10-d8-product-pages/_product-t3-extra-videos.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/04-pages/10-d8-product-pages/_product-t3-extra-videos.twig
@@ -90,6 +90,33 @@
           tag: "h2"
         } only %}
 
+        {% set icon_1 %}
+          {% include "@bolt-components-icon/icon.twig" with {
+            name: "app-development",
+            size: "large",
+            background: "circle",
+            color: "teal"
+          } only %}
+        {% endset %}
+
+        {% set icon_2 %}
+          {% include "@bolt-components-icon/icon.twig" with {
+            name: "sales-automation",
+            size: "large",
+            background: "circle",
+            color: "teal"
+          } only %}
+        {% endset %}
+
+        {% set icon_3 %}
+          {% include "@bolt-components-icon/icon.twig" with {
+            name: "customer-service",
+            size: "large",
+            background: "circle",
+            color: "teal"
+          } only %}
+        {% endset %}
+
         {% include "@bolt/ui-list.twig" with {
           size: "small",
           contentItems : [
@@ -100,12 +127,7 @@
                   valign: "middle",
                   url: "#!",
                   figure: {
-                    "icon": {
-                      name: "app-development",
-                      size: "large",
-                      background: "circle",
-                      color: "teal"
-                    }
+                    content: icon_1
                   },
                   items: [
                     {
@@ -129,12 +151,7 @@
                   valign: "middle",
                   url: "#!",
                   figure: {
-                    "icon": {
-                      name: "sales-automation",
-                      size: "large",
-                      background: "circle",
-                      color: "teal"
-                    }
+                    content: icon_2
                   },
                   items: [
                     {
@@ -157,12 +174,7 @@
                   valign: "middle",
                   url: "#!",
                   figure: {
-                    "icon": {
-                      name: "customer-service",
-                      size: "large",
-                      background: "circle",
-                      color: "teal"
-                    }
+                    content: icon_3
                   },
                   items: [
                     {

--- a/docs-site/src/pages/pattern-lab/_patterns/04-pages/10-d8-product-pages/_product-t3.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/04-pages/10-d8-product-pages/_product-t3.twig
@@ -91,6 +91,33 @@
           tag: "h2"
         } only %}
 
+        {% set icon_1 %}
+          {% include "@bolt-components-icon/icon.twig" with {
+            name: "app-development",
+            size: "large",
+            background: "circle",
+            color: "teal"
+          } only %}
+        {% endset %}
+
+        {% set icon_2 %}
+          {% include "@bolt-components-icon/icon.twig" with {
+            name: "sales-automation",
+            size: "large",
+            background: "circle",
+            color: "teal"
+          } only %}
+        {% endset %}
+
+        {% set icon_3 %}
+          {% include "@bolt-components-icon/icon.twig" with {
+            name: "customer-service",
+            size: "large",
+            background: "circle",
+            color: "teal"
+          } only %}
+        {% endset %}
+
         {% include "@bolt/ui-list.twig" with {
           size: "small",
           contentItems : [
@@ -101,12 +128,7 @@
                   valign: "middle",
                   url: "#!",
                   figure: {
-                    "icon": {
-                      name: "app-development",
-                      size: "large",
-                      background: "circle",
-                      color: "teal"
-                    }
+                    content: icon_1
                   },
                   items: [
                     {
@@ -130,12 +152,7 @@
                   valign: "middle",
                   url: "#!",
                   figure: {
-                    "icon": {
-                      name: "sales-automation",
-                      size: "large",
-                      background: "circle",
-                      color: "teal"
-                    }
+                    content: icon_2
                   },
                   items: [
                     {
@@ -158,12 +175,7 @@
                   valign: "middle",
                   url: "#!",
                   figure: {
-                    "icon": {
-                      name: "customer-service",
-                      size: "large",
-                      background: "circle",
-                      color: "teal"
-                    }
+                    content: icon_3
                   },
                   items: [
                     {

--- a/docs-site/src/pages/pattern-lab/_patterns/04-pages/10-d8-product-pages/product-landing.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/04-pages/10-d8-product-pages/product-landing.twig
@@ -83,6 +83,32 @@
         } only %}
       {% endcell %}
 
+      {% set icon_1 %}
+        {% include "@bolt-components-icon/icon.twig" with {
+          name: "app-development",
+          size: "xlarge",
+          background: "circle",
+          color: "teal"
+        } only %}
+      {% endset %}
+
+      {% set icon_2 %}
+        {% include "@bolt-components-icon/icon.twig" with {
+          name: "sales-automation",
+          size: "xlarge",
+          background: "circle",
+          color: "teal"
+        } only %}
+      {% endset %}
+
+      {% set icon_3 %}
+        {% include "@bolt-components-icon/icon.twig" with {
+          name: "customer-service",
+          size: "xlarge",
+          background: "circle",
+          color: "teal"
+        } only %}
+      {% endset %}
 
       {% cell "u-bolt-width-1/1 u-bolt-width-1/2@small" %}
         {% set flag_item_1 %}
@@ -90,12 +116,7 @@
             valign: "middle",
             url: "#!",
             figure: {
-              "icon": {
-                name: "app-development",
-                size: "xlarge",
-                background: "circle",
-                color: "teal"
-              }
+              content: icon_1
             },
             items: [
               {
@@ -120,12 +141,7 @@
             valign: "middle",
             url: "#!",
             figure: {
-              "icon": {
-                name: "sales-automation",
-                size: "xlarge",
-                background: "circle",
-                color: "teal"
-              }
+              content: icon_2
             },
             items: [
               {
@@ -150,12 +166,7 @@
             valign: "middle",
             url: "#!",
             figure: {
-              "icon": {
-                name: "customer-service",
-                size: "xlarge",
-                background: "circle",
-                color: "teal"
-              }
+              content: icon_3
             },
             items: [
               {

--- a/docs-site/src/pages/pattern-lab/_patterns/04-pages/10-d8-product-pages/product-t2.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/04-pages/10-d8-product-pages/product-t2.twig
@@ -81,6 +81,32 @@
         } only %}
       {% endcell %}
 
+      {% set icon_1 %}
+        {% include "@bolt-components-icon/icon.twig" with {
+          name: "app-development",
+          size: "xlarge",
+          background: "circle",
+          color: "teal"
+        } only %}
+      {% endset %}
+
+      {% set icon_2 %}
+        {% include "@bolt-components-icon/icon.twig" with {
+          name: "sales-automation",
+          size: "xlarge",
+          background: "circle",
+          color: "teal"
+        } only %}
+      {% endset %}
+
+      {% set icon_3 %}
+        {% include "@bolt-components-icon/icon.twig" with {
+          name: "customer-service",
+          size: "xlarge",
+          background: "circle",
+          color: "teal"
+        } only %}
+      {% endset %}
 
       {% cell "u-bolt-width-1/1 u-bolt-width-1/2@small" %}
         {% set flag_item_1 %}
@@ -88,12 +114,7 @@
             valign: "middle",
             url: "#!",
             figure: {
-              icon: {
-                name: "app-development",
-                size: "xlarge",
-                background: "circle",
-                color: "teal"
-              }
+              content: icon_1
             },
             items: [
               {
@@ -114,12 +135,7 @@
             valign: "middle",
             url: "#!",
             figure: {
-              icon: {
-                name: "sales-automation",
-                size: "xlarge",
-                background: "circle",
-                color: "teal"
-              }
+              content: icon_2
             },
             items: [
               {
@@ -139,12 +155,7 @@
             valign: "middle",
             url: "#!",
             figure: {
-              icon: {
-                name: "customer-service",
-                size: "xlarge",
-                background: "circle",
-                color: "teal"
-              }
+              content: icon_3
             },
             items: [
               {

--- a/docs-site/src/pages/pattern-lab/_patterns/04-pages/10-d8-product-pages/product-t4.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/04-pages/10-d8-product-pages/product-t4.twig
@@ -90,6 +90,33 @@
           tag: "h2"
         } only %}
 
+        {% set icon_1 %}
+          {% include "@bolt-components-icon/icon.twig" with {
+            name: "app-development",
+            size: "large",
+            background: "circle",
+            color: "teal"
+          } only %}
+        {% endset %}
+
+        {% set icon_2 %}
+          {% include "@bolt-components-icon/icon.twig" with {
+            name: "sales-automation",
+            size: "large",
+            background: "circle",
+            color: "teal"
+          } only %}
+        {% endset %}
+
+        {% set icon_3 %}
+          {% include "@bolt-components-icon/icon.twig" with {
+            name: "customer-service",
+            size: "large",
+            background: "circle",
+            color: "teal"
+          } only %}
+        {% endset %}
+
         {% include "@bolt/ui-list.twig" with {
           size: "small",
           contentItems : [
@@ -100,12 +127,7 @@
                   valign: "middle",
                   url: "#!",
                   figure: {
-                    "icon": {
-                      name: "app-development",
-                      size: "large",
-                      background: "circle",
-                      color: "teal"
-                    }
+                    content: icon_1
                   },
                   items: [
                     {
@@ -129,12 +151,7 @@
                   valign: "middle",
                   url: "#!",
                   figure: {
-                    "icon": {
-                      name: "sales-automation",
-                      size: "large",
-                      background: "circle",
-                      color: "teal"
-                    }
+                    content: icon_2
                   },
                   items: [
                     {
@@ -157,12 +174,7 @@
                   valign: "middle",
                   url: "#!",
                   figure: {
-                    "icon": {
-                      name: "customer-service",
-                      size: "large",
-                      background: "circle",
-                      color: "teal"
-                    }
+                    content: icon_3
                   },
                   items: [
                     {

--- a/docs-site/src/pages/pattern-lab/_patterns/06-experiments/micro-journeys/combos/-95-in-page-example.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/06-experiments/micro-journeys/combos/-95-in-page-example.twig
@@ -84,6 +84,32 @@
           } only %}
         {% endcell %}
 
+        {% set icon_1 %}
+          {% include "@bolt-components-icon/icon.twig" with {
+            name: "app-development",
+            size: "xlarge",
+            background: "circle",
+            color: "teal"
+          } only %}
+        {% endset %}
+
+        {% set icon_2 %}
+          {% include "@bolt-components-icon/icon.twig" with {
+            name: "sales-automation",
+            size: "xlarge",
+            background: "circle",
+            color: "teal"
+          } only %}
+        {% endset %}
+
+        {% set icon_3 %}
+          {% include "@bolt-components-icon/icon.twig" with {
+            name: "customer-service",
+            size: "xlarge",
+            background: "circle",
+            color: "teal"
+          } only %}
+        {% endset %}
 
         {% cell "u-bolt-width-1/1 u-bolt-width-1/2@small" %}
           {% set flag_item_1 %}
@@ -91,12 +117,7 @@
               valign: "middle",
               url: "#!",
               figure: {
-                icon: {
-                  name: "app-development",
-                  size: "xlarge",
-                  background: "circle",
-                  color: "teal"
-                }
+                content: icon_1
               },
               items: [
                 {
@@ -117,12 +138,7 @@
               valign: "middle",
               url: "#!",
               figure: {
-                icon: {
-                  name: "sales-automation",
-                  size: "xlarge",
-                  background: "circle",
-                  color: "teal"
-                }
+                content: icon_2
               },
               items: [
                 {
@@ -142,12 +158,7 @@
               valign: "middle",
               url: "#!",
               figure: {
-                icon: {
-                  name: "customer-service",
-                  size: "xlarge",
-                  background: "circle",
-                  color: "teal"
-                }
+                content: icon_3
               },
               items: [
                 {

--- a/packages/components/bolt-figure/__tests__/__snapshots__/figure.js.snap
+++ b/packages/components/bolt-figure/__tests__/__snapshots__/figure.js.snap
@@ -1,5 +1,213 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`figure figure with deprecated "icon" prop still renders 1`] = `
+<bolt-figure>
+  <replace-with-grandchildren>
+    <figure class="c-bolt-figure">
+      <replace-with-children class="c-bolt-figure__media">
+        <div slot="media">
+          <bolt-icon name="add-open"
+                     size="large"
+          >
+          </bolt-icon>
+        </div>
+      </replace-with-children>
+      <replace-with-grandchildren>
+        <figcaption class="c-bolt-figure__caption">
+          Figure with icon.
+        </figcaption>
+      </replace-with-grandchildren>
+    </figure>
+  </replace-with-grandchildren>
+</bolt-figure>
+`;
+
+exports[`figure figure with deprecated "image" prop still renders 1`] = `
+<bolt-figure>
+  <replace-with-grandchildren>
+    <figure class="c-bolt-figure">
+      <replace-with-children class="c-bolt-figure__media">
+        <div slot="media">
+          <bolt-image src="/fixtures/landscape-16x9-mountains.jpg"
+                      srcset="/fixtures/landscape-16x9-mountains-50.jpg 50w, /fixtures/landscape-16x9-mountains-100.jpg 100w, /fixtures/landscape-16x9-mountains-200.jpg 200w, /fixtures/landscape-16x9-mountains-320.jpg 320w, /fixtures/landscape-16x9-mountains-480.jpg 480w, /fixtures/landscape-16x9-mountains-640.jpg 640w, /fixtures/landscape-16x9-mountains-800.jpg 800w, /fixtures/landscape-16x9-mountains-1024.jpg 1024w"
+                      sizes="auto"
+                      ratio="1151/638"
+                      placeholder-color="hsl(233, 33%, 97%)"
+                      placeholder-image="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+                      no-lazy
+                      style="background-color: hsl(233, 33%, 97%);"
+          >
+            <bolt-ratio ratio="1151/638">
+              <replace-with-children class="c-bolt-ratio"
+                                     style="padding-bottom: calc((638 / 1151) * 100%); --aspect-ratio: 1.8040752351097;"
+              >
+                <img class="c-bolt-image__image-placeholder"
+                     sizes="auto"
+                     src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+                >
+                <img class="c-bolt-image__image"
+                     srcset="/fixtures/landscape-16x9-mountains-50.jpg 50w, /fixtures/landscape-16x9-mountains-100.jpg 100w, /fixtures/landscape-16x9-mountains-200.jpg 200w, /fixtures/landscape-16x9-mountains-320.jpg 320w, /fixtures/landscape-16x9-mountains-480.jpg 480w, /fixtures/landscape-16x9-mountains-640.jpg 640w, /fixtures/landscape-16x9-mountains-800.jpg 800w, /fixtures/landscape-16x9-mountains-1024.jpg 1024w"
+                     sizes="auto"
+                     src="/fixtures/landscape-16x9-mountains.jpg"
+                >
+              </replace-with-children>
+            </bolt-ratio>
+          </bolt-image>
+        </div>
+      </replace-with-children>
+      <replace-with-grandchildren>
+        <figcaption class="c-bolt-figure__caption">
+          Figure with image.
+        </figcaption>
+      </replace-with-grandchildren>
+    </figure>
+  </replace-with-grandchildren>
+</bolt-figure>
+`;
+
+exports[`figure figure with deprecated "table" prop still renders 1`] = `
+<bolt-figure>
+  <replace-with-grandchildren>
+    <figure class="c-bolt-figure">
+      <replace-with-children class="c-bolt-figure__media">
+        <div slot="media">
+          <bolt-table format="regular">
+            <table class="c-bolt-table">
+              <thead class="c-bolt-table__head">
+                <tr class="c-bolt-table__row">
+                  <td class="c-bolt-table__cell">
+                  </td>
+                  <th class="c-bolt-table__cell c-bolt-table__cell--header"
+                      scope="col"
+                  >
+                    Column 1
+                  </th>
+                  <th class="c-bolt-table__cell c-bolt-table__cell--header"
+                      scope="col"
+                  >
+                    Column 2
+                  </th>
+                  <th class="c-bolt-table__cell c-bolt-table__cell--header"
+                      scope="col"
+                  >
+                    Column 3
+                  </th>
+                </tr>
+              </thead>
+              <tbody class="c-bolt-table__body">
+                <tr class="c-bolt-table__row">
+                  <th class="c-bolt-table__cell c-bolt-table__cell--header"
+                      scope="row"
+                  >
+                    Row 1
+                  </th>
+                  <td class="c-bolt-table__cell c-bolt-table__cell--data">
+                    R1C1
+                  </td>
+                  <td class="c-bolt-table__cell c-bolt-table__cell--data">
+                    R1C2
+                  </td>
+                  <td class="c-bolt-table__cell c-bolt-table__cell--data">
+                    R1C3
+                  </td>
+                </tr>
+                <tr class="c-bolt-table__row">
+                  <th class="c-bolt-table__cell c-bolt-table__cell--header"
+                      scope="row"
+                  >
+                    Row 2
+                  </th>
+                  <td class="c-bolt-table__cell c-bolt-table__cell--data">
+                    R2C1
+                  </td>
+                  <td class="c-bolt-table__cell c-bolt-table__cell--data">
+                    R2C2
+                  </td>
+                  <td class="c-bolt-table__cell c-bolt-table__cell--data">
+                    R2C3
+                  </td>
+                </tr>
+                <tr class="c-bolt-table__row">
+                  <th class="c-bolt-table__cell c-bolt-table__cell--header"
+                      scope="row"
+                  >
+                    Row 3
+                  </th>
+                  <td class="c-bolt-table__cell c-bolt-table__cell--data">
+                    R3C1
+                  </td>
+                  <td class="c-bolt-table__cell c-bolt-table__cell--data">
+                    R3C2
+                  </td>
+                  <td class="c-bolt-table__cell c-bolt-table__cell--data">
+                    R3C3
+                  </td>
+                </tr>
+              </tbody>
+              <tfoot class="c-bolt-table__foot">
+                <tr class="c-bolt-table__row">
+                  <th class="c-bolt-table__cell c-bolt-table__cell--header">
+                    Footer
+                  </th>
+                  <td class="c-bolt-table__cell c-bolt-table__cell--data">
+                    FC1
+                  </td>
+                  <td class="c-bolt-table__cell c-bolt-table__cell--data">
+                    FC2
+                  </td>
+                  <td class="c-bolt-table__cell c-bolt-table__cell--data">
+                    FC3
+                  </td>
+                </tr>
+              </tfoot>
+            </table>
+          </bolt-table>
+        </div>
+      </replace-with-children>
+      <replace-with-grandchildren>
+        <figcaption class="c-bolt-figure__caption">
+          Figure with table.
+        </figcaption>
+      </replace-with-grandchildren>
+    </figure>
+  </replace-with-grandchildren>
+</bolt-figure>
+`;
+
+exports[`figure figure with deprecated "video" prop still renders 1`] = `
+<bolt-figure>
+  <replace-with-grandchildren>
+    <figure class="c-bolt-figure">
+      <replace-with-children class="c-bolt-figure__media">
+        <div slot="media">
+          <bolt-ratio ratio="16/9">
+            <replace-with-children class="c-bolt-ratio"
+                                   style="padding-bottom: calc((9 / 16) * 100%); --aspect-ratio: 1.7777777777778;"
+            >
+              <bolt-video class="js-bolt-video-uuid--12345"
+                          video-id="4892122320001"
+                          account-id="1900410236"
+                          show-meta
+                          show-meta-title
+                          player-id="r1CAdLzTW"
+                          controls
+                          share-description="Share This Video"
+              >
+              </bolt-video>
+            </replace-with-children>
+          </bolt-ratio>
+        </div>
+      </replace-with-children>
+      <replace-with-grandchildren>
+        <figcaption class="c-bolt-figure__caption">
+          Figure with video.
+        </figcaption>
+      </replace-with-grandchildren>
+    </figure>
+  </replace-with-grandchildren>
+</bolt-figure>
+`;
+
 exports[`figure figure with icon 1`] = `
 <bolt-figure>
   <replace-with-grandchildren>

--- a/packages/components/bolt-figure/__tests__/figure.js
+++ b/packages/components/bolt-figure/__tests__/figure.js
@@ -14,6 +14,20 @@ describe('figure', () => {
 
   Object.keys(media).forEach(async item => {
     test(`figure with ${item}`, async () => {
+      const data = JSON.stringify(media[item]);
+      const results = await renderString(`
+        {% include '@bolt-components-figure/figure.twig' with {
+          media: {
+            content: include('@bolt-components-${item}/${item}.twig', ${data})
+          },
+          caption: 'Figure with ${item}.'
+         } %}
+      `);
+      expect(results.ok).toBe(true);
+      expect(results.html).toMatchSnapshot();
+    });
+
+    test(`figure with deprecated "${item}" prop still renders`, async () => {
       const results = await render('@bolt-components-figure/figure.twig', {
         media: {
           [item]: media[item],

--- a/packages/components/bolt-figure/figure.schema.yml
+++ b/packages/components/bolt-figure/figure.schema.yml
@@ -8,19 +8,26 @@ properties:
     type: object
     description: Media accepts either image, icon, video, or table.
     properties:
+      content:
+        type: any
+        description: Figure media content. Pass any renderable content, e.g image, icon, video, etc.
       image:
+        title: 'Deprecated'
         type: object
         description: A Bolt image object.
         ref: '@bolt-components-image/image.schema.yml'
       icon:
+        title: 'Deprecated'
         type: object
         description: A Bolt icon object.
         ref: '@bolt-components-icon/icon.schema.json'
       video:
+        title: 'Deprecated'
         type: object
         description: A Bolt video object.
         ref: '@bolt-components-video/video.schema.yml'
       table:
+        title: 'Deprecated'
         type: object
         description: A Bolt table object.
         ref: '@bolt-components-table/table.schema.yml'

--- a/packages/components/bolt-figure/figure.schema.yml
+++ b/packages/components/bolt-figure/figure.schema.yml
@@ -7,29 +7,39 @@ properties:
   media:
     type: object
     description: Pass in any renderable media content via the `media.content` prop.
+    not:
+      anyOf:
+        - required:
+            - image
+        - required:
+            - icon
+        - required:
+            - video
+        - required:
+            - table
     properties:
       content:
         type: any
         description: Figure media content, e.g image, icon, video, etc.
       image:
-        title: 'Deprecated'
+        title: DEPRECATED
         type: object
-        description: A Bolt image object.
+        description: Use the `content` prop instead.
         ref: '@bolt-components-image/image.schema.yml'
       icon:
-        title: 'Deprecated'
+        title: DEPRECATED
         type: object
-        description: A Bolt icon object.
+        description: Use the `content` prop instead.
         ref: '@bolt-components-icon/icon.schema.json'
       video:
-        title: 'Deprecated'
+        title: DEPRECATED
         type: object
-        description: A Bolt video object.
+        description: Use the `content` prop instead.
         ref: '@bolt-components-video/video.schema.yml'
       table:
-        title: 'Deprecated'
+        title: DEPRECATED
         type: object
-        description: A Bolt table object.
+        description: Use the `content` prop instead.
         ref: '@bolt-components-table/table.schema.yml'
   caption:
     type: [string, object, array]

--- a/packages/components/bolt-figure/figure.schema.yml
+++ b/packages/components/bolt-figure/figure.schema.yml
@@ -6,11 +6,11 @@ properties:
     description: A Drupal-style attributes object with extra attributes to append to this component.
   media:
     type: object
-    description: Media accepts either image, icon, video, or table.
+    description: Pass in any renderable media content via the `media.content` prop.
     properties:
       content:
         type: any
-        description: Figure media content. Pass any renderable content, e.g image, icon, video, etc.
+        description: Figure media content, e.g image, icon, video, etc.
       image:
         title: 'Deprecated'
         type: object

--- a/packages/components/bolt-figure/src/figure.twig
+++ b/packages/components/bolt-figure/src/figure.twig
@@ -41,12 +41,17 @@
       {% if media %}
         <replace-with-children class="{{ "#{base_class}__media" }}">
           <div slot="media">
+            {% set content = media.content %}
+
+            {# `image`, `icon`, `video`, and `table` are DEPRECATED. Use `content` instead. #}
             {% set image = media.image %}
             {% set icon = media.icon %}
             {% set video = media.video %}
             {% set table = media.table %}
 
-            {% if image %}
+            {% if content %}
+              {{ content }}
+            {% elseif image %}
               {% include "@bolt-components-image/image.twig" with image only %}
             {% elseif icon %}
               {% include "@bolt-components-icon/icon.twig" with icon only %}

--- a/packages/global/styles/05-objects/objects-flag/src/flag.twig
+++ b/packages/global/styles/05-objects/objects-flag/src/flag.twig
@@ -29,13 +29,20 @@
 
 <div {{ attributes.addClass(classes | raw) }}>
   {% if figure %}
+    {% set old_figure_with_content = figure.content %}
     {% set old_figure_with_icon = figure.icon %}
     {% set old_figure_with_image = figure.image %}
 
     <div class="o-bolt-flag__figure">
       {% block flag_figure %}
         {% set figureContent %}
-          {% if old_figure_with_icon %}
+          {% if old_figure_with_content %}
+            {% include "@bolt-components-figure/figure.twig" with {
+              media: {
+                content: old_figure_with_content
+              }
+            } only %}
+          {% elseif old_figure_with_icon %}
             {% include "@bolt-components-figure/figure.twig" with {
               media: {
                 icon: old_figure_with_icon


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1781

## Summary

Add `media.content` prop to Figure. Deprecate `media.image`, `media.icon`, `media.video`, `media.table`.

## Details

This makes the Figure component more flexible. Users can pass in any renderable content to the `media.content` prop. This opens up the possibility of passing in a Drupal render array. Previously users could only pass in data.

Before:
```
{% include "@bolt-components-figure/figure.twig" with {
  media: {
    image: {
      src: "/images/placeholders/500x500.jpg",
    },
  },
  caption: "Figure caption"
} only %}
```
After:
```
{% include "@bolt-components-figure/figure.twig" with {
  media: {
    content: include("@bolt-components-image/image.twig", {
      src: "/images/placeholders/500x500.jpg"
    }),
  },
  caption: "Figure caption"
} only %}
```

## How to test

- Review files changed
- Checkout locally and review all Figure demo pages
- Tests are passing
