### PR TITLE
feat(editor): add ability to remove icon from status-dialogue-bar

### DIFF
--- a/packages/micro-journeys/src/status-dialogue-bar.js
+++ b/packages/micro-journeys/src/status-dialogue-bar.js
@@ -59,16 +59,17 @@ class BoltStatusDialogueBar extends withLitHtml() {
             `
           : ''}
         <div class="c-bolt-status-dialogue-bar__content">
-          ${props.iconName &&
-            html`
-              <div class="c-bolt-micro-journeys-flex-aspect">
-                <bolt-icon
-                  size="medium"
-                  name="${props.iconName}"
-                  class="c-bolt-status-dialogue-bar__icon"
-                />
-              </div>
-            `}
+          ${!props.iconName || props.iconName === '-none-'
+            ? ''
+            : html`
+                <div class="c-bolt-micro-journeys-flex-aspect">
+                  <bolt-icon
+                    size="medium"
+                    name="${props.iconName}"
+                    class="c-bolt-status-dialogue-bar__icon"
+                  />
+                </div>
+              `}
           <span class="c-bolt-status-dialogue-bar__slot--text">
             <div
               class="c-bolt-micro-journeys-flex-aspect c-bolt-micro-journeys-flex-aspect-full"

--- a/packages/micro-journeys/src/status-dialogue-bar.schema.js
+++ b/packages/micro-journeys/src/status-dialogue-bar.schema.js
@@ -14,7 +14,7 @@ module.exports = {
       type: 'string',
       description: 'Icon name.',
       default: 'mobility',
-      enum: ['', ...iconSchema.properties.name.enum],
+      enum: ['-none-', ...iconSchema.properties.name.enum],
     },
     isAlertMessage: {
       type: 'boolean',


### PR DESCRIPTION
## Jira

https://app.asana.com/0/1126340469288208/1150972142674288/f

## Summary

Add ability to remove icon from `bolt-status-dialogue-bar`. 

## Details

Previously the empty attribute `""`was not getting removed when selected through the editor UI. The old value persisted. I created a value `-none-` that can be selected more explicitly.

## How to test

Use the 2-char starter in the editor, remove the icon from `bolt-status-dialogue-bar` by selecting `iconName` as `-none-`.
