### PR TITLE
feat: add `children` to figure schema, setup basic demo

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/figure/05-figure.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/figure/05-figure.twig
@@ -1,9 +1,17 @@
+{% set image %}
+  {% include "@bolt-components-image/image.twig" with {
+    src: "/images/placeholders/500x500.jpg"
+  } only %}
+{% endset %}
+
 {% include "@bolt-components-figure/figure.twig" with {
-  media: {
-    image: {
-      src: "/images/placeholders/500x500.jpg",
-      lazyload: false
+  children: [
+    {
+      component: image,
+      slot: 'media'
     },
-  },
-  caption: "Fig. 1: This is Bill. He is awesome."
+    {
+      component: "Fig. 1: This is Bill. He is awesome."
+    }
+  ],
 } only %}

--- a/packages/components/bolt-figure/figure.schema.yml
+++ b/packages/components/bolt-figure/figure.schema.yml
@@ -4,6 +4,18 @@ properties:
   attributes:
     type: object
     description: A Drupal-style attributes object with extra attributes to append to this component.
+  children:
+    type: array
+    description: Array of renderable items
+    items:
+      type: object
+      properties:
+        component:
+          type: any
+          description: A renderable item
+        slot:
+          type: string
+          description: Name of slot where the item will be placed
   media:
     type: object
     description: Media accepts either image, icon, video, or table.

--- a/packages/components/bolt-figure/src/figure.twig
+++ b/packages/components/bolt-figure/src/figure.twig
@@ -31,6 +31,26 @@
   {% endif %}
 {% endfor %}
 
+{# 
+  Sort `children` into separate arrays, one for each `slot`:
+  1. `media` slot: contains the media content
+  2. `default` slot: contains caption
+  Note: don't set a `slot` value to `default`, just leave it undefined
+#}
+{% if children and children is iterable %}
+  {% set media_slot = [] %}
+  {% set default_slot = [] %}
+  {% for item in children %}
+    {% if item.component %}
+      {% if item.slot == 'media' %}
+        {% set media_slot = media_slot|merge([item.component]) %}
+      {% elseif item.slot == 'default' or not item.slot %}
+        {% set default_slot = default_slot|merge([item.component]) %}
+      {% endif %}
+    {% endif %}
+  {% endfor %}
+{% endif %}
+
 {# figure component's custom element wrapper #}
 <bolt-figure
   {% if outer_classes %} class="{{ outer_classes|join(' ') }}" {% endif %}
@@ -38,32 +58,53 @@
 >
   <replace-with-grandchildren>
     <figure {{ inner_attributes.addClass(inner_classes) }}>
-      {% if media %}
-        <replace-with-children class="{{ "#{base_class}__media" }}">
-          <div slot="media">
-            {% set image = media.image %}
-            {% set icon = media.icon %}
-            {% set video = media.video %}
-            {% set table = media.table %}
+      {% if children %}
+        {% if media_slot|length %}
+          <replace-with-children class="{{ "#{base_class}__media" }}">
+            <div slot="media">
+              {% for item in media_slot %}
+                {{ item }}
+              {% endfor %}
+            </div>
+          </replace-with-children>
+        {% endif %}
+        {% if default_slot|length %}
+          <replace-with-grandchildren>
+            <figcaption class="{{ "#{base_class}__caption" }}">
+              {% for item in default_slot %}
+                {{ item }}
+              {% endfor %}
+            </figcaption>
+          </replace-with-grandchildren>
+        {% endif %}
+      {% else %}
+        {% if media %}
+          <replace-with-children class="{{ "#{base_class}__media" }}">
+            <div slot="media">
+              {% set image = media.image %}
+              {% set icon = media.icon %}
+              {% set video = media.video %}
+              {% set table = media.table %}
 
-            {% if image %}
-              {% include "@bolt-components-image/image.twig" with image only %}
-            {% elseif icon %}
-              {% include "@bolt-components-icon/icon.twig" with icon only %}
-            {% elseif video %}
-              {% include "@bolt-components-video/video.twig" with video only %}
-            {% elseif table %}
-              {% include "@bolt-components-table/table.twig" with table only %}
-            {% endif %}
-          </div>
-        </replace-with-children>
-      {% endif %}
-      {% if caption %}
-        <replace-with-grandchildren>
-          <figcaption class="{{ "#{base_class}__caption" }}">
-            {{ caption }}
-          </figcaption>
-        </replace-with-grandchildren>
+              {% if image %}
+                {% include "@bolt-components-image/image.twig" with image only %}
+              {% elseif icon %}
+                {% include "@bolt-components-icon/icon.twig" with icon only %}
+              {% elseif video %}
+                {% include "@bolt-components-video/video.twig" with video only %}
+              {% elseif table %}
+                {% include "@bolt-components-table/table.twig" with table only %}
+              {% endif %}
+            </div>
+          </replace-with-children>
+        {% endif %}
+        {% if caption %}
+          <replace-with-grandchildren>
+            <figcaption class="{{ "#{base_class}__caption" }}">
+              {{ caption }}
+            </figcaption>
+          </replace-with-grandchildren>
+        {% endif %}
       {% endif %}
     </figure>
   </replace-with-grandchildren>


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1781

## Summary

To bring Twig schema more in line with WC schema, I'm demoing a potential new pattern: passing inner renderable items (`children`) as an array of objects, with an optional slot.

Relates to #1548.

## Details

(Explain the changes in enough detail fo reviewers to understand.  Raise any questions for reviewers to consider.)

## How to test

(List clear steps to test that the changes are working)
