### PR TITLE
ES Modules: Base Component Function to Class Migration + Dependency Cleanup

### DIFF
--- a/docs-site/src/components/bolt-select/bolt-select.standalone.js
+++ b/docs-site/src/components/bolt-select/bolt-select.standalone.js
@@ -1,20 +1,15 @@
 // Initially inspired by https://github.com/adidas/choicesjs-stencil/blob/master/src/components/choicesjs-stencil/choicesjs-stencil.tsx
 
-import { props, define } from '@bolt/core/utils';
+import { props } from '@bolt/core/utils';
+import { customElement, html } from '@bolt/element';
 import Choices from 'choices.js';
-import {
-  withLitHtml,
-  html,
-  // render,
-} from '@bolt/core/renderers/renderer-lit-html';
+import { withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 import { filterObject, isDefined, createSelectOptionData } from './utils';
 
 import styles from './bolt-select.scss';
 
-@define
-class BoltSelect extends withLitHtml() {
-  static is = 'bolt-select';
-
+@customElement('bolt-select')
+class BoltSelect extends withLitHtml {
   static props = {
     type: props.string, // single | multiple | text
     value: props.string,

--- a/docs-site/src/components/docs-search/docs-search.js
+++ b/docs-site/src/components/docs-search/docs-search.js
@@ -1,13 +1,11 @@
-import { props, define } from '@bolt/core/utils';
-import { withLitHtml, html } from '@bolt/core/renderers/renderer-lit-html';
-import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+import { props } from '@bolt/core/utils';
+import { customElement, unsafeHTML, html } from '@bolt/element';
+import { withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 import docsearch from 'docsearch.js/dist/npm/src/lib/main.js';
 import qs from 'querystring';
 
-@define
-class BoltDocsSearch extends withLitHtml() {
-  static is = 'bds-docs-search';
-
+@customElement('bds-docs-search')
+class BoltDocsSearch extends withLitHtml {
   static props = {
     apiKey: props.string,
     indexName: props.string,

--- a/docs-site/src/components/radio-switch/change-case.js
+++ b/docs-site/src/components/radio-switch/change-case.js
@@ -1,11 +1,10 @@
-import { props, define } from '@bolt/core/utils';
-import { html, withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
+import { props } from '@bolt/core/utils';
+import { customElement, html } from '@bolt/element';
+import { withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 const changeCase = require('change-case');
 
-@define
-class BoltChangeCase extends withLitHtml() {
-  static is = 'bolt-change-case';
-
+@customElement('bolt-change-case')
+class BoltChangeCase extends withLitHtml {
   static props = {
     mode: props.string,
   };

--- a/docs-site/src/components/radio-switch/radio-switch.js
+++ b/docs-site/src/components/radio-switch/radio-switch.js
@@ -1,13 +1,11 @@
-import { props, define, hasNativeShadowDomSupport } from '@bolt/core/utils';
-import { html, withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
+import { html, customElement } from '@bolt/element';
+import { withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 import classNames from 'classnames/bind';
 import styles from './radio-switch.scss';
 // let cx = classNames.bind(styles);
 
-@define
-class BoltRadioSwitch extends withLitHtml() {
-  static is = 'bolt-radio-switch';
-
+@customElement('bolt-radio-switch')
+class BoltRadioSwitch extends withLitHtml {
   // static props = {
   //   schema: props.object,
   //   formData: props.object,

--- a/docs-site/src/components/schema-form/component-explorer.js
+++ b/docs-site/src/components/schema-form/component-explorer.js
@@ -1,11 +1,10 @@
 import qs from 'querystring';
-import { define, props, defineContext, withContext } from '@bolt/core/utils';
+import { props, defineContext, withContext } from '@bolt/core/utils';
 import { prepSchema } from './utils';
 import isEqual from 'react-fast-compare';
-import { withLitHtml, html } from '@bolt/core/renderers/renderer-lit-html';
-import { styleMap } from 'lit-html/directives/style-map.js';
+import { withLitHtml,  } from '@bolt/core/renderers/renderer-lit-html';
 import { guard } from 'lit-html/directives/guard';
-import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+import { styleMap, html, unsafeHTML, customElement } from '@bolt/element';
 
 // define which specific props to provide to children that subscribe
 export const ComponentExplorerContext = defineContext({
@@ -18,10 +17,9 @@ export const ComponentExplorerContext = defineContext({
 import styles from './component-explorer.scss';
 import globalStyles from '@bolt/global/styles/index.scss';
 
-@define
-export default class ComponentExplorer extends withContext(withLitHtml()) {
-  static is = 'bolt-component-explorer';
 
+@customElement('bolt-component-explorer')
+export default class ComponentExplorer extends withContext(withLitHtml) {
   static props = {
     schemaUuid: props.string,
     schema: props.object,

--- a/docs-site/src/components/schema-form/schema-form.js
+++ b/docs-site/src/components/schema-form/schema-form.js
@@ -118,7 +118,7 @@ export default class SchemaForm extends withContext(withPreact) {
         schema={this.state.schema}
         formData={this.state.formData}
         uiSchema={uiSchema}
-        // widgets={customWidgets}
+        // widgets={customWidgets} 
         onChange={data => this.onFormChange(data)}
         onError={(data) => console.error('Error in Schema Form', formData)}>
       </Form>

--- a/docs-site/src/components/schema-form/schema-form.js
+++ b/docs-site/src/components/schema-form/schema-form.js
@@ -4,10 +4,10 @@ import { h, withPreact } from '@bolt/core/renderers';
 import isEqual from 'react-fast-compare';
 import { ComponentExplorerContext } from './component-explorer';
 
-@define
-export default class SchemaForm extends withContext(withPreact()) {
-  static is = 'bolt-schema-form';
+import { customElement } from '@bolt/element';
 
+@customElement('bolt-schema-form')
+export default class SchemaForm extends withContext(withPreact) {
   static props = {
     schema: props.object,
     formData: props.object,

--- a/docs-site/src/components/schema-form/schema-form.js
+++ b/docs-site/src/components/schema-form/schema-form.js
@@ -118,7 +118,7 @@ export default class SchemaForm extends withContext(withPreact()) {
         schema={this.state.schema}
         formData={this.state.formData}
         uiSchema={uiSchema}
-        // widgets={customWidgets} 
+        // widgets={customWidgets}
         onChange={data => this.onFormChange(data)}
         onError={(data) => console.error('Error in Schema Form', formData)}>
       </Form>

--- a/packages/base-element/index.js
+++ b/packages/base-element/index.js
@@ -9,7 +9,10 @@ export {
   findParentTag,
 } from './src/lib/utils';
 
+export { convertInitialTags } from './src/lib/decorators';
 export { customElement, unsafeCSS } from 'lit-element';
 export { render, html } from 'lit-html';
 export { ifDefined } from 'lit-html/directives/if-defined';
+export { classMap } from 'lit-html/directives/class-map.js';
 export { styleMap } from 'lit-html/directives/style-map.js';
+export { unsafeHTML } from 'lit-html/directives/unsafe-html';

--- a/packages/base-element/src/BoltActionElement.js
+++ b/packages/base-element/src/BoltActionElement.js
@@ -21,12 +21,11 @@ class BoltActionElement extends BoltElement {
     };
   }
 
-  constructor(self) {
-    self = super(self);
-    self.rootElementTags = [];
-    self.delegateFocus = true;
-    self.clickHandler = self.clickHandler.bind(self);
-    return self;
+  constructor() {
+    super();
+    this.rootElementTags = [];
+    this.delegateFocus = true;
+    this.clickHandler = this.clickHandler.bind(this);
   }
 
   connectedCallback() {

--- a/packages/base-element/src/BoltActionElement.js
+++ b/packages/base-element/src/BoltActionElement.js
@@ -21,11 +21,12 @@ class BoltActionElement extends BoltElement {
     };
   }
 
-  constructor() {
-    super();
-    this.rootElementTags = [];
-    this.delegateFocus = true;
-    this.clickHandler = this.clickHandler.bind(this);
+  constructor(self) {
+    self = super(self);
+    self.rootElementTags = [];
+    self.delegateFocus = true;
+    self.clickHandler = self.clickHandler.bind(self);
+    return self;
   }
 
   connectedCallback() {

--- a/packages/base-element/src/BoltElement.js
+++ b/packages/base-element/src/BoltElement.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-unused-expressions */
-import { LitElement } from 'lit-element';
 import { supportsAdoptingStyleSheets } from 'lit-element/lib/css-tag.js';
 import { Slotify } from './Slotify.js';
 import {
@@ -11,7 +10,7 @@ import {
 @renderAndRenderedEvents()
 @lazyStyles()
 @conditionalShadowDom()
-class BoltElement extends Slotify(LitElement) {
+class BoltElement extends Slotify {
   // patch to https://github.com/Polymer/lit-element/blob/master/src/lit-element.ts#L208
   // as a temp workaround to constructible stylesheets not working when
   // rendering inside + outside an iframe. Filing a bug with lit-element shortly!

--- a/packages/components/bolt-accordion/src/AccordionItem/index.js
+++ b/packages/components/bolt-accordion/src/AccordionItem/index.js
@@ -1,15 +1,13 @@
-import { withContext, define, props, css } from '@bolt/core/utils';
-import { withLitHtml, html } from '@bolt/core/renderers/renderer-lit-html';
-
+import { html, customElement } from '@bolt/element';
+import { withContext, props, css } from '@bolt/core/utils';
+import { withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 import styles from './accordion-item.scss';
 import { AccordionItemTrigger } from './AccordionItemTrigger';
 import { AccordionItemContent } from './AccordionItemContent';
 import { AccordionContext } from '../accordion';
 
-@define
-class AccordionItem extends withContext(withLitHtml()) {
-  static is = 'bolt-accordion-item';
-
+@customElement('bolt-accordion-item')
+class AccordionItem extends withContext(withLitHtml) {
   static props = {
     open: props.boolean,
     contentSpacing: props.string,

--- a/packages/components/bolt-accordion/src/accordion.js
+++ b/packages/components/bolt-accordion/src/accordion.js
@@ -1,15 +1,8 @@
-import {
-  defineContext,
-  withContext,
-  define,
-  props,
-  css,
-} from '@bolt/core/utils';
-import { withLitHtml, html } from '@bolt/core/renderers/renderer-lit-html';
-
+import { html, customElement } from '@bolt/element';
+import { defineContext, withContext, props, css } from '@bolt/core/utils';
+import { withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 import styles from './accordion.scss';
 import schema from '../accordion.schema.yml';
-
 import { Accordion } from './_accordion-handorgel';
 
 // define which specific props to provide to children that subscribe
@@ -20,10 +13,8 @@ export const AccordionContext = defineContext({
   iconValign: schema.properties.icon_valign.default,
 });
 
-@define
-class BoltAccordion extends withContext(withLitHtml()) {
-  static is = 'bolt-accordion';
-
+@customElement('bolt-accordion')
+class BoltAccordion extends withContext(withLitHtml) {
   static props = {
     single: props.boolean,
     noSeparator: props.boolean,

--- a/packages/components/bolt-animate/src/animate.js
+++ b/packages/components/bolt-animate/src/animate.js
@@ -1,13 +1,10 @@
+import { classMap, styleMap, html, customElement } from '@bolt/element';
 import {
   withLitHtml,
-  html,
   props,
-  define,
   hasNativeShadowDomSupport,
   convertSchemaToProps,
 } from '@bolt/core';
-import { styleMap } from 'lit-html/directives/style-map.js';
-import { classMap } from 'lit-html/directives/class-map.js';
 import styles from './animate.scss';
 import schema from '../animate.schema';
 
@@ -31,10 +28,8 @@ export const ANIM_STAGES = {
   OUT: 'OUT',
 };
 
-@define
-class BoltAnimate extends withLitHtml() {
-  static is = 'bolt-animate';
-
+@customElement('bolt-animate')
+class BoltAnimate extends withLitHtml {
   static props = convertSchemaToProps(schema);
 
   constructor(self) {

--- a/packages/components/bolt-band/src/band.js
+++ b/packages/components/bolt-band/src/band.js
@@ -1,5 +1,4 @@
-import { customElement, html } from 'lit-element';
-import { BoltElement } from '@bolt/element';
+import { BoltElement, customElement, html } from '@bolt/element';
 
 @customElement('bolt-band')
 class BoltBand extends BoltElement {

--- a/packages/components/bolt-block-list/src/block-list.standalone.js
+++ b/packages/components/bolt-block-list/src/block-list.standalone.js
@@ -1,5 +1,10 @@
-import { BoltElement, customElement, unsafeCSS, html } from '@bolt/element';
-import { unsafeHTML } from 'lit-html/directives/unsafe-html';
+import {
+  BoltElement,
+  unsafeCSS,
+  html,
+  customElement,
+  unsafeHTML,
+} from '@bolt/element';
 import blockListStyles from './block-list.scss';
 
 @customElement('bolt-block-list')

--- a/packages/components/bolt-blockquote/src/blockquote.js
+++ b/packages/components/bolt-blockquote/src/blockquote.js
@@ -32,7 +32,7 @@ class BoltBlockquote extends withLitHtml() {
   constructor(self) {
     self = super(self);
     self.useShadow = hasNativeShadowDomSupport;
-    self.schema = this.getModifiedSchema(schema);
+    self.schema = self.getModifiedSchema(schema);
     return self;
   }
 

--- a/packages/components/bolt-blockquote/src/blockquote.js
+++ b/packages/components/bolt-blockquote/src/blockquote.js
@@ -1,20 +1,22 @@
-import { props, define, hasNativeShadowDomSupport } from '@bolt/core/utils';
-import { withLitHtml, html } from '@bolt/core/renderers/renderer-lit-html';
-import { ifDefined } from 'lit-html/directives/if-defined';
-import { convertInitialTags } from '@bolt/core/decorators';
+import { props, hasNativeShadowDomSupport } from '@bolt/core/utils';
+import { withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 import classNames from 'classnames/bind';
 import textStyles from '@bolt/components-text/index.scss';
+import {
+  ifDefined,
+  html,
+  convertInitialTags,
+  customElement,
+} from '@bolt/element';
 import styles from './blockquote.scss';
 import schema from '../blockquote.schema.yml';
 import { AuthorImage, AuthorName, AuthorTitle } from './Author';
 
 let cx = classNames.bind([styles, textStyles]);
 
-@define
+@customElement('bolt-blockquote')
 @convertInitialTags('blockquote') // The first matching tag will have its attributes converted to component props
-class BoltBlockquote extends withLitHtml() {
-  static is = 'bolt-blockquote';
-
+class BoltBlockquote extends withLitHtml {
   static props = {
     size: props.string,
     alignItems: props.string,

--- a/packages/components/bolt-blockquote/src/blockquote.js
+++ b/packages/components/bolt-blockquote/src/blockquote.js
@@ -34,7 +34,7 @@ class BoltBlockquote extends withLitHtml {
   constructor(self) {
     self = super(self);
     self.useShadow = hasNativeShadowDomSupport;
-    self.schema = self.getModifiedSchema(schema);
+    self.schema = this.getModifiedSchema(schema);
     return self;
   }
 

--- a/packages/components/bolt-button/src/button.js
+++ b/packages/components/bolt-button/src/button.js
@@ -4,8 +4,9 @@ import {
   render,
   html,
   ifDefined,
+  convertInitialTags,
+  customElement,
 } from '@bolt/element';
-import { convertInitialTags } from '@bolt/core/decorators';
 import classNames from 'classnames/bind';
 
 import buttonStyles from './button.scss';
@@ -13,6 +14,7 @@ import buttonStyles from './button.scss';
 
 let cx = classNames.bind(buttonStyles);
 
+@customElement('bolt-button')
 @convertInitialTags(['button', 'a'])
 class BoltButton extends BoltActionElement {
   static get styles() {
@@ -175,7 +177,5 @@ class BoltButton extends BoltActionElement {
     `;
   }
 }
-
-customElements.define('bolt-button', BoltButton);
 
 export { BoltButton };

--- a/packages/components/bolt-carousel/src/carousel.js
+++ b/packages/components/bolt-carousel/src/carousel.js
@@ -1,10 +1,6 @@
-import {
-  renameKey,
-  props,
-  define,
-  hasNativeShadowDomSupport,
-} from '@bolt/core/utils';
-import { html, withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
+import { props, hasNativeShadowDomSupport } from '@bolt/core/utils';
+import { html, customElement } from '@bolt/element';
+import { withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 import classNames from 'classnames/bind';
 import changeCase from 'change-case';
 import Swiper from 'swiper';
@@ -59,10 +55,8 @@ for (const key of schemaPropKeys) {
   }
 }
 
-@define
-class BoltCarousel extends withLitHtml() {
-  static is = 'bolt-carousel';
-
+@customElement('bolt-carousel')
+class BoltCarousel extends withLitHtml {
   static props = {
     ...carouselProps,
     slideOffsetBefore: props.boolean,
@@ -665,10 +659,8 @@ class BoltCarousel extends withLitHtml() {
   }
 }
 
-@define
-class BoltCarouselSlide extends withLitHtml() {
-  static is = 'bolt-carousel-slide';
-
+@customElement('bolt-carousel-slide')
+class BoltCarouselSlide extends withLitHtml {
   // https://github.com/WebReflection/document-register-element#upgrading-the-constructor-context
   constructor(self) {
     self = super(self);

--- a/packages/components/bolt-chip/src/chip.js
+++ b/packages/components/bolt-chip/src/chip.js
@@ -1,20 +1,16 @@
-import { props, define } from '@bolt/core/utils';
-import { html, render } from '@bolt/core/renderers/renderer-lit-html';
+import { convertInitialTags, customElement, html } from '@bolt/element';
+import { props } from '@bolt/core/utils';
+import { render } from '@bolt/core/renderers/renderer-lit-html';
 import { BoltAction } from '@bolt/core/elements/bolt-action';
-import { convertInitialTags } from '@bolt/core/decorators';
-
 import classNames from 'classnames/bind';
-
 import styles from './chip.scss';
 import schema from '../chip.schema.yml';
 
 let cx = classNames.bind(styles);
 
-@define
+@customElement('bolt-chip')
 @convertInitialTags('a', 'span') // The first matching tag will have its attributes converted to component props
 class BoltChip extends BoltAction {
-  static is = 'bolt-chip';
-
   static props = {
     ...BoltAction.props, // Provides: disabled, onClick, onClickTarget, target, url
     size: props.string,

--- a/packages/components/bolt-code-snippet/src/code-snippet.standalone.js
+++ b/packages/components/bolt-code-snippet/src/code-snippet.standalone.js
@@ -1,9 +1,5 @@
-import {
-  define,
-  props,
-  css,
-  hasNativeShadowDomSupport,
-} from '@bolt/core/utils';
+import { customElement } from '@bolt/element';
+import { props, css, hasNativeShadowDomSupport } from '@bolt/core/utils';
 import { h, withPreact, Markup } from '@bolt/core/renderers';
 import Prism from 'prismjs/components/prism-core';
 import styles from './code-snippet.scss';
@@ -19,10 +15,8 @@ import 'prismjs/components/prism-bash';
 import 'prismjs/components/prism-markdown';
 import 'prismjs/components/prism-yaml';
 
-@define
-class BoltCodeSnippetClass extends withPreact() {
-  static is = 'bolt-code-snippet';
-
+@customElement('bolt-code-snippet')
+class BoltCodeSnippetClass extends withPreact {
   static props = {
     lang: props.string,
     display: props.string,

--- a/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.standalone.js
+++ b/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.standalone.js
@@ -9,7 +9,7 @@ class BoltCopyToClipboard extends withLitHtml() {
 
   constructor(self) {
     self = super(self);
-    this.useShadow = false;
+    self.useShadow = false;
     return self;
   }
 

--- a/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.standalone.js
+++ b/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.standalone.js
@@ -6,7 +6,7 @@ import { withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 class BoltCopyToClipboard extends withLitHtml {
   constructor(self) {
     self = super(self);
-    self.useShadow = false;
+    this.useShadow = false;
     return self;
   }
 

--- a/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.standalone.js
+++ b/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.standalone.js
@@ -1,12 +1,9 @@
+import { html, customElement } from '@bolt/element';
 import ClipboardJS from 'clipboard';
+import { withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 
-import { props, define } from '@bolt/core/utils';
-import { withLitHtml, html } from '@bolt/core/renderers/renderer-lit-html';
-
-@define
-class BoltCopyToClipboard extends withLitHtml() {
-  static is = 'bolt-copy-to-clipboard';
-
+@customElement('bolt-copy-to-clipboard')
+class BoltCopyToClipboard extends withLitHtml {
   constructor(self) {
     self = super(self);
     self.useShadow = false;

--- a/packages/components/bolt-device-viewer/src/device-viewer.standalone.js
+++ b/packages/components/bolt-device-viewer/src/device-viewer.standalone.js
@@ -36,7 +36,7 @@ class BoltDeviceViewer extends withLitHtml {
 
   constructor(self) {
     self = super(self);
-    self.useShadow = hasNativeShadowDomSupport;
+    this.useShadow = hasNativeShadowDomSupport;
     return self;
   }
 

--- a/packages/components/bolt-device-viewer/src/device-viewer.standalone.js
+++ b/packages/components/bolt-device-viewer/src/device-viewer.standalone.js
@@ -40,7 +40,7 @@ class BoltDeviceViewer extends withLitHtml() {
 
   constructor(self) {
     self = super(self);
-    this.useShadow = hasNativeShadowDomSupport;
+    self.useShadow = hasNativeShadowDomSupport;
     return self;
   }
 

--- a/packages/components/bolt-device-viewer/src/device-viewer.standalone.js
+++ b/packages/components/bolt-device-viewer/src/device-viewer.standalone.js
@@ -1,14 +1,12 @@
+import { html, customElement } from '@bolt/element';
 import Drift from 'drift-zoom';
-
 import {
-  define,
   props,
   css,
   hasNativeShadowDomSupport,
   passiveSupported,
 } from '@bolt/core/utils';
-
-import { withLitHtml, html } from '@bolt/core/renderers/renderer-lit-html';
+import { withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 
 /* From Modernizr */
 function whichAnimationEvent() {
@@ -30,10 +28,8 @@ function whichAnimationEvent() {
 }
 const animationEvent = whichAnimationEvent();
 
-@define
-class BoltDeviceViewer extends withLitHtml() {
-  static is = 'bolt-device-viewer';
-
+@customElement('bolt-device-viewer')
+class BoltDeviceViewer extends withLitHtml {
   static props = {
     // name: props.string,
   };
@@ -65,10 +61,8 @@ class BoltDeviceViewer extends withLitHtml() {
   }
 }
 
-@define
-class BoltImageZoom extends withLitHtml() {
-  static is = 'bolt-image-zoom';
-
+@customElement('bolt-image-zoom')
+class BoltImageZoom extends withLitHtml {
   static props = {
     mangify: props.boolean,
   };

--- a/packages/components/bolt-dropdown/dropdown.js
+++ b/packages/components/bolt-dropdown/dropdown.js
@@ -32,14 +32,14 @@ class BoltDropdown extends withLitHtml {
   constructor(self) {
     self = super(self);
 
-    self.useShadow = hasNativeShadowDomSupport;
+    this.useShadow = hasNativeShadowDomSupport;
 
-    self.state = {
-      open: self.props.autoOpen ? self.props.autoOpen : false,
-      collapse: self.props.collapse ? self.props.collapse : false,
+    this.state = {
+      open: this.props.autoOpen ? this.props.autoOpen : false,
+      collapse: this.props.collapse ? this.props.collapse : false,
     };
 
-    self.uuid = '12345';
+    this.uuid = '12345';
     return self;
   }
 

--- a/packages/components/bolt-dropdown/dropdown.js
+++ b/packages/components/bolt-dropdown/dropdown.js
@@ -32,14 +32,14 @@ class BoltDropdown extends withLitHtml() {
   constructor(self) {
     self = super(self);
 
-    this.useShadow = hasNativeShadowDomSupport;
+    self.useShadow = hasNativeShadowDomSupport;
 
-    this.state = {
-      open: this.props.autoOpen ? this.props.autoOpen : false,
-      collapse: this.props.collapse ? this.props.collapse : false,
+    self.state = {
+      open: self.props.autoOpen ? self.props.autoOpen : false,
+      collapse: self.props.collapse ? self.props.collapse : false,
     };
 
-    this.uuid = '12345';
+    self.uuid = '12345';
     return self;
   }
 

--- a/packages/components/bolt-dropdown/dropdown.js
+++ b/packages/components/bolt-dropdown/dropdown.js
@@ -15,7 +15,7 @@ import Handorgel from 'handorgel';
 import heightUtils from '@bolt/global/styles/07-utilities/_utilities-height.scss';
 import styles from './dropdown.scss';
 
-class BoltDropdown extends withLitHtml() {
+class BoltDropdown extends withLitHtml {
   static is = 'bolt-dropdown';
 
   static props = {

--- a/packages/components/bolt-figure/src/figure.js
+++ b/packages/components/bolt-figure/src/figure.js
@@ -16,12 +16,6 @@ let cx = classNames.bind(styles);
 class BoltFigure extends withLitHtml() {
   static is = 'bolt-figure';
 
-  // https://github.com/WebReflection/document-register-element#upgrading-the-constructor-context
-  constructor(self) {
-    self = super(self);
-    return self;
-  }
-
   render() {
     const classes = cx('c-bolt-figure');
 

--- a/packages/components/bolt-figure/src/figure.js
+++ b/packages/components/bolt-figure/src/figure.js
@@ -1,21 +1,13 @@
-import { define } from '@bolt/core/utils';
-import {
-  withLitHtml,
-  html,
-  render,
-} from '@bolt/core/renderers/renderer-lit-html';
-import { convertInitialTags } from '@bolt/core/decorators';
-
+import { html, customElement } from '@bolt/element';
+import { withLitHtml, render } from '@bolt/core/renderers/renderer-lit-html';
 import classNames from 'classnames/bind';
 
 import styles from './figure.scss';
 
 let cx = classNames.bind(styles);
 
-@define
-class BoltFigure extends withLitHtml() {
-  static is = 'bolt-figure';
-
+@customElement('bolt-figure')
+class BoltFigure extends withLitHtml {
   render() {
     const classes = cx('c-bolt-figure');
 

--- a/packages/components/bolt-figure/src/figure.js
+++ b/packages/components/bolt-figure/src/figure.js
@@ -8,6 +8,12 @@ let cx = classNames.bind(styles);
 
 @customElement('bolt-figure')
 class BoltFigure extends withLitHtml {
+  // https://github.com/WebReflection/document-register-element#upgrading-the-constructor-context
+  constructor(self) {
+    self = super(self);
+    return self;
+  }
+
   render() {
     const classes = cx('c-bolt-figure');
 

--- a/packages/components/bolt-icon/src/icon.standalone.js
+++ b/packages/components/bolt-icon/src/icon.standalone.js
@@ -2,7 +2,6 @@ import {
   colorContrast,
   css,
   define,
-  hasNativeShadowDomSupport,
   props,
   rgb2hex,
   supportsCSSVars,
@@ -33,15 +32,10 @@ class BoltIcon extends withPreact() {
     contrastColor: props.string,
   };
 
-  constructor(self) {
-    self = super(self);
-    this.useShadow = hasNativeShadowDomSupport;
-    this.useCssVars = supportsCSSVars;
-    return self;
-  }
-
-  connecting() {
+  connectedCallback() {
+    super.connectedCallback && super.connectedCallback();
     const elem = this;
+    this.useCssVars = supportsCSSVars;
 
     this.state = {
       primaryColor: 'var(--bolt-theme-icon, currentColor)',
@@ -67,7 +61,7 @@ class BoltIcon extends withPreact() {
         }
       };
 
-      const colorObserver = PubSub.subscribe(
+      this.colorObserver = PubSub.subscribe(
         'component.icon',
         checkIfColorChanged,
       );
@@ -83,6 +77,14 @@ class BoltIcon extends withPreact() {
           rgb2hex(window.getComputedStyle(this).getPropertyValue('color')),
         );
       }
+    }
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback && super.disconnectedCallback();
+
+    if (this.colorObserver) {
+      PubSub.unsubscribe(this.colorObserver);
     }
   }
 

--- a/packages/components/bolt-icon/src/icon.standalone.js
+++ b/packages/components/bolt-icon/src/icon.standalone.js
@@ -1,7 +1,7 @@
+import { customElement } from '@bolt/element';
 import {
   colorContrast,
   css,
-  define,
   props,
   rgb2hex,
   supportsCSSVars,
@@ -18,10 +18,8 @@ const backgroundStyles = ['circle', 'square'];
 
 const colors = ['teal', 'blue'];
 
-@define
-class BoltIcon extends withPreact() {
-  static is = 'bolt-icon';
-
+@customElement('bolt-icon')
+class BoltIcon extends withPreact {
   static props = {
     name: props.string,
     size: props.string,

--- a/packages/components/bolt-icon/src/icon.standalone.js
+++ b/packages/components/bolt-icon/src/icon.standalone.js
@@ -2,6 +2,7 @@ import { customElement } from '@bolt/element';
 import {
   colorContrast,
   css,
+  hasNativeShadowDomSupport,
   props,
   rgb2hex,
   supportsCSSVars,
@@ -30,10 +31,15 @@ class BoltIcon extends withPreact {
     contrastColor: props.string,
   };
 
-  connectedCallback() {
-    super.connectedCallback && super.connectedCallback();
-    const elem = this;
+  constructor(self) {
+    self = super(self);
+    this.useShadow = hasNativeShadowDomSupport;
     this.useCssVars = supportsCSSVars;
+    return self;
+  }
+
+  connecting() {
+    const elem = this;
 
     this.state = {
       primaryColor: 'var(--bolt-theme-icon, currentColor)',
@@ -59,7 +65,7 @@ class BoltIcon extends withPreact {
         }
       };
 
-      this.colorObserver = PubSub.subscribe(
+      const colorObserver = PubSub.subscribe(
         'component.icon',
         checkIfColorChanged,
       );
@@ -75,14 +81,6 @@ class BoltIcon extends withPreact {
           rgb2hex(window.getComputedStyle(this).getPropertyValue('color')),
         );
       }
-    }
-  }
-
-  disconnectedCallback() {
-    super.disconnectedCallback && super.disconnectedCallback();
-
-    if (this.colorObserver) {
-      PubSub.unsubscribe(this.colorObserver);
     }
   }
 

--- a/packages/components/bolt-image/src/image.js
+++ b/packages/components/bolt-image/src/image.js
@@ -75,16 +75,17 @@ class BoltImage extends BoltElement {
     };
   }
 
-  constructor() {
-    super();
-    this.onResize = this.onResize.bind(this);
-    this.onLazyLoaded = this.onLazyLoaded.bind(this);
-    this.initialClasses = [];
-    this.valign = 'center';
-    this.placeholderImage =
+  constructor(self) {
+    self = super(self);
+    self.onResize = self.onResize.bind(self);
+    self.onLazyLoaded = self.onLazyLoaded.bind(self);
+    self.initialClasses = [];
+    self.valign = 'center';
+    self.placeholderImage =
       'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
-    this.sizes = 'auto';
-    this.ratio = 'auto';
+    self.sizes = 'auto';
+    self.ratio = 'auto';
+    return self;
   }
 
   disconnectedCallback() {

--- a/packages/components/bolt-image/src/image.js
+++ b/packages/components/bolt-image/src/image.js
@@ -75,17 +75,16 @@ class BoltImage extends BoltElement {
     };
   }
 
-  constructor(self) {
-    self = super(self);
-    self.onResize = self.onResize.bind(self);
-    self.onLazyLoaded = self.onLazyLoaded.bind(self);
-    self.initialClasses = [];
-    self.valign = 'center';
-    self.placeholderImage =
+  constructor() {
+    super();
+    this.onResize = this.onResize.bind(this);
+    this.onLazyLoaded = this.onLazyLoaded.bind(this);
+    this.initialClasses = [];
+    this.valign = 'center';
+    this.placeholderImage =
       'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
-    self.sizes = 'auto';
-    self.ratio = 'auto';
-    return self;
+    this.sizes = 'auto';
+    this.ratio = 'auto';
   }
 
   disconnectedCallback() {

--- a/packages/components/bolt-li/src/li.js
+++ b/packages/components/bolt-li/src/li.js
@@ -1,15 +1,13 @@
-import { define, props, mapWithDepth } from '@bolt/core/utils';
+import { props, mapWithDepth } from '@bolt/core/utils';
 import classNames from 'classnames/bind';
-import { withLitHtml, html } from '@bolt/core/renderers/renderer-lit-html';
-
+import { withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
+import { html, customElement } from '@bolt/element';
 import styles from './li.scss';
 
 let cx = classNames.bind(styles);
 
-@define
-class BoltListItem extends withLitHtml() {
-  static is = 'bolt-li';
-
+@customElement('bolt-li')
+class BoltListItem extends withLitHtml {
   static props = {
     last: {
       ...props.boolean,

--- a/packages/components/bolt-list/src/_list-item.js
+++ b/packages/components/bolt-list/src/_list-item.js
@@ -1,16 +1,14 @@
-import { withContext, define, props } from '@bolt/core/utils';
+import { html, customElement } from '@bolt/element';
+import { withContext, props } from '@bolt/core/utils';
 import classNames from 'classnames/bind';
-import { withLitHtml, html } from '@bolt/core/renderers/renderer-lit-html';
-
+import { withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 import styles from './_list-item.scss';
 import { ListContext } from './list';
 
 let cx = classNames.bind(styles);
 
-@define
-class BoltListItem extends withContext(withLitHtml()) {
-  static is = 'bolt-list-item';
-
+@customElement('bolt-list-item')
+class BoltListItem extends withContext(withLitHtml) {
   static props = {
     last: props.boolean,
   };

--- a/packages/components/bolt-list/src/list.js
+++ b/packages/components/bolt-list/src/list.js
@@ -1,3 +1,4 @@
+import { html, customElement } from '@bolt/element';
 import {
   defineContext,
   withContext,
@@ -6,7 +7,7 @@ import {
   hasNativeShadowDomSupport,
 } from '@bolt/core/utils';
 import classNames from 'classnames/bind';
-import { withLitHtml, html } from '@bolt/core/renderers/renderer-lit-html';
+import { withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 import Ajv from 'ajv';
 
 import themes from '@bolt/global/styles/06-themes/_themes.all.scss';
@@ -27,10 +28,8 @@ export const ListContext = defineContext({
   separator: 'none',
 });
 
-@define
-class BoltList extends withContext(withLitHtml()) {
-  static is = 'bolt-list';
-
+@customElement('bolt-list')
+class BoltList extends withContext(withLitHtml) {
   // provide context info to children that subscribe
   // (context + subscriber idea originally from https://codepen.io/trusktr/project/editor/XbEOMk)
   static get provides() {

--- a/packages/components/bolt-modal/focus-trap/focus-trap.js
+++ b/packages/components/bolt-modal/focus-trap/focus-trap.js
@@ -1,5 +1,6 @@
-import { props, define } from '@bolt/core/utils';
-import { html, withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
+import { html, customElement } from '@bolt/element';
+import { props } from '@bolt/core/utils';
+import { withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 import { isFocusable, isHidden } from './focusable';
 import { queryShadowRoot } from './shadow';
 
@@ -7,10 +8,9 @@ import { queryShadowRoot } from './shadow';
  * Focus trap web component.
  * @slot - Default content.
  */
-@define
-class FocusTrap extends withLitHtml() {
-  static is = 'focus-trap';
 
+@customElement('focus-trap')
+class FocusTrap extends withLitHtml {
   static props = {
     readonly: props.boolean,
     focused: props.boolean,

--- a/packages/components/bolt-modal/src/modal.js
+++ b/packages/components/bolt-modal/src/modal.js
@@ -49,9 +49,9 @@ class BoltModal extends withLitHtml {
     self = super(self);
     self.useShadow = hasNativeShadowDomSupport;
     self.schema = schema;
-    self.show = self.show.bind(self);
-    self.hide = self.hide.bind(self);
-    self._handleKeyPresseskeypress = self._handleKeyPresseskeypress.bind(self);
+    self.show = self.show.bind(this);
+    self.hide = self.hide.bind(this);
+    self._handleKeyPresseskeypress = this._handleKeyPresseskeypress.bind(this);
     self._noBodyScroll = false; // Internal switch to enable 'no-body-scroll' feature which is not ready for release
 
     return self;

--- a/packages/components/bolt-modal/src/modal.js
+++ b/packages/components/bolt-modal/src/modal.js
@@ -1,8 +1,8 @@
 // based originally off of https://github.com/edenspiekermann/a11y-dialog before heavy modifications and customizations
 
+import { html, customElement } from '@bolt/element';
 import {
   props,
-  define,
   hasNativeShadowDomSupport,
   getTransitionDuration,
   bodyHasScrollbar,
@@ -10,7 +10,7 @@ import {
   setScrollbarPadding,
   resetScrollbarPadding,
 } from '@bolt/core/utils';
-import { html, withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
+import { withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 import classNames from 'classnames/bind';
 import styles from './modal.scss';
 import schema from '../modal.schema.yml';
@@ -21,10 +21,8 @@ import '../focus-trap';
 const ESCAPE_KEY = 27;
 let cx = classNames.bind(styles);
 
-@define
-class BoltModal extends withLitHtml() {
-  static is = 'bolt-modal';
-
+@customElement('bolt-modal')
+class BoltModal extends withLitHtml {
   static props = {
     width: props.string,
     spacing: props.string,

--- a/packages/components/bolt-modal/src/modal.js
+++ b/packages/components/bolt-modal/src/modal.js
@@ -51,9 +51,9 @@ class BoltModal extends withLitHtml() {
     self = super(self);
     self.useShadow = hasNativeShadowDomSupport;
     self.schema = schema;
-    self.show = self.show.bind(this);
-    self.hide = self.hide.bind(this);
-    self._handleKeyPresseskeypress = this._handleKeyPresseskeypress.bind(this);
+    self.show = self.show.bind(self);
+    self.hide = self.hide.bind(self);
+    self._handleKeyPresseskeypress = self._handleKeyPresseskeypress.bind(self);
     self._noBodyScroll = false; // Internal switch to enable 'no-body-scroll' feature which is not ready for release
 
     return self;

--- a/packages/components/bolt-nav-indicator/nav-indicator.js
+++ b/packages/components/bolt-nav-indicator/nav-indicator.js
@@ -1,5 +1,6 @@
-import { define, hasNativeShadowDomSupport } from '@bolt/core/utils';
-import { withLitHtml, html } from '@bolt/core/renderers/renderer-lit-html';
+import { html, customElement } from '@bolt/element';
+import { hasNativeShadowDomSupport } from '@bolt/core/utils';
+import { withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 
 import gumshoe from 'gumshoejs';
 import isVisible from 'is-visible';
@@ -150,10 +151,8 @@ let gumshoeStateModule = (function() {
   return pub;
 })();
 
-@define
-class BoltNavIndicator extends withLitHtml() {
-  static is = 'bolt-nav-indicator';
-
+@customElement('bolt-nav-indicator')
+class BoltNavIndicator extends withLitHtml {
   // Behavior for `<bolt-nav>` parent container
   static get observedAttributes() {
     return ['offset'];

--- a/packages/components/bolt-nav-priority/nav-priority.js
+++ b/packages/components/bolt-nav-priority/nav-priority.js
@@ -18,13 +18,15 @@ import '@bolt/core/utils/optimized-resize';
 class BoltNavPriority extends withLitHtml {
   constructor(self) {
     self = super(self);
-    self.activeLink = false;
-    self.useShadow = false;
-    self.isReady = false;
-    self.transitionEvent = whichTransitionEvent();
+    this.activeLink = false;
+    this.useShadow = false;
+    this.isReady = false;
+    this.transitionEvent = whichTransitionEvent();
 
-    self._adaptPriorityNav = self._adaptPriorityNav.bind(self);
-    self._handleDropdownToggle = self._handleDropdownToggle.bind(self);
+    this._adaptPriorityNav = this._adaptPriorityNav.bind(this);
+    this._handleDropdownToggle = this._handleDropdownToggle.bind(this);
+
+    return self;
   }
 
   static props = {
@@ -48,7 +50,7 @@ class BoltNavPriority extends withLitHtml {
         <li class="c-bolt-nav-priority__item c-bolt-nav-priority__show-more">
           <button type="button" aria-haspopup="true" aria-expanded="false" class="c-bolt-nav-priority__button c-bolt-nav-priority__show-button">
             <span class="c-bolt-nav-priority__show-text">
-              ${this.moreText ? this.moreText : 'More'}
+              ${this.props.moreText ? this.props.moreText : 'More'}
             </span>
             <span class="c-bolt-nav-priority__show-icon">
               <bolt-icon name="chevron-down"></bolt-icon>

--- a/packages/components/bolt-nav-priority/nav-priority.js
+++ b/packages/components/bolt-nav-priority/nav-priority.js
@@ -1,10 +1,10 @@
+import { html, customElement } from '@bolt/element';
 import {
-  define,
   props,
   whichTransitionEvent,
   waitForTransitionEnd,
 } from '@bolt/core/utils';
-import { withLitHtml, html } from '@bolt/core/renderers/renderer-lit-html';
+import { withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 
 import '@bolt/core/utils/optimized-resize';
 
@@ -14,10 +14,8 @@ import '@bolt/core/utils/optimized-resize';
     — https://www.npmjs.com/package/nodelist-foreach-polyfill
 */
 
-@define
-class BoltNavPriority extends withLitHtml() {
-  static is = 'bolt-nav-priority';
-
+@customElement('bolt-nav-priority')
+class BoltNavPriority extends withLitHtml {
   constructor(self) {
     self = super(self);
     self.activeLink = false;

--- a/packages/components/bolt-nav-priority/nav-priority.js
+++ b/packages/components/bolt-nav-priority/nav-priority.js
@@ -20,15 +20,13 @@ class BoltNavPriority extends withLitHtml() {
 
   constructor(self) {
     self = super(self);
-    this.activeLink = false;
-    this.useShadow = false;
-    this.isReady = false;
-    this.transitionEvent = whichTransitionEvent();
+    self.activeLink = false;
+    self.useShadow = false;
+    self.isReady = false;
+    self.transitionEvent = whichTransitionEvent();
 
-    this._adaptPriorityNav = this._adaptPriorityNav.bind(this);
-    this._handleDropdownToggle = this._handleDropdownToggle.bind(this);
-
-    return self;
+    self._adaptPriorityNav = self._adaptPriorityNav.bind(self);
+    self._handleDropdownToggle = self._handleDropdownToggle.bind(self);
   }
 
   static props = {
@@ -52,7 +50,7 @@ class BoltNavPriority extends withLitHtml() {
         <li class="c-bolt-nav-priority__item c-bolt-nav-priority__show-more">
           <button type="button" aria-haspopup="true" aria-expanded="false" class="c-bolt-nav-priority__button c-bolt-nav-priority__show-button">
             <span class="c-bolt-nav-priority__show-text">
-              ${this.props.moreText ? this.props.moreText : 'More'}
+              ${this.moreText ? this.moreText : 'More'}
             </span>
             <span class="c-bolt-nav-priority__show-icon">
               <bolt-icon name="chevron-down"></bolt-icon>

--- a/packages/components/bolt-navlink/navlink.js
+++ b/packages/components/bolt-navlink/navlink.js
@@ -1,5 +1,6 @@
-import { props, define } from '@bolt/core/utils';
-import { withLitHtml, html } from '@bolt/core/renderers/renderer-lit-html';
+import { html, customElement } from '@bolt/element';
+import { props } from '@bolt/core/utils';
+import { withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 import isVisible from 'is-visible';
 
 // Used for attaching smooth scroll behavior to dynamically created <bolt-navlink> instances
@@ -9,10 +10,8 @@ import {
   getScrollTarget,
 } from '@bolt/components-smooth-scroll';
 
-@define
-class BoltNavLink extends withLitHtml() {
-  static is = 'bolt-navlink';
-
+@customElement('bolt-navlink')
+class BoltNavLink extends withLitHtml {
   static props = {
     active: props.boolean,
     isDropdownLink: props.boolean,

--- a/packages/components/bolt-navlink/navlink.js
+++ b/packages/components/bolt-navlink/navlink.js
@@ -19,9 +19,9 @@ class BoltNavLink extends withLitHtml {
 
   constructor(self) {
     self = super(self);
-    self.activeClass = 'is-active';
-    self.useShadow = false; // just-in-case workaround given that the current <bolt-navlink> doesn't actually render any HTML...
-    self.dropdownLinkClass = 'is-dropdown-link';
+    this.activeClass = 'is-active';
+    this.useShadow = false; // just-in-case workaround given that the current <bolt-navlink> doesn't actually render any HTML...
+    this.dropdownLinkClass = 'is-dropdown-link';
     return self;
   }
 
@@ -129,8 +129,8 @@ class BoltNavLink extends withLitHtml {
     this._shadowLink.classList.remove(this.activeClass);
   }
 
-  connectedCallback() {
-    super.connectedCallback && super.connectedCallback();
+  connecting() {
+    super.connecting && super.connecting();
     this.addEventListener('click', this.onClick);
 
     this._shadowLink = this.querySelector('a');
@@ -146,8 +146,8 @@ class BoltNavLink extends withLitHtml {
     }
   }
 
-  disconnectedCallback() {
-    super.disconnectedCallback && super.disconnectedCallback();
+  disconnecting() {
+    super.disconnecting && super.disconnecting();
     this.removeEventListener('click', this.onClick);
   }
 }

--- a/packages/components/bolt-navlink/navlink.js
+++ b/packages/components/bolt-navlink/navlink.js
@@ -20,9 +20,9 @@ class BoltNavLink extends withLitHtml() {
 
   constructor(self) {
     self = super(self);
-    this.activeClass = 'is-active';
-    this.useShadow = false; // just-in-case workaround given that the current <bolt-navlink> doesn't actually render any HTML...
-    this.dropdownLinkClass = 'is-dropdown-link';
+    self.activeClass = 'is-active';
+    self.useShadow = false; // just-in-case workaround given that the current <bolt-navlink> doesn't actually render any HTML...
+    self.dropdownLinkClass = 'is-dropdown-link';
     return self;
   }
 
@@ -130,8 +130,8 @@ class BoltNavLink extends withLitHtml() {
     this._shadowLink.classList.remove(this.activeClass);
   }
 
-  connecting() {
-    super.connecting && super.connecting();
+  connectedCallback() {
+    super.connectedCallback && super.connectedCallback();
     this.addEventListener('click', this.onClick);
 
     this._shadowLink = this.querySelector('a');
@@ -147,8 +147,8 @@ class BoltNavLink extends withLitHtml() {
     }
   }
 
-  disconnecting() {
-    super.disconnecting && super.disconnecting();
+  disconnectedCallback() {
+    super.disconnectedCallback && super.disconnectedCallback();
     this.removeEventListener('click', this.onClick);
   }
 }

--- a/packages/components/bolt-ol/src/ol.js
+++ b/packages/components/bolt-ol/src/ol.js
@@ -1,7 +1,7 @@
-import { props, define, mapWithDepth } from '@bolt/core/utils';
+import { html, customElement } from '@bolt/element';
+import { props, mapWithDepth } from '@bolt/core/utils';
 import classNames from 'classnames/bind';
-import { withLitHtml, html } from '@bolt/core/renderers/renderer-lit-html';
-
+import { withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 import styles from './ol.scss';
 
 let cx = classNames.bind(styles);
@@ -17,10 +17,8 @@ function addNestedLevelProps(childNode, level) {
   return currentLevel;
 }
 
-@define
-class BoltOrderedList extends withLitHtml() {
-  static is = 'bolt-ol';
-
+@customElement('bolt-ol')
+class BoltOrderedList extends withLitHtml {
   static props = {
     level: {
       ...props.number,

--- a/packages/components/bolt-placeholder/placeholder.standalone.js
+++ b/packages/components/bolt-placeholder/placeholder.standalone.js
@@ -20,7 +20,7 @@ class BoltPlaceholder extends withLitHtml() {
   // https://github.com/WebReflection/document-register-element#upgrading-the-constructor-context
   constructor(self) {
     self = super(self);
-    this.useShadow = hasNativeShadowDomSupport;
+    self.useShadow = hasNativeShadowDomSupport;
     return self;
   }
 

--- a/packages/components/bolt-placeholder/placeholder.standalone.js
+++ b/packages/components/bolt-placeholder/placeholder.standalone.js
@@ -13,7 +13,7 @@ class BoltPlaceholder extends withLitHtml {
   // https://github.com/WebReflection/document-register-element#upgrading-the-constructor-context
   constructor(self) {
     self = super(self);
-    self.useShadow = hasNativeShadowDomSupport;
+    this.useShadow = hasNativeShadowDomSupport;
     return self;
   }
 

--- a/packages/components/bolt-placeholder/placeholder.standalone.js
+++ b/packages/components/bolt-placeholder/placeholder.standalone.js
@@ -1,17 +1,10 @@
-import {
-  define,
-  props,
-  css,
-  hasNativeShadowDomSupport,
-} from '@bolt/core/utils';
-import { withLitHtml, html } from '@bolt/core/renderers/renderer-lit-html';
-
+import { props, css, hasNativeShadowDomSupport } from '@bolt/core/utils';
+import { withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
+import { html, customElement } from '@bolt/element';
 import placeholderStyles from './placeholder.scss';
 
-@define
-class BoltPlaceholder extends withLitHtml() {
-  static is = 'bolt-placeholder';
-
+@customElement('bolt-placeholder')
+class BoltPlaceholder extends withLitHtml {
   static props = {
     animated: props.boolean,
     size: props.string,

--- a/packages/components/bolt-ratio/src/ratio.js
+++ b/packages/components/bolt-ratio/src/ratio.js
@@ -33,8 +33,8 @@ class BoltRatio extends BoltElement {
     };
   }
 
-  constructor() {
-    super();
+  connectedCallback() {
+    super.connectedCallback && super.connectedCallback();
     this.noCssVars = supportsCSSVars ? false : true;
   }
 

--- a/packages/components/bolt-ratio/src/ratio.js
+++ b/packages/components/bolt-ratio/src/ratio.js
@@ -33,8 +33,8 @@ class BoltRatio extends BoltElement {
     };
   }
 
-  connectedCallback() {
-    super.connectedCallback && super.connectedCallback();
+  constructor() {
+    super();
     this.noCssVars = supportsCSSVars ? false : true;
   }
 

--- a/packages/components/bolt-stack/src/stack.js
+++ b/packages/components/bolt-stack/src/stack.js
@@ -20,13 +20,6 @@ class BoltStack extends withLitHtml() {
     },
   };
 
-  // https://github.com/WebReflection/document-register-element#upgrading-the-constructor-context
-  constructor(self) {
-    self = super(self);
-    self.useShadow = hasNativeShadowDomSupport;
-    return self;
-  }
-
   render() {
     // validate the original prop data passed along -- returns back the validated data w/ added default values
     const { disabled } = this.validateProps(this.props);

--- a/packages/components/bolt-stack/src/stack.js
+++ b/packages/components/bolt-stack/src/stack.js
@@ -19,6 +19,13 @@ class BoltStack extends withLitHtml {
     },
   };
 
+  // https://github.com/WebReflection/document-register-element#upgrading-the-constructor-context
+  constructor(self) {
+    self = super(self);
+    self.useShadow = hasNativeShadowDomSupport;
+    return self;
+  }
+
   render() {
     // validate the original prop data passed along -- returns back the validated data w/ added default values
     const { disabled } = this.validateProps(this.props);

--- a/packages/components/bolt-stack/src/stack.js
+++ b/packages/components/bolt-stack/src/stack.js
@@ -1,14 +1,13 @@
-import { props, define, hasNativeShadowDomSupport } from '@bolt/core/utils';
-import { withLitHtml, html } from '@bolt/core/renderers/renderer-lit-html';
+import { html, customElement } from '@bolt/element';
+import { props } from '@bolt/core/utils';
+import { withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 import classNames from 'classnames/bind';
 import styles from './stack.scss';
 
 let cx = classNames.bind(styles);
 
-@define
-class BoltStack extends withLitHtml() {
-  static is = 'bolt-stack';
-
+@customElement('bolt-stack')
+class BoltStack extends withLitHtml {
   static props = {
     noShadow: {
       ...props.boolean,

--- a/packages/components/bolt-table/src/table.js
+++ b/packages/components/bolt-table/src/table.js
@@ -1,5 +1,6 @@
-import { props, define } from '@bolt/core/utils';
-import { withLitHtml, html } from '@bolt/core/renderers/renderer-lit-html';
+import { html, customElement } from '@bolt/element';
+import { props } from '@bolt/core/utils';
+import { withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html';
 import { ifDefined } from 'lit-html/directives/if-defined';
 import { parse, stringify } from 'himalaya';
@@ -11,10 +12,8 @@ import schema from '../table.schema.yml';
 
 let cx = classNames.bind(styles);
 
-@define
-class BoltTable extends withLitHtml() {
-  static is = 'bolt-table';
-
+@customElement('bolt-table')
+class BoltTable extends withLitHtml {
   static props = {
     format: {
       ...props.string,

--- a/packages/components/bolt-tabs/src/TabPanel/index.js
+++ b/packages/components/bolt-tabs/src/TabPanel/index.js
@@ -1,20 +1,14 @@
-import {
-  withContext,
-  define,
-  props,
-  hasNativeShadowDomSupport,
-} from '@bolt/core/utils';
-import { withLitHtml, html } from '@bolt/core/renderers/renderer-lit-html';
+import { html, customElement } from '@bolt/element';
+import { withContext, props } from '@bolt/core/utils';
+import { withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 import classNames from 'classnames/bind';
 import styles from './tab-panel.scss';
 import { TabsContext } from '../tabs';
 
 let cx = classNames.bind(styles);
 
-@define
-class TabPanel extends withContext(withLitHtml()) {
-  static is = 'bolt-tab-panel';
-
+@customElement('bolt-tab-panel')
+class TabPanel extends withContext(withLitHtml) {
   static props = {
     selected: props.boolean,
   };

--- a/packages/components/bolt-tabs/src/tabs.js
+++ b/packages/components/bolt-tabs/src/tabs.js
@@ -1,3 +1,4 @@
+import { html, customElement } from '@bolt/element';
 import {
   defineContext,
   withContext,
@@ -8,8 +9,7 @@ import {
   whichTransitionEvent,
   waitForTransitionEnd,
 } from '@bolt/core/utils';
-import { withLitHtml, html } from '@bolt/core/renderers/renderer-lit-html';
-
+import { withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 import classNames from 'classnames/bind';
 import styles from './tabs.scss';
 import schema from '../tabs.schema.yml';
@@ -26,10 +26,8 @@ export const TabsContext = defineContext({
 
 let cx = classNames.bind(styles);
 
-@define
-class BoltTabs extends withContext(withLitHtml()) {
-  static is = 'bolt-tabs';
-
+@customElement('bolt-tabs')
+class BoltTabs extends withContext(withLitHtml) {
   static props = {
     align: props.string,
     inset: props.string,

--- a/packages/components/bolt-text/src/text.js
+++ b/packages/components/bolt-text/src/text.js
@@ -47,7 +47,7 @@ class BoltText extends withLitHtml() {
 
   constructor(self) {
     self = super(self);
-    this.useShadow = hasNativeShadowDomSupport;
+    self.useShadow = hasNativeShadowDomSupport;
     return self;
   }
 

--- a/packages/components/bolt-text/src/text.js
+++ b/packages/components/bolt-text/src/text.js
@@ -40,7 +40,7 @@ class BoltText extends withLitHtml {
 
   constructor(self) {
     self = super(self);
-    self.useShadow = hasNativeShadowDomSupport;
+    this.useShadow = hasNativeShadowDomSupport;
     return self;
   }
 

--- a/packages/components/bolt-text/src/text.js
+++ b/packages/components/bolt-text/src/text.js
@@ -1,18 +1,11 @@
-import {
-  define,
-  props,
-  css,
-  hasNativeShadowDomSupport,
-} from '@bolt/core/utils';
-import { withLitHtml, html } from '@bolt/core/renderers/renderer-lit-html';
-
+import { html, customElement } from '@bolt/element';
+import { props, css, hasNativeShadowDomSupport } from '@bolt/core/utils';
+import { withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 import styles from './text.scss';
 import schema from '../text.schema.yml';
 
-@define
-class BoltText extends withLitHtml() {
-  static is = 'bolt-text';
-
+@customElement('bolt-text')
+class BoltText extends withLitHtml {
   static props = {
     tag: props.string,
     display: props.string,

--- a/packages/components/bolt-tooltip/src/tooltip.js
+++ b/packages/components/bolt-tooltip/src/tooltip.js
@@ -1,15 +1,13 @@
-import { define, props } from '@bolt/core/utils';
+import { html, customElement, ifDefined } from '@bolt/element';
+import { props } from '@bolt/core/utils';
 import classNames from 'classnames/bind';
-import { html, withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
-import { ifDefined } from 'lit-html/directives/if-defined';
+import { withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 import styles from './tooltip.scss';
 
 let cx = classNames.bind(styles);
 
-@define
-class BoltTooltip extends withLitHtml() {
-  static is = 'bolt-tooltip';
-
+@customElement('bolt-tooltip')
+class BoltTooltip extends withLitHtml {
   static props = {
     triggerText: {
       ...props.string,

--- a/packages/components/bolt-trigger/src/trigger.js
+++ b/packages/components/bolt-trigger/src/trigger.js
@@ -1,9 +1,8 @@
-import { props, define } from '@bolt/core/utils';
-import { html, render } from '@bolt/core/renderers/renderer-lit-html';
+import { html, convertInitialTags, customElement } from '@bolt/element';
+import { props } from '@bolt/core/utils';
+import { render } from '@bolt/core/renderers/renderer-lit-html';
 import { BoltAction } from '@bolt/core/elements/bolt-action';
-import { convertInitialTags } from '@bolt/core/decorators';
 import { ifDefined } from 'lit-html/directives/if-defined';
-
 import classNames from 'classnames/bind';
 
 import styles from './trigger.scss';
@@ -11,11 +10,9 @@ import schema from '../trigger.schema.yml';
 
 let cx = classNames.bind(styles);
 
-@define
+@customElement('bolt-trigger')
 @convertInitialTags(['button', 'a']) // The first matching tag will have its attributes converted to component props
 class BoltTrigger extends BoltAction {
-  static is = 'bolt-trigger';
-
   static props = {
     ...BoltAction.props, // Provides: disabled, onClick, onClickTarget, target, url
     type: props.string,

--- a/packages/components/bolt-typeahead/typeahead.autosuggest.js
+++ b/packages/components/bolt-typeahead/typeahead.autosuggest.js
@@ -1,5 +1,6 @@
 // @ts-nocheck
-import { define, props } from 'skatejs';
+import { customElement } from '@bolt/element';
+import { props } from 'skatejs';
 import { h, withPreact, Fragment } from '@bolt/core/renderers';
 import { getUniqueId } from '@bolt/core/utils/get-unique-id';
 import Fuse from 'fuse.js';
@@ -47,10 +48,8 @@ export const highlightSearchResults = function(item) {
   });
 };
 
-@define
-class BoltAutosuggest extends withPreact() {
-  static is = 'bolt-autosuggest';
-
+@customElement('bolt-autosuggest')
+class BoltAutosuggest extends withPreact {
   get getParent() {
     return this.$parent;
   }

--- a/packages/components/bolt-typeahead/typeahead.js
+++ b/packages/components/bolt-typeahead/typeahead.js
@@ -1,17 +1,15 @@
 // @ts-nocheck
-import { define, props } from 'skatejs';
-import { withLitHtml, html } from '@bolt/core/renderers/renderer-lit-html';
-import { withEvents } from '@bolt/core/renderers/with-events';
+import { html, customElement } from '@bolt/element';
+import { props } from 'skatejs';
+import { withLitEvents } from '@bolt/core/renderers/with-events';
 import { bind } from './classnames';
 import './typeahead.autosuggest'; // main Preact logic split from lit-html wrapper
-
 import styles from './typeahead.scoped.scss';
+
 const cx = bind(styles);
 
-@define
-class BoltTypeahead extends withEvents(withLitHtml()) {
-  static is = 'bolt-typeahead';
-
+@customElement('bolt-typeahead')
+class BoltTypeahead extends withLitEvents {
   // @todo: replace with auto-wired up props approach used in Carousel
   static props = {
     inputPlaceholder: props.string,

--- a/packages/components/bolt-ul/src/ul.js
+++ b/packages/components/bolt-ul/src/ul.js
@@ -1,7 +1,7 @@
-import { props, define, mapWithDepth } from '@bolt/core/utils';
+import { html, customElement } from '@bolt/element';
+import { props, mapWithDepth } from '@bolt/core/utils';
 import classNames from 'classnames/bind';
-import { withLitHtml, html } from '@bolt/core/renderers/renderer-lit-html';
-
+import { withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 import styles from './ul.scss';
 
 let cx = classNames.bind(styles);
@@ -17,10 +17,8 @@ function addNestedLevelProps(childNode, level) {
   return currentLevel;
 }
 
-@define
-class BoltUnorderedList extends withLitHtml() {
-  static is = 'bolt-ul';
-
+@customElement('bolt-ul')
+class BoltUnorderedList extends withLitHtml {
   static props = {
     level: {
       ...props.number,

--- a/packages/components/bolt-video/src/video-meta.js
+++ b/packages/components/bolt-video/src/video-meta.js
@@ -1,15 +1,9 @@
-import { define, props } from '@bolt/core/utils';
+import { customElement } from '@bolt/element';
+import { props } from '@bolt/core/utils';
 import { h, withPreact } from '@bolt/core/renderers';
 
-@define
-class BoltVideoMeta extends withPreact() {
-  static is = `${bolt.namespace}-video-meta`;
-
-  constructor(self) {
-    self = super(self);
-    return self;
-  }
-
+@customElement('bolt-video-meta')
+class BoltVideoMeta extends withPreact {
   static props = {
     duration: props.string,
     title: props.string,

--- a/packages/components/bolt-video/src/video.standalone.js
+++ b/packages/components/bolt-video/src/video.standalone.js
@@ -1,4 +1,5 @@
-import { beforeNextRender, define, props, css } from '@bolt/core/utils';
+import { customElement } from '@bolt/element';
+import { beforeNextRender, props, css } from '@bolt/core/utils';
 import { h, withPreact } from '@bolt/core/renderers';
 import Mousetrap from 'mousetrap';
 import classNames from 'classnames';
@@ -12,10 +13,8 @@ import {
 import { datasetToObject, formatVideoDuration } from '../utils';
 
 let index = 0;
-@define
-class BoltVideo extends withPreact() {
-  static is = `${bolt.namespace}-video`;
-
+@customElement('bolt-video')
+class BoltVideo extends withPreact {
   static props = {
     videoId: props.string,
     accountId: props.string,

--- a/packages/components/bolt-video/src/video.standalone.js
+++ b/packages/components/bolt-video/src/video.standalone.js
@@ -49,27 +49,26 @@ class BoltVideo extends withPreact() {
     self = super(self);
     self.useShadow = false;
 
-    this.defaultPlugins = ['playback'];
+    self.defaultPlugins = ['playback'];
 
     index += 1;
 
     // These bindings are necessary to make `this` work in the callback
-    this.onPlay = this.onPlay.bind(this);
-    this.onPause = this.onPause.bind(this);
-    this.onEnded = this.onEnded.bind(this);
-    this.onDurationChange = this.onDurationChange.bind(this);
-    this.onSeeked = this.onSeeked.bind(this);
-    this.handleClose = this.handleClose.bind(this);
-    this.collapseOnClickAway = this.collapseOnClickAway.bind(this);
+    self.onPlay = self.onPlay.bind(self);
+    self.onPause = self.onPause.bind(self);
+    self.onEnded = self.onEnded.bind(self);
+    self.onDurationChange = self.onDurationChange.bind(self);
+    self.onSeeked = self.onSeeked.bind(self);
+    self.handleClose = self.handleClose.bind(self);
+    self.collapseOnClickAway = self.collapseOnClickAway.bind(self);
 
-    // BoltVideo.globalErrors.forEach(this.props.onError);
+    // BoltVideo.globalErrors.forEach(self.props.onError);
 
-    this.shareDescription = this.shareDescription || 'Share This Video';
+    self.shareDescription = self.shareDescription || 'Share This Video';
 
     // Ensure that 'this' inside the _onWindowResize event handler refers to <bolt-nav-link>
     // even if the handler is attached to another element (window in this case)
-    this._onWindowResize = this._onWindowResize.bind(this);
-
+    self._onWindowResize = self._onWindowResize.bind(self);
     return self;
   }
 

--- a/packages/components/bolt-video/src/video.standalone.js
+++ b/packages/components/bolt-video/src/video.standalone.js
@@ -48,26 +48,27 @@ class BoltVideo extends withPreact {
     self = super(self);
     self.useShadow = false;
 
-    self.defaultPlugins = ['playback'];
+    this.defaultPlugins = ['playback'];
 
     index += 1;
 
     // These bindings are necessary to make `this` work in the callback
-    self.onPlay = self.onPlay.bind(self);
-    self.onPause = self.onPause.bind(self);
-    self.onEnded = self.onEnded.bind(self);
-    self.onDurationChange = self.onDurationChange.bind(self);
-    self.onSeeked = self.onSeeked.bind(self);
-    self.handleClose = self.handleClose.bind(self);
-    self.collapseOnClickAway = self.collapseOnClickAway.bind(self);
+    this.onPlay = this.onPlay.bind(this);
+    this.onPause = this.onPause.bind(this);
+    this.onEnded = this.onEnded.bind(this);
+    this.onDurationChange = this.onDurationChange.bind(this);
+    this.onSeeked = this.onSeeked.bind(this);
+    this.handleClose = this.handleClose.bind(this);
+    this.collapseOnClickAway = this.collapseOnClickAway.bind(this);
 
-    // BoltVideo.globalErrors.forEach(self.props.onError);
+    // BoltVideo.globalErrors.forEach(this.props.onError);
 
-    self.shareDescription = self.shareDescription || 'Share This Video';
+    this.shareDescription = this.shareDescription || 'Share This Video';
 
     // Ensure that 'this' inside the _onWindowResize event handler refers to <bolt-nav-link>
     // even if the handler is attached to another element (window in this case)
-    self._onWindowResize = self._onWindowResize.bind(self);
+    this._onWindowResize = this._onWindowResize.bind(this);
+
     return self;
   }
 

--- a/packages/core/elements/bolt-action/index.js
+++ b/packages/core/elements/bolt-action/index.js
@@ -1,15 +1,13 @@
 import {
   props,
-  define,
   declarativeClickHandler,
   hasNativeShadowDomSupport,
   afterNextRender,
   watchForComponentMutations,
 } from '@bolt/core/utils';
-import { withLitHtml, html } from '@bolt/core/renderers/renderer-lit-html';
+import { withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 
-@define
-class BoltAction extends withLitHtml() {
+class BoltAction extends withLitHtml {
   static props = {
     url: props.string,
     target: props.string,

--- a/packages/core/elements/replace-with-children/index.js
+++ b/packages/core/elements/replace-with-children/index.js
@@ -1,10 +1,7 @@
-import { define } from '@bolt/core/utils';
-import { withLitHtml, html } from '@bolt/core/renderers/renderer-lit-html';
+import { customElement } from '@bolt/element';
 
-@define
+@customElement('replace-with-children')
 class ReplaceWithChildren extends HTMLElement {
-  static is = 'replace-with-children';
-
   connectedCallback() {
     const parentElement = this.parentElement;
 

--- a/packages/core/elements/replace-with-grandchildren/index.js
+++ b/packages/core/elements/replace-with-grandchildren/index.js
@@ -1,10 +1,8 @@
-import { define } from '@bolt/core/utils';
+import { customElement } from '@bolt/element';
 import { ReplaceWithChildren } from '../replace-with-children';
 
-@define
+@customElement('replace-with-grandchildren')
 class ReplaceWithGrandchildren extends ReplaceWithChildren {
-  static is = 'replace-with-grandchildren';
-
   connectedCallback() {
     if (bolt.isServer) {
       return false;

--- a/packages/core/elements/ssr-keep/index.js
+++ b/packages/core/elements/ssr-keep/index.js
@@ -1,9 +1,7 @@
-import { define } from '@bolt/core/utils';
+import { customElement } from '@bolt/element';
 
-@define
+@customElement('ssr-keep')
 class ssrKeep extends HTMLElement {
-  static is = 'ssr-keep';
-
   get for() {
     return this.getAttribute('for');
   }

--- a/packages/generators/yeoman-create-component/generators/component/__tests__/__snapshots__/component-generator.js.snap
+++ b/packages/generators/yeoman-create-component/generators/component/__tests__/__snapshots__/component-generator.js.snap
@@ -1,18 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Yeoman component generator JS file exist 1`] = `
-"import { props, define } from '@bolt/core/utils';
-import { withLitHtml, html } from '@bolt/core/renderers/renderer-lit-html';
+"import { html, customElement } from '@bolt/element';
+import { props } from '@bolt/core/utils';
+import { withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 import classNames from 'classnames/bind';
 import styles from './test.scss';
 import schema from '../test.schema.yml';
 
 let cx = classNames.bind(styles);
 
-@define
-class BoltTest extends withLitHtml() {
-  static is = 'bolt-test';
-
+@customElement('bolt-test')
+class BoltTest extends withLitHtml {
   static props = {
     noShadow: {
       ...props.boolean,

--- a/packages/generators/yeoman-create-component/generators/component/templates/component.js
+++ b/packages/generators/yeoman-create-component/generators/component/templates/component.js
@@ -1,15 +1,14 @@
-import { props, define } from '@bolt/core/utils';
-import { withLitHtml, html } from '@bolt/core/renderers/renderer-lit-html';
+import { html, customElement } from '@bolt/element';
+import { props } from '@bolt/core/utils';
+import { withLitHtml } from '@bolt/core/renderers/renderer-lit-html';
 import classNames from 'classnames/bind';
 import styles from './<%= props.name.kebabCase %>.scss';
 import schema from '../<%= props.name.kebabCase %>.schema.yml';
 
 let cx = classNames.bind(styles);
 
-@define
-class Bolt<%= props.name.pascalCase %> extends withLitHtml() {
-  static is = 'bolt-<%= props.name.kebabCase %>';
-
+@customElement('bolt-<%= props.name.kebabCase %>')
+class Bolt<%= props.name.pascalCase %> extends withLitHtml {
   static props = {
     noShadow: {
       ...props.boolean,

--- a/packages/micro-journeys/src/bolt-svg-animations/svg-animations.js
+++ b/packages/micro-journeys/src/bolt-svg-animations/svg-animations.js
@@ -1,5 +1,6 @@
-import { define, hasNativeShadowDomSupport } from '@bolt/core/utils';
-import { withLitContext, html, convertSchemaToProps } from '@bolt/core';
+import { html, customElement } from '@bolt/element';
+import { hasNativeShadowDomSupport } from '@bolt/core/utils';
+import { withLitContext, convertSchemaToProps } from '@bolt/core';
 import classNames from 'classnames/bind';
 import * as SVGs from './svg';
 import styles from './svg-animations.scss';
@@ -7,10 +8,8 @@ import schema from './svg-animations.schema';
 
 let cx = classNames.bind(styles);
 
-@define
-class SVGAnimations extends withLitContext() {
-  static is = 'bolt-svg-animations';
-
+@customElement('bolt-svg-animations')
+class SVGAnimations extends withLitContext {
   static props = {
     ...convertSchemaToProps(schema),
   };

--- a/packages/micro-journeys/src/character.js
+++ b/packages/micro-journeys/src/character.js
@@ -1,5 +1,6 @@
-import { props, define, hasNativeShadowDomSupport } from '@bolt/core/utils';
-import { withLitHtml, html, convertSchemaToProps } from '@bolt/core';
+import { html, customElement } from '@bolt/element';
+import { props, hasNativeShadowDomSupport } from '@bolt/core/utils';
+import { withLitHtml, convertSchemaToProps } from '@bolt/core';
 import classNames from 'classnames/bind';
 import schema from './character.schema';
 import styles from './character.scss';
@@ -35,10 +36,8 @@ const centerClass = `${rootClass}__center`;
 const connectionClass = `${rootClass}__slot--connection`;
 const boltCharacterIs = 'bolt-character';
 
-@define
-class BoltCharacter extends withLitHtml() {
-  static is = 'bolt-character';
-
+@customElement('bolt-character')
+class BoltCharacter extends withLitHtml {
   static props = {
     noShadow: {
       ...props.boolean,

--- a/packages/micro-journeys/src/connection.js
+++ b/packages/micro-journeys/src/connection.js
@@ -1,5 +1,6 @@
-import { props, define, hasNativeShadowDomSupport } from '@bolt/core/utils';
-import { withLitContext, html, convertSchemaToProps } from '@bolt/core';
+import { html, customElement } from '@bolt/element';
+import { props, hasNativeShadowDomSupport } from '@bolt/core/utils';
+import { withLitContext, convertSchemaToProps } from '@bolt/core';
 import classNames from 'classnames/bind';
 import styles from './connection.scss';
 import schema from './connection.schema';
@@ -7,9 +8,10 @@ import schema from './connection.schema';
 let cx = classNames.bind(styles);
 
 const boltConnectionIs = 'bolt-connection';
-@define
-class BoltConnection extends withLitContext() {
-  static is = boltConnectionIs;
+
+@customElement('bolt-connection')
+class BoltConnection extends withLitContext {
+  static is = 'bolt-connection';
 
   static props = {
     noShadow: {

--- a/packages/micro-journeys/src/cta.js
+++ b/packages/micro-journeys/src/cta.js
@@ -1,14 +1,13 @@
-import { props, define, hasNativeShadowDomSupport } from '@bolt/core/utils';
-import { withLitHtml, html } from '@bolt/core';
+import { html, customElement } from '@bolt/element';
+import { props, hasNativeShadowDomSupport } from '@bolt/core/utils';
+import { withLitHtml } from '@bolt/core';
 import classNames from 'classnames/bind';
 import styles from './cta.scss';
 
 let cx = classNames.bind(styles);
 
-@define
-class BoltCta extends withLitHtml() {
-  static is = 'bolt-cta';
-
+@customElement('bolt-cta')
+class BoltCta extends withLitHtml {
   static props = {
     noShadow: {
       ...props.boolean,

--- a/packages/micro-journeys/src/interactive-pathway.js
+++ b/packages/micro-journeys/src/interactive-pathway.js
@@ -1,11 +1,11 @@
+import { html, customElement } from '@bolt/element';
 import {
   props,
-  define,
   hasNativeShadowDomSupport,
   query,
   convertSchemaToProps,
 } from '@bolt/core/utils';
-import { withLitContext, html } from '@bolt/core';
+import { withLitContext } from '@bolt/core';
 import classNames from 'classnames';
 import debounce from 'lodash.debounce';
 import styles from './interactive-pathway.scss';
@@ -13,8 +13,8 @@ import schema from './interactive-pathway.schema';
 
 let cx = classNames.bind(styles);
 
-@define
-class BoltInteractivePathway extends withLitContext() {
+@customElement('bolt-interactive-pathway')
+class BoltInteractivePathway extends withLitContext {
   static is = 'bolt-interactive-pathway';
 
   static props = {

--- a/packages/micro-journeys/src/interactive-pathways.js
+++ b/packages/micro-journeys/src/interactive-pathways.js
@@ -1,5 +1,6 @@
-import { props, define, hasNativeShadowDomSupport } from '@bolt/core/utils';
-import { withLitContext, html, convertSchemaToProps } from '@bolt/core';
+import { html, customElement } from '@bolt/element';
+import { props, hasNativeShadowDomSupport } from '@bolt/core/utils';
+import { withLitContext, convertSchemaToProps } from '@bolt/core';
 import classNames from 'classnames/bind';
 import debounce from 'lodash.debounce';
 import themes from '@bolt/global/styles/06-themes/_themes.all.scss';
@@ -10,8 +11,8 @@ import pathwaysLogo from './images/interactive-pathways-logo.png';
 
 let cx = classNames.bind(styles);
 
-@define
-class BoltInteractivePathways extends withLitContext() {
+@customElement('bolt-interactive-pathways')
+class BoltInteractivePathways extends withLitContext {
   static is = 'bolt-interactive-pathways';
 
   static props = {

--- a/packages/micro-journeys/src/interactive-pathways.js
+++ b/packages/micro-journeys/src/interactive-pathways.js
@@ -39,26 +39,26 @@ class BoltInteractivePathways extends withLitContext() {
     self._hasBeenInViewport = false;
     self._isVisible = false;
     self.dropdownActive = false;
-    self._handleClosingEvent = this._handleClosingEvent.bind(this);
+    self._handleClosingEvent = self._handleClosingEvent.bind(self);
     self._isReady = false;
 
-    this.checkChildrenAndRender = debounce(done => {
-      this.pathways = this.getPathways();
-      this.triggerUpdate();
+    self.checkChildrenAndRender = debounce(done => {
+      self.pathways = self.getPathways();
+      self.triggerUpdate();
       // using callback since debounced promises require a different library that's not already in Bolt
       if (done) setTimeout(done, 0);
     }, 150);
 
     self.addEventListener(
       'bolt-interactive-pathway:connected',
-      this.handlePathwayConnect,
+      self.handlePathwayConnect,
     );
     self.addEventListener(
       'bolt-interactive-pathway:disconnected',
-      this.handlePathwayDisconnect,
+      self.handlePathwayDisconnect,
     );
     self.addEventListener('bolt-interactive-pathway:title-updated', () => {
-      this.checkChildrenAndRender();
+      self.checkChildrenAndRender();
     });
 
     return self;

--- a/packages/micro-journeys/src/interactive-pathways.js
+++ b/packages/micro-journeys/src/interactive-pathways.js
@@ -40,26 +40,26 @@ class BoltInteractivePathways extends withLitContext {
     self._hasBeenInViewport = false;
     self._isVisible = false;
     self.dropdownActive = false;
-    self._handleClosingEvent = self._handleClosingEvent.bind(self);
+    self._handleClosingEvent = this._handleClosingEvent.bind(this);
     self._isReady = false;
 
-    self.checkChildrenAndRender = debounce(done => {
-      self.pathways = self.getPathways();
-      self.triggerUpdate();
+    this.checkChildrenAndRender = debounce(done => {
+      this.pathways = this.getPathways();
+      this.triggerUpdate();
       // using callback since debounced promises require a different library that's not already in Bolt
       if (done) setTimeout(done, 0);
     }, 150);
 
     self.addEventListener(
       'bolt-interactive-pathway:connected',
-      self.handlePathwayConnect,
+      this.handlePathwayConnect,
     );
     self.addEventListener(
       'bolt-interactive-pathway:disconnected',
-      self.handlePathwayDisconnect,
+      this.handlePathwayDisconnect,
     );
     self.addEventListener('bolt-interactive-pathway:title-updated', () => {
-      self.checkChildrenAndRender();
+      this.checkChildrenAndRender();
     });
 
     return self;

--- a/packages/micro-journeys/src/interactive-step.js
+++ b/packages/micro-journeys/src/interactive-step.js
@@ -1,5 +1,6 @@
-import { props, define } from '@bolt/core/utils';
-import { withLitContext, html, convertSchemaToProps } from '@bolt/core';
+import { html, customElement } from 'lit-element';
+import { props } from '@bolt/core/utils';
+import { withLitContext, convertSchemaToProps } from '@bolt/core';
 import { triggerAnims } from '@bolt/components-animate/utils';
 import classNames from 'classnames/bind';
 import { boltTwoCharacterLayoutIs } from '@bolt/micro-journeys/src/two-character-layout';
@@ -8,8 +9,8 @@ import schema from './interactive-step.schema';
 
 const cx = classNames.bind(styles);
 
-@define
-class BoltInteractiveStep extends withLitContext() {
+@customElement('bolt-interactive-step')
+class BoltInteractiveStep extends withLitContext {
   static is = 'bolt-interactive-step';
 
   static props = {

--- a/packages/micro-journeys/src/one-character-layout.js
+++ b/packages/micro-journeys/src/one-character-layout.js
@@ -1,14 +1,13 @@
-import { props, define, hasNativeShadowDomSupport } from '@bolt/core/utils';
-import { withLitHtml, html } from '@bolt/core';
+import { props, hasNativeShadowDomSupport } from '@bolt/core/utils';
+import { withLitHtml } from '@bolt/core';
 import classNames from 'classnames/bind';
+import { html, customElement } from '@bolt/element';
 import styles from './one-character-layout.scss';
 
 let cx = classNames.bind(styles);
 
-@define
-class BoltOneCharacterLayout extends withLitHtml() {
-  static is = 'bolt-one-character-layout';
-
+@customElement('bolt-one-character-layout')
+class BoltOneCharacterLayout extends withLitHtml {
   static props = {
     noShadow: {
       ...props.boolean,

--- a/packages/micro-journeys/src/status-dialogue-bar.js
+++ b/packages/micro-journeys/src/status-dialogue-bar.js
@@ -1,15 +1,14 @@
-import { props, define, hasNativeShadowDomSupport } from '@bolt/core/utils';
-import { withLitHtml, html, convertSchemaToProps } from '@bolt/core';
+import { html, customElement } from '@bolt/element';
+import { props, hasNativeShadowDomSupport } from '@bolt/core/utils';
+import { withLitHtml, convertSchemaToProps } from '@bolt/core';
 import classNames from 'classnames/bind';
 import styles from './status-dialogue-bar.scss';
 import schema from './status-dialogue-bar.schema';
 
 let cx = classNames.bind(styles);
 
-@define
-class BoltStatusDialogueBar extends withLitHtml() {
-  static is = 'bolt-status-dialogue-bar';
-
+@customElement('bolt-status-dialogue-bar')
+class BoltStatusDialogueBar extends withLitHtml {
   static props = {
     noShadow: {
       ...props.boolean,

--- a/packages/micro-journeys/src/two-character-layout.js
+++ b/packages/micro-journeys/src/two-character-layout.js
@@ -32,7 +32,7 @@ class BoltTwoCharacterLayout extends withLitHtml {
   constructor(self) {
     self = super(self);
     self.useShadow = hasNativeShadowDomSupport;
-    self.hasConnection = !!self.querySelector(boltConnectionIs);
+    self.hasConnection = !!this.querySelector(boltConnectionIs);
     self.requiredComponentCount = self.hasConnection ? 3 : 2;
     self.renderedComponentCount = 0;
     self.isInitialRender = true;

--- a/packages/micro-journeys/src/two-character-layout.js
+++ b/packages/micro-journeys/src/two-character-layout.js
@@ -1,5 +1,6 @@
-import { props, define, hasNativeShadowDomSupport } from '@bolt/core/utils';
-import { withLitHtml, html } from '@bolt/core';
+import { html, customElement } from '@bolt/element';
+import { props, hasNativeShadowDomSupport } from '@bolt/core/utils';
+import { withLitHtml } from '@bolt/core';
 import classNames from 'classnames/bind';
 import {
   boltCharacterCenterClass,
@@ -14,10 +15,8 @@ let cx = classNames.bind(styles);
 
 const boltTwoCharacterLayoutIs = 'bolt-two-character-layout';
 
-@define
-class BoltTwoCharacterLayout extends withLitHtml() {
-  static is = boltTwoCharacterLayoutIs;
-
+@customElement('bolt-two-character-layout')
+class BoltTwoCharacterLayout extends withLitHtml {
   static props = {
     noShadow: {
       ...props.boolean,

--- a/packages/micro-journeys/src/two-character-layout.js
+++ b/packages/micro-journeys/src/two-character-layout.js
@@ -33,7 +33,7 @@ class BoltTwoCharacterLayout extends withLitHtml() {
   constructor(self) {
     self = super(self);
     self.useShadow = hasNativeShadowDomSupport;
-    self.hasConnection = !!this.querySelector(boltConnectionIs);
+    self.hasConnection = !!self.querySelector(boltConnectionIs);
     self.requiredComponentCount = self.hasConnection ? 3 : 2;
     self.renderedComponentCount = 0;
     self.isInitialRender = true;


### PR DESCRIPTION
## Jira
N/A

## Summary
Migrates all existing components in Bolt to use a Class-based Base Component (vs the function-based Base Component in use currently). This is one of THE most important pieces to the broader ES Module-related work in https://github.com/boltdesignsystem/bolt/pull/1579.

As an added bonus, not only will Class-based components further improve Typescript / JSDoc support in Bolt, they are also a central part of the performance improvements this ES Module work should result in. 

## Details
- Lit-html and Preact-based base classes in use are no longer function-based (note how there aren't parentheses getting used in almost all of the component Class definitions)
- Because of this, the `@define` decorator is no longer in use (not supported with the new plumbing) and all component instances switch over to use the new `@bolt/element` `@customElement('component-name')` syntax instead
- With the `customElement` decorator in use, I also cleaned up and consolidated a handful of common dependencies used, namely lit-html based dependencies like `html` or `unsafeHTML`
- Additionally, because we're now using Class-based component definitions, all of our custom decorators created will no longer work — work that's taken care of in https://github.com/boltdesignsystem/bolt/pull/1586

## How to Test
In a nutshell, you can't, at least not yet. 

In order to split up the code changes from https://github.com/boltdesignsystem/bolt/pull/1579 into more sensible chunks to review, these component updates require virtually [every update](https://github.com/boltdesignsystem/bolt/pull/1579#user-content-related-prs) listed out in these related PRs required to ship section in order to compile and work as expected.