### PR TITLE
Remove slot-based CSS selector so status bar color works in IE

### DIFF
--- a/packages/micro-journeys/src/status-dialogue-bar.scss
+++ b/packages/micro-journeys/src/status-dialogue-bar.scss
@@ -36,10 +36,6 @@ $bolt-tooltip-bubble-triangle-width: 8px;
   &--alert &__content {
     color: bolt-color(white);
     background-color: bolt-color(orange);
-
-    slot[name="text"] {
-      color: bolt-color(white);
-    }
   }
 
   &__icon {
@@ -55,7 +51,6 @@ $bolt-tooltip-bubble-triangle-width: 8px;
 
   &__slot {
     &--text {
-      color: bolt-color(black);
       line-height: ($bolt-line-height--xsmall + 0.2);
       text-align: left;
       @include bolt-font-weight(regular);


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/WWWD-4363

## Summary

Fixes color of dialog bar text in IE

## Details

Previously, a slot-based CSS selector was being used to set text color.  This won't work in IE.

Additionally, setting a color on &__slot--text seems redundant and unnecessary-- removing this appears to allow colors to work as originally intended.

## How to test

### Reproduce the bug
- In IE 11, go to https://boltdesignsystem.com/pattern-lab/patterns/06-experiments-micro-journeys-35-status-dialogue-bar-kitchen-sink/06-experiments-micro-journeys-35-status-dialogue-bar-kitchen-sink.html
- Confirm that the text color within the red status bar is black, not white as in other browsers

In IE/Edge
![dialog-bar-alert-edgeie11](https://user-images.githubusercontent.com/677668/70149617-7bf7a280-1676-11ea-9da3-9cb4593e901b.jpg)

In Chrome/Firefox (expected behavior)
![dialog-bar-alert-chromeffsaf](https://user-images.githubusercontent.com/677668/70149613-79954880-1676-11ea-9ed5-95ce1a77f9f8.jpg)

### Confirm the fix
- In IE 11, go to `/pattern-lab/patterns/06-experiments-micro-journeys-35-status-dialogue-bar-kitchen-sink/06-experiments-micro-journeys-35-status-dialogue-bar-kitchen-sink.html` on this branch.
- Confirm that the alert text color is white in all browsers
