### PR TITLE
Core: Add New Text on Background/Secondary Background Options to Theme Options

### DIFF
--- a/packages/build-tools/__tests__/multi-lang/__snapshots__/index.js.snap
+++ b/packages/build-tools/__tests__/multi-lang/__snapshots__/index.js.snap
@@ -1388,6 +1388,8 @@ bolt-inline-list:not(:last-child) {
   --bolt-theme-text-on-brand-darken-20: 255, 255, 255;
   --bolt-theme-brand-darken-25: 29, 34, 71;
   --bolt-theme-text-on-brand-darken-25: 255, 255, 255;
+  --bolt-theme-text-on-background: 21, 22, 25;
+  --bolt-theme-text-on-background-secondary: 21, 22, 25;
   color: #151619;
   color: rgba(var(--bolt-theme-text), 1);
   background-color: #fff;
@@ -1477,6 +1479,8 @@ bolt-inline-list:not(:last-child) {
   --bolt-theme-text-on-brand-darken-20: 255, 255, 255;
   --bolt-theme-brand-darken-25: 29, 34, 71;
   --bolt-theme-text-on-brand-darken-25: 255, 255, 255;
+  --bolt-theme-text-on-background: 21, 22, 25;
+  --bolt-theme-text-on-background-secondary: 21, 22, 25;
   color: #151619;
   color: rgba(var(--bolt-theme-text), 1);
   background-color: #f6f6f9;
@@ -1566,6 +1570,8 @@ bolt-inline-list:not(:last-child) {
   --bolt-theme-text-on-brand-darken-20: 255, 255, 255;
   --bolt-theme-brand-darken-25: 29, 34, 71;
   --bolt-theme-text-on-brand-darken-25: 255, 255, 255;
+  --bolt-theme-text-on-background: 255, 255, 255;
+  --bolt-theme-text-on-background-secondary: 255, 255, 255;
   color: #fff;
   color: rgba(var(--bolt-theme-text), 1);
   background-color: #1f2656;
@@ -1655,6 +1661,8 @@ bolt-inline-list:not(:last-child) {
   --bolt-theme-text-on-brand-darken-20: 255, 255, 255;
   --bolt-theme-brand-darken-25: 29, 34, 71;
   --bolt-theme-text-on-brand-darken-25: 255, 255, 255;
+  --bolt-theme-text-on-background: 255, 255, 255;
+  --bolt-theme-text-on-background-secondary: 255, 255, 255;
   color: #fff;
   color: rgba(var(--bolt-theme-text), 1);
   background-color: #161a3c;
@@ -15037,6 +15045,8 @@ bolt-inline-list:not(:last-child) {
   --bolt-theme-text-on-brand-darken-20: 255, 255, 255;
   --bolt-theme-brand-darken-25: 29, 34, 71;
   --bolt-theme-text-on-brand-darken-25: 255, 255, 255;
+  --bolt-theme-text-on-background: 21, 22, 25;
+  --bolt-theme-text-on-background-secondary: 21, 22, 25;
   color: #151619;
   color: rgba(var(--bolt-theme-text), 1);
   background-color: #fff;
@@ -15126,6 +15136,8 @@ bolt-inline-list:not(:last-child) {
   --bolt-theme-text-on-brand-darken-20: 255, 255, 255;
   --bolt-theme-brand-darken-25: 29, 34, 71;
   --bolt-theme-text-on-brand-darken-25: 255, 255, 255;
+  --bolt-theme-text-on-background: 21, 22, 25;
+  --bolt-theme-text-on-background-secondary: 21, 22, 25;
   color: #151619;
   color: rgba(var(--bolt-theme-text), 1);
   background-color: #f6f6f9;
@@ -15215,6 +15227,8 @@ bolt-inline-list:not(:last-child) {
   --bolt-theme-text-on-brand-darken-20: 255, 255, 255;
   --bolt-theme-brand-darken-25: 29, 34, 71;
   --bolt-theme-text-on-brand-darken-25: 255, 255, 255;
+  --bolt-theme-text-on-background: 255, 255, 255;
+  --bolt-theme-text-on-background-secondary: 255, 255, 255;
   color: #fff;
   color: rgba(var(--bolt-theme-text), 1);
   background-color: #1f2656;
@@ -15304,6 +15318,8 @@ bolt-inline-list:not(:last-child) {
   --bolt-theme-text-on-brand-darken-20: 255, 255, 255;
   --bolt-theme-brand-darken-25: 29, 34, 71;
   --bolt-theme-text-on-brand-darken-25: 255, 255, 255;
+  --bolt-theme-text-on-background: 255, 255, 255;
+  --bolt-theme-text-on-background-secondary: 255, 255, 255;
   color: #fff;
   color: rgba(var(--bolt-theme-text), 1);
   background-color: #161a3c;

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -19,7 +19,7 @@
     "extends @bolt/browserslist-config"
   ],
   "scripts": {
-    "test": "FORCE_COLOR=1 npx lerna exec --scope @bolt/build-tools--test* --concurrency 1 -- npm run test"
+    "test": "FORCE_COLOR=1 npx lerna exec --scope @bolt/build-tools--test* --concurrency 1 -- yarn run test"
   },
   "dependencies": {
     "@babel/core": "^7.4.5",

--- a/packages/core/styles/01-settings/settings-themes/index.scss
+++ b/packages/core/styles/01-settings/settings-themes/index.scss
@@ -41,6 +41,9 @@ $bolt-theme-ui-colors: (
 
 $bolt-theme-interactive-ui: (primary, secondary, brand) !default;
 
+// auto-generate additional text-on-NAME-HERE variations w/o outputting extra lighten / darken options
+$bolt-theme-extra-ui-with-text: (background, background-secondary) !default;
+
 $bolt-theme-interactive-shades: (
   default: (
     0,
@@ -128,6 +131,21 @@ $bolt-themes: (
         );
       }
     }
+  }
+
+  @each $element in $bolt-theme-extra-ui-with-text {
+    $propName: #{$element};
+    $propValue: map-get-deep($bolt-themes, $themeName, $element);
+    $bolt-themes: bolt-recursive-map-merge(
+      $bolt-themes,
+      (
+        #{$themeName}:
+          (
+            $propName: $propValue,
+            text-on-#{$propName}: bolt-text-contrast($propValue),
+          )
+      )
+    );
   }
 }
 


### PR DESCRIPTION
## Jira
N/A

## Summary
Adds two new options to Bolt's color theming system: `text-on-background` (which I was surprised we didn't actually have) and `text-on-background-secondary`.

## Details
These updates are a subset of the work from https://github.com/boltdesignsystem/bolt/pull/1542 and are a hard dependency on the theme-specific updates to Typeahead.

- Updates the build tools Jest snapshot with the CSS custom property additions
- Tweaks the build tool's test command to make it easier to update Jest snapshots, simply by switching to yarn
- Modifies the theming system's Sass logic in `@bolt/core` to support adding new theme options that include text variations (`text-on-THEME-OPTION`) without requiring a bunch of auto-generated variations that we might not actually need.

## How to test
- Confirm build compiles as expected