### PR TITLE
Feature/bds 1911 icon cleanup

### DIFF
--- a/packages/build-tools/tasks/icon-tasks.js
+++ b/packages/build-tools/tasks/icon-tasks.js
@@ -23,9 +23,7 @@ const failedRebuildingIconsMsg = 'Failed to rebuild Bolt SVG Icons!';
 
 async function build() {
   const iconSpinner = new Ora(
-    chalk.blue(
-      initialBuild ? startBuildingIconsMsg : startRebuildingIconsMsg,
-    ),
+    chalk.blue(initialBuild ? startBuildingIconsMsg : startRebuildingIconsMsg),
   ).start();
 
   try {
@@ -37,7 +35,7 @@ async function build() {
       extendedIconDirs,
     );
 
-    await function generateSchemaFile(icons);
+    await generateSchemaFile(icons);
 
     iconSpinner.succeed(
       chalk.green(
@@ -65,42 +63,22 @@ build.description = 'Minify & convert raw SVG files to browser-friendly icons.';
 build.displayName = 'icons:build';
 
 async function generateSchemaFile(icons) {
-  try {
-    const config = await getConfig();
-    const iconComponentDir = path.dirname(
-      resolve.sync('@bolt/components-icon/package.json'),
-    );
-    const iconComponentSchema = path.join(iconComponentDir, 'icon.schema.json');
-    const names = icons.map(icon => icon.id);
-    const schema = await fs.readJson(iconComponentSchema);
-    schema.properties.name.enum = names;
+  const config = await getConfig();
+  const iconComponentDir = path.dirname(
+    resolve.sync('@bolt/components-icon/package.json'),
+  );
+  const iconComponentSchema = path.join(iconComponentDir, 'icon.schema.json');
+  const names = icons.map(icon => icon.id);
+  const schema = await fs.readJson(iconComponentSchema);
+  schema.properties.name.enum = names;
 
-    // update bolt-icon schema with newest icons from svgs folder
-    await fs.writeJson(iconComponentSchema, schema, { spaces: 2 });
-    // generate `icons.bolt.json` file with newest icons array
-    await fs.writeFile(
-      path.join(config.dataDir, 'icons.bolt.json'),
-      JSON.stringify(names, null, 4),
-    );
-
-    iconSpinner.succeed(
-      chalk.green(
-        initialBuild ? finishedBuildingIconsMsg : finishedRebuildingIconsMsg,
-      ),
-    );
-
-    initialBuild = false;
-  } catch (error) {
-    iconSpinner.fail(
-      chalk.red(
-        initialBuild
-          ? `Error trying to generate Icon YAML document for "@bolt/components-icon". ${error}`
-          : `Error trying to regenerate Icon YAML document for "@bolt/components-icon". ${error}`,
-      ),
-    );
-
-    process.exitCode = 1;
-  }
+  // update bolt-icon schema with newest icons from svgs folder
+  await fs.writeJson(iconComponentSchema, schema, { spaces: 2 });
+  // generate `icons.bolt.json` file with newest icons array
+  await fs.writeFile(
+    path.join(config.dataDir, 'icons.bolt.json'),
+    JSON.stringify(names, null, 4),
+  );
 }
 
 async function watch() {

--- a/packages/build-tools/tasks/icon-tasks.js
+++ b/packages/build-tools/tasks/icon-tasks.js
@@ -1,21 +1,15 @@
-const fs = require('fs-extra');
-const globby = require('globby');
-const uppercamelcase = require('uppercamelcase');
-const path = require('path');
-const cheerio = require('cheerio');
-const prettier = require('prettier');
-const SVGO = require('svgo');
-const yaml = require('js-yaml');
 const resolve = require('resolve');
+const fs = require('fs-extra');
+const path = require('path');
 const debounce = require('lodash.debounce');
 const chokidar = require('chokidar');
 const Ora = require('ora');
 const chalk = require('chalk');
 const { getConfig } = require('@bolt/build-utils/config-store');
 const log = require('@bolt/build-utils/log');
+const iconGenerator = require('@bolt/build-utils/icon-generator');
 
 let initialBuild = true;
-let iconSpinner;
 
 const startBuildingIconsMsg = 'Building Bolt SVG Icons for the first time...';
 const startRebuildingIconsMsg = 'Rebuilding Bolt SVG Icons...';
@@ -27,287 +21,29 @@ const finishedRebuildingIconsMsg =
 const failedBuildingIconsMsg = 'Initial build of the Bolt SVG Icons failed!';
 const failedRebuildingIconsMsg = 'Failed to rebuild Bolt SVG Icons!';
 
-const svgo = new SVGO({
-  plugins: [
-    {
-      removeViewBox: false,
-    },
-    {
-      removeXMLNS: true,
-    },
-    {
-      cleanupAttrs: true,
-    },
-    {
-      removeDoctype: true,
-    },
-    {
-      removeXMLProcInst: true,
-    },
-    {
-      removeComments: true,
-    },
-    {
-      removeMetadata: true,
-    },
-    {
-      removeTitle: true,
-    },
-    {
-      removeDesc: true,
-    },
-    {
-      removeUselessDefs: true,
-    },
-    {
-      removeEditorsNSData: true,
-    },
-    {
-      removeEmptyAttrs: true,
-    },
-    {
-      removeHiddenElems: true,
-    },
-    {
-      removeEmptyText: true,
-    },
-    {
-      removeEmptyContainers: true,
-    },
-    {
-      removeViewBox: false,
-    },
-    {
-      cleanupEnableBackground: true,
-    },
-    {
-      convertStyleToAttrs: true,
-    },
-    {
-      convertColors: true,
-    },
-    {
-      convertPathData: true,
-    },
-    {
-      convertTransform: true,
-    },
-    {
-      removeUnknownsAndDefaults: true,
-    },
-    {
-      removeNonInheritableGroupAttrs: true,
-    },
-    {
-      removeUselessStrokeAndFill: true,
-    },
-    {
-      removeUnusedNS: true,
-    },
-    {
-      cleanupIDs: true,
-    },
-    {
-      cleanupNumericValues: true,
-    },
-    {
-      moveElemsAttrsToGroup: true,
-    },
-    {
-      moveGroupAttrsToElems: true,
-    },
-    {
-      collapseGroups: true,
-    },
-    {
-      removeRasterImages: false,
-    },
-    {
-      mergePaths: true,
-    },
-    {
-      convertShapeToPath: true,
-    },
-    {
-      sortAttrs: true,
-    },
-    {
-      removeDimensions: true,
-    },
-  ],
-});
-
-const rootDir = path.dirname(
-  resolve.sync('@bolt/components-icons/package.json'),
-);
-const buildDir = path.join(rootDir, 'src/icons');
-const globPattern = '**/*.svg';
-
-/**
- * Transpile Icons
- * @param {array} icons
- * @returns {Promise<[{ id, fileName, location, icon}]>} - Returns an array of objects about each icon with props: id, fileName, location, & icon
- */
-async function transpileIcons(icons) {
-  await fs.mkdirp(buildDir);
-
-  return Promise.all(
-    icons.map(async icon => {
-      const svg = await fs.readFile(icon, 'utf-8');
-      const id = path
-        .basename(icon, '.svg')
-        .replace(/ /g, '-')
-        .replace('.colored', '-colored');
-
-      const $ = cheerio.load(svg, {
-        xmlMode: true,
-      });
-
-      const fileName = path
-        .basename(icon)
-        .replace(/ /g, '-')
-        .replace('.colored', '-colored')
-        .replace('.svg', '.js');
-      const location = path.join(buildDir, fileName);
-
-      $('*').each((index, el) => {
-        Object.keys(el.attribs).forEach(x => {
-          if (x === 'stroke') {
-            $(el).attr(x, 'currentColor');
-          }
-
-          if (x === 'fill') {
-            $(el).attr(x, 'currentColor');
-          }
-        });
-
-        if (el.name === 'svg') {
-          $(el).attr('otherProps', '...');
-        }
-
-        // Remove artboard rectangle that sometimes pops up in exported SVGs
-        if ($(el).attr('id') === 'Rectangle-6') {
-          $(el).remove();
-        }
-
-        $(el).removeAttr('xmlns:xlink');
-
-        if ($(el).attr('xlink:href')) {
-          const xlinkHrefVal = $(el).attr('xlink:href');
-          $(el).removeAttr('xlink:href');
-          $(el).attr('xlinkHref', xlinkHrefVal);
-        }
-
-        if ($(el).attr('xlink:href')) {
-          const xlinkHrefVal = $(el).attr('xlink:href');
-          $(el).removeAttr('xlink:href');
-          $(el).attr('xlinkHref', xlinkHrefVal);
-        }
-      });
-
-      const result = await svgo.optimize(svg);
-      const optimizedSVG = result.data;
-
-      const element = `
-  import { h } from '@bolt/core/renderers';
-
-  export const ${uppercamelcase(
-    id,
-  )} = ({ bgColor, fgColor, size, ...otherProps }) => {
-      return (
-        ${
-          fileName.includes('-color')
-            ? $(optimizedSVG)
-                .toString()
-                .replace('viewBox', '{...otherProps} viewBox') // tack on extra props next to viewBox attribute
-                .replace('d="M0 0h24v24H0z"', '')
-                .replace(/width=".*?"/, 'width={size}')
-                .replace(/height=".*?"/, 'height={size}')
-                .replace('otherProps="..."', '{...otherProps}')
-            : $(optimizedSVG)
-                .toString()
-                .replace('fill="#FFF"', 'fill={fgColor}')
-                .replace('stroke="#FFF"', 'stroke={fgColor}')
-                .replace(new RegExp(/ stroke=".*?"/, 'g'), ' stroke={bgColor}')
-                .replace(
-                  new RegExp(/ fill="(?!#fff|none).*?"/, 'g'),
-                  ' fill={bgColor}',
-                )
-                .replace('viewBox', '{...otherProps} viewBox') // tack on extra props next to viewBox attribute
-                .replace('d="M0 0h24v24H0z"', '')
-                .replace(/width=".*?"/, 'width={size}')
-                .replace(/height=".*?"/, 'height={size}')
-                .replace('otherProps="..."', '{...otherProps}')
-        }
-      )
-};
-`;
-
-      const component = prettier.format(element, {
-        singleQuote: true,
-        trailingComma: 'es5',
-        bracketSpacing: true,
-        jsxBracketSameLine: true,
-        parser: 'flow',
-      });
-
-      await fs.outputFile(location, component, 'utf-8');
-      // Later when we call `const icons = await transpileIcons(iconPaths);` - `icons` will be an array of these objects:
-      return {
-        location,
-        id,
-        icon,
-        fileName,
-      };
-    }),
-  );
-}
-
-function alphabetizeIconList(a, b) {
-  if (a.id === b.id) {
-    const iconDir = a.icon.includes('@bolt/components-icons') ? b.icon : a.icon;
-
-    throw new TypeError(`SVG filenames must be unique but '${a.id}' is not.
-  Please change filename in location: '${iconDir}'`);
-  }
-
-  if (a.id < b.id) return -1;
-  if (a.id > b.id) return 1;
-  return 0;
-}
-
 async function build() {
+  const iconSpinner = new Ora(
+    chalk.blue(
+      initialBuild ? startBuildingIconsMsg : startRebuildingIconsMsg,
+    ),
+  ).start();
+
   try {
     const config = await getConfig();
-
     const extendedIconDirs = config.iconDir ? config.iconDir : [];
 
-    const dirs = [rootDir, ...extendedIconDirs];
-    const allIcons = dirs.map(dir => path.join(dir, globPattern));
-
-    const iconPaths = await globby(allIcons);
-
-    iconSpinner = new Ora(
-      chalk.blue(
-        initialBuild ? startBuildingIconsMsg : startRebuildingIconsMsg,
-      ),
-    ).start();
-
-    await fs.remove(path.join(rootDir, 'src/icons')); // Clean folder
-    await fs.outputFile(path.join(rootDir, 'src', 'index.js'), '', 'utf-8');
-
-    const icons = await transpileIcons(iconPaths);
-    const allExports = icons
-      .sort(alphabetizeIconList) // we alphabetize the list so multiple compiles on same set doesn't result in a change that git notices
-      .map(icon => `export * from './icons/${icon.id}';`); // building up `export` lines
-    allExports.push(''); // Adding empty item to end of array so file has empty line at bottom to conform to `.editorconfig`
-
-    await fs.outputFile(
-      path.join(rootDir, 'src', 'index.js'),
-      allExports.join('\n'),
-      'utf-8',
+    const icons = await iconGenerator.generate(
+      '@bolt/components-icons',
+      extendedIconDirs,
     );
-    await generateFile(icons);
+
+    await function generateSchemaFile(icons);
+
+    iconSpinner.succeed(
+      chalk.green(
+        initialBuild ? finishedBuildingIconsMsg : finishedRebuildingIconsMsg,
+      ),
+    );
 
     if (config.verbosity > 2) {
       log.dim(`Built ${iconPaths.length} icons.`);
@@ -328,7 +64,7 @@ async function build() {
 build.description = 'Minify & convert raw SVG files to browser-friendly icons.';
 build.displayName = 'icons:build';
 
-async function generateFile(icons) {
+async function generateSchemaFile(icons) {
   try {
     const config = await getConfig();
     const iconComponentDir = path.dirname(
@@ -372,12 +108,14 @@ async function watch() {
 
   // for now, only watch the main @bolt/components-icons folder for .svg file changes.
   const extendedIconDirs = config.iconDir ? config.iconDir : [];
-  const dirs = [rootDir, ...extendedIconDirs];
 
   // Used by watches
   const debouncedCompile = debounce(build, config.debounceRate);
 
-  const watchedFiles = dirs.map(dir => path.join(dir, globPattern));
+  const watchedFiles = await iconGenerator.getIconSourcePaths(
+    '@bolt/components-icons',
+    extendedIconDirs,
+  );
 
   // The watch event ~ same engine gulp uses https://www.npmjs.com/package/chokidar
   const watcher = chokidar.watch(watchedFiles, {

--- a/packages/build-tools/utils/icon-generator.js
+++ b/packages/build-tools/utils/icon-generator.js
@@ -1,0 +1,306 @@
+const fs = require('fs-extra');
+const prettier = require('prettier');
+const cheerio = require('cheerio');
+const uppercamelcase = require('uppercamelcase');
+const globby = require('globby');
+const path = require('path');
+const resolve = require('resolve');
+const SVGO = require('svgo');
+
+const globPattern = '**/*.svg';
+
+const svgo = new SVGO({
+  plugins: [
+    {
+      removeViewBox: false,
+    },
+    {
+      removeXMLNS: true,
+    },
+    {
+      cleanupAttrs: true,
+    },
+    {
+      removeDoctype: true,
+    },
+    {
+      removeXMLProcInst: true,
+    },
+    {
+      removeComments: true,
+    },
+    {
+      removeMetadata: true,
+    },
+    {
+      removeTitle: true,
+    },
+    {
+      removeDesc: true,
+    },
+    {
+      removeUselessDefs: true,
+    },
+    {
+      removeEditorsNSData: true,
+    },
+    {
+      removeEmptyAttrs: true,
+    },
+    {
+      removeHiddenElems: true,
+    },
+    {
+      removeEmptyText: true,
+    },
+    {
+      removeEmptyContainers: true,
+    },
+    {
+      removeViewBox: false,
+    },
+    {
+      cleanupEnableBackground: true,
+    },
+    {
+      convertStyleToAttrs: true,
+    },
+    {
+      convertColors: true,
+    },
+    {
+      convertPathData: true,
+    },
+    {
+      convertTransform: true,
+    },
+    {
+      removeUnknownsAndDefaults: true,
+    },
+    {
+      removeNonInheritableGroupAttrs: true,
+    },
+    {
+      removeUselessStrokeAndFill: true,
+    },
+    {
+      removeUnusedNS: true,
+    },
+    {
+      cleanupIDs: true,
+    },
+    {
+      cleanupNumericValues: true,
+    },
+    {
+      moveElemsAttrsToGroup: true,
+    },
+    {
+      moveGroupAttrsToElems: true,
+    },
+    {
+      collapseGroups: true,
+    },
+    {
+      removeRasterImages: false,
+    },
+    {
+      mergePaths: true,
+    },
+    {
+      convertShapeToPath: true,
+    },
+    {
+      sortAttrs: true,
+    },
+    {
+      removeDimensions: true,
+    },
+  ],
+});
+
+function alphabetizeIconList(a, b) {
+  if (a.id === b.id) {
+    const iconDir = a.icon.includes('@bolt/components-icons') ? b.icon : a.icon;
+
+    throw new TypeError(`SVG filenames must be unique but '${a.id}' is not.
+  Please change filename in location: '${iconDir}'`);
+  }
+
+  if (a.id < b.id) return -1;
+  if (a.id > b.id) return 1;
+  return 0;
+}
+
+/**
+ * Transpile Icons
+ * @param {string} outputDir
+ * @param {array} icons
+ * @returns {Promise<[{ id, fileName, location, icon}]>} - Returns an array of objects about each icon with props: id, fileName, location, & icon
+ */
+async function transpileIcons(outputDir, icons) {
+  await fs.mkdirp(outputDir);
+
+  return Promise.all(
+    icons.map(async icon => {
+      const svg = await fs.readFile(icon, 'utf-8');
+      const id = path
+        .basename(icon, '.svg')
+        .replace(/ /g, '-')
+        .replace('.colored', '-colored');
+
+      const $ = cheerio.load(svg, {
+        xmlMode: true,
+      });
+
+      const fileName = path
+        .basename(icon)
+        .replace(/ /g, '-')
+        .replace('.colored', '-colored')
+        .replace('.svg', '.js');
+      const location = path.join(outputDir, fileName);
+
+      $('*').each((index, el) => {
+        Object.keys(el.attribs).forEach(x => {
+          if (x === 'stroke') {
+            $(el).attr(x, 'currentColor');
+          }
+
+          if (x === 'fill') {
+            $(el).attr(x, 'currentColor');
+          }
+        });
+
+        if (el.name === 'svg') {
+          $(el).attr('otherProps', '...');
+        }
+
+        // Remove artboard rectangle that sometimes pops up in exported SVGs
+        if ($(el).attr('id') === 'Rectangle-6') {
+          $(el).remove();
+        }
+
+        $(el).removeAttr('xmlns:xlink');
+
+        if ($(el).attr('xlink:href')) {
+          const xlinkHrefVal = $(el).attr('xlink:href');
+          $(el).removeAttr('xlink:href');
+          $(el).attr('xlinkHref', xlinkHrefVal);
+        }
+
+        if ($(el).attr('xlink:href')) {
+          const xlinkHrefVal = $(el).attr('xlink:href');
+          $(el).removeAttr('xlink:href');
+          $(el).attr('xlinkHref', xlinkHrefVal);
+        }
+      });
+
+      const result = await svgo.optimize(svg);
+      const optimizedSVG = result.data;
+      const upperCamelName = uppercamelcase(id);
+
+      const element = `
+  import * as Icons from '@bolt/components-icon/registry';
+  import { h } from '@bolt/core/renderers';
+
+  export const ${upperCamelName} = ({ bgColor, fgColor, size, ...otherProps }) => {
+      return (
+        ${
+          fileName.includes('-color')
+            ? $(optimizedSVG)
+                .toString()
+                .replace('viewBox', '{...otherProps} viewBox') // tack on extra props next to viewBox attribute
+                .replace('d="M0 0h24v24H0z"', '')
+                .replace(/width=".*?"/, 'width={size}')
+                .replace(/height=".*?"/, 'height={size}')
+                .replace('otherProps="..."', '{...otherProps}')
+            : $(optimizedSVG)
+                .toString()
+                .replace('fill="#FFF"', 'fill={fgColor}')
+                .replace('stroke="#FFF"', 'stroke={fgColor}')
+                .replace(new RegExp(/ stroke=".*?"/, 'g'), ' stroke={bgColor}')
+                .replace(
+                  new RegExp(/ fill="(?!#fff|none).*?"/, 'g'),
+                  ' fill={bgColor}',
+                )
+                .replace('viewBox', '{...otherProps} viewBox') // tack on extra props next to viewBox attribute
+                .replace('d="M0 0h24v24H0z"', '')
+                .replace(/width=".*?"/, 'width={size}')
+                .replace(/height=".*?"/, 'height={size}')
+                .replace('otherProps="..."', '{...otherProps}')
+        }
+      )
+  };
+
+  Icons.set('${id}', ${upperCamelName});
+`;
+
+      const component = prettier.format(element, {
+        singleQuote: true,
+        trailingComma: 'es5',
+        bracketSpacing: true,
+        jsxBracketSameLine: true,
+        parser: 'flow',
+      });
+
+      await fs.outputFile(location, component, 'utf-8');
+      // Later when we call `const icons = await transpileIcons(iconPaths);` - `icons` will be an array of these objects:
+      return {
+        location,
+        id,
+        icon,
+        fileName,
+      };
+    }),
+  );
+}
+
+async function getPackageBasePath(outputPackageName) {
+  return path.dirname(
+    await new Promise((accept, reject) => {
+      resolve(`${outputPackageName}/package.json`, (err, res) => {
+        err ? reject(err) : accept(res);
+      });
+    }),
+  );
+}
+
+async function getIconSourcePaths(outputPackageName, extendedIconDirs) {
+  const packageDir = await getPackageBasePath(outputPackageName);
+  const dirs = [packageDir, ...extendedIconDirs];
+  return dirs.map(dir => path.join(dir, globPattern));
+}
+
+async function generate(outputPackageName, extendedIconDirs) {
+  extendedIconDirs = extendedIconDirs || [];
+
+  const packageDir = await getPackageBasePath(outputPackageName);
+  const buildDir = path.join(packageDir, 'src/icons');
+  const indexPath = path.join(packageDir, 'src', 'index.js');
+
+  await fs.remove(buildDir);
+  await fs.outputFile(indexPath, '', 'utf-8');
+
+  const allIcons = await getIconSourcePaths(
+    outputPackageName,
+    extendedIconDirs,
+  );
+  const iconPaths = await globby(allIcons);
+
+  const icons = (await transpileIcons(buildDir, iconPaths))
+    .sort(alphabetizeIconList); // we alphabetize the list so multiple compiles on same set doesn't result in a change that git notices
+
+  const allExports = icons
+    .map(icon => `export * from './icons/${icon.id}';`); // building up `export` lines
+
+  allExports.push('');
+
+  await fs.outputFile(indexPath, allExports.join("\n"), 'utf-8');
+
+  return icons;
+}
+
+module.exports = {
+  generate,
+  getIconSourcePaths,
+};

--- a/packages/build-tools/utils/icon-generator.js
+++ b/packages/build-tools/utils/icon-generator.js
@@ -287,15 +287,14 @@ async function generate(outputPackageName, extendedIconDirs) {
   );
   const iconPaths = await globby(allIcons);
 
-  const icons = (await transpileIcons(buildDir, iconPaths))
-    .sort(alphabetizeIconList); // we alphabetize the list so multiple compiles on same set doesn't result in a change that git notices
+  const icons = (await transpileIcons(buildDir, iconPaths)).sort(
+    alphabetizeIconList,
+  ); // we alphabetize the list so multiple compiles on same set doesn't result in a change that git notices
 
-  const allExports = icons
-    .map(icon => `export * from './icons/${icon.id}';`); // building up `export` lines
-
+  const allExports = icons.map(icon => `export * from './icons/${icon.id}';`); // building up `export` lines
   allExports.push('');
 
-  await fs.outputFile(indexPath, allExports.join("\n"), 'utf-8');
+  await fs.outputFile(indexPath, allExports.join('\n'), 'utf-8');
 
   return icons;
 }

--- a/packages/components/bolt-icon/registry.js
+++ b/packages/components/bolt-icon/registry.js
@@ -1,0 +1,1 @@
+module.exports = new Map();

--- a/packages/components/bolt-icon/src/icon.standalone.js
+++ b/packages/components/bolt-icon/src/icon.standalone.js
@@ -11,8 +11,7 @@ import { spacingSizes } from '@bolt/core/data';
 import { h, withPreact } from '@bolt/core/renderers';
 
 import PubSub from 'pubsub-js';
-import upperCamelCase from 'uppercamelcase';
-import * as Icons from '@bolt/components-icons';
+import * as Icons from '../registry';
 import styles from './icon.scss';
 
 const backgroundStyles = ['circle', 'square'];
@@ -108,8 +107,8 @@ class BoltIcon extends withPreact() {
         : '',
     );
 
-    const Icon = name ? upperCamelCase(name) : '';
-    const IconTag = Icons[`${Icon}`];
+    const Icon = name;
+    const IconTag = Icons.get(`${Icon}`);
     const iconSize =
       size && spacingSizes[size]
         ? spacingSizes[size].replace('rem', '') * (16 / 2)


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1911

## Summary

Currently, the way icon builds / custom icons work creates a tight coupling between the components-icon package, components-icons package, and the build process itself. The goal of this PR is to remove the circular dependency between components-icon and components-icons in the build process, allowing packages other than components-icons to provide icons, without directly altering components-icon(s).

## Details

There are no user facing changes here. It just consolidates logic for icon generation into a package-independent library (utility/icon-generator.js) that can be called for any package in the system to package icons in that package.

Most of the logic from the icon task has been moved there. There is one holdout "generateSchemaFile", which can't be made package independent yet, so it seems, but we should address that in a follow up.

## How to test

Test:
1. Building bolt and viewing icons in pattern lab.
2. Doing a build using the documented custom icon procedure, and testing the result.