### PR TITLE
fix(editor): restore pathways editable traits; fix opacity: 0 issue o…

### DIFF
--- a/packages/editor/src/setup-bolt.js
+++ b/packages/editor/src/setup-bolt.js
@@ -564,44 +564,39 @@ export function setupBolt(editor) {
     </bolt-interactive-pathways>`,
   });
 
-  // Commented this out because this was superceded by above starters. But leaving because they're simpler and client may want to reinstate.
-  // registerBoltComponent({
-  //   name: 'bolt-interactive-pathways',
-  //   schema: pathwaysSchema,
-  //   propsToTraits: ['customImageSrc', 'imageAlt', 'theme', 'hidePathwaysImage'],
-  //   category: 'Starters',
-  //   blockTitle: 'Multiple Pathways',
-  //   draggable: true,
-  //   editable: false,
-  //   highlightable: false,
-  //   registerBlock: true,
-  //   slots: {
-  //     default: 'bolt-interactive-pathway',
-  //   },
-  //   initialContent: [
-  //     `<bolt-text subheadline font-size="xxlarge" slot="interactive-pathways-lead-text">How Pega technology resolves</bolt-text>`,
-  //     `<bolt-interactive-pathway pathway-title="First Title">
-  //       ${starters.stepOneCharacterLorem}
-  //       ${starters.stepTwoCharacterLorem}
-  //     </bolt-interactive-pathway>`,
-  //     `<bolt-interactive-pathway pathway-title="Second Title">
-  //       ${starters.stepOneCharacterLorem}
-  //       ${starters.stepTwoCharacterLorem}
-  //     </bolt-interactive-pathway>`,
-  //   ],
-  //   slotControls: [
-  //     {
-  //       slotName: 'default',
-  //       components: [
-  //         {
-  //           id: 'pathways',
-  //           title: 'Pathways',
-  //           content: starters.pathwayLorem,
-  //         },
-  //       ],
-  //     },
-  //   ],
-  // });
+  registerBoltComponent({
+    name: 'bolt-interactive-pathways',
+    schema: pathwaysSchema,
+    propsToTraits: ['customImageSrc', 'imageAlt', 'theme', 'hidePathwaysImage'],
+    draggable: true,
+    editable: false,
+    highlightable: false,
+    registerBlock: false,
+    slots: {
+      default: 'bolt-interactive-pathway',
+    },
+    // This way of adding pathways is superseded by the Starters. Thus: `registerBlock: false`.
+    // Prior sample content left commented out in case alternate starters are desired in the future.
+    initialContent: [
+      // `<bolt-text subheadline font-size="xxlarge" slot="interactive-pathways-lead-text">How Pega technology resolves</bolt-text>`,
+      // `<bolt-interactive-pathway pathway-title="First Title">
+      //   ${starters.stepOneCharacterLorem}
+      //   ${starters.stepTwoCharacterLorem}
+      // </bolt-interactive-pathway>`,
+    ],
+    slotControls: [
+      {
+        slotName: 'default',
+        components: [
+          {
+            id: 'pathways',
+            title: 'Pathways',
+            content: starters.pathwayLorem,
+          },
+        ],
+      },
+    ],
+  });
 
   registerBoltComponent({
     name: 'bolt-interactive-pathway',

--- a/packages/micro-journeys/index.scss
+++ b/packages/micro-journeys/index.scss
@@ -19,6 +19,7 @@ bolt-interactive-pathways {
 }
 
 bolt-interactive-pathways {
+  // Set to 1 in bolt-interactive-pathways render
   opacity: 0;
 }
 

--- a/packages/micro-journeys/src/interactive-pathways.js
+++ b/packages/micro-journeys/src/interactive-pathways.js
@@ -72,7 +72,19 @@ class BoltInteractivePathways extends withLitContext() {
 
   connectedCallback() {
     super.connectedCallback();
-    this.style.opacity = 1;
+    // create an observer instance
+    var observer = new MutationObserver(function(mutations) {
+      console.log(mutations);
+      mutations.forEach(function(mutation) {
+        console.log(mutation.type);
+      });
+    });
+
+    // configuration of the observer:
+    var config = { attributes: true, childList: true, characterData: true };
+
+    // start the observer, pass in the target node, as well as the observer options
+    observer.observe(this, config);
 
     if (window.IntersectionObserver) {
       const observer = new IntersectionObserver(
@@ -180,6 +192,8 @@ class BoltInteractivePathways extends withLitContext() {
   }
 
   render() {
+    this.style.opacity = 1;
+
     const props = this.validateProps(this.props);
 
     const classes = cx('c-bolt-interactive-pathways', {


### PR DESCRIPTION
…n edit

## Jira

https://app.asana.com/0/1126340469288208/1151276850580121/f

## Summary

Restores ability to edit `bolt-interactive-pathways` props/traits in grapesjs editor.

## Details

This was a [regression](https://github.com/boltdesignsystem/bolt/commit/2b0f041b433bb3062243de201c027ffc62d950ea#diff-27caa8682bd8e50f4bac0c03ec5ef089L598), now the `bolt-interactive-pathways` element is properly registered.

I also fixed a bug wherein editing the `bolt-interactive-pathways` props caused it to have `opacity: 0`.

## How to test

Go to editor page, add pathway, edit `bolt-interactive-pathways` layer, add `customImageSrc`.
