### PR TITLE
Hotfix: Pattern Lab CSS Fix for IE 11

### DIFF
--- a/packages/uikit-workshop/src/sass/scss/02-base/_body.scss
+++ b/packages/uikit-workshop/src/sass/scss/02-base/_body.scss
@@ -10,6 +10,7 @@
 .pl-c-html {
   min-height: 100%;
   display: flex;
+  height: 100%; // fix for IE 11
 }
 
 .pl-c-body {


### PR DESCRIPTION
## Jira
N/A

## Summary
Pattern Lab UIKit CSS fix for IE 11 to address the main viewport container collapsing in height. This change matches up with the hotfix that went out earlier today: https://github.com/pattern-lab/patternlab-node/pull/1099
