### PR TITLE
Add Optional Chaining Support to Babel

### DIFF
--- a/packages/configs/babel-preset-bolt/index.js
+++ b/packages/configs/babel-preset-bolt/index.js
@@ -12,6 +12,7 @@ const preset = function(api, opts = {}) {
       ],
     ],
     plugins: [
+      '@babel/plugin-proposal-optional-chaining',
       /**
        * 1. Helps with our Web Component Preact renderer
        */

--- a/packages/configs/babel-preset-bolt/package.json
+++ b/packages/configs/babel-preset-bolt/package.json
@@ -26,6 +26,7 @@
     "extends @bolt/browserslist-config"
   ],
   "dependencies": {
+    "@babel/plugin-proposal-optional-chaining": "^7.7.5",
     "@babel/cli": "^7.5.0",
     "@babel/core": "^7.5.4",
     "@babel/plugin-proposal-class-properties": "^7.5.0",


### PR DESCRIPTION
## Jira
N/A

## Summary
Adds optional chaining support to Babel. Subset of the work from #1602.


