### PR TITLE
ES Modules: Bolt Core / BoltElement Updates

### DIFF
--- a/packages/base-element/src/Slotify.js
+++ b/packages/base-element/src/Slotify.js
@@ -1,83 +1,81 @@
 /* eslint-disable class-methods-use-this */
+import { LitElement } from 'lit-element';
 
-const Slotify = Base =>
-  class extends Base {
-    templateMap = new Map();
+export class Slotify extends LitElement {
+  templateMap = new Map();
 
-    assignSlotToContent(child) {
-      return child.getAttribute
-        ? child.getAttribute('slot') || 'default'
-        : 'default';
+  assignSlotToContent(child) {
+    return child.getAttribute
+      ? child.getAttribute('slot') || 'default'
+      : 'default';
+  }
+
+  isEmptyTextNode(child) {
+    return child && (!child.textContent || !child.textContent.trim());
+  }
+
+  addChildToTemplateMap(slot, child) {
+    if (!slot) return;
+
+    if (!this.templateMap.has(slot)) {
+      this.templateMap.set(slot, [child]);
+    } else {
+      this.templateMap.set(slot, [...this.templateMap.get(slot), child]);
+    }
+  }
+
+  // Save a reference to the pseudoSlot content before lit-element renders
+  saveSlots() {
+    Array.from(this.childNodes).forEach(child => {
+      const slot = this.assignSlotToContent(child);
+
+      if (!child.textContent || child.textContent.trim().length > 0) {
+        this.addChildToTemplateMap(slot, child);
+      } else if (slot && child instanceof HTMLElement) {
+        this.addChildToTemplateMap(slot, child);
+      }
+    });
+  }
+
+  update(changedProperties) {
+    if (!this.hasUpdated) {
+      this.saveSlots();
     }
 
-    isEmptyTextNode(child) {
-      return child && (!child.textContent || !child.textContent.trim());
+    super.update(changedProperties);
+  }
+
+  slotify(slot = 'default', defaultContent) {
+    const slotContent = this.templateMap.get(slot);
+
+    // render actualy slots if Shadow DOM supported + getting used
+    // @todo: what's a better way to allow customizing the checks to perform?
+    if (
+      this.shadowRoot &&
+      (this.useShadow === undefined || this.useShadow === true) &&
+      (this.noShadow === undefined || this.useShadow === false) &&
+      slotContent
+    ) {
+      const realSlot = document.createElement('slot');
+      if (slot !== 'default') {
+        realSlot.setAttribute('name', slot);
+      }
+      return realSlot;
     }
 
-    addChildToTemplateMap(slot, child) {
-      if (!slot) return;
-
-      if (!this.templateMap.has(slot)) {
-        this.templateMap.set(slot, [child]);
-      } else {
-        this.templateMap.set(slot, [...this.templateMap.get(slot), child]);
-      }
+    if (slotContent && slotContent.content) {
+      return slotContent.content;
+    }
+    if (slotContent && slotContent.childNodes) {
+      return Array.from(slotContent.childNodes);
+    }
+    if (slotContent) {
+      return slotContent;
+    }
+    if (defaultContent) {
+      return defaultContent;
     }
 
-    // Save a reference to the pseudoSlot content before lit-element renders
-    saveSlots() {
-      Array.from(this.childNodes).forEach(child => {
-        const slot = this.assignSlotToContent(child);
-
-        if (!child.textContent || child.textContent.trim().length > 0) {
-          this.addChildToTemplateMap(slot, child);
-        } else if (slot && child instanceof HTMLElement) {
-          this.addChildToTemplateMap(slot, child);
-        }
-      });
-    }
-
-    update(changedProperties) {
-      if (!this.hasUpdated) {
-        this.saveSlots();
-      }
-
-      super.update(changedProperties);
-    }
-
-    slotify(slot = 'default', defaultContent) {
-      const slotContent = this.templateMap.get(slot);
-
-      // render actualy slots if Shadow DOM supported + getting used
-      // @todo: what's a better way to allow customizing the checks to perform?
-      if (
-        this.shadowRoot &&
-        (this.useShadow === undefined || this.useShadow === true) &&
-        (this.noShadow === undefined || this.useShadow === false) &&
-        slotContent
-      ) {
-        const realSlot = document.createElement('slot');
-        if (slot !== 'default') {
-          realSlot.setAttribute('name', slot);
-        }
-        return realSlot;
-      }
-
-      if (slotContent && slotContent.content) {
-        return slotContent.content;
-      }
-      if (slotContent && slotContent.childNodes) {
-        return Array.from(slotContent.childNodes);
-      }
-      if (slotContent) {
-        return slotContent;
-      }
-      if (defaultContent) {
-        return defaultContent;
-      }
-
-      return null;
-    }
-  };
-
-export { Slotify };
+    return null;
+  }
+}

--- a/packages/base-element/src/lib/decorators.js
+++ b/packages/base-element/src/lib/decorators.js
@@ -1,134 +1,289 @@
 import styleInjector from './style-injector';
-import { shouldUseShadowDom } from './utils';
+import { getComponentRootElement, shouldUseShadowDom } from './utils';
 
-export function renderAndRenderedEvents() {
-  return target => {
-    return class extends target {
-      firstUpdated(changedProperties) {
-        this._wasInitiallyRendered = true; // legacy internal prop used internally by many of Bolt's Web Components
-        super.firstUpdated && super.firstUpdated(changedProperties);
+/**
+ * A Class decorator that extends the `connecting()` method to find the first matching element in the component root and assign it to `this.rootElement`.
+ * Components can then check for `this.rootElement` and convert that element's attributes to props.
+ * Example: `<bolt-link>` will convert attributes on an `<a>` into component props.
+ *
+ * @param {(string|string[])} tags - A tag name or a list of tag names.
+ * @param {boolean} moveChildrenToRoot - If true, moves children of the root element to the custom element root.
+ * @returns {Object} - The original Class with extended `connecting()` method.
+ */
+const convertInitialClass = (tags, moveChildrenToRoot, clazz) => {
+  return class extends clazz {
+    connectedCallback() {
+      super.connectedCallback && super.connectedCallback();
+      // Make sure the component ONLY ever reuses any existing HTML ONCE.
+      if (
+        (this._wasInitiallyRendered === false ||
+          this._wasInitiallyRendered === undefined) &&
+        !this._convertedInitialTags
+      ) {
+        // If the initial element contains a child node, break apart the original HTML so we can retain the a tag but swap out the inner content with slots.
+        let rootElement = getComponentRootElement(this.childNodes, tags);
 
-        // Fired only once, when the component has finished rendering for the first time.
-        this.dispatchEvent(
-          new CustomEvent('ready', {
-            detail: {
-              name: this.tagName.toLowerCase(),
-              shadowDom: this.noShadow ? false : true,
-            },
-            bubbles: true,
-          }),
-        );
-      }
+        if (rootElement) {
+          this.rootElement = document.createDocumentFragment();
 
-      updated(changedProps) {
-        super.updated && super.updated(changedProps);
+          if (moveChildrenToRoot) {
+            // Take any child elements and move them to the root of the custom element
+            while (rootElement.firstChild) {
+              this.appendChild(rootElement.firstChild);
+            }
+          }
 
-        this.dispatchEvent(
-          new CustomEvent('rendered', {
-            detail: {
-              name: this.tagName.toLowerCase(),
-              shadowDom: this.noShadow ? false : true,
-            },
-            bubbles: true,
-          }),
-        );
-      }
-    };
-  };
-}
-
-export function lazyStyles() {
-  return target => {
-    return class extends target {
-      connectedCallback() {
-        super.connectedCallback && super.connectedCallback();
-
-        this.lazyStyles = this.constructor.lazyStyles;
-
-        if (this.lazyStyles && this.noShadow) {
-          styleInjector(...this.lazyStyles).add();
+          this.rootElement.appendChild(rootElement);
+          this._convertedInitialTags = true;
         }
       }
-
-      disconnectedCallback() {
-        super.disconnectedCallback && super.disconnectedCallback();
-
-        if (this.lazyStyles && this.noShadow) {
-          styleInjector(...this.lazyStyles).remove();
-        }
-      }
-    };
+    }
   };
-}
+};
 
-export function conditionalShadowDom() {
-  return target => {
-    return class extends target {
-      static get properties() {
-        return {
-          noShadow: {
-            type: Boolean,
-            attribute: 'no-shadow',
-            reflect: true,
-            hasChanged(newVal, oldVal) {
-              if (newVal === oldVal) {
-                return false;
-              } else {
-                return true;
-              }
-            },
+const legacyConvertInitialTags = (tags, moveChildrenToRoot = true, clazz) => {
+  return convertInitialClass(tags, moveChildrenToRoot, clazz);
+};
+
+const standardConvertInitialTags = (
+  tags,
+  moveChildrenToRoot = true,
+  descriptor,
+) => {
+  const { kind, elements } = descriptor;
+  return {
+    kind,
+    elements,
+    finisher(clazz) {
+      return convertInitialClass(tags, moveChildrenToRoot, clazz);
+    },
+  };
+};
+
+// output the correct decorator syntax depending on the the env being compiled
+export const convertInitialTags = (
+  tags,
+  moveChildrenToRoot,
+) => classOrDescriptor =>
+  typeof classOrDescriptor === 'function'
+    ? legacyConvertInitialTags(tags, moveChildrenToRoot, classOrDescriptor)
+    : standardConvertInitialTags(tags, moveChildrenToRoot, classOrDescriptor);
+
+/**
+ * A Class decorator that automatically renders to the Light DOM if/when Shadow DOM is unsupported
+ *
+ * @returns {Class} - The extended Class with an updated createRenderRoot method + hooks to opt out of rendering to Shadow DOM even after initially rendering
+ */
+const conditionalShadowDomClass = clazz => {
+  return class extends clazz {
+    static get properties() {
+      return {
+        noShadow: {
+          type: Boolean,
+          attribute: 'no-shadow',
+          reflect: true,
+          hasChanged(newVal, oldVal) {
+            if (newVal === oldVal) {
+              return false;
+            } else {
+              return true;
+            }
           },
-        };
+        },
+      };
+    }
+
+    createRenderRoot() {
+      this.useShadow = shouldUseShadowDom(this);
+
+      if (this.useShadow) {
+        return this.attachShadow({ mode: 'open' });
+      } else {
+        return this;
       }
+    }
 
-      createRenderRoot() {
-        this.useShadow = shouldUseShadowDom(this);
+    // re-initialize components configured to opt in / out of Shadow DOM too late (after createRenderRoot has fired)
+    _disableShadowDom() {
+      this.useShadow = false;
+      this.renderRoot = this;
 
-        if (this.useShadow) {
-          return this.attachShadow({ mode: 'open' });
-        } else {
-          return this;
-        }
+      const skipRerenderingIfContainsThisMarkup = `
+        <!---->
+          <slot></slot>
+        <!---->
+      `;
+
+      const removeWhitespaceRegex = /(\r\n|\n|\r| )/gm;
+
+      if (
+        this.shadowRoot.innerHTML.replace(removeWhitespaceRegex, '') !==
+        skipRerenderingIfContainsThisMarkup.replace(removeWhitespaceRegex, '')
+      ) {
+        console.log('re-rendering to the light DOM...');
+        this.shadowRoot.innerHTML = '<slot>';
+        this.requestUpdate();
       }
+    }
 
-      // re-initialize components configured to opt in / out of Shadow DOM too late (after createRenderRoot has fired)
-      _disableShadowDom() {
-        this.useShadow = false;
-        this.renderRoot = this;
+    connectedCallback() {
+      super.connectedCallback && super.connectedCallback();
 
-        const skipRerenderingIfContainsThisMarkup = `
-          <!---->
-            <slot></slot>
-          <!---->
-        `;
-
-        const removeWhitespaceRegex = /(\r\n|\n|\r| )/gm;
-
-        if (
-          this.shadowRoot.innerHTML.replace(removeWhitespaceRegex, '') !==
-          skipRerenderingIfContainsThisMarkup.replace(removeWhitespaceRegex, '')
-        ) {
-          console.log('re-rendering to the light DOM...');
-          this.shadowRoot.innerHTML = '<slot>';
-          this.requestUpdate();
-        }
+      if (this.noShadow && this.useShadow) {
+        this._disableShadowDom();
       }
+    }
 
-      connectedCallback() {
-        super.connectedCallback && super.connectedCallback();
+    updated(changedProps) {
+      super.updated && super.updated(changedProps);
 
-        if (this.noShadow && this.useShadow) {
-          this._disableShadowDom();
-        }
+      if (this.noShadow && this.useShadow) {
+        this._disableShadowDom();
       }
-
-      updated(changedProps) {
-        super.updated && super.updated(changedProps);
-
-        if (this.noShadow && this.useShadow) {
-          this._disableShadowDom();
-        }
-      }
-    };
+    }
   };
-}
+};
+
+const legacyConditionalShadowDom = clazz => {
+  return conditionalShadowDomClass(clazz);
+};
+
+const standardConditionalShadowDom = descriptor => {
+  const { kind, elements } = descriptor;
+  return {
+    kind,
+    elements,
+    finisher(clazz) {
+      return conditionalShadowDomClass(clazz);
+    },
+  };
+};
+
+/**
+ * Class decorator factory to apply conditional Shadow DOM rendering logic
+ */
+export const conditionalShadowDom = () => classOrDescriptor =>
+  typeof classOrDescriptor === 'function'
+    ? legacyConditionalShadowDom(classOrDescriptor)
+    : standardConditionalShadowDom(classOrDescriptor);
+
+/**
+ * A Class decorator that automatically renders to the Light DOM if/when Shadow DOM is unsupported
+ *
+ * @returns {Class} - The extended Class with an updated createRenderRoot method + hooks to opt out of rendering to Shadow DOM even after initially rendering
+ */
+const lazyStylesClass = clazz => {
+  return class extends clazz {
+    connectedCallback() {
+      super.connectedCallback && super.connectedCallback();
+
+      this.lazyStyles = this.constructor.lazyStyles;
+
+      if (this.lazyStyles && this.noShadow) {
+        styleInjector(...this.lazyStyles).add();
+      }
+    }
+
+    disconnectedCallback() {
+      super.disconnectedCallback && super.disconnectedCallback();
+
+      if (this.lazyStyles && this.noShadow) {
+        styleInjector(...this.lazyStyles).remove();
+      }
+    }
+  };
+};
+
+/**
+ * A conditional Shadow DOM decorator for the old (legacy) decorator syntax
+ */
+const legacyLazyStyles = clazz => {
+  return lazyStylesClass(clazz);
+};
+
+/**
+ * A conditional Shadow DOM decorator for the new decorator syntax
+ */
+const standardLazyStyles = descriptor => {
+  const { kind, elements } = descriptor;
+  return {
+    kind,
+    elements,
+    finisher(clazz) {
+      return lazyStylesClass(clazz);
+    },
+  };
+};
+
+/**
+ * Class decorator factory that defines the decorated class as a custom element.
+ */
+export const lazyStyles = () => classOrDescriptor =>
+  typeof classOrDescriptor === 'function'
+    ? legacyLazyStyles(classOrDescriptor)
+    : standardLazyStyles(classOrDescriptor);
+
+/**
+ * A Class decorator that extends the LitElement `firstUpdated` and `updated` lifecycle events,
+ * adding a `ready` and `rendered` custom events for other components to hook into
+ *
+ * @param {Class} clazz - The original Class to extend
+ * @returns {Class} - The extended Class with added events when rendering + updating
+ */
+const renderEventsClass = clazz => {
+  return class extends clazz {
+    firstUpdated(changedProperties) {
+      this._wasInitiallyRendered = true; // legacy internal prop used internally by many of Bolt's Web Components
+      super.firstUpdated && super.firstUpdated(changedProperties);
+
+      // Fired only once, when the component has finished rendering for the first time.
+      this.dispatchEvent(
+        new CustomEvent('ready', {
+          detail: {
+            name: this.tagName.toLowerCase(),
+            shadowDom: this.noShadow ? false : true,
+          },
+          bubbles: true,
+        }),
+      );
+    }
+
+    updated(changedProps) {
+      super.updated && super.updated(changedProps);
+
+      this.dispatchEvent(
+        new CustomEvent('rendered', {
+          detail: {
+            name: this.tagName.toLowerCase(),
+            shadowDom: this.noShadow ? false : true,
+          },
+          bubbles: true,
+        }),
+      );
+    }
+  };
+};
+
+const legacyRenderEventDecorator = clazz => {
+  return renderEventsClass(clazz);
+};
+
+const standardRenderEventDecorator = descriptor => {
+  const { kind, elements } = descriptor;
+  return {
+    kind,
+    elements,
+    finisher(clazz) {
+      return renderEventsClass(clazz);
+    },
+  };
+};
+
+/**
+ * Class decorator factory that adds `render` and `rendered` custom events to the LitElement-based web component
+ * Automatically uses the appropriate decorator syntax based on what's supported / how the code is being compiled.
+ */
+export const renderAndRenderedEvents = () => classOrDescriptor =>
+  typeof classOrDescriptor === 'function'
+    ? legacyRenderEventDecorator(classOrDescriptor)
+    : standardRenderEventDecorator(classOrDescriptor);

--- a/packages/base-element/src/lib/utils.js
+++ b/packages/base-element/src/lib/utils.js
@@ -33,3 +33,64 @@ export function supportsShadowDom() {
     return false;
   }
 }
+
+export function sanitizeBoltClasses(
+  elementToSanitize,
+  prefixesToRemove = ['c-bolt-'],
+) {
+  let prefixes = Array.from(prefixesToRemove);
+  // Remove any `c-bolt-` prefixed classes but leave the rest
+  let remainingClasses;
+
+  prefixes.forEach(function(prefix) {
+    remainingClasses = elementToSanitize.className
+      .split(' ')
+      .filter(function(c) {
+        return c.lastIndexOf(prefix, 0) !== 0;
+      });
+  });
+
+  return remainingClasses.join(' ').trim();
+}
+
+/**
+ * Get the first matching element in list of nodes. Sanitize classes and attributes, and return the element.
+ *
+ * @param {NodeList} nodeList - A list of nodes in the DOM tree.
+ * @param {(string|string[])} tags - A tag name or a list of tag names.
+ * @returns {Element} - The first matching element
+ */
+export function getComponentRootElement(nodeList, tags) {
+  let rootElement;
+
+  if (typeof tags === 'string') {
+    tags = [tags];
+  } else if (!Array.isArray(tags)) {
+    return null;
+  }
+
+  tags = tags.map(name => name.toUpperCase());
+
+  nodeList.forEach((childElement, i) => {
+    if (
+      childElement.tagName &&
+      tags.includes(childElement.tagName) &&
+      rootElement === undefined
+    ) {
+      if (childElement.className) {
+        childElement.className = sanitizeBoltClasses(childElement);
+      }
+
+      if (
+        childElement.getAttribute('is') &&
+        childElement.getAttribute('is') === 'shadow-root'
+      ) {
+        childElement.removeAttribute('is');
+      }
+
+      rootElement = childElement;
+    }
+  });
+
+  return rootElement;
+}

--- a/packages/core/decorators/convert-initial-tags.js
+++ b/packages/core/decorators/convert-initial-tags.js
@@ -8,7 +8,7 @@
  * @returns {Object} - The original Class with extended `connecting()` method.
  */
 
-import { getComponentRootElement } from '@bolt/core/utils';
+import { getComponentRootElement } from '@bolt/core/utils/get-component-root-element';
 
 export function convertInitialTags(tags, moveChildrenToRoot = true) {
   return target => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,7 @@
   "types": "index.d.ts",
   "repository": "https://github.com/bolt-design-system/bolt/tree/master/packages/core",
   "dependencies": {
+    "camelcase": "^5.3.1",
     "preact-markup": "^2.0.0",
     "sassy-lists": "^3.0.1",
     "@bolt/element": "^2.12.0",

--- a/packages/core/renderers/bolt-base.js
+++ b/packages/core/renderers/bolt-base.js
@@ -1,7 +1,13 @@
 import Ajv from 'ajv';
-import { withComponent, props } from 'skatejs';
-import changeCase from 'change-case';
-import { shouldUseShadowDom, hasNativeShadowDomSupport } from '@bolt/element';
+import { props } from 'skatejs';
+import { withLifecycle } from 'skatejs/dist/esnext/with-lifecycle.js';
+import { withUpdate } from 'skatejs/dist/esnext/with-update.js';
+import { withRenderer } from 'skatejs/dist/esnext/with-renderer.js';
+import camelcase from 'camelcase';
+import {
+  shouldUseShadowDom,
+  hasNativeShadowDomSupport,
+} from '@bolt/element/src/lib/utils';
 import { renameKey } from '../utils';
 
 export function shadow(elem) {
@@ -17,257 +23,241 @@ export function shadow(elem) {
   );
 }
 
-export function BoltBase(Base = HTMLElement) {
-  return class extends Base {
-    constructor(self) {
-      super(self);
-      this._wasInitiallyRendered = false;
-      return self;
+export const withComponent = (Base = HTMLElement) =>
+  withLifecycle(withUpdate(withRenderer(Base)));
+
+export class BoltBase extends withComponent(HTMLElement) {
+  connectedCallback() {
+    super.connectedCallback && super.connectedCallback();
+
+    // Check if any `<ssr-keep>` elements have registered themselves here. If so, kick off the one-time hydration prep task.
+    if (this.ssrKeep && !this.ssrPrepped) {
+      this.ssrHydrationPrep();
     }
+  }
 
-    connectedCallback() {
-      super.connectedCallback && super.connectedCallback();
+  /**
+   * Update component state and schedule a re-render.
+   * @param {object} state A dict of state properties to be shallowly merged
+   * 	into the current state
+   */
+  setState(state) {
+    this.state = Object.assign({}, this.state, state);
+    // super.shouldUpdate && super.shouldUpdate();
+  }
 
-      // Check if any `<ssr-keep>` elements have registered themselves here. If so, kick off the one-time hydration prep task.
-      if (this.ssrKeep && !this.ssrPrepped) {
-        this.ssrHydrationPrep();
-      }
-    }
-
-    /**
-     * Update component state and schedule a re-render.
-     * @param {object} state A dict of state properties to be shallowly merged
-     * 	into the current state
-     */
-    setState(state) {
-      this.state = Object.assign({}, this.state, state);
-      // super.shouldUpdate && super.shouldUpdate();
-    }
-
-    setupSlots() {
-      // Automatically adjust which inner element inside the custom element gets used as the base when evaluating slotted children. Necessary when including deeply nested slots in the initial HTML being rendered, which might include a few wrapping containers that get removed when the JavaScript kicks in. <-- this is how we get slotted buttons to work!
-      const isShadowRootSelector = this.querySelector('[is="shadow-root"]');
-      if (isShadowRootSelector) {
-        if (isShadowRootSelector.childNodes) {
-          this.slots = this._checkSlots(isShadowRootSelector.childNodes);
-        } else {
-          this.slots = this._checkSlots();
-        }
+  setupSlots() {
+    // Automatically adjust which inner element inside the custom element gets used as the base when evaluating slotted children. Necessary when including deeply nested slots in the initial HTML being rendered, which might include a few wrapping containers that get removed when the JavaScript kicks in. <-- this is how we get slotted buttons to work!
+    const isShadowRootSelector = this.querySelector('[is="shadow-root"]');
+    if (isShadowRootSelector) {
+      if (isShadowRootSelector.childNodes) {
+        this.slots = this._checkSlots(isShadowRootSelector.childNodes);
       } else {
         this.slots = this._checkSlots();
       }
+    } else {
+      this.slots = this._checkSlots();
+    }
+  }
+
+  setupShadow() {
+    this.useShadow = shouldUseShadowDom(this);
+  }
+
+  get renderRoot() {
+    // ensure every component instance renders to the light DOM when needed (ex. if nested inside of a form, render to the light DOM)
+    // this ensures that things work as expected, even when a component gets removed / re-added to the page
+    this.setupShadow();
+
+    // double-check if any `<ssr-keep>` elements have registered anything after connectedCallback fired.
+    // this extra check addresses a bug encountered where components like accordions connect BEFORE <ssr-keep> fires
+    if (this.ssrKeep && !this.ssrPrepped) {
+      this.ssrHydrationPrep();
     }
 
-    setupShadow() {
-      this.useShadow = shouldUseShadowDom(this);
+    // @todo: add debug flag the build to allow conditionally enabling / disabling this extra slot setup check here.
+    if (!this.slots) {
+      this.setupSlots(); // hotfix to ensure heavily nested elements containing text-nodes like <replace-with-children> re-render consistently in browsers that don't natively support custom elements Fixes wwwd8-2678
     }
 
-    get renderRoot() {
-      // ensure every component instance renders to the light DOM when needed (ex. if nested inside of a form, render to the light DOM)
-      // this ensures that things work as expected, even when a component gets removed / re-added to the page
-      this.setupShadow();
-
-      // double-check if any `<ssr-keep>` elements have registered anything after connectedCallback fired.
-      // this extra check addresses a bug encountered where components like accordions connect BEFORE <ssr-keep> fires
-      if (this.ssrKeep && !this.ssrPrepped) {
-        this.ssrHydrationPrep();
-      }
-
-      // @todo: add debug flag the build to allow conditionally enabling / disabling this extra slot setup check here.
-      if (!this.slots) {
-        this.setupSlots(); // hotfix to ensure heavily nested elements containing text-nodes like <replace-with-children> re-render consistently in browsers that don't natively support custom elements Fixes wwwd8-2678
-      }
-
-      if (hasNativeShadowDomSupport && this.useShadow === true) {
-        return super.renderRoot || shadow(this);
-      } else {
-        return this;
-      }
+    if (hasNativeShadowDomSupport && this.useShadow === true) {
+      return super.renderRoot || shadow(this);
+    } else {
+      return this;
     }
+  }
 
-    validateProps(propData) {
-      var validatedData = propData;
-      const ajv = new Ajv({ useDefaults: 'shared', coerceTypes: true });
+  validateProps(propData) {
+    var validatedData = propData;
+    const ajv = new Ajv({ useDefaults: 'shared', coerceTypes: true });
 
-      // remove default strings in prop data so schema validation can fill in the default
-      for (let property in validatedData) {
-        if (validatedData[property] === '') {
-          delete validatedData[property];
-        }
-      }
-
-      // Skip this if formatted schema data is already stored
-      if (this.schema && !this.formattedSchema) {
-        this.formattedSchema = {};
-        Object.assign(this.formattedSchema, this.schema);
-        Object.keys(this.formattedSchema.properties).map(key => {
-          this.formattedSchema.properties = renameKey(
-            key,
-            changeCase.camelCase(key),
-            this.formattedSchema.properties,
-          );
-        });
-      }
-
-      if (this.formattedSchema) {
-        let isValid = ajv.validate(this.formattedSchema, validatedData);
-
-        // bark at any schema validation errors
-        if (!isValid) {
-          console.log(ajv.errors);
-        }
-      }
-
-      return validatedData;
-    }
-
-    /**
-     * Get modified version of schema, removing any properties not wanted on Web Component
-     * @param {object} schema A valid JSON schema
-     * @param {(string|string[])} propsToRemove A prop or list of props to be removed from the schema
-     * @returns {object} returns the modified JSON schema
-     */
-    getModifiedSchema(schema, propsToRemove = 'content') {
-      let modifiedSchema = schema;
-
-      if (typeof propsToRemove === 'string') {
-        propsToRemove = [propsToRemove];
-      }
-
-      try {
-        propsToRemove.forEach(item => {
-          if (modifiedSchema.properties && modifiedSchema.properties[item]) {
-            // Delete property key from schema
-            delete modifiedSchema.properties[item];
-          }
-
-          if (modifiedSchema.required) {
-            const index = modifiedSchema.required.indexOf(item);
-            if (index !== -1) {
-              // Remove from list of required fields
-              modifiedSchema.required.splice(index, 1);
-              if (!modifiedSchema.required.length) {
-                // If no required props remain, just delete the whole key
-                delete modifiedSchema.required;
-              }
-            }
-          }
-        });
-      } catch (e) {
-        console.warn(e.message, e.name);
-      }
-
-      return modifiedSchema;
-    }
-
-    /**
-     * Replace server-side rendered HTML with only the markup needed to hydrate web component, as marked by `<ssr-keep>` elements.
-     */
-    ssrHydrationPrep() {
-      this.nodesToKeep = [];
-
-      this.ssrKeep.forEach(item => {
-        while (item.firstChild) {
-          this.nodesToKeep.push(item.firstChild); // track the nodes that will be preserved
-          this.appendChild(item.firstChild);
-        }
-      });
-
-      // Remove all children not in the "keep" array
-      Array.from(this.children)
-        .filter(item => !this.nodesToKeep.includes(item))
-        .forEach(node => {
-          node.parentElement.removeChild(node);
-        });
-
-      this.ssrPrepped = true;
-    }
-
-    addStyles(stylesheet) {
-      let styles = Array.from(stylesheet);
-      styles = styles.join(' ');
-
-      if (this.useShadow && this.renderStyles) {
-        return this.renderStyles(styles);
+    // remove default strings in prop data so schema validation can fill in the default
+    for (let property in validatedData) {
+      if (validatedData[property] === '') {
+        delete validatedData[property];
       }
     }
 
-    /**
-     * Automatically adds classes for the first and last slotted item (in the default slot) to help with tricky ::slotted selectors
-     * @param {string[]} slotNames an array of slot names as strings
-     */
-    addClassesToSlottedChildren(slotNames = ['default']) {
-      if (this.slots) {
-        const applyClasses = slotName => {
-          if (!(slotName in this.slots)) return;
-
-          const currentSlot = [];
-
-          this.slots[slotName].forEach(item => {
-            if (item.tagName) {
-              item.classList.remove('is-first-child');
-              item.classList.remove('is-last-child'); // clean up existing classes
-              currentSlot.push(item);
-            }
-          });
-
-          if (currentSlot[0]) {
-            currentSlot[0].classList.add('is-first-child');
-
-            if (currentSlot.length === 1) {
-              currentSlot[0].classList.add('is-last-child');
-            }
-          }
-
-          if (currentSlot[currentSlot.length - 1]) {
-            currentSlot[currentSlot.length - 1].classList.add('is-last-child');
-          }
-        };
-
-        slotNames.forEach(name => applyClasses(name));
-      }
-    }
-
-    // Inspired by https://codepen.io/jovdb/pen/ddRZKo
-    _checkSlots(selector = this.childNodes) {
-      const slots = { default: [] };
-
-      // Loop through nodelist
-      selector.forEach(function(child, index, nodelist) {
-        const slotName = child.getAttribute ? child.getAttribute('slot') : null;
-
-        if (!slotName) {
-          slots.default.push(child);
-        } else if (slots[slotName]) {
-          slots[slotName].push(child);
-        } else {
-          slots[slotName] = [];
-          slots[slotName].push(child);
-        }
-      });
-
-      return slots;
-    }
-
-    rendered() {
-      if (!this._wasInitiallyRendered) {
-        this._wasInitiallyRendered = true;
-
-        // Fired only once, when the component has finished rendering for the first time.
-        this.dispatchEvent(
-          new CustomEvent('ready', {
-            detail: {
-              name: this.tagName.toLowerCase(),
-              shadowDom: this.useShadow ? true : false,
-            },
-            bubbles: true,
-          }),
+    // Skip this if formatted schema data is already stored
+    if (this.schema && !this.formattedSchema) {
+      this.formattedSchema = {};
+      Object.assign(this.formattedSchema, this.schema);
+      Object.keys(this.formattedSchema.properties).map(key => {
+        this.formattedSchema.properties = renameKey(
+          key,
+          camelcase(key),
+          this.formattedSchema.properties,
         );
-      }
+      });
+    }
 
-      // Fired every time an element has rendered
+    if (this.formattedSchema) {
+      let isValid = ajv.validate(this.formattedSchema, validatedData);
+
+      // bark at any schema validation errors
+      if (!isValid) {
+        console.log(ajv.errors);
+      }
+    }
+
+    return validatedData;
+  }
+
+  /**
+   * Get modified version of schema, removing any properties not wanted on Web Component
+   * @param {object} schema A valid JSON schema
+   * @param {(string|string[])} propsToRemove A prop or list of props to be removed from the schema
+   * @returns {object} returns the modified JSON schema
+   */
+  getModifiedSchema(schema, propsToRemove = 'content') {
+    let modifiedSchema = schema;
+
+    if (typeof propsToRemove === 'string') {
+      propsToRemove = [propsToRemove];
+    }
+
+    try {
+      propsToRemove.forEach(item => {
+        if (modifiedSchema.properties && modifiedSchema.properties[item]) {
+          // Delete property key from schema
+          delete modifiedSchema.properties[item];
+        }
+
+        if (modifiedSchema.required) {
+          const index = modifiedSchema.required.indexOf(item);
+          if (index !== -1) {
+            // Remove from list of required fields
+            modifiedSchema.required.splice(index, 1);
+            if (!modifiedSchema.required.length) {
+              // If no required props remain, just delete the whole key
+              delete modifiedSchema.required;
+            }
+          }
+        }
+      });
+    } catch (e) {
+      console.warn(e.message, e.name);
+    }
+
+    return modifiedSchema;
+  }
+
+  /**
+   * Replace server-side rendered HTML with only the markup needed to hydrate web component, as marked by `<ssr-keep>` elements.
+   */
+  ssrHydrationPrep() {
+    this.nodesToKeep = [];
+
+    this.ssrKeep.forEach(item => {
+      while (item.firstChild) {
+        this.nodesToKeep.push(item.firstChild); // track the nodes that will be preserved
+        this.appendChild(item.firstChild);
+      }
+    });
+
+    // Remove all children not in the "keep" array
+    Array.from(this.children)
+      .filter(item => !this.nodesToKeep.includes(item))
+      .forEach(node => {
+        node.parentElement.removeChild(node);
+      });
+
+    this.ssrPrepped = true;
+  }
+
+  addStyles(stylesheet) {
+    let styles = Array.from(stylesheet);
+    styles = styles.join(' ');
+
+    if (this.useShadow && this.renderStyles) {
+      return this.renderStyles(styles);
+    }
+  }
+
+  /**
+   * Automatically adds classes for the first and last slotted item (in the default slot) to help with tricky ::slotted selectors
+   * @param {string[]} slotNames an array of slot names as strings
+   */
+  addClassesToSlottedChildren(slotNames = ['default']) {
+    if (this.slots) {
+      const applyClasses = slotName => {
+        if (!(slotName in this.slots)) return;
+
+        const currentSlot = [];
+
+        this.slots[slotName].forEach(item => {
+          if (item.tagName) {
+            item.classList.remove('is-first-child');
+            item.classList.remove('is-last-child'); // clean up existing classes
+            currentSlot.push(item);
+          }
+        });
+
+        if (currentSlot[0]) {
+          currentSlot[0].classList.add('is-first-child');
+
+          if (currentSlot.length === 1) {
+            currentSlot[0].classList.add('is-last-child');
+          }
+        }
+
+        if (currentSlot[currentSlot.length - 1]) {
+          currentSlot[currentSlot.length - 1].classList.add('is-last-child');
+        }
+      };
+
+      slotNames.forEach(name => applyClasses(name));
+    }
+  }
+
+  // Inspired by https://codepen.io/jovdb/pen/ddRZKo
+  _checkSlots(selector = this.childNodes) {
+    const slots = { default: [] };
+
+    // Loop through nodelist
+    selector.forEach(function(child, index, nodelist) {
+      const slotName = child.getAttribute ? child.getAttribute('slot') : null;
+
+      if (!slotName) {
+        slots.default.push(child);
+      } else if (slots[slotName]) {
+        slots[slotName].push(child);
+      } else {
+        slots[slotName] = [];
+        slots[slotName].push(child);
+      }
+    });
+
+    return slots;
+  }
+
+  rendered() {
+    if (!this._wasInitiallyRendered) {
+      this._wasInitiallyRendered = true;
+
+      // Fired only once, when the component has finished rendering for the first time.
       this.dispatchEvent(
-        new CustomEvent('rendered', {
+        new CustomEvent('ready', {
           detail: {
             name: this.tagName.toLowerCase(),
             shadowDom: this.useShadow ? true : false,
@@ -276,5 +266,16 @@ export function BoltBase(Base = HTMLElement) {
         }),
       );
     }
-  };
+
+    // Fired every time an element has rendered
+    this.dispatchEvent(
+      new CustomEvent('rendered', {
+        detail: {
+          name: this.tagName.toLowerCase(),
+          shadowDom: this.useShadow ? true : false,
+        },
+        bubbles: true,
+      }),
+    );
+  }
 }

--- a/packages/core/renderers/renderer-lit-html.js
+++ b/packages/core/renderers/renderer-lit-html.js
@@ -1,83 +1,64 @@
 import { html, render } from 'lit-html';
-import { withChildren, withLifecycle, withUpdate, withRenderer } from 'skatejs';
 import { withContext } from 'wc-context/skatejs';
-
-import {
-  withComponent,
-  shadow,
-  props,
-  hasNativeShadowDomSupport,
-} from '../utils';
+import { props, hasNativeShadowDomSupport } from '../utils';
 import { BoltBase } from './bolt-base';
 
 export { html, render } from 'lit-html';
 
-export const withLit = (Base = HTMLElement) =>
-  class extends Base {
-    // 1. Remove line breaks before and after lit-html template tags, causes unwanted space inside and around inline links
+export class withLit extends BoltBase {
+  // 1. Remove line breaks before and after lit-html template tags, causes unwanted space inside and around inline links
 
-    static props = {
-      onClick: props.string,
-      onClickTarget: props.string,
-      isServer: {
-        ...props.boolean,
-        ...{ default: bolt.isServer },
-      },
-      isClient: {
-        ...props.boolean,
-        ...{ default: bolt.isClient },
-      },
-    };
-
-    constructor(...args) {
-      super(...args);
-    }
-
-    renderStyles(styles) {
-      if (styles) {
-        // [1]
-        // prettier-ignore
-        return html`<style>${styles}</style>`;
-      }
-    }
-
-    slot(name) {
-      if (typeof this.slots[name] === 'undefined') {
-        this.slots[name] = [];
-      }
-
-      // [1]
-      // prettier-ignore
-      if (this.useShadow && hasNativeShadowDomSupport) {
-        if (name === 'default') {
-          return html`<slot />`;
-        } else {
-          return html`<slot name="${name}" />`;
-        }
-      } else {
-        if (name === 'default') {
-          return html`${this.slots.default}`;
-        } else if (this.slots[name] && this.slots[name] !== []) {
-          return html`${this.slots[name]}`;
-        } else {
-          return ''; // No slots assigned so don't return any markup.
-          console.log(`The ${name} slot doesn't appear to exist...`);
-        }
-      }
-    }
-
-    renderer(root, call) {
-      render(call(), root);
-    }
+  static props = {
+    onClick: props.string,
+    onClickTarget: props.string,
+    isServer: {
+      ...props.boolean,
+      ...{ default: bolt.isServer },
+    },
+    isClient: {
+      ...props.boolean,
+      ...{ default: bolt.isClient },
+    },
   };
 
-export function withLitHtml(Base = HTMLElement) {
-  return class extends withLit(withComponent(BoltBase(Base))) {};
+  renderStyles(styles) {
+    if (styles) {
+      // [1]
+      // prettier-ignore
+      return html`<style>${styles}</style>`;
+    }
+  }
+
+  slot(name) {
+    if (typeof this.slots[name] === 'undefined') {
+      this.slots[name] = [];
+    }
+
+    // [1]
+    // prettier-ignore
+    if (this.useShadow && hasNativeShadowDomSupport) {
+      if (name === 'default') {
+        return html`<slot />`;
+      } else {
+        return html`<slot name="${name}" />`;
+      }
+    } else {
+      if (name === 'default') {
+        return html`${this.slots.default}`;
+      } else if (this.slots[name] && this.slots[name] !== []) {
+        return html`${this.slots[name]}`;
+      } else {
+        return ''; // No slots assigned so don't return any markup.
+        console.log(`The ${name} slot doesn't appear to exist...`);
+      }
+    }
+  }
+
+  renderer(root, call) {
+    render(call(), root);
+  }
 }
 
-export const withLitContext = (Base = HTMLElement) =>
-  withLit(
-    withContext(
-      withLifecycle(withChildren(withUpdate(withRenderer(BoltBase(Base))))),
-    ),
-  );
+export class withLitHtml extends withLit {}
+
+export class withLitContext extends withContext(withLit) {}

--- a/packages/core/renderers/renderer-preact.js
+++ b/packages/core/renderers/renderer-preact.js
@@ -1,45 +1,52 @@
-/** @jsx h */
 import { withComponent, props } from 'skatejs';
 import { h, render } from 'preact';
-import { BoltBase } from './bolt-base';
+import { BoltBase, shadow } from './bolt-base';
 export { default as Markup } from './preact-markup.js';
 export { Fragment, h } from 'preact';
 
-export function withPreact(Base = HTMLElement) {
-  return class extends withComponent(BoltBase(Base)) {
-    get props() {
-      // We override props so that we can satisfy most use
-      // cases for children by using a slot.
-      return {
-        ...super.props,
-        isServer: {
-          ...props.boolean,
-          ...{ default: bolt.isServer },
-        },
-        isClient: {
-          ...props.boolean,
-          ...{ default: bolt.isClient },
-        },
-      };
-    }
-
-    constructor(...args) {
-      super(...args);
-    }
-
-    renderStyles(styles) {
-      if (styles) {
-        return this.useShadow && <style>{styles}</style>;
+var _extends =
+  Object.assign ||
+  function(target) {
+    for (var i = 1; i < arguments.length; i++) {
+      var source = arguments[i];
+      for (var key in source) {
+        if (Object.prototype.hasOwnProperty.call(source, key)) {
+          target[key] = source[key];
+        }
       }
     }
-
-    renderer(root, call) {
-      this._renderRoot = root;
-      render(call(), this._renderRoot);
-    }
-
-    disconnectedCallback() {
-      super.disconnectedCallback && super.disconnectedCallback();
-    }
+    return target;
   };
+
+export class withPreact extends BoltBase {
+  get props() {
+    // We override props so that we can satisfy most use
+    // cases for children by using a slot.
+    return _extends({}, super.props, {
+      isServer: {
+        ...props.boolean,
+        ...{ default: bolt.isServer },
+      },
+      isClient: {
+        ...props.boolean,
+        ...{ default: bolt.isClient },
+      },
+      children: h('slot', null),
+    });
+  }
+
+  renderStyles(styles) {
+    if (styles) {
+      return this.useShadow && <style>{styles}</style>;
+    }
+  }
+
+  renderer(root, call) {
+    this._renderRoot = root;
+    this._preactDom = render(call(), root);
+  }
+
+  get renderRoot() {
+    return super.renderRoot || shadow(this);
+  }
 }

--- a/packages/core/renderers/wc-context.core.js
+++ b/packages/core/renderers/wc-context.core.js
@@ -1,0 +1,110 @@
+const orphanMap = {};
+
+const resolved = Promise.resolve();
+
+const orphanResolveQueue = {
+  contexts: new Set(),
+  running: false,
+  add(context) {
+    this.contexts.add(context);
+    if (!this.running) {
+      this.running = true;
+      resolved.then(() => {
+        this.contexts.forEach(context => {
+          const orphans = orphanMap[context];
+          orphans.forEach(orphan => {
+            const event = sendContextEvent(orphan, context);
+            if (event.detail.handled) {
+              orphans.delete(orphan);
+            }
+          });
+        });
+        this.contexts.clear();
+        this.running = false;
+      });
+    }
+  },
+};
+
+function addOrphan(el, name) {
+  const orphans = orphanMap[name] || (orphanMap[name] = new Set());
+  orphans.add(el);
+}
+
+function removeOrphan(el, name) {
+  const orphans = orphanMap[name];
+  if (orphans) {
+    orphans.delete(el);
+  }
+}
+
+function sendContextEvent(el, name) {
+  const event = new CustomEvent(`context-request-${name}`, {
+    detail: {},
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+  });
+  el.dispatchEvent(event);
+  return event;
+}
+
+function registerProvidedContext(el, name, providedContexts) {
+  const observerMap =
+    el.__wcContextObserverMap || (el.__wcContextObserverMap = {});
+  const observers = observerMap[name] || (observerMap[name] = []);
+  const orphans = orphanMap[name];
+  el.addEventListener(`context-request-${name}`, event => {
+    event.stopPropagation();
+    const targetEl = event.target;
+    const value = providedContexts[name];
+    const context = targetEl.context;
+    const oldValue = context[name];
+    if (oldValue !== value) {
+      context[name] = value;
+      if (targetEl.contextChangedCallback) {
+        targetEl.contextChangedCallback(name, oldValue, value);
+      }
+    }
+    observers.push(targetEl);
+    event.detail.handled = true;
+  });
+  if (orphans && orphans.size) {
+    orphanResolveQueue.add(name);
+  }
+}
+
+function observeContext(el, name) {
+  const event = sendContextEvent(el, name);
+  if (!event.detail.handled) {
+    addOrphan(el, name);
+  }
+}
+
+function unobserveContext(el, name) {
+  removeOrphan(el, name);
+}
+
+function notifyContextChange(el, name, value) {
+  const observerMap = el.__wcContextObserverMap;
+  const observers = observerMap && observerMap[name];
+  if (observers) {
+    observers.forEach(observer => {
+      const context = observer.context;
+      const oldValue = context[name];
+      if (oldValue !== value) {
+        context[name] = value;
+        if (observer.contextChangedCallback) {
+          observer.contextChangedCallback(name, oldValue, value);
+        }
+      }
+    });
+  }
+}
+
+export {
+  registerProvidedContext,
+  observeContext,
+  unobserveContext,
+  notifyContextChange,
+};

--- a/packages/core/renderers/wc-context.js
+++ b/packages/core/renderers/wc-context.js
@@ -1,0 +1,73 @@
+import {
+  observeContext,
+  unobserveContext,
+  registerProvidedContext,
+  notifyContextChange,
+} from './wc-context.core';
+
+const initializedElements = new WeakSet();
+
+const withContext = Base => {
+  return class extends Base {
+    get context() {
+      // eslint-disable-next-line no-return-assign
+      return this.__wcContext || (this.__wcContext = {});
+    }
+
+    connectedCallback() {
+      super.connectedCallback && super.connectedCallback();
+      const observedContexts = this.constructor.observedContexts;
+      if (observedContexts) {
+        observedContexts.forEach(context => observeContext(this, context));
+      }
+
+      if (!initializedElements.has(this)) {
+        const providedContextConfigs = this.constructor.providedContexts;
+        if (providedContextConfigs) {
+          const providedContexts =
+            this.__wcProvidedContexts || (this.__wcProvidedContexts = {});
+          const mappedProps =
+            this.__wcMappedProps || (this.__wcMappedProps = {});
+          Object.keys(providedContextConfigs).forEach(name => {
+            const config = providedContextConfigs[name];
+            const property =
+              typeof config === 'string' ? config : config.property;
+            providedContexts[name] = property ? this[property] : config.value;
+            if (property) {
+              mappedProps[name] = property;
+            }
+            registerProvidedContext(this, name, providedContexts);
+          });
+        }
+        initializedElements.add(this);
+      }
+    }
+
+    disconnectedCallback() {
+      super.disconnectedCallback && super.disconnectedCallback();
+      const observedContexts = this.constructor.observedContexts;
+      if (observedContexts) {
+        observedContexts.forEach(context => unobserveContext(this, context));
+      }
+    }
+
+    updated(props) {
+      super.updated && super.updated(props);
+      const mappedProps = this.__wcMappedProps;
+      if (mappedProps) {
+        const providedContexts =
+          this.__wcProvidedContexts || (this.__wcProvidedContexts = {});
+        Object.keys(mappedProps).forEach(contextName => {
+          const property = mappedProps[contextName];
+          if (property in props) {
+            const value = this[property];
+            providedContexts[contextName] = value;
+            notifyContextChange(this, contextName, value);
+          }
+        });
+      }
+    }
+  };
+};
+
+export { withContext };

--- a/packages/core/renderers/with-events.js
+++ b/packages/core/renderers/with-events.js
@@ -1,65 +1,65 @@
-export function withEvents(Base = HTMLElement) {
-  return class extends Base {
-    connecting() {
-      super.connecting && super.connecting();
-      // Keep an object of listener types mapped to callback functions
-      this._listeners = {};
+import { withLitHtml } from './renderer-lit-html';
+
+export class withLitEvents extends withLitHtml {
+  connecting() {
+    super.connecting && super.connecting();
+    // Keep an object of listener types mapped to callback functions
+    this._listeners = {};
+  }
+
+  disconnecting() {
+    super.disconnecting && super.disconnecting();
+    // Keep an object of listener types mapped to callback functions
+    this._listeners = {};
+  }
+
+  /**
+   * Register a new callback for the given event type
+   *
+   * @param {string} type
+   * @param {Function} handler
+   */
+  on(type, handler) {
+    if (typeof this._listeners[type] === 'undefined') {
+      this._listeners[type] = [];
     }
 
-    disconnecting() {
-      super.disconnecting && super.disconnecting();
-      // Keep an object of listener types mapped to callback functions
-      this._listeners = {};
+    this._listeners[type].push(handler);
+
+    return this;
+  }
+
+  /**
+   * Unregister an existing callback for the given event type
+   *
+   * @param {string} type
+   * @param {Function} handler
+   */
+  off(type, handler) {
+    var index = this._listeners[type].indexOf(handler);
+
+    if (index > -1) {
+      this._listeners[type].splice(index, 1);
     }
 
-    /**
-     * Register a new callback for the given event type
-     *
-     * @param {string} type
-     * @param {Function} handler
-     */
-    on(type, handler) {
-      if (typeof this._listeners[type] === 'undefined') {
-        this._listeners[type] = [];
-      }
+    return this;
+  }
 
-      this._listeners[type].push(handler);
+  /**
+   * Iterate over all registered handlers for given type and call them all with
+   * the dialog element as first argument, event as second argument (if any).
+   *
+   * @access private
+   * @param {string} type
+   * @param {Event} event
+   */
+  _fire(type, ...props) {
+    var listeners = this._listeners[type] || [];
 
-      return this;
-    }
-
-    /**
-     * Unregister an existing callback for the given event type
-     *
-     * @param {string} type
-     * @param {Function} handler
-     */
-    off(type, handler) {
-      var index = this._listeners[type].indexOf(handler);
-
-      if (index > -1) {
-        this._listeners[type].splice(index, 1);
-      }
-
-      return this;
-    }
-
-    /**
-     * Iterate over all registered handlers for given type and call them all with
-     * the dialog element as first argument, event as second argument (if any).
-     *
-     * @access private
-     * @param {string} type
-     * @param {Event} event
-     */
-    _fire(type, ...props) {
-      var listeners = this._listeners[type] || [];
-
-      listeners.forEach(
-        function(listener) {
-          listener(this, props);
-        }.bind(this),
-      );
-    }
-  };
+    listeners.forEach(
+      function(listener) {
+        listener(this, props);
+      }.bind(this),
+    );
+  }
 }

--- a/packages/core/utils/environment.js
+++ b/packages/core/utils/environment.js
@@ -1,4 +1,4 @@
-import { hasNativeShadowDomSupport } from '@bolt/element';
+import { hasNativeShadowDomSupport } from '@bolt/element/src/lib/utils';
 
 // Helper util to check the current node environment + check if the browser supports shadow DOM for shimming purposes
 export const IS_DEV = process.env.NODE_ENV === 'development';

--- a/packages/core/utils/find-parent-tag.js
+++ b/packages/core/utils/find-parent-tag.js
@@ -1,5 +1,5 @@
 // Util to recursively look to see if parent is a specific HTML tag
-import { findParentTag } from '@bolt/element';
+import { findParentTag } from '@bolt/element/src/lib/utils';
 export { findParentTag };
 
 export default findParentTag;

--- a/packages/core/utils/index.js
+++ b/packages/core/utils/index.js
@@ -7,13 +7,11 @@ export * from './debounce';
 export * from './declarative-click-handler';
 export * from './environment';
 export * from './find-parent-tag';
-export * from './get-component-root-element';
 export * from './get-transition-duration';
 export * from './get-unique-id';
 export * from './is-valid-selector';
 export * from './rgb2hex';
 export * from './rename-key';
-export * from './sanitize-classes';
 export * from './scrollbar';
 export * from './supports-css-vars';
 export * from './supports-passive-event-listener';
@@ -33,4 +31,4 @@ export {
   afterNextRender,
 } from '@polymer/polymer/lib/utils/render-status.js';
 
-export { shadow, withComponent, props, define } from 'skatejs/dist/esnext';
+export { shadow, withComponent, props, define } from 'skatejs';


### PR DESCRIPTION
## Jira
N/A

## Summary
Bolt Core renderer, decorator, and BoltElement-related Class updates that are all a required part of the broader ES Module work https://github.com/boltdesignsystem/bolt/pull/1579.

## Details
- Migrates existing component decorators over to use the new decorator spec when supported (using[ lit-element's approach](https://github.com/Polymer/lit-element/blob/master/src/lib/decorators.ts#L80) as a starting point).
- Migrates a handful of the most common Core utils over to the new `@bolt/element` base
- Refactors `withLitHtml`, `withEvents`, `withPreact` base classes to directly extend classes (required otherwise blocking errors are thrown when all the ES Module-related work is switched on)
- Forks (temporarily?) the `wc-context` package (the library used for our newest Context approach with minimal config required) in order to fix a breaking JS error encountered otherwise due to not checking if something exists first before calling super... https://github.com/boltdesignsystem/bolt/pull/1586/files#diff-cd43fc9b53340e11a3fb872caf823a6fR18

## How to test
Unfortunately, like the updates that actually [migrate our components over](https://github.com/boltdesignsystem/bolt/pull/1591) to use the new Class syntax, these updates can't be used in isolation (hence why I created https://github.com/boltdesignsystem/bolt/pull/1579 since most of the pieces required don't / can't work by themselves).

Similarly to what I mentioned in the [polyfill loader PR](https://github.com/boltdesignsystem/bolt/pull/1587), I'm honestly not sure we can practically ship this without proactively doing a major SEMVER bump, given that the Core / BaseElement updates must happen in conjunction with the polyfill, component Class migration, and build tool updates.

The only possibly I can think of to get around this would be to take all of the changes to core here + in the related PRs and add them to a brand new (temporary) `@bolt/v3-core` package that could live along-side the unmodified core package. 

This approach would at least give us a guarantee that any v2.x written components would definitely work while we work and on start to ship broader v3.0-related work without any backward breaking changes...

Thoughts?