### PR TITLE
Bugfix/editor component save regressions

### DIFF
--- a/packages/editor/src/index.js
+++ b/packages/editor/src/index.js
@@ -271,6 +271,7 @@ function init() {
             cleanup();
             container.innerHTML = html;
             trigger.innerText = 'Edit';
+            editorState = EDITOR_STATES.CLOSED;
           } else {
             const msg = `Error: could not save editor: ${message}`;
             console.error(msg);

--- a/packages/editor/src/index.js
+++ b/packages/editor/src/index.js
@@ -263,7 +263,7 @@ function init() {
           trigger.innerText = 'Saving...';
 
           const { ok, message } = await handleEditorSave({
-            html: container.innerHTML,
+            html,
             id: config.id,
           });
 

--- a/packages/editor/src/index.js
+++ b/packages/editor/src/index.js
@@ -277,6 +277,7 @@ function init() {
             console.error(msg);
             // eslint-disable-next-line no-alert
             window.alert(msg);
+            trigger.innerText = 'Save & Close';
           }
           break;
         }


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/WWWD-4312

## Summary

Fixes several regressions related to saving in the editor

## Details
Specifically, this addresses the following bugs:
1. The editor state no longer resets to "Closed" upon a successful save, which results in the user being unable to edit it again after the first save (without first refreshing the page)
2. The html of the editor content no longer gets passed to the `handleEditorSave` function, so the content itself can no longer be saved.
3. After an unsuccessful save, the button state still says "Saving...". 

## How to test
Confirm that the bugs described above are resolved.