### PR TITLE
ES Modules: Upgrade Link to BoltElement

### DIFF
--- a/packages/components/bolt-link/__tests__/__snapshots__/link.js.snap
+++ b/packages/components/bolt-link/__tests__/__snapshots__/link.js.snap
@@ -1,20 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`link Default <bolt-link> w/o Shadow DOM renders 1`] = `
-<bolt-link url="http://pega.com">
-  <a href="http://pega.com"
-     class="c-bolt-link c-bolt-link--display-inline c-bolt-link--valign-center"
-     target="_self"
+<div>
+  <bolt-link url="http://pega.com"
+             no-shadow
   >
-    <slot name="before">
-    </slot>
-    <span class="c-bolt-link__text">
-      This is a link
-    </span>
-    <slot name="after">
-    </slot>
-  </a>
-</bolt-link>
+    <a href="http://pega.com"
+       class="c-bolt-link c-bolt-link--display-inline c-bolt-link--valign-center"
+       target="_self"
+    >
+      <slot name="before">
+      </slot>
+      <span class="c-bolt-link__text">
+        This is a link
+      </span>
+      <slot name="after">
+      </slot>
+    </a>
+  </bolt-link>
+</div>
 `;
 
 exports[`link Default <bolt-link> w/o Shadow DOM renders 3`] = `
@@ -22,12 +26,13 @@ exports[`link Default <bolt-link> w/o Shadow DOM renders 3`] = `
   style=""
 >
   <bolt-link
+    no-shadow=""
     style=""
     url="http://pega.com"
   >
     <!---->
-    <!---->
-    <!---->
+    
+      
   </bolt-link>
   <a
     class="c-bolt-link c-bolt-link--display-inline c-bolt-link--valign-center"
@@ -48,9 +53,7 @@ exports[`link Default <bolt-link> w/o Shadow DOM renders 3`] = `
     >
       <!---->
       <!---->
-      <!---->
       This is a link
-      <!---->
       <!---->
       <!---->
     </span>
@@ -62,16 +65,13 @@ exports[`link Default <bolt-link> w/o Shadow DOM renders 3`] = `
     <!---->
     <!---->
   </a>
-  <!---->
+  
+    
   <!---->
 </div>
 `;
 
 exports[`link Default <bolt-link> with Shadow DOM renders 1`] = `
-<style>
-  <!---->bolt-link{outline:0}:host{outline:0}.c-bolt-link{padding:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Fira Sans","Droid Sans","Helvetica Neue",sans-serif;font-family:var(--bolt-font-family-body);-webkit-appearance:none;-moz-appearance:none;appearance:none;background:0 0;display:inline;opacity:1;margin-left:-.25rem;color:rgba(var(--bolt-theme-link), 1);text-decoration:underline;cursor:pointer;border:none;-webkit-transition:.2s ease-in-out;transition:.2s ease-in-out}.js-fonts-loaded .c-bolt-link{font-family:"Open Sans","Helvetica Neue",sans-serif;font-family:var(--bolt-font-family-body)}.c-bolt-link:hover{opacity:.8}.c-bolt-link:active,.c-bolt-link:focus:active{opacity:.6}.c-bolt-link--display-flex{display:-webkit-inline-box;display:inline-flex}.c-bolt-link--display-flex.c-bolt-link--valign-start{-webkit-box-align:start;align-items:flex-start}.c-bolt-link--display-flex.c-bolt-link--valign-center{-webkit-box-align:center;align-items:center}.c-bolt-link--display-inline .c-bolt-link__icon{display:inline;white-space:nowrap}.c-bolt-link__icon,.c-bolt-link__text{padding-left:.25rem}.c-bolt-link__text{display:inline}.c-bolt-link--headline{color:rgba(var(--bolt-theme-headline-link), 1);text-decoration:none}.c-bolt-link--headline:hover{text-decoration:underline}
-  <!---->
-</style>
 <a href="http://pega.com"
    class="c-bolt-link c-bolt-link--display-inline c-bolt-link--valign-center"
    target="_self"

--- a/packages/components/bolt-link/__tests__/link.js
+++ b/packages/components/bolt-link/__tests__/link.js
@@ -128,19 +128,18 @@ describe('link', () => {
   });
 
   test('Default <bolt-link> w/o Shadow DOM renders', async function() {
-    const renderedLinkHTML = await page.evaluate(() => {
-      const link = document.createElement('bolt-link');
-      link.textContent = 'This is a link';
-      link.setAttribute('url', 'http://pega.com');
-      document.body.appendChild(link);
-      link.useShadow = false;
-      link.updated();
-      return link.outerHTML;
+    const renderedLinkHTML = await page.evaluate(async () => {
+      document.body.insertAdjacentHTML(
+        'beforeend',
+        '<div><bolt-link url="http://pega.com" no-shadow>This is a link</bolt-link></div>',
+      );
+      const link = document.querySelector('bolt-link');
+      await link.updateComplete;
+      return link.parentNode.outerHTML;
     });
     expect(renderedLinkHTML).toMatchSnapshot();
 
-    const renderedHTML = await html('<div></div>');
-    renderedHTML.innerHTML = renderedLinkHTML;
+    const renderedHTML = await html(renderedLinkHTML);
 
     expect(
       renderedHTML
@@ -158,22 +157,23 @@ describe('link', () => {
   });
 
   test('Default <bolt-link> with Shadow DOM renders', async function() {
-    const defaultLinkShadowRoot = await page.evaluate(() => {
-      const link = document.createElement('bolt-link');
-      link.textContent = 'Link Test -- Shadow Root HTML';
-      link.setAttribute('url', 'http://pega.com');
-      document.body.appendChild(link);
-      link.updated();
+    const defaultLinkShadowRoot = await page.evaluate(async () => {
+      document.body.insertAdjacentHTML(
+        'beforeend',
+        '<bolt-link url="http://pega.com">Link Test -- Shadow Root HTML</bolt-link>',
+      );
+      const link = document.querySelector('bolt-link');
+      await link.updateComplete;
       return link.renderRoot.innerHTML;
     });
     expect(defaultLinkShadowRoot).toMatchSnapshot();
 
-    const defaultLinkOuter = await page.evaluate(() => {
+    const defaultLinkOuter = await page.evaluate(async () => {
       const link = document.createElement('bolt-link');
       link.setAttribute('url', 'http://pega.com');
       link.textContent = 'Link Test -- Outer HTML';
       document.body.appendChild(link);
-      link.updated();
+      await link.updateComplete;
       return link.outerHTML;
     });
     expect(defaultLinkOuter).toMatchSnapshot();
@@ -190,18 +190,14 @@ describe('link', () => {
   });
 
   test('Default <bolt-link> with Shadow DOM renders with no extra whitespace', async function() {
-    const defaultLinkOuter = await page.evaluate(() => {
-      const link = document.createElement('bolt-link');
-      link.setAttribute('url', 'http://pega.com');
-      link.textContent = 'Link Test -- No extra whitespace';
-
-      const linkWrapper = document.createElement('div');
-      linkWrapper.innerHTML += '(';
-      linkWrapper.append(link);
-      linkWrapper.innerHTML += ')';
-      document.body.appendChild(linkWrapper);
-      link.updated();
-      return linkWrapper.outerHTML;
+    const defaultLinkOuter = await page.evaluate(async () => {
+      document.body.insertAdjacentHTML(
+        'beforeend',
+        '<div>(<bolt-link url="http://pega.com">Link Test -- No extra whitespace</bolt-link>)</div>',
+      );
+      const link = document.querySelector('bolt-link').parentNode;
+      await link.updateComplete;
+      return link.outerHTML;
     });
     expect(defaultLinkOuter).toMatchSnapshot();
 
@@ -235,13 +231,11 @@ describe('link', () => {
     `);
 
     // Next, convert to a javascript node and disable shadow dom so we can evaluate it with js.
-    const renderedLinkHTML = await page.evaluate(html => {
+    const renderedLinkHTML = await page.evaluate(async html => {
       const div = document.createElement('div');
-      div.innerHTML = `${html}`;
-      document.body.appendChild(div);
+      document.body.insertAdjacentHTML('beforeend', html);
       const link = document.querySelector('bolt-link');
-      link.useShadow = false;
-      link.updated();
+      await link.updateComplete;
       return link.outerHTML;
     }, template.html);
 

--- a/packages/components/bolt-link/src/link.js
+++ b/packages/components/bolt-link/src/link.js
@@ -1,31 +1,44 @@
-import { props, define } from '@bolt/core/utils';
-import { html, render } from '@bolt/core/renderers/renderer-lit-html';
-import { BoltAction } from '@bolt/core/elements/bolt-action';
-import { convertInitialTags } from '@bolt/core/decorators';
-
+import {
+  BoltActionElement,
+  unsafeCSS,
+  render,
+  html,
+  ifDefined,
+  customElement,
+  BoltElement,
+  convertInitialTags,
+} from '@bolt/element';
 import classNames from 'classnames/bind';
-
-import styles from './link.scss';
+import linkStyles from './link.scss';
 import schema from '../link.schema.yml';
 
-let cx = classNames.bind(styles);
+let cx = classNames.bind(linkStyles);
 
-@define
-@convertInitialTags('a') // The first matching tag will have its attributes converted to component props
-class BoltLink extends BoltAction {
-  static is = 'bolt-link';
+@customElement('bolt-link')
+@convertInitialTags(['button', 'a'])
+class BoltLink extends BoltActionElement {
+  static get styles() {
+    return [unsafeCSS(linkStyles)];
+  }
 
-  static props = {
-    ...BoltAction.props, // Provides: disabled, onClick, onClickTarget, target, url
-    display: props.string,
-    valign: props.string,
-    isHeadline: props.boolean,
-  };
+  static get properties() {
+    return {
+      ...BoltActionElement.properties,
+      display: String,
+      valign: String,
+      isHeadline: {
+        type: Boolean,
+        attribute: 'is-headline',
+      },
+    };
+  }
 
   // https://github.com/WebReflection/document-register-element#upgrading-the-constructor-context
   constructor(self) {
     self = super(self);
     self.schema = schema;
+    self.display = schema.properties.display.default;
+    self.valign = schema.properties.valign.default;
     return self;
   }
 
@@ -34,22 +47,21 @@ class BoltLink extends BoltAction {
     // 2. Zero Width No-break Space (&#xfeff;) is needed to make the last word always stick with the icon, so the icon will never become an orphan.
 
     // Validate the original prop data passed along -- returns back the validated data w/ added default values
-    const { display, valign, url, target, isHeadline } = this.validateProps(
-      this.props,
-    );
+    // const { display, valign, url, target, isHeadline } = this.validateProps(
+    //   this.props,
+    // );
 
     const classes = cx('c-bolt-link', {
-      [`c-bolt-link--display-${display}`]: display,
-      [`c-bolt-link--valign-${valign}`]: valign,
-      [`c-bolt-link--headline`]: isHeadline,
+      [`c-bolt-link--display-${this.display}`]: this.display,
+      [`c-bolt-link--valign-${this.valign}`]: this.valign,
+      [`c-bolt-link--headline`]: this.isHeadline,
     });
 
     // Decide on if the rendered button tag should be a <button> or <a> tag, based on if a URL exists OR if a link was passed in from the getgo
-    const hasUrl = this.props.url.length > 0 && this.props.url !== 'null';
+    const hasUrl = this.url && this.url.length > 0 && this.url !== 'null';
 
     // Assign default target attribute value if one isn't specified
-    const anchorTarget =
-      this.props.target && hasUrl ? this.props.target : '_self';
+    const anchorTarget = this.target && hasUrl ? this.target : '_self';
 
     // The linkElement to render, based on the initial HTML passed alone.
     let renderedLink;
@@ -57,35 +69,41 @@ class BoltLink extends BoltAction {
     // 1. Remove line breaks before and after lit-html template tags, causes unwanted space inside and around inline links
     // 2. Zero Width No-break Space (&#xfeff;) is needed to make the last word always stick with the icon, so the icon will never become an orphan.
     // prettier-ignore
+
     const innerSlots = html`${
-      'before' in this.slots
-        ? html`<span class="${cx(`c-bolt-link__icon`)}">&#xfeff;${this.slot('before')}</span>`
+      this.templateMap.get('before')
+        ? html`<span class="${cx(`c-bolt-link__icon`)}">&#xfeff;${this.slotify('before')}</span>`
         : html`<slot name="before" />`}${
-      'default' in this.slots
-        ? html`<span class="${cx(`c-bolt-link__text`)}">${this.slot('default')}</span>`
+      this.templateMap.get('default')
+        ? html`<span class="${cx(`c-bolt-link__text`)}">${this.slotify('default')}</span>`
         : html`<slot />`}${
-      'after' in this.slots
-        ? html`<span class="${cx(`c-bolt-link__icon`)}">&#xfeff;${this.slot('after')}</span>`
+      this.templateMap.get('after')
+        ? html`<span class="${cx(`c-bolt-link__icon`)}">&#xfeff;${this.slotify('after')}</span>`
         : html`<slot name="after" />`}`;
 
     if (this.rootElement) {
       renderedLink = this.rootElement.firstChild.cloneNode(true);
-      if (renderedLink.getAttribute('href') === null && hasUrl) {
-        renderedLink.setAttribute('href', this.props.url);
+      if (hasUrl) {
+        renderedLink.setAttribute('href', this.url);
+      }
+      if (anchorTarget) {
+        renderedLink.setAttribute('target', anchorTarget);
       }
       renderedLink.className += ' ' + classes;
       render(innerSlots, renderedLink);
     } else {
       // [1]
       // prettier-ignore
-      renderedLink = html`<a href="${this.props.url}" class="${classes}" target="${anchorTarget}"
+      renderedLink = html`<a href="${this.url}" class="${classes}" target="${anchorTarget}"
           >${innerSlots}</a
         >`;
     }
 
     // [1]
     // prettier-ignore
-    return html`${this.addStyles([styles])}${renderedLink}`;
+    return html`
+      ${renderedLink}
+    `;
   }
 }
 


### PR DESCRIPTION
## Jira
N/A

## Summary
Upgrades the Link over to the new LitElement-based BoltElement base class after running into complications (ex. not being able to stack up decorators / use the original version of `convertInitialTags`) while working on the [broader ES Module work](https://github.com/boltdesignsystem/bolt/pull/1579).

## Details
Except for very minor prop validation logic (which will come to all new BoltElement components in the near future), the updated logic here is almost 1:1.

This PR also updates the related component Jest tests based on the internal syntax differences with LitElement accordingly.

Note: because this work uses some small changes in Core (the upgraded [`convertInitialTags` decorator](https://github.com/boltdesignsystem/bolt/pull/1586/files#diff-9e82038665bdf44b4be8e5c8f32a5994R64)) this PR requires that decorator work to be in place before the code here will work as expected.