### PR TITLE
Modal | FE | Add auto-close demo

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/modal/35-modal-usage-javascript.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/modal/35-modal-usage-javascript.twig
@@ -1,4 +1,4 @@
-{% set javascript %}
+{% set javascript_open %}
 <script>
   // Add parameter to the URL - demo helper function, not required in production
   var setAutoOpenModalParam = function(set){
@@ -68,7 +68,7 @@
         id: "js-modal-advanced-auto-open"
       },
     } only %}
-    {{ javascript }}
+    {{ javascript_open }}
   {% endset %}
   {% set description %}
     <bolt-text headline font-size="large">Automatically open a modal</bolt-text>
@@ -98,7 +98,101 @@
 
 <bolt-text headline font-size="large">Custom JavaScript</bolt-text>
 <bolt-code-snippet syntax="dark" lang="html">{% spaceless %}
-  {{ javascript | replace({
+  {{ javascript_open | replace({
+    '<': '&lt;',
+    '>': '&gt;',
+  }) | trim | raw }}
+{% endspaceless %}</bolt-code-snippet>
+
+
+{% set javascript_close %}
+<script>
+  openAutoCloseModal = function() {
+    // Reference to the modal
+    var autoCloseModal = document.querySelector('#js-modal-advanced-auto-close');
+
+    // When modal opens, start a timer and close after 3 seconds
+    var onModalShow = function() {
+      setTimeout(function() {
+        autoCloseModal.hide();
+        // Don't forget to remove the event listener
+        autoCloseModal.removeEventListener('modal:show', onModalShow);
+      }, 3000);
+    };
+
+    // Wait for 'modal:show' event and call custom function
+    autoCloseModal.addEventListener('modal:show', onModalShow);
+
+    if (autoCloseModal._wasInitiallyRendered) {
+      // If modal is ready, show it now
+      autoCloseModal.show();
+    } else {
+      // Otherwise, wait to show until 'modal:ready' event is emitted
+      autoCloseModal.addEventListener('modal:ready', function() {
+        autoCloseModal.show();
+      });
+    }
+  };
+</script>
+{% endset %}
+
+<bolt-text headline font-size="large">Demo</bolt-text>
+<div class="t-bolt-light u-bolt-padding-medium u-bolt-margin-bottom-small">
+  {% set modal_content %}
+    {% include "@bolt-components-headline/headline.twig" with {
+      size: "xlarge",
+      text: "Auto-close Modal",
+    } only %}
+    {% include "@bolt-components-headline/text.twig" with {
+      text: "This modal will close 3 seconds after opening."
+    } only %}
+  {% endset %}
+  {% set trigger %}
+    {% include "@bolt-components-button/button.twig" with {
+      text: "Open Modal",
+      size: "small",
+      width: "full",
+      attributes: {
+        onclick: "openAutoCloseModal()",
+      }
+    } only %}
+    {% include "@bolt-components-modal/modal.twig" with {
+      content: modal_content,
+      attributes: {
+        id: "js-modal-advanced-auto-close"
+      },
+    } only %}
+    {{ javascript_close }}
+  {% endset %}
+  {% set description %}
+    <bolt-text headline font-size="large">Automatically close a modal</bolt-text>
+    <bolt-text>Use custom JavaScript to automatically close a modal after a set period of time. Click on the "Open Modal" button to see a demo. The modal will open and automatically close after 3 seconds.</bolt-text>
+  {% endset %}
+  {% include "@bolt-components-grid/grid.twig" with {
+    items: [
+      {
+        column_start: "1 1@small",
+        column_span: "12 8@small 9@medium",
+        row_start: "2 1@small",
+        row_span: "1",
+        valign: "center",
+        content: description,
+      },
+      {
+        column_start: "1 10@small 11@medium",
+        column_span: "6 3@small 2@medium",
+        row_start: "1 1@small",
+        row_span: "1",
+        valign: "center",
+        content: trigger,
+      },
+    ]
+  } only %}
+</div>
+
+<bolt-text headline font-size="large">Custom JavaScript</bolt-text>
+<bolt-code-snippet syntax="dark" lang="html">{% spaceless %}
+  {{ javascript_close | replace({
     '<': '&lt;',
     '>': '&gt;',
   }) | trim | raw }}


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1361

## Summary

Add demo of modal auto-closing after a set period of time.

## Details

Adds another Custom JavaScript Usage demo, showing how to hook into modal component to auto-close after 3 seconds.

## How to test
- Checkout `feature/modal-auto-close` locally
- Review the second demo on the [Custom JS Usage](http://localhost:3000/pattern-lab/patterns/02-components-modal-35-modal-usage-javascript/02-components-modal-35-modal-usage-javascript.html) page
- Verify demo works as expected
- Review the custom JS