### PR TITLE
Accordion | Test | Use Jest page selector instead of evaluate

### DIFF
--- a/packages/components/bolt-accordion/__tests__/accordion.js
+++ b/packages/components/bolt-accordion/__tests__/accordion.js
@@ -202,14 +202,15 @@ describe('<bolt-accordion> Component', () => {
     // Wait for Handorgel to run, starts after component 'ready' event
     await page.waitFor(250);
 
-    const accordionShadowRoot = await page.evaluate(async () => {
-      return document.querySelector('bolt-accordion').renderRoot.innerHTML;
-    });
+    const accordionShadowRoot = await page.$eval(
+      'bolt-accordion',
+      el => el.renderRoot.innerHTML,
+    );
 
-    const accordionItemShadowRoot = await page.evaluate(async () => {
-      const item = document.querySelector('bolt-accordion-item');
-      return item.renderRoot.innerHTML;
-    });
+    const accordionItemShadowRoot = await page.$eval(
+      'bolt-accordion-item',
+      el => el.renderRoot.innerHTML,
+    );
 
     const renderedShadowRoot = await html(`<div>${accordionShadowRoot}</div>`);
     const renderedItemShadowRoot = await html(


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1871

## Summary

Switch to using Puppeteer's page selector in Jest test.

## Details

This is a small PR just to capture an example of where we can use Puppeteer's page selector instead of always using evaluate to interact with the `page`.

https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pageselector

## How to test

- Review the file changed
- Tests are passing
