### PR TITLE
BDS-1905 Reference icon schema in button schema

### DIFF
--- a/packages/components/bolt-button/button.schema.js
+++ b/packages/components/bolt-button/button.schema.js
@@ -1,3 +1,18 @@
+const iconSchema = require('@bolt/components-icon/icon.schema.json');
+let buttonIconSchema = { ...iconSchema };
+
+buttonIconSchema.properties = {
+  position: {
+    type: 'string',
+    default: 'after',
+    enum: ['before', 'after'],
+  },
+  ...iconSchema.properties,
+};
+
+buttonIconSchema.description =
+  'Icon data as expected by the icon component. Accepts an additional position prop that determines placement within the button.';
+
 module.exports = {
   $schema: 'http://json-schema.org/draft-04/schema#',
   title: 'Bolt Button',
@@ -66,19 +81,7 @@ module.exports = {
       enum: ['start', 'center', 'end'],
       default: 'center',
     },
-    icon: {
-      type: 'object',
-      description:
-        'Icon data as expected by the icon component. Accepts an additional position prop that determines placement within the button.',
-      ref: '@bolt-components-icon/icon.schema.json',
-      properties: {
-        position: {
-          type: 'string',
-          default: 'after',
-          enum: ['before', 'after'],
-        },
-      },
-    },
+    icon: buttonIconSchema,
     iconOnly: {
       type: 'boolean',
       description:

--- a/packages/components/bolt-button/button.schema.js
+++ b/packages/components/bolt-button/button.schema.js
@@ -2,6 +2,7 @@ const iconSchema = require('@bolt/components-icon/icon.schema.json');
 
 iconSchema.properties = {
   position: {
+    description: 'Where to position the icon within the button',
     type: 'string',
     default: 'after',
     enum: ['before', 'after'],

--- a/packages/components/bolt-button/button.schema.js
+++ b/packages/components/bolt-button/button.schema.js
@@ -1,7 +1,6 @@
 const iconSchema = require('@bolt/components-icon/icon.schema.json');
-let buttonIconSchema = { ...iconSchema };
 
-buttonIconSchema.properties = {
+iconSchema.properties = {
   position: {
     type: 'string',
     default: 'after',
@@ -10,7 +9,7 @@ buttonIconSchema.properties = {
   ...iconSchema.properties,
 };
 
-buttonIconSchema.description =
+iconSchema.description =
   'Icon data as expected by the icon component. Accepts an additional position prop that determines placement within the button.';
 
 module.exports = {
@@ -81,7 +80,7 @@ module.exports = {
       enum: ['start', 'center', 'end'],
       default: 'center',
     },
-    icon: buttonIconSchema,
+    icon: iconSchema,
     iconOnly: {
       type: 'boolean',
       description:


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1905

## Summary

Demos the usage of one schema (icon) within another (button), with modification

## Details

One visible change in the docs is that the details for icon no longer appear within a collapsed fieldset, as shown in the screenshots below.  We could probably make that still happen by modifying the schema docs template (and adding some indication that a schema should be collapsed?).

One advantage to the new method, however, is that the schema now includes the additional `position` prop that only icons within buttons can include.

Before
![Screen Shot 2019-11-12 at 7 55 09 PM](https://user-images.githubusercontent.com/677668/68723398-7aaaec80-0586-11ea-9afd-f3c4ab028a50.png)

After:
![Screen Shot 2019-11-12 at 7 54 55 PM](https://user-images.githubusercontent.com/677668/68723397-7aaaec80-0586-11ea-947f-3bf519e3bf74.png)

## How to test

Confirm no regressions.
