### PR TITLE
Hotfix/editor remove valign option from bolt link

### DIFF
--- a/packages/editor/src/setup-bolt.js
+++ b/packages/editor/src/setup-bolt.js
@@ -717,7 +717,7 @@ export function setupBolt(editor) {
     extend: 'link',
     registerBlock: true,
     draggable: true,
-    propsToTraits: ['display', 'valign', 'url', 'isHeadline'],
+    propsToTraits: ['display', 'url', 'isHeadline'],
     slots: {
       default: true,
     },


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/WWWD-4346

## Summary

Editor: Remove valign trait for bolt-link component.