### PR TITLE
Core: Add Sassy List to @bolt/core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,7 @@
   "types": "index.d.ts",
   "repository": "https://github.com/bolt-design-system/bolt/tree/master/packages/core",
   "dependencies": {
+    "sassy-lists": "^3.0.1",
     "@bolt/element": "^2.11.4",
     "@bolt/polyfills": "^2.11.0",
     "@polymer/polymer": "^3.3.0",

--- a/packages/core/styles/index.scss
+++ b/packages/core/styles/index.scss
@@ -2,6 +2,7 @@
   BOLT CSS CORE
 \* ------------------------------------ */
 
+@import 'sassy-lists';
 @import 'sass-mq/_mq';
 @import 'sassy-maps/sass/sassy-maps';
 @import '@bolt/sass-export-data/export-data.scss';


### PR DESCRIPTION
## Jira
N/A

## Summary
Adds [SassyLists](https://github.com/at-import/SassyLists) to @bolt/core's styles. Used to the handle the updated theming system used with Typeahead in #1542 which require this as a hard dependency.

NOTE: this is getting added to Core directly (vs just to Typeahead, as I did originally), since we already have a number of places where this new library could easily get used (and likely replace some custom code we're currently maintaining). 

## How to test
If the build's not broken then we're good to go.