### PR TITLE
Fix: Device Viewer CSS Fix

### DIFF
--- a/packages/components/bolt-device-viewer/src/device-viewer.scss
+++ b/packages/components/bolt-device-viewer/src/device-viewer.scss
@@ -69,6 +69,7 @@ bolt-device-viewer {
 // Image zoom custom element
 bolt-image-zoom {
   display: block; // Required to render magnifying glass properly
+  user-select: none; // prevent accidentally highlighting image with cursor
 }
 
 $bolt-magnifier-size: 350px;
@@ -399,6 +400,7 @@ bolt-image-zoom:hover > .c-bolt-image-zoom__overlay {
 
   background: rgba(0, 0, 0, 0.5);
   will-change: top, left;
+  transition: none; // prevents jank when moving around the magnifier
 
   img {
     object-fit: cover;


### PR DESCRIPTION
## Jira
N/A

## Summary
Two small Device Viewer-related CSS fixes I ran into the need for while working on https://github.com/boltdesignsystem/bolt/pull/1579.

## Details
Prevents accidentally highlighting the device viewer image (which actually happened to me while zooming in on an image) + fixes the terribly janky transition when the device viewer image is magnified.

## How to test
Check out the device viewer section in Pattern Lab and confirm that images can no longer get highlighted (click and drag) + the animation when magnifying an image with your mouse is much smoother.
