### PR TITLE
Hotfix/vertical align bottom does not work with grid

### DIFF
--- a/packages/build-tools/__tests__/multi-lang/__snapshots__/index.js.snap
+++ b/packages/build-tools/__tests__/multi-lang/__snapshots__/index.js.snap
@@ -1115,6 +1115,10 @@ bolt-bare-list > * {
 .o-bolt-grid--middle > .o-bolt-grid__cell {
   vertical-align: middle;
 }
+.o-bolt-grid--bottom.o-bolt-grid--flex {
+  -webkit-box-align: end;
+  align-items: flex-end;
+}
 .o-bolt-grid--bottom > .o-bolt-grid__cell {
   vertical-align: bottom;
 }
@@ -14771,6 +14775,10 @@ bolt-bare-list > * {
 }
 .o-bolt-grid--middle > .o-bolt-grid__cell {
   vertical-align: middle;
+}
+.o-bolt-grid--bottom.o-bolt-grid--flex {
+  -webkit-box-align: end;
+  align-items: flex-end;
 }
 .o-bolt-grid--bottom > .o-bolt-grid__cell {
   vertical-align: bottom;

--- a/packages/global/styles/05-objects/objects-grid/_objects-grid.scss
+++ b/packages/global/styles/05-objects/objects-grid/_objects-grid.scss
@@ -75,6 +75,10 @@
 }
 
 .o-bolt-grid--bottom {
+  &.o-bolt-grid--flex {
+    align-items: flex-end;
+  }
+
   > .o-bolt-grid__cell {
     vertical-align: bottom;
   }


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/WWWD-3920

## Summary

Vertical alignment did not work with bottom alignment. 

## Details

There was missing styles to for `.o-bolt-grid--flex.o-bolt-grid--bottom`.
