### PR TITLE
Hotfix: define handleEditorSave at runtime

### DIFF
--- a/packages/editor/src/index.js
+++ b/packages/editor/src/index.js
@@ -87,9 +87,6 @@ function exampleHandleEditorSave({ html, id }) {
   });
 }
 
-// @ts-ignore
-const handleEditorSave = window.__handleEditorSave || exampleHandleEditorSave;
-
 function addJsToPage(src) {
   return new Promise((resolve, reject) => {
     if (document.querySelector(`script[src="${src}"]`)) {
@@ -251,6 +248,9 @@ function init() {
           break;
         }
         case EDITOR_STATES.OPEN: {
+          // @ts-ignore
+          const handleEditorSave =
+            window.__handleEditorSave || exampleHandleEditorSave;
           const html = editor.getHtml();
           const unsavedChanges = editor.getDirtyCount();
           if (unsavedChanges) {


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/WWWD-4312

## Summary

Allow handleEditorSave to be defined at runtime.

## Details

Previously, handleEditorSave got defined on load, which meant that other javascript that wanted to define it using window.__handleEditorSave needed to run before it.  This commit instead waits until runtime (i.e. when the edit save button is clicked), which gives other scripts more time to set window.__handleEditorSave.

## How to test

I've only tested in Drupal-- to test in Bolt, you'd have to set window.__handleEditorSave after the editor js loads, then confirm that the function you defined is used when closing the editor.