### PR TITLE
hotfix: patch lit-element's constructable stylesheet rendering behavior

### DIFF
--- a/packages/base-element/src/BoltElement.js
+++ b/packages/base-element/src/BoltElement.js
@@ -23,6 +23,7 @@ class BoltElement extends Slotify(LitElement) {
     // styling after rendering to ensure adoptedStyles have highest priority.
     if (
       supportsAdoptingStyleSheets &&
+      this.renderRoot.adoptedStyleSheets &&
       this.renderRoot.adoptedStyleSheets.length === 0
     ) {
       this._needsShimAdoptedStyleSheets = false;

--- a/packages/base-element/src/BoltElement.js
+++ b/packages/base-element/src/BoltElement.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-unused-expressions */
 import { LitElement } from 'lit-element';
 import { Slotify } from './Slotify.js';
+import { supportsAdoptingStyleSheets } from 'lit-element/lib/css-tag.js';
 import {
   renderAndRenderedEvents,
   lazyStyles,
@@ -10,6 +11,28 @@ import {
 @renderAndRenderedEvents()
 @lazyStyles()
 @conditionalShadowDom()
-class BoltElement extends Slotify(LitElement) {}
+class BoltElement extends Slotify(LitElement) {
+  // patch to https://github.com/Polymer/lit-element/blob/master/src/lit-element.ts#L208
+  // as a temp workaround to constructible stylesheets not working when
+  // rendering inside + outside an iframe. Filing a bug with lit-element shortly!
+  update(changedProperties) {
+    super.update(changedProperties);
+
+    // When native Shadow DOM is used but adoptedStyles are not supported
+    // (or can't be used -- ex. attached to more than one document), insert
+    // styling after rendering to ensure adoptedStyles have highest priority.
+    if (
+      supportsAdoptingStyleSheets &&
+      this.renderRoot.adoptedStyleSheets.length === 0
+    ) {
+      this._needsShimAdoptedStyleSheets = false;
+      this.constructor._styles.forEach(s => {
+        const style = document.createElement('style');
+        style.textContent = s.cssText;
+        this.renderRoot.appendChild(style);
+      });
+    }
+  }
+}
 
 export { BoltElement };

--- a/packages/base-element/src/BoltElement.js
+++ b/packages/base-element/src/BoltElement.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-expressions */
 import { LitElement } from 'lit-element';
-import { Slotify } from './Slotify.js';
 import { supportsAdoptingStyleSheets } from 'lit-element/lib/css-tag.js';
+import { Slotify } from './Slotify.js';
 import {
   renderAndRenderedEvents,
   lazyStyles,


### PR DESCRIPTION
## Jira
N/A

## Summary
Patches the constructable stylesheet rendering in lit-element to address an issue encountered in Chrome (when rendering Button in the GrapeJS editor) where styles no longer show up.

![CleanShot 2019-11-18 at 12 19 29](https://user-images.githubusercontent.com/1617209/69074630-bec24500-09fd-11ea-91e4-bd69498a3c0b.gif)

## Details
Adds a new check to the default lit-element render function to automatically render styles via a `<style>` tag (the default fallback for browsers supporting Shadow DOM but not adoptedStyles) when the render root doesn't have any adoptedStyleSheets, the symptom of the error that is silently thrown when I tried to force the behavior in this particular use case.

### With Patch Applied (Working)
![CleanShot 2019-11-18 at 12 20 55](https://user-images.githubusercontent.com/1617209/69074806-1496ed00-09fe-11ea-8b56-b652789cb511.gif)


### Error if trying to force render adoptedStyleSheets
![image](https://user-images.githubusercontent.com/1617209/69074441-60956200-09fd-11ea-9b94-db1b96b1823d.png)


I'll be submitting a patch to lit-element shortly!

## How to test
Confirm that Button styles now show up correctly when editing http://localhost:3000/pattern-lab/patterns/06-experiments-editor-10-editor-simple/06-experiments-editor-10-editor-simple.html
