### PR TITLE
ES Modules: Simplified "Polyfill Loader"

### DIFF
--- a/packages/base-polyfills/index.js
+++ b/packages/base-polyfills/index.js
@@ -14,6 +14,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
  */
 
 import 'regenerator-runtime/runtime';
+import '@webcomponents/custom-elements/src/native-shim.js';
 import 'core-js/modules/es.array.find';
 import '@bolt/polyfills/platform/remove-polyfill.js';
 import '@bolt/polyfills/platform/es6-misc';
@@ -26,3 +27,43 @@ import '@webcomponents/custom-elements/src/custom-elements.js';
 import '@webcomponents/url/url.js';
 import '@bolt/polyfills/platform/baseuri';
 import '@bolt/polyfills/platform/unresolved';
+import 'element-closest';
+import 'whatwg-fetch';
+import 'mdn-polyfills/Node.prototype.prepend';
+import 'mdn-polyfills/Node.prototype.replaceWith'; // used in dropdown
+import 'core-js/modules/es.array.iterator';
+import 'core-js/modules/es.array.from';
+import 'core-js/modules/es.string.starts-with';
+import 'core-js/modules/es.array.includes';
+import 'core-js/modules/es.array.for-each';
+import 'core-js/modules/es.object.assign';
+import 'core-js/modules/es.string.includes';
+import 'core-js/modules/es.string.repeat';
+import WeakSet from '@ungap/weakset';
+window.WeakSet = WeakSet;
+
+import smoothscroll from 'smoothscroll-polyfill';
+
+// kick off the polyfill!
+smoothscroll.polyfill();
+
+/**
+ * closest() polyfill
+ * @link https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#Polyfill
+ */
+if (window.Element && !Element.prototype.closest) {
+  Element.prototype.closest = function(s) {
+    var matches = (this.document || this.ownerDocument).querySelectorAll(s),
+      i,
+      el = this;
+    do {
+      i = matches.length;
+      while (--i >= 0 && matches.item(i) !== el) {}
+    } while (i < 0 && (el = el.parentElement));
+    return el;
+  };
+}
+
+if (window.NodeList && !NodeList.prototype.forEach) {
+  NodeList.prototype.forEach = Array.prototype.forEach;
+}

--- a/packages/base-polyfills/modern.js
+++ b/packages/base-polyfills/modern.js
@@ -1,0 +1,16 @@
+/**
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+
+/*
+ * Polyfills loaded: Custom Elements (for Edge only)
+ * Used in all Modern Browsers
+ */
+
+import '@webcomponents/custom-elements/src/custom-elements.js';

--- a/packages/components/bolt-button/index.js
+++ b/packages/components/bolt-button/index.js
@@ -1,21 +1,2 @@
-import { polyfillLoader } from '@bolt/core/polyfills';
-
-polyfillLoader.then(res => {
-  if (!window.customElements.get('replace-with-children')) {
-    import(
-      /*
-      webpackMode: 'eager',
-      webpackChunkName: 'replace-with-children'
-    */ '@bolt/core/elements/replace-with-children'
-    );
-  }
-
-  if (!window.customElements.get('bolt-button')) {
-    import(
-      /*
-      webpackMode: 'eager',
-      webpackChunkName: 'bolt-button'
-    */ './src/button'
-    );
-  }
-});
+import '@bolt/core/elements/replace-with-children';
+import './src/button';

--- a/packages/core/polyfills/index.js
+++ b/packages/core/polyfills/index.js
@@ -1,48 +1,9 @@
+// @todo: remove this import once the ES Module work is merged in + migration place for existing external use of polyfills in place
 import '@bolt/polyfills';
-import 'element-closest';
-import 'whatwg-fetch';
-import 'mdn-polyfills/Node.prototype.prepend';
-import 'mdn-polyfills/Node.prototype.replaceWith'; // used in dropdown
-import 'core-js/modules/es.array.iterator';
-import 'core-js/modules/es.array.from';
-import 'core-js/modules/es.string.starts-with';
-import 'core-js/modules/es.array.includes';
-import 'core-js/modules/es.array.for-each';
-import 'core-js/modules/es.object.assign';
-import 'core-js/modules/es.string.includes';
-import 'core-js/modules/es.string.repeat';
-import WeakSet from '@ungap/weakset';
-window.WeakSet = WeakSet;
-
-import smoothscroll from 'smoothscroll-polyfill';
-
-// kick off the polyfill!
-smoothscroll.polyfill();
-
-/**
- * closest() polyfill
- * @link https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#Polyfill
- */
-if (window.Element && !Element.prototype.closest) {
-  Element.prototype.closest = function(s) {
-    var matches = (this.document || this.ownerDocument).querySelectorAll(s),
-      i,
-      el = this;
-    do {
-      i = matches.length;
-      while (--i >= 0 && matches.item(i) !== el) {}
-    } while (i < 0 && (el = el.parentElement));
-    return el;
-  };
-}
-
-if (window.NodeList && !NodeList.prototype.forEach) {
-  NodeList.prototype.forEach = Array.prototype.forEach;
-}
 
 let polyfills = [];
 
-// // Detect Shadow Dom Support
+// Detect Shadow Dom Support
 if (
   !(
     'attachShadow' in Element.prototype && 'getRootNode' in Element.prototype
@@ -82,8 +43,6 @@ export const polyfillLoader = new Promise(resolve => {
   ) {
     resolve();
   } else {
-    import('@webcomponents/custom-elements/src/native-shim.js').then(() => {
-      resolve();
-    });
+    resolve();
   }
 });


### PR DESCRIPTION
## Jira
N/A

## Summary
Incorporates the majority of the polyfill consolidation / simplification that's part of the [broader ES Module work](https://github.com/boltdesignsystem/bolt/pull/1579) without any component or build tool related changes required, or inadvertently introducing any major breaking changes. 

## Details
When the full set of updates from https://github.com/boltdesignsystem/bolt/pull/1579 are in place, the Core polyfill loader essentially becomes unnecessary since we only include the necessary polyfills once in the main `bolt-global` Webpack bundle.

That said (and something I especially use @danielamorse and @remydenton's feedback on) — the upstream ES Module work does NOT auto-include polyfills in any of the independent bundles from Webpack since these may or may not require the polyfill loader in order to work. 

Because of that, I'm a bit unsure if / where the polyfill loader is getting used downstream in Drupal which we'd need to account for here, either by manually adjusting the code downstream OR by keeping the original polyfill loader exactly the same and instead renaming this slimmed down version to something else...

Thoughts?

## How to test
- Review changes
- Confirm tests passing
- Confirm overall browsers supported continue to work as expected (no errors, etc)