### PR TITLE
Fix Micro Journey-related Issues with the Two-Character Layout

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/06-experiments/editor/25-editor-with-two-character-layout.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/06-experiments/editor/25-editor-with-two-character-layout.twig
@@ -1,0 +1,14 @@
+{% set content %}
+  <bolt-interactive-pathways theme="{{ theme ? theme }}">
+    <bolt-text subheadline font-size="xxlarge" slot="interactive-pathways-lead-text">How Pega technology resolves</bolt-text>
+    <bolt-interactive-pathway pathway-title="Billing Inquires">
+      <bolt-interactive-step tab-title="Proactive service that meets or exeeds customer needs and offers a high return on investment to customers">
+        {% include "./billing-micro-journey-fragments/_step-one.twig" %}
+      </bolt-interactive-step>
+    </bolt-interactive-pathway>
+  </bolt-interactive-pathways>
+{% endset %}
+
+{% include '@bolt-components-editor/editor-in-pl.twig' with {
+  content: content,
+} only %}

--- a/packages/micro-journeys/src/character.js
+++ b/packages/micro-journeys/src/character.js
@@ -54,6 +54,7 @@ class BoltCharacter extends withLitHtml() {
   }
 
   connectedCallback() {
+    console.log('char connect');
     super.connectedCallback();
     setTimeout(() => {
       this.dispatchEvent(
@@ -65,6 +66,7 @@ class BoltCharacter extends withLitHtml() {
   }
 
   render() {
+    console.log('char render');
     const props = this.validateProps(this.props);
     const hasSideContent = !!this.slots['left'] || !!this.slots['right'];
     const hasBothSideContent = !!this.slots['left'] && !!this.slots['right'];

--- a/packages/micro-journeys/src/character.js
+++ b/packages/micro-journeys/src/character.js
@@ -54,7 +54,6 @@ class BoltCharacter extends withLitHtml() {
   }
 
   connectedCallback() {
-    console.log('char connect');
     super.connectedCallback();
     setTimeout(() => {
       this.dispatchEvent(
@@ -66,7 +65,6 @@ class BoltCharacter extends withLitHtml() {
   }
 
   render() {
-    console.log('char render');
     const props = this.validateProps(this.props);
     const hasSideContent = !!this.slots['left'] || !!this.slots['right'];
     const hasBothSideContent = !!this.slots['left'] && !!this.slots['right'];

--- a/packages/micro-journeys/src/character.scss
+++ b/packages/micro-journeys/src/character.scss
@@ -10,7 +10,7 @@ bolt-svg-animations {
 }
 
 bolt-animate[slot="connection"] {
-  display: flex;
+  display: block;
 }
 
 .c-bolt-character {

--- a/packages/micro-journeys/src/character.scss
+++ b/packages/micro-journeys/src/character.scss
@@ -9,6 +9,10 @@ bolt-svg-animations {
   width: 100%;
 }
 
+bolt-animate[slot="connection"] {
+  display: flex;
+}
+
 .c-bolt-character {
   display: flex;
   flex-wrap: wrap;

--- a/packages/micro-journeys/src/connection.js
+++ b/packages/micro-journeys/src/connection.js
@@ -67,7 +67,6 @@ class BoltConnection extends withLitContext() {
   }
 
   render() {
-    console.log('connection render');
     const props = this.validateProps(this.props);
     const classes = cx('c-bolt-connection');
     return html`

--- a/packages/micro-journeys/src/connection.js
+++ b/packages/micro-journeys/src/connection.js
@@ -45,7 +45,29 @@ class BoltConnection extends withLitContext() {
     this.triggerUpdate();
   }
 
+  /**
+   * Chrome gets confused about the linear gradient and renders it as nothing in
+   * some arbitrary cases, specifically switching to a new step--but not always.
+   * It needs to be re-rendered to make it show. Many other things attempted.
+   */
+  refreshLinearGradient() {
+    // @TODO make this less dependent on `bolt-svg-animations` `connnectionBand` markup.
+    // Turns out that selectors `#connectionGradientBG, stop` must all be refreshed to re-render.
+    [
+      ...this.renderRoot
+        .querySelector('bolt-svg-animations')
+        .renderRoot.querySelector('svg')
+        .querySelectorAll('#connectionGradientBG, stop'),
+    ].forEach(e => {
+      e.style.display = 'none';
+      setTimeout(() => {
+        e.style.display = 'block';
+      }, 0);
+    });
+  }
+
   render() {
+    console.log('connection render');
     const props = this.validateProps(this.props);
     const classes = cx('c-bolt-connection');
     return html`

--- a/packages/micro-journeys/src/connection.scss
+++ b/packages/micro-journeys/src/connection.scss
@@ -2,6 +2,9 @@
 
 bolt-connection {
   display: block;
+  @include bolt-ie11-only {
+    width: 250px;
+  }
 }
 
 .c-bolt-connection {

--- a/packages/micro-journeys/src/connection.scss
+++ b/packages/micro-journeys/src/connection.scss
@@ -5,7 +5,6 @@ bolt-connection {
 }
 
 .c-bolt-connection {
-  display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;

--- a/packages/micro-journeys/src/interactive-step.js
+++ b/packages/micro-journeys/src/interactive-step.js
@@ -104,17 +104,14 @@ class BoltInteractiveStep extends withLitContext() {
     if (this.animateInExclusions.length) {
       const animateInExclusions = [
         ...this.querySelectorAll(
-          `${this.animateInExclusions.join(
-            ' bolt-animate',
-          )} bolt-animate`,
+          `${this.animateInExclusions.join(' bolt-animate')} bolt-animate`,
         ),
       ];
-      [
-        ...this.querySelectorAll(this.animateInExclusions.join(' ')),
-      ].forEach(exclusion => {
-        console.log('step triggerAnimIns triggering animate on 2char');
-        exclusion.triggerAnimIns();
-      });
+      [...this.querySelectorAll(this.animateInExclusions.join(' '))].forEach(
+        exclusion => {
+          exclusion.triggerAnimIns();
+        },
+      );
       animEls = animEls.filter(animateEl => {
         return !animateInExclusions.find(exclusion =>
           animateEl.isSameNode(exclusion),

--- a/packages/micro-journeys/src/interactive-step.js
+++ b/packages/micro-journeys/src/interactive-step.js
@@ -30,8 +30,7 @@ class BoltInteractiveStep extends withLitContext() {
     self._isActiveStep = false;
     self._isBecomingActive = false;
     // These components are responsible for their own inital animate in.
-    self.animateInInitialExclusions = [boltTwoCharacterLayoutIs];
-    self.initializedAnimationExclusions = [];
+    self.animateInExclusions = [boltTwoCharacterLayoutIs];
     return self;
   }
 
@@ -67,12 +66,6 @@ class BoltInteractiveStep extends withLitContext() {
   connectedCallback() {
     super.connectedCallback();
     this.addEventListener('bolt:transitionend', this.handleAnimationEnd);
-    this.animateInInitialExclusions.forEach(exclusionComponent => {
-      this.addEventListener(
-        `${exclusionComponent}:animation-initialized`,
-        this.handleExcludedAnimationInitializedOnChild,
-      );
-    });
     setTimeout(() => {
       this.dispatchEvent(
         new CustomEvent(`${BoltInteractiveStep.is}:connected`, {
@@ -88,13 +81,6 @@ class BoltInteractiveStep extends withLitContext() {
   disconnectedCallback() {
     super.disconnectedCallback();
     this.removeEventListener('bolt:transitionend', this.handleAnimationEnd);
-    this.animateInInitialExclusions.forEach(exclusionComponent => {
-      this.removeEventListener(
-        `${exclusionComponent}:animation-initialized`,
-        this.handleExcludedAnimationInitializedOnChild,
-      );
-    });
-
     setTimeout(() => {
       this.dispatchEvent(
         new CustomEvent(`${BoltInteractiveStep.is}:disconnected`, {
@@ -107,43 +93,34 @@ class BoltInteractiveStep extends withLitContext() {
     }, 0);
   }
 
-  handleExcludedAnimationInitializedOnChild(e) {
-    this.initializedAnimationExclusions = [
-      ...this.initializedAnimationExclusions,
-      ...e.target.querySelectorAll('bolt-animate'),
-    ];
-  }
-
   async triggerAnimOuts(durationOverride = null) {
     const anims = this.querySelectorAll('bolt-animate');
     return triggerAnims({ animEls: anims, stage: 'OUT', durationOverride });
   }
 
   async triggerAnimIns() {
-    let anims = [...this.querySelectorAll('bolt-animate')];
-    // Filter bolt-animates inside animateInInitialExclusions.
-    if (this.animateInInitialExclusions.length) {
-      const animateInInitialExclusions = [
+    let animEls = [...this.querySelectorAll('bolt-animate')];
+    // Filter bolt-animates inside animateInExclusions.
+    if (this.animateInExclusions.length) {
+      const animateInExclusions = [
         ...this.querySelectorAll(
-          `${this.animateInInitialExclusions.join(
+          `${this.animateInExclusions.join(
             ' bolt-animate',
           )} bolt-animate`,
         ),
       ];
-      // Tell the excluded components they can animate themselves.
       [
-        ...this.querySelectorAll(this.animateInInitialExclusions.join(' ')),
+        ...this.querySelectorAll(this.animateInExclusions.join(' ')),
       ].forEach(exclusion => {
-        exclusion.setAttribute('parent-animations-triggered', true);
+        console.log('step triggerAnimIns triggering animate on 2char');
+        exclusion.triggerAnimIns();
       });
-      anims = anims.filter(animateEl => {
-        return !animateInInitialExclusions.find(exclusion =>
+      animEls = animEls.filter(animateEl => {
+        return !animateInExclusions.find(exclusion =>
           animateEl.isSameNode(exclusion),
         );
       });
     }
-    // Add any excluded components that have finished initializing to trigger list.
-    const animEls = [...anims, ...this.initializedAnimationExclusions];
     return triggerAnims({
       animEls,
       stage: 'IN',

--- a/packages/micro-journeys/src/interactive-step.scss
+++ b/packages/micro-journeys/src/interactive-step.scss
@@ -93,6 +93,14 @@ bolt-interactive-step {
     }
   }
 
+  // for IE
+  &__top-slot,
+  &__bottom-slot,
+  bolt-animate[slot="top"],
+  bolt-animate[slot="bottom"] {
+    width: 100%;
+  }
+
   &__body-inner {
     display: flex;
     flex-direction: column;

--- a/packages/micro-journeys/src/two-character-layout.js
+++ b/packages/micro-journeys/src/two-character-layout.js
@@ -38,8 +38,6 @@ class BoltTwoCharacterLayout extends withLitHtml() {
   connected() {
     this.connection = this.querySelector(boltConnectionIs);
     this.characters = [...this.querySelectorAll(boltCharacterIs)];
-    // console.log('this.connection', this.connection);
-    // console.log('this.characters', this.characters);
   }
 
   /**
@@ -67,12 +65,8 @@ class BoltTwoCharacterLayout extends withLitHtml() {
 
   triggerAnimIns = async () => {
     if (!this.areCharactersEqualized()) {
-      console.log('2char triggerAnimIns: about to equalize components');
-      // return this._triggerAnimIns();
-
       try {
         await this.ensureComponentsRendered();
-        console.log('2char triggerAnimIns: ensureComponentsRendered happened');
         await this.equalizeCharactersAndStyleConnection();
         this.triggerUpdate();
         return this._triggerAnimIns();
@@ -80,9 +74,6 @@ class BoltTwoCharacterLayout extends withLitHtml() {
         console.error(e);
       }
     } else {
-      console.log(
-        '2char triggerAnimIns: chars are equalized and in this event simply triggerAnimIns was called',
-      );
       return this._triggerAnimIns();
     }
   };
@@ -166,11 +157,6 @@ class BoltTwoCharacterLayout extends withLitHtml() {
       }
     });
     if (this.connection) {
-      console.log(
-        `connectionheight: ${this.connection.offsetHeight}`,
-        this.connection,
-      );
-
       if (!this.connection.offsetHeight) {
         return false;
       }
@@ -198,10 +184,6 @@ class BoltTwoCharacterLayout extends withLitHtml() {
     const classes = cx('c-bolt-two-character-layout', {
       'c-bolt-two-character-layout__initial': !this.areCharactersEqualized(),
     });
-    console.log(
-      '2char render: this.areCharactersEqualized()',
-      this.areCharactersEqualized(),
-    );
     return html`
       ${this.addStyles([styles])}
       <div class="${classes}">

--- a/packages/micro-journeys/src/two-character-layout.js
+++ b/packages/micro-journeys/src/two-character-layout.js
@@ -78,8 +78,10 @@ class BoltTwoCharacterLayout extends withLitHtml() {
       this.isInitialRender
     ) {
       setTimeout(() => {
-        this.charactersAreReadyInitialization();
-        this.isInitialRender = false;
+        window.requestAnimationFrame(() => {
+          this.charactersAreReadyInitialization();
+          this.isInitialRender = false;
+        });
       });
     }
   }

--- a/packages/micro-journeys/src/two-character-layout.js
+++ b/packages/micro-journeys/src/two-character-layout.js
@@ -7,7 +7,10 @@ import {
 } from '@bolt/micro-journeys/src/character';
 import { boltConnectionIs } from '@bolt/micro-journeys/src/connection';
 import { triggerAnims } from '@bolt/components-animate/utils';
-import { equalizeRelativeHeights } from './utils/equalize-relative-heights';
+import {
+  equalizeRelativeHeights,
+  equalizeRelativeHeightsClass,
+} from './utils/equalize-relative-heights';
 import styles from './two-character-layout.scss';
 
 let cx = classNames.bind(styles);
@@ -23,6 +26,7 @@ class BoltTwoCharacterLayout extends withLitHtml() {
       ...props.boolean,
       ...{ default: false },
     },
+    // Has the parent `bolt-interactive-step` attempted its animation of its children in?
     parentAnimationsTriggered: {
       ...props.boolean,
       ...{ default: false },
@@ -33,67 +37,10 @@ class BoltTwoCharacterLayout extends withLitHtml() {
   constructor(self) {
     self = super(self);
     self.useShadow = hasNativeShadowDomSupport;
-    self.hasConnection = !!this.querySelector(boltConnectionIs);
-    self.requiredComponentCount = self.hasConnection ? 3 : 2;
-    self.renderedComponentCount = 0;
+    self.connection = this.querySelector(boltConnectionIs);
+    self.characters = [...this.querySelectorAll(boltCharacterIs)];
     self.isInitialRender = true;
     return self;
-  }
-
-  /**
-   * Callback for when child components report ready. Figure out if they're
-   * characters and count them if so. Then attempt to initialize.
-   *
-   * @param event
-   */
-  handleChildrenReady(event) {
-    if (
-      event.detail.name !== boltCharacterIs &&
-      event.detail.name !== boltConnectionIs
-    ) {
-      return;
-    }
-    this.renderedComponentCount++;
-    if (this.isConnected) {
-      this.attemptCharactersAreReadyInitialization();
-    }
-  }
-
-  /**
-   * Make sure that the component is rendering for the first time and `bolt-character`s are ready.
-   * Both characters have to be on the dom with width and height before this can run.
-   * The problem is that this component connects and components report as rendered
-   * before content is slotted. Thus, we have to wait for the parent to tell us
-   * that it has attempted to animate content as a sigh that we can actually
-   * perform calculations against slotted elements that have height/width.
-   * We only do this on initial render after we're told the parent has animated.
-   * After this, bolt-interactive-step is in charge of animating this in and out.
-   */
-  attemptCharactersAreReadyInitialization() {
-    const charsAreReady =
-      this.renderedComponentCount >= this.requiredComponentCount;
-    if (
-      this.parentAnimationsTriggered &&
-      charsAreReady &&
-      this.isInitialRender
-    ) {
-      setTimeout(() => {
-        window.requestAnimationFrame(() => {
-          this.charactersAreReadyInitialization();
-          this.isInitialRender = false;
-        });
-      });
-    }
-  }
-
-  connected() {
-    this.addEventListener('ready', this.handleChildrenReady);
-  }
-
-  disconnecting() {
-    if (this.parentAnimationsTriggered && !this.isInitialRender) {
-      this.removeEventListener('ready', this.handleChildrenReady);
-    }
   }
 
   /**
@@ -101,10 +48,8 @@ class BoltTwoCharacterLayout extends withLitHtml() {
    * to one another so a connection can be centered between them, while
    * preserving document flow by avoiding absolute positioning.
    */
-  charactersAreReadyInitialization = async () => {
-    const anims = this.querySelectorAll('bolt-animate');
-    this.boltCharacters = [...this.querySelectorAll(boltCharacterIs)];
-    const eqHeightArgs = this.boltCharacters.map(character => {
+  equalizeCharactersAndStyleConnection = () => {
+    const eqHeightArgs = this.characters.map(character => {
       return {
         container: character,
         elToEqualize: character.renderRoot.querySelector(
@@ -113,12 +58,16 @@ class BoltTwoCharacterLayout extends withLitHtml() {
         paddingEqualizationTarget: character,
       };
     });
+
     equalizeRelativeHeights(
       eqHeightArgs,
-      this.hasConnection ? this.setConnectionWidth : null,
+      this.connection ? this.setConnectionWidth : null,
     );
     this.triggerUpdate();
+  };
 
+  animateContentIn = () => {
+    const anims = this.querySelectorAll('bolt-animate');
     triggerAnims({ animEls: anims, stage: 'IN' });
     // Tell the parent step that it can now normally animate this element.
     this.dispatchEvent(
@@ -126,6 +75,7 @@ class BoltTwoCharacterLayout extends withLitHtml() {
         bubbles: true,
       }),
     );
+    this.isInitialRender = false;
   };
 
   /**
@@ -133,9 +83,9 @@ class BoltTwoCharacterLayout extends withLitHtml() {
    * `bolt-character`. Note: requires page refresh.
    */
   setConnectionWidth = () => {
-    this.boltCharacters.forEach((e, i) => {
-      const connection = e.querySelector(boltConnectionIs);
-      const nextCharacter = this.boltCharacters[i + 1];
+    this.characters.forEach((e, i) => {
+      const connection = e.querySelector('bolt-animate[slot="connection"');
+      const nextCharacter = this.characters[i + 1];
       if (connection && nextCharacter) {
         const nextCharacterCenter = nextCharacter.renderRoot.querySelector(
           `.${boltCharacterCenterClass}`,
@@ -144,14 +94,89 @@ class BoltTwoCharacterLayout extends withLitHtml() {
           .left - connection.getBoundingClientRect().left}px + 50%)`;
         connection.renderRoot.querySelector('.c-bolt-connection__main-image');
       }
+      // Hack for chrome which gets confused by [slot='connection']
+      // e.querySelector('bolt-animate[slot="connection"').style.display = 'flex';
     });
+  };
+
+  /**
+   * Create a delay and return a promise.
+   *
+   * @param {int} timeoutAmount in MS
+   * @return {Promise<unknown>}
+   */
+  delay = async timeoutAmount =>
+    new Promise(resolve => {
+      setTimeout(resolve, timeoutAmount);
+    });
+
+  /**
+   * Ensure with recursive promises that the `bolt-character`s and `bolt-connection`
+   * are rendered. This is necessary because bolt element ready
+   * event fires after JS render but before render to the actual DOM.
+   *
+   * @param attemptCount
+   * @return {Promise<Promise|Promise>}
+   */
+  ensureComponentsRendered = async (attemptCount = 0) => {
+    const attemptMax = 15;
+    const attemptTimeout = 900;
+    return new Promise((resolve, reject) => {
+      if (attemptMax <= attemptCount) {
+        return reject(
+          new Error(
+            "Uh oh. Characters didn't render to the dom in a timely fashion.",
+          ),
+        );
+      }
+      if (this.areComponentsRendered()) {
+        return resolve(true);
+      } else {
+        // I realize this seems primitive, but it is the best way.
+        this.delay(attemptTimeout).then(() => {
+          return this.ensureComponentsRendered(attemptCount + 1);
+        });
+      }
+    });
+  };
+
+  /**
+   * Check the `bolt-character`s and `bolt-connection` to see if they have
+   * offsetHeight, that is, if they are painted in the browser yet.
+   *
+   * @return {boolean} if all required components have offsetHeight.
+   */
+  areComponentsRendered = () => {
+    this.characters.forEach(character => {
+      if (!character.offsetHeight) {
+        return false;
+      }
+    });
+    if (this.connection) {
+      if (!this.connection.offsetHeight) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  /**
+   * Check to see if `bolt-character`s have had their heights equalized.
+   *
+   * @return {boolean} true if equalized else false.
+   */
+  areCharactersEqualized = () => {
+    let isEqualized = true;
+    this.characters.forEach(character => {
+      if (!character.classList.contains(equalizeRelativeHeightsClass)) {
+        isEqualized = false;
+      }
+    });
+    return isEqualized;
   };
 
   render() {
     const props = this.validateProps(this.props);
-    if (this.isInitialRender) {
-      this.attemptCharactersAreReadyInitialization();
-    }
     const classes = cx('c-bolt-two-character-layout', {
       'c-bolt-two-character-layout__initial':
         !props.parentAnimationsTriggered && this.isInitialRender,
@@ -173,6 +198,37 @@ class BoltTwoCharacterLayout extends withLitHtml() {
         </div>
       </div>
     `;
+  }
+
+  /**
+   * Make sure that the component is rendering for the first time and `bolt-character`s are ready.
+   * Both characters have to be on the dom with width and height before this can run.
+   * The problem is that this component connects and components report as rendered
+   * before content is slotted. Thus, we have to wait for the parent to tell us
+   * that it has attempted to animate content as a sign that we can actually
+   * perform calculations against slotted elements that have height/width.
+   * We only do this on initial render after we're told the parent has animated.
+   * After this, `bolt-interactive-step` is in charge of animating `this` in and out.
+   */
+  rendered() {
+    super.rendered();
+    // The editor disconnects the old component and copies the HTML to an iframe.
+    // Don't perform animations or calculations on an unconnected component.
+    if (!this.isConnected) {
+      return;
+    }
+    if (this.isInitialRender && this.parentAnimationsTriggered) {
+      if (!this.areCharactersEqualized()) {
+        this.ensureComponentsRendered()
+          .then(() => {
+            this.equalizeCharactersAndStyleConnection();
+            this.animateContentIn();
+          })
+          .catch(e => console.error(e));
+      } else {
+        this.animateContentIn();
+      }
+    }
   }
 }
 

--- a/packages/micro-journeys/src/two-character-layout.js
+++ b/packages/micro-journeys/src/two-character-layout.js
@@ -77,8 +77,10 @@ class BoltTwoCharacterLayout extends withLitHtml() {
       charsAreReady &&
       this.isInitialRender
     ) {
-      this.charactersAreReadyInitialization();
-      this.isInitialRender = false;
+      setTimeout(() => {
+        this.charactersAreReadyInitialization();
+        this.isInitialRender = false;
+      });
     }
   }
 

--- a/packages/micro-journeys/src/utils/equalize-relative-heights.js
+++ b/packages/micro-journeys/src/utils/equalize-relative-heights.js
@@ -6,6 +6,8 @@
  * @prop {HTMLElement} paddingEqualizationTarget
  */
 
+export const equalizeRelativeHeightsClass = 'isEqualized';
+
 /**
  *
  * @param {EqualizeRelativeHeightArgItem} item
@@ -83,6 +85,7 @@ export const equalizeRelativeHeights = (
         paddingEqualizationTarget.style.paddingTop = `calc(${items[
           indexOfLongest
         ].relativeOffsetTop - relativeOffsetTop}px + ${previousPadding})`;
+        paddingEqualizationTarget.classList.add(equalizeRelativeHeightsClass);
       }
     });
     if (callback) {

--- a/packages/micro-journeys/src/utils/equalize-relative-heights.js
+++ b/packages/micro-journeys/src/utils/equalize-relative-heights.js
@@ -31,6 +31,7 @@ const validateItem = item => {
  */
 const validateParamsForEqualizeRelativeHeights = items => {
   items.forEach((item, i) => {
+    const { container, elToEqualize, paddingEqualizationTarget } = item;
     if (!validateItem(item)) {
       throw new Error(
         `Element provided to equalizeRelativeHeights has no width. container: ${container.offsetWidth}, elToEqualize: ${elToEqualize.offsetWidth}, paddingEqualizationTarget: ${paddingEqualizationTarget.offsetWidth}`,

--- a/packages/micro-journeys/src/utils/equalize-relative-heights.js
+++ b/packages/micro-journeys/src/utils/equalize-relative-heights.js
@@ -6,7 +6,7 @@
  * @prop {HTMLElement} paddingEqualizationTarget
  */
 
-export const equalizeRelativeHeightsClass = 'isEqualized';
+export const equalizeRelativeHeightsKey = 'boltIsEqualized';
 
 /**
  *
@@ -77,16 +77,19 @@ export const equalizeRelativeHeights = (
 
     // Add padding to the shorter ones to equalize the height.
     items.forEach((item, i) => {
+      const { paddingEqualizationTarget, relativeOffsetTop } = item;
+      if (paddingEqualizationTarget[equalizeRelativeHeightsKey] === true) {
+        return;
+      }
       if (indexOfLongest !== i) {
-        const { paddingEqualizationTarget, relativeOffsetTop } = item;
         // Remove 'calc': Nested calcs in IE work fine if wrapped only in parens.
         const previousPadding = `${paddingEqualizationTarget.style.paddingTop ||
           '0px'}`.replace('calc', '');
         paddingEqualizationTarget.style.paddingTop = `calc(${items[
           indexOfLongest
         ].relativeOffsetTop - relativeOffsetTop}px + ${previousPadding})`;
-        paddingEqualizationTarget.classList.add(equalizeRelativeHeightsClass);
       }
+      paddingEqualizationTarget[equalizeRelativeHeightsKey] = true;
     });
     if (callback) {
       callback();

--- a/packages/micro-journeys/starters/step-two-character-starter.html
+++ b/packages/micro-journeys/starters/step-two-character-starter.html
@@ -32,11 +32,11 @@
             </bolt-list-item>
           </bolt-list>
         </bolt-animate>
+        <bolt-animate slot="connection" in="fade-in" in-order="1" out="fade-out" out-order="1" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out-duration="350" out-easing="ease">
+          <bolt-connection anim-type="connectionBand" direction="left">
+          </bolt-connection>
+        </bolt-animate>
       </bolt-character>
-    </bolt-animate>
-    <bolt-animate slot="connection" in="fade-in" in-order="1" out="fade-out" out-order="1" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out-duration="350" out-easing="ease">
-      <bolt-connection anim-type="connectionBand" direction="left">
-      </bolt-connection>
     </bolt-animate>
     <bolt-animate slot="character--right" in="fade-in" in-order="1" out="fade-out" out-order="1" initial-appearance="hidden" in-duration="500" in-easing="ease" idle="none" idle-duration="500" out-duration="350" out-easing="ease">
       <bolt-character size="medium" character-image="customer-surprise" character-custom-url="https://www.fillmurray.com/g/200/200">


### PR DESCRIPTION
This fixes several `bolt-two-character-layout` issues, including:
* https://app.asana.com/0/1126340469288208/1130525745807684/f
* https://app.asana.com/0/1126340469288208/1151276850580125/f
* Connection band disappears in editor
* Connection band background is sometimes invisible in Chrome
* `bolt-two-character-layout` layout problems in IE

Detail:
In general I simplified the code here a bunch and made it readable and maintainable. I also added a persistent `setTimeout` promise to ensure that child components have `offsetHeight`. This is because bolt `render` event was reporting that components were rendered when they had not yet been painted on the dom. I also tried mutation observers on both shadow and non-shadow components, as well as `requestAnimationFrame` and `setTimeout(0)`

How to test:
Visit http://localhost:3000/pattern-lab/?p=experiments-micro-journeys and click around
Visit http://localhost:3000/pattern-lab/?p=experiments-editor-simple, drag in the 2-character starter, and hit Edit->Save->Edit->Save->Edit->Save. Character layout should be good
Check out http://localhost:3000/pattern-lab/?p=experiments-micro-journeys in IE 11 and Edge
In Chrome, click http://localhost:3000/pattern-lab/?p=experiments-micro-journeys and click the "Empowered Agents" step. Connection should retain background.
