### PR TITLE
fix(editor): remove false error on editor navigation away from saved …

### DIFF
--- a/packages/editor/src/editor.js
+++ b/packages/editor/src/editor.js
@@ -89,7 +89,7 @@ export function enableEditor({ space, uiWrapper, config }) {
     // height: '100vh',
     // width: 'auto',
     plugins: [setupBolt, setupComponents, setupPanels, setupBlocks],
-    noticeOnUnload: false,
+    noticeOnUnload: true,
     panels: {
       stylePrefix: `${stylePrefix}panels-`,
       defaults: [

--- a/packages/editor/src/editor.js
+++ b/packages/editor/src/editor.js
@@ -89,7 +89,7 @@ export function enableEditor({ space, uiWrapper, config }) {
     // height: '100vh',
     // width: 'auto',
     plugins: [setupBolt, setupComponents, setupPanels, setupBlocks],
-    noticeOnUnload: IS_PROD,
+    noticeOnUnload: false,
     panels: {
       stylePrefix: `${stylePrefix}panels-`,
       defaults: [

--- a/packages/editor/src/index.js
+++ b/packages/editor/src/index.js
@@ -252,12 +252,6 @@ function init() {
             // @ts-ignore
             window.__handleEditorSave || exampleHandleEditorSave;
           const html = editor.getHtml();
-          const unsavedChanges = editor.getDirtyCount();
-          if (unsavedChanges) {
-            console.warn(
-              'There were unsaved changes we will lose on next page reload...',
-            );
-          }
           const container = editor.getContainer();
 
           trigger.innerText = 'Saving...';

--- a/packages/editor/src/index.js
+++ b/packages/editor/src/index.js
@@ -262,6 +262,7 @@ function init() {
           });
 
           if (ok) {
+            window.onbeforeunload = null;
             cleanup();
             container.innerHTML = html;
             trigger.innerText = 'Edit';

--- a/packages/editor/src/index.js
+++ b/packages/editor/src/index.js
@@ -209,6 +209,8 @@ function init() {
     let uiWrapper;
 
     function cleanup() {
+      // Remove the onbeforeunload function that fires the unsaved warning.
+      window.onbeforeunload = null;
       if (editor) {
         editor.destroy();
       }
@@ -262,7 +264,6 @@ function init() {
           });
 
           if (ok) {
-            window.onbeforeunload = null;
             cleanup();
             container.innerHTML = html;
             trigger.innerText = 'Edit';


### PR DESCRIPTION
…content

## Jira

https://app.asana.com/0/1126340469288208/1150897080194573/f

## Summary

Remove false error on editor navigation away from saved content.

## Details

Previously, the editor setting `noticeOnUnload` was set to `PROD` which meant it warned when navigating away from content on prod only. However, we're handling the save event and throwing an `alert` when the drupal save promise fails. So this is no longer needed.

## How to test

-     Go to /pattern-lab/patterns/06-experiments-editor-10-editor-simple/06-experiments-editor-10-editor-simple.html
-     Click edit
-     Make a change
-     Click save (IMPORTANT!)
-     Navigate to another page
