### PR TITLE
Add Lighthouse CI Performance Monitoring / Github Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,18 +70,20 @@ jobs:
 
     # quicker build + Nightwatch tests for feature branches
     - stage: Pre-deploy
-      name: 'Build + Deploy Website (Quick)'
+      name: 'Build + Deploy Website + Lighthouse CLI'
       if: (NOT tag =~ ^v) AND (NOT branch =~ /(master|release|bug|fix)/)
       install:
         - npx json -I -f package.json -e 'delete this.dependencies'
         - npx json -I -f package.json -e 'delete this.scripts.postinstall'
         - yarn run setup
         - npx lerna run postbootstrap
+        - yarn global add @lhci/cli@0.3.x
       script:
         - yarn run build
         - yarn run deploy
         - export NOW_URL=$(./scripts/get-latest-deploy.js)
         - travis_retry yarn run test:e2e:quick
+        - lhci autorun --collect.numberOfRuns=3 --collect.url=$NOW_URL --collect.url=$NOW_URL/pattern-lab/patterns/04-pages-10-d8-product-pages-product-t2/04-pages-10-d8-product-pages-product-t2.html --collect.url=$NOW_URL/pattern-lab/patterns/06-experiments-micro-journeys-90-micro-journeys/06-experiments-micro-journeys-90-micro-journeys.html
       after_success:
         - ./scripts/deploy-branch-alias.js
 

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,28 @@
+{
+  "ci": {
+    "assert": {
+      "preset": "lighthouse:no-pwa",
+      "assertions": {
+        "unused-css-rules": "warn",
+        "button-name": "warn",
+        "external-anchors-use-rel-noopener": "warn",
+        "meta-description": "warn",
+        "no-document-write": "warn",
+        "offscreen-images": "warn",
+        "uses-rel-preconnect": "warn",
+        "dom-size": "warn",
+        "aria-required-attr": "warn",
+        "aria-required-children": "warn",
+        "aria-valid-attr-value": "warn",
+        "image-alt": "warn",
+        "label": "warn",
+        "list": "warn",
+        "listitem": "warn",
+        "link-name": "warn"
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}


### PR DESCRIPTION
## Jira

## Summary
Wires up Lighthouse CI for monitoring performance and accessibility moving forward — subset of updates from https://github.com/boltdesignsystem/bolt/pull/1579.

Supersedes the work from https://github.com/boltdesignsystem/bolt/pull/1495.
