### PR TITLE
Editor component bugfixes

### DIFF
--- a/packages/editor/src/setup-bolt.js
+++ b/packages/editor/src/setup-bolt.js
@@ -423,8 +423,6 @@ export function setupBolt(editor) {
       'subheadline',
       'tag',
       'text-transform',
-      'text',
-      'url',
     ],
   });
 

--- a/packages/editor/src/setup-bolt.js
+++ b/packages/editor/src/setup-bolt.js
@@ -369,7 +369,7 @@ export function setupBolt(editor) {
     registerBlock: true,
     schema: buttonSchema,
     extend: 'text',
-    initialContent: ['Button'],
+    initialContent: ['<span>Button</span>'],
     propsToTraits: ['size', 'width', 'border_radius'],
     extraTraits: [
       colorTrait,


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/WWWD-4331
http://vjira2:8080/browse/WWWD-4332

## Summary

- Makes the text in bolt-button components editable
- Removes unused/non-functional options from the bolt-text component

## Details

Fixes these the two bugs refrenced in Jira, which I will copy here for those who can't see it ;).

*Bug 1*: When adding a bolt-text component in the editor, several fields appear in the 'Selected' palette that do nothing.

#### Steps to reproduce
- Go to https://boltdesignsystem.com/pattern-lab/patterns/06-experiments-editor-10-editor-simple/06-experiments-editor-10-editor-simple.html
- Add a bolt-text element by dragging and dropping into the editor
- In the Selected pane, change the text or url field
Expected: something updates
Actual: Nothing changes

*Bug 2*: After dragging a new button into the editor, the text cannot be changed.

#### Steps to Reproduce
- Go to https://boltdesignsystem.com/pattern-lab/patterns/06-experiments-editor-10-editor-simple/06-experiments-editor-10-editor-simple.html
- Add a button by dragging and dropping into the editor
- Try to edit the text
Expected: you can edit the text the same way you can with the pre-existing demo button
Actual: There doesn’t appear to be a way to change the text from “Button” to anything else

## How to test
Confirm the above bugs are fixed.