### PR TITLE
Fix/wwwd 4357 pathway ready event only when ready

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -31,7 +31,7 @@ module.exports = {
   },
   transformIgnorePatterns: [
     'node_modules/(?!(lit-html|@bolt|@open-wc)/)', // add any additional packages in node_modules that need to be transpiled for Jest
-    'packages/(?!(components|core|analytics|config|testing|generators)/)', // add any additional packages in node_modules that need to be transpiled for Jest
+    'packages/(?!(components|core|analytics|config|testing|generators|micro-journeys)/)', // add any additional packages in node_modules that need to be transpiled for Jest
     './scripts/monorepo.test.js',
   ],
   globalSetup: './packages/testing/testing-jest/jest-global-setup.js',

--- a/packages/micro-journeys/__tests__/microjourneys.js
+++ b/packages/micro-journeys/__tests__/microjourneys.js
@@ -1,0 +1,60 @@
+import { stopServer, html } from '../../testing/testing-helpers';
+
+const timeout = 120000;
+
+describe('Micro journeys', () => {
+  let page;
+
+  beforeEach(async () => {
+    await page.evaluate(() => {
+      document.body.innerHTML = '';
+    });
+  }, timeout);
+
+  beforeAll(async () => {
+    page = await global.__BROWSER__.newPage();
+    await page.goto('http://127.0.0.1:4444/', {
+      timeout: 0,
+    });
+  }, timeout);
+
+  afterAll(async () => {
+    await stopServer();
+    await page.close();
+  }, timeout);
+
+  test('<bolt-interactive-pathway> ready event emits only when actually ready', async function() {
+    await page.evaluate(async () => {
+      const wrapper = document.createElement('div');
+      wrapper.innerHTML = `
+        <bolt-interactive-pathways>
+          <bolt-interactive-pathway pathway-title="My pathway title">
+            <bolt-interactive-step tab-title="My step title">Hello world</bolt-interactive-step>
+          </bolt-interactive-pathway>
+        </bolt-interactive-pathways>
+      `;
+      document.body.appendChild(wrapper);
+
+      const interactivePathway = document.querySelector(
+        'bolt-interactive-pathway',
+      );
+
+      return new Promise((resolve, reject) => {
+        interactivePathway.addEventListener('ready', e => {
+          // Make sure that this is the ready event on interactivePathway and not a child element.
+          if (interactivePathway === e.target) {
+            resolve();
+          }
+        });
+        interactivePathway.addEventListener('error', reject);
+      });
+    });
+
+    const interactivePathwayShadowRoot = await page.evaluate(async () => {
+      return document.querySelector('bolt-interactive-pathway').renderRoot
+        .innerHTML;
+    });
+
+    expect(interactivePathwayShadowRoot).toContain('My step title');
+  });
+});

--- a/packages/micro-journeys/src/interactive-pathway.js
+++ b/packages/micro-journeys/src/interactive-pathway.js
@@ -198,6 +198,15 @@ class BoltInteractivePathway extends withLitContext() {
     });
   };
 
+  rendered() {
+    // The rendered content will be empty until the following condition is met.
+    // Therefore, hold off on calling super.rendered() (which in turn emits the
+    // "ready" event) until the condition is true.
+    if (this.isActivePathway || this.isBecomingActive) {
+      super.rendered && super.rendered();
+    }
+  }
+
   render() {
     if (!this.isActivePathway && !this.isBecomingActive) {
       return '';


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/WWWD-4357

## Summary

Fixes support for analytics click tracking on `bolt-interactive-pathway` elements

## Details

Previously, the `bolt-interactive-pathway` component would emit a `ready` event before there was any content in the ShadowDOM.  That was caused by the following line which would result in an empty render under certain conditions https://github.com/boltdesignsystem/bolt/blob/master/packages/micro-journeys/src/interactive-pathway.js#L170

This PR updates the `rendered()` function so that it will only run (and, in turn, trigger the "ready" event) if those same conditions are met.

## How to test

- Run the jest test.  It should fail without the fix commit on the branch, and pass after it's applied.
