### PR TITLE
Tabs | SCSS | Fix resize bug in IE11

### DIFF
--- a/packages/components/bolt-tabs/src/tabs-dropdown.scss
+++ b/packages/components/bolt-tabs/src/tabs-dropdown.scss
@@ -134,6 +134,7 @@ $bolt-tabs-xsmall-bp: 420px; // Slightly increase the default 400px xsmall break
   @include bolt-font-size(medium);
   @include bolt-font-weight(semibold);
   display: flex;
+  flex-shrink: 0; // without this IE sometimes stacks text and icon
   align-items: center;
   position: relative;
   color: bolt-theme(headline);


### PR DESCRIPTION
## Jira

n/a

## Summary

Fixes miscalculation of width in IE11 which causes e2e test to intermittently fail.

## Details

Adds `flex-shrink: 0` to prevent "More" button and icon from stacking on resize in IE11. When they stack, the button width is miscalculated and menu does not resize properly.

## How to test

- Test locally in Chrome and IE, especially around 600px breakpoint
- e2e Tabs tests are passing