### PR TITLE
New Docs Site Helper: Breakpoint Indicator UI

### DIFF
--- a/docs-site/.boltrc.js
+++ b/docs-site/.boltrc.js
@@ -74,6 +74,7 @@ const config = {
 
   components: {
     global: [
+      '@bolt/breakpoint-indicator',
       '@bolt/theme-switcher',
       '@bolt/components-radio-switch',
       '@bolt/components-carousel',

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -26,6 +26,7 @@
     "watch": "bolt watch"
   },
   "dependencies": {
+    "@bolt/breakpoint-indicator": "^2.12.0",
     "@bolt/analytics-autolink": "^2.12.0",
     "@bolt/analytics-autotrack": "^2.12.0",
     "@bolt/animations": "^2.13.0",

--- a/docs-site/src/components/breakpoint-indicator/breakpoint-indicator.js
+++ b/docs-site/src/components/breakpoint-indicator/breakpoint-indicator.js
@@ -1,0 +1,88 @@
+import { LitElement, html, customElement } from 'lit-element';
+import { ResizeObserver } from '@juggle/resize-observer';
+
+const ro = new ResizeObserver(entries => {
+  entries.forEach(entry => entry.target.resizedCallback(entry.contentRect));
+});
+
+@customElement('bolt-breakpoint-indicator')
+class BreakpointIndicator extends LitElement {
+  static get properties() {
+    return {
+      width: Number,
+      height: Number,
+      state: {
+        type: String,
+        reflect: true,
+      },
+    };
+  }
+
+  render() {
+    return html`
+      <style>
+        :host {
+          display: flex;
+          justify-content: flex-end;
+          align-items: flex-end;
+          flex-flow: column nowrap;
+          height: 100vh;
+          width: 100vw;
+          color: white;
+          overflow: hidden;
+          font-size: 1rem;
+          pointer-events: none;
+          color: white;
+          font-weight: bold;
+          text-shadow: 0px 1px 1px black;
+          position: fixed;
+          top: 0;
+          left: 0;
+          bottom: 0;
+          right: 0;
+        }
+
+        code {
+          background-color: rgba(0, 0, 0, 0.4);
+          padding: 0.125rem 0.5rem;
+        }
+      </style>
+      <code>${this.width}px (${this.state})</code>
+    `;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+
+    // @todo: replace with the actual Breakpoint config options from @bolt/core
+    this.breakpoints = {
+      xxsmall: 320,
+      xsmall: 400,
+      small: 600,
+      medium: 800,
+      large: 1000,
+      xlarge: 1200,
+      xxlarge: 1400,
+      xxxlarge: 1600,
+      xxxxlarge: 1920,
+    };
+
+    ro.observe(this);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    ro.unobserve(this);
+  }
+
+  resizedCallback({ width, height }) {
+    this.width = width;
+    this.height = height;
+
+    for (let [key, value] of Object.entries(this.breakpoints)) {
+      if (this.width >= value) {
+        this.state = key;
+      }
+    }
+  }
+}

--- a/docs-site/src/components/breakpoint-indicator/breakpoint-indicator.js
+++ b/docs-site/src/components/breakpoint-indicator/breakpoint-indicator.js
@@ -1,4 +1,4 @@
-import { LitElement, html, customElement } from 'lit-element';
+import { BoltElement, html, customElement } from '@bolt/element';
 import { ResizeObserver } from '@juggle/resize-observer';
 
 const ro = new ResizeObserver(entries => {
@@ -6,7 +6,7 @@ const ro = new ResizeObserver(entries => {
 });
 
 @customElement('bolt-breakpoint-indicator')
-class BreakpointIndicator extends LitElement {
+class BreakpointIndicator extends BoltElement {
   static get properties() {
     return {
       width: Number,

--- a/docs-site/src/components/breakpoint-indicator/index.js
+++ b/docs-site/src/components/breakpoint-indicator/index.js
@@ -1,14 +1,12 @@
+import '@bolt/polyfills';
 import { hasNativeShadowDomSupport } from '@bolt/element';
-import { polyfillLoader } from '@bolt/core/polyfills';
 
-// Don't try to run if Shadow DOM isn't supported
+// opt-out of rendering on older browsers since this is a nice-to-have vs must-have
 if (hasNativeShadowDomSupport) {
-  polyfillLoader.then(res => {
-    import(
-      /*
-      webpackMode: 'lazy',
-      webpackChunkName: 'bolt-breakpoint-indicator'
-    */ './breakpoint-indicator'
-    );
-  });
+  import(
+    /*
+    webpackMode: 'lazy',
+    webpackChunkName: 'breakpoint-indicator'
+  */ './breakpoint-indicator'
+  );
 }

--- a/docs-site/src/components/breakpoint-indicator/index.js
+++ b/docs-site/src/components/breakpoint-indicator/index.js
@@ -1,0 +1,14 @@
+import { hasNativeShadowDomSupport } from '@bolt/element';
+import { polyfillLoader } from '@bolt/core/polyfills';
+
+// Don't try to run if Shadow DOM isn't supported
+if (hasNativeShadowDomSupport) {
+  polyfillLoader.then(res => {
+    import(
+      /*
+      webpackMode: 'lazy',
+      webpackChunkName: 'bolt-breakpoint-indicator'
+    */ './breakpoint-indicator'
+    );
+  });
+}

--- a/docs-site/src/components/breakpoint-indicator/package.json
+++ b/docs-site/src/components/breakpoint-indicator/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@bolt/breakpoint-indicator",
+  "description": "Internal Docs Site Breakpoint Helper used by the Bolt Design System",
+  "keywords": [
+    "bolt design system",
+    "bolt",
+    "css framework",
+    "design system"
+  ],
+  "version": "2.12.0",
+  "maintainers": [
+    {
+      "name": "Salem Ghoweri",
+      "email": "me@salemghoweri.com",
+      "web": "https://github.com/sghoweri"
+    }
+  ],
+  "homepage": "https://boltdesignsystem.com",
+  "license": "MIT",
+  "bugs": "https://github.com/boltdesignsystem/bolt/issues",
+  "private": true,
+  "main": "index.js",
+  "dependencies": {
+    "@juggle/resize-observer": "^2.5.0",
+    "@bolt/core": "^2.12.0",
+    "@bolt/element": "^2.12.0"
+  }
+}

--- a/docs-site/src/components/breakpoint-indicator/package.json
+++ b/docs-site/src/components/breakpoint-indicator/package.json
@@ -21,7 +21,7 @@
   "private": true,
   "main": "index.js",
   "dependencies": {
-    "@bolt/polyfills": "^2.13.0",
+    "@bolt/polyfills": "^2.12.0",
     "@juggle/resize-observer": "^2.5.0",
     "@bolt/element": "^2.12.0"
   }

--- a/docs-site/src/components/breakpoint-indicator/package.json
+++ b/docs-site/src/components/breakpoint-indicator/package.json
@@ -1,28 +1,28 @@
 {
   "name": "@bolt/breakpoint-indicator",
+  "version": "2.12.0",
+  "private": true,
   "description": "Internal Docs Site Breakpoint Helper used by the Bolt Design System",
   "keywords": [
-    "bolt design system",
     "bolt",
+    "bolt design system",
     "css framework",
     "design system"
   ],
-  "version": "2.12.0",
+  "homepage": "https://boltdesignsystem.com",
+  "bugs": "https://github.com/boltdesignsystem/bolt/issues",
+  "license": "MIT",
+  "main": "index.js",
+  "dependencies": {
+    "@bolt/element": "^2.12.0",
+    "@bolt/polyfills": "^2.12.0",
+    "@juggle/resize-observer": "^2.5.0"
+  },
   "maintainers": [
     {
       "name": "Salem Ghoweri",
       "email": "me@salemghoweri.com",
       "web": "https://github.com/sghoweri"
     }
-  ],
-  "homepage": "https://boltdesignsystem.com",
-  "license": "MIT",
-  "bugs": "https://github.com/boltdesignsystem/bolt/issues",
-  "private": true,
-  "main": "index.js",
-  "dependencies": {
-    "@bolt/polyfills": "^2.12.0",
-    "@juggle/resize-observer": "^2.5.0",
-    "@bolt/element": "^2.12.0"
-  }
+  ]
 }

--- a/docs-site/src/components/breakpoint-indicator/package.json
+++ b/docs-site/src/components/breakpoint-indicator/package.json
@@ -21,8 +21,8 @@
   "private": true,
   "main": "index.js",
   "dependencies": {
+    "@bolt/polyfills": "^2.13.0",
     "@juggle/resize-observer": "^2.5.0",
-    "@bolt/core": "^2.12.0",
     "@bolt/element": "^2.12.0"
   }
 }

--- a/docs-site/src/templates/_site-footer.twig
+++ b/docs-site/src/templates/_site-footer.twig
@@ -16,6 +16,8 @@
 
   {{ patternLabFoot | raw }}
 
+  <bolt-breakpoint-indicator></bolt-breakpoint-indicator>
+
   {# {{ console_log(_context) }} #}
   {# Showing off global vars in Browsers Console #}
   {# {% if not bolt.data.config.prod %}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
       "docs-site/src/components/theme-switcher",
       "docs-site/src/components/docs-search",
       "docs-site/src/components/radio-switch",
+      "docs-site/src/components/breakpoint-indicator",
       "packages/*",
       "packages/*/*",
       "packages/build-tools/__tests__/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1185,9 +1185,9 @@
     sleep-promise "^8.0.1"
 
 "@bolt/components-page-footer@file:packages/components/bolt-page-footer":
-  version "2.12.0"
+  version "2.13.0"
   dependencies:
-    "@bolt/core" "^2.12.0"
+    "@bolt/core" "^2.13.0"
 
 "@ckeditor/ckeditor5-build-classic@^12.1.0":
   version "12.4.0"
@@ -1622,6 +1622,11 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
+
+"@juggle/resize-observer@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-2.5.0.tgz#dbe3ebfa7b46b465dc85677ca23b15e854225a99"
+  integrity sha512-Nmkeaj5LalJeciRVEqi9Uxi61r0LvGc2yhUCykhXuft9fMyb/6VkZbwJ+UmUl8bk2k6qhwd1qJw6S2YJ0joXlA==
 
 "@lerna/add@3.16.2":
   version "3.16.2"


### PR DESCRIPTION
## Jira
N/A

## Summary
Adds a new helper component for the Bolt docs site that displays the current breakpoint size in pixels + the _corresponding name_ of that breakpoint! 

Should be super helpful when you're trying to figure out what utility class breakpoint syntax to use / writing media queries and can't remember what breakpoint name = what size in pixels...

Good Docs = No Docs Needed 😄 
