### PR TITLE
New Theme Switcher Demo Component

### DIFF
--- a/docs-site/.boltrc.js
+++ b/docs-site/.boltrc.js
@@ -74,6 +74,7 @@ const config = {
 
   components: {
     global: [
+      '@bolt/theme-switcher',
       '@bolt/components-radio-switch',
       '@bolt/components-carousel',
       '@bolt/global',

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -26,6 +26,7 @@
     "watch": "bolt watch"
   },
   "dependencies": {
+    "@bolt/theme-switcher": "^0.0.0",
     "@bolt/analytics-autolink": "^2.11.0",
     "@bolt/analytics-autotrack": "^2.11.0",
     "@bolt/animations": "^2.11.2",

--- a/docs-site/src/components/theme-switcher/index.js
+++ b/docs-site/src/components/theme-switcher/index.js
@@ -1,0 +1,10 @@
+import { polyfillLoader } from '@bolt/core/polyfills';
+
+polyfillLoader.then(res => {
+  import(
+    /*
+    webpackMode: 'eager',
+    webpackChunkName: 'bolt-theme-switcher'
+  */ './theme-switcher'
+  );
+});

--- a/docs-site/src/components/theme-switcher/package.json
+++ b/docs-site/src/components/theme-switcher/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@bolt/theme-switcher",
+  "description": "Internal Docs Site Theme Switcher for the Bolt Design System",
+  "keywords": [
+    "bolt design system",
+    "bolt",
+    "css framework",
+    "design system"
+  ],
+  "version": "0.0.0",
+  "maintainers": [
+    {
+      "name": "Salem Ghoweri",
+      "email": "me@salemghoweri.com",
+      "web": "https://github.com/sghoweri"
+    }
+  ],
+  "homepage": "https://boltdesignsystem.com",
+  "license": "MIT",
+  "bugs": "https://github.com/bolt-design-system/bolt/issues",
+  "private": true,
+  "main": "index.js",
+  "style": "theme-switcher.scss",
+  "dependencies": {
+    "@bolt/core": "^2.11.2",
+    "@bolt/element": "^2.11.2"
+  }
+}

--- a/docs-site/src/components/theme-switcher/theme-switcher.js
+++ b/docs-site/src/components/theme-switcher/theme-switcher.js
@@ -1,0 +1,157 @@
+import { styleMap } from 'lit-html/directives/style-map.js';
+import { BoltElement } from '@bolt/element';
+import { html, customElement } from 'lit-element';
+import { getUniqueId } from '@bolt/core/utils/get-unique-id';
+
+/**
+ * Generates a UUID.
+ * https://gist.github.com/jed/982883
+ * @param {string|undefined=} a
+ * @return {string}
+ */
+
+// @todo: move to Bolt Element's new utils file
+// const uuid = getUniqueId();
+
+@customElement('bolt-theme-switcher')
+class BoltThemeSwitcher extends BoltElement {
+  static get properties() {
+    return {
+      theme: String,
+    };
+  }
+
+  connectedCallback() {
+    super.connectedCallback && super.connectedCallback();
+    this.theme = this.theme || 'none';
+    this.uuid = getUniqueId();
+  }
+
+  switchTheme(themeName) {
+    this.theme = themeName;
+  }
+
+  createRenderRoot() {
+    return this;
+  }
+
+  firstUpdated() {
+    if (this.theme) {
+      this.renderRoot
+        .querySelector(`#theme-${this.theme}-${this.uuid}`)
+        .setAttribute('checked', '');
+    }
+  }
+
+  render() {
+    return html`
+      <div
+        class="u-bolt-flex-grow u-bolt-flex-shrink u-bolt-width-1/1 ${this
+          .theme === ''
+          ? ''
+          : `t-bolt-${this.theme}`}"
+        style="${styleMap({
+          display: 'flex',
+          flexDirection: 'column',
+          position: 'relative',
+        })}"
+      >
+        <bolt-list
+          class="u-bolt-padding-small-squished u-bolt-padding-bottom-none u-bolt-margin-bottom-none"
+          tag="ul"
+          display="inline"
+          spacing="none"
+          separator="none"
+          align="end"
+          valign="center"
+          inset
+        >
+          <bolt-list-item class="u-bolt-margin-left-small">
+            <input
+              type="radio"
+              id="theme-none-${this.uuid}"
+              name="radio-theme-picker-${this.uuid}"
+              @click=${() => this.switchTheme('')}
+              class="c-bolt-input c-bolt-input--radio is-filled"
+            />
+
+            <label
+              for="theme-none-${this.uuid}"
+              class="c-bolt-inline-label c-bolt-inline-label--radio"
+              >none</label
+            >
+          </bolt-list-item>
+
+          <bolt-list-item class="u-bolt-margin-left-small">
+            <input
+              type="radio"
+              id="theme-xlight-${this.uuid}"
+              name="radio-theme-picker-${this.uuid}"
+              @click=${() => this.switchTheme('xlight')}
+              checked
+              class="c-bolt-input c-bolt-input--radio"
+            />
+
+            <label
+              for="theme-xlight-${this.uuid}"
+              class="c-bolt-inline-label c-bolt-inline-label--radio"
+              >xlight</label
+            >
+          </bolt-list-item>
+
+          <bolt-list-item class="u-bolt-margin-left-small">
+            <input
+              type="radio"
+              id="theme-light-${this.uuid}"
+              name="radio-theme-picker-${this.uuid}"
+              @click=${() => this.switchTheme('light')}
+              class="c-bolt-input c-bolt-input--radio is-filled"
+            />
+
+            <label
+              for="theme-light-${this.uuid}"
+              class="c-bolt-inline-label c-bolt-inline-label--radio"
+              >light</label
+            >
+          </bolt-list-item>
+
+          <bolt-list-item class="u-bolt-margin-left-small">
+            <input
+              type="radio"
+              id="theme-dark-${this.uuid}"
+              name="radio-theme-picker-${this.uuid}"
+              @click=${() => this.switchTheme('dark')}
+              class="c-bolt-input c-bolt-input--radio is-filled"
+            />
+
+            <label
+              for="theme-dark-${this.uuid}"
+              class="c-bolt-inline-label c-bolt-inline-label--radio"
+              >dark</label
+            >
+          </bolt-list-item>
+
+          <bolt-list-item class="u-bolt-margin-left-small">
+            <input
+              type="radio"
+              id="theme-xdark-${this.uuid}"
+              name="radio-theme-picker-${this.uuid}"
+              @click=${() => this.switchTheme('xdark')}
+              class="c-bolt-input c-bolt-input--radio is-filled"
+            />
+
+            <label
+              for="theme-xdark-${this.uuid}"
+              class="c-bolt-inline-label c-bolt-inline-label--radio"
+              >xdark</label
+            >
+          </bolt-list-item>
+        </bolt-list>
+
+        <div class="u-bolt-padding-small-squished">
+          ${this.slotify('default')}
+        </div>
+      </div>
+    `;
+  }
+}

--- a/docs-site/src/components/theme-switcher/theme-switcher.js
+++ b/docs-site/src/components/theme-switcher/theme-switcher.js
@@ -3,16 +3,6 @@ import { BoltElement } from '@bolt/element';
 import { html, customElement } from 'lit-element';
 import { getUniqueId } from '@bolt/core/utils/get-unique-id';
 
-/**
- * Generates a UUID.
- * https://gist.github.com/jed/982883
- * @param {string|undefined=} a
- * @return {string}
- */
-
-// @todo: move to Bolt Element's new utils file
-// const uuid = getUniqueId();
-
 @customElement('bolt-theme-switcher')
 class BoltThemeSwitcher extends BoltElement {
   static get properties() {

--- a/docs-site/src/components/theme-switcher/theme-switcher.scss
+++ b/docs-site/src/components/theme-switcher/theme-switcher.scss
@@ -1,0 +1,7 @@
+@import '@bolt/core';
+
+bolt-theme-switcher {
+  display: block;
+  border: 1px dashed rgba(0, 0, 0, 0.2);
+  border-radius: 6px;
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "packages": [
       "docs-site",
       "docs-site/src/components/banner",
+      "docs-site/src/components/theme-switcher",
       "docs-site/src/components/docs-search",
       "docs-site/src/components/radio-switch",
       "packages/*",


### PR DESCRIPTION
## Jira
N/A

## Summary
Manually ports over the new `<bolt-theme-switcher>` helper component from #1542; allows devs to more easily demo and test components within different themes. 

![image](https://user-images.githubusercontent.com/1617209/69369579-4dd39500-0c6a-11ea-9774-f1aa85b8168b.png)


## How to test
- Actual usage can be viewed in the original [Typeahead theming demo](https://feature-typeahead-filtering.boltdesignsystem.com/pattern-lab/?p=components-typeahead--customize-theming)
- Test using the new helper component within the docs site (ex. test dropping a Button into this)
```html

<bolt-theme-switcher>
  <bolt-button color="primary">
</bolt-theme-switcher>
```

## Dependencies
- Depended on for the [incoming Typeahead theme updates]( https://github.com/boltdesignsystem/bolt/pull/1542)