### PR TITLE
Automatically Format Package.json Files

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,9 +53,12 @@
     "cz": "git-cz",
     "deploy": "./scripts/deploy.js",
     "fix": "yarn lint:js --fix; yarn lint:scss --fix",
+    "postinstall": "patch-package && npx lerna run postbootstrap",
+    "jest": "jest --maxWorkers=3 --all --colors",
     "lint": "npm-run-all --parallel lint:*",
     "lint:js": "eslint --max-warnings 0 'packages/**/*.js' 'docs-site/**/*.js'",
     "lint:scss": "stylelint 'packages/**/*.scss' 'docs-site/**/*.scss' --config .stylelintrc",
+    "release": "node ./auto-release.js",
     "serve": "node packages/servers/default-server",
     "setup": "yarn && yarn run setup:php",
     "setup:full": "yarn --force && yarn run setup:php",
@@ -63,26 +66,23 @@
     "setup:quick": "yarn && yarn run setup:php",
     "start": "cd docs-site && yarn run start",
     "test": "npm-run-all --parallel --aggregate-output test:js test:php test:monorepo test:build-tools",
+    "test:build-tools": "cd packages/build-tools && yarn run test",
     "test:e2e:full": "./node_modules/.bin/nightwatch --config packages/testing/testing-nightwatch/nightwatch.js --env chrome,firefox,ie11",
-    "test:e2e:quick": "./node_modules/.bin/nightwatch --config packages/testing/testing-nightwatch/nightwatch.js --env chrome,ie11",
     "test:e2e:full-live": " NOW_URL=https://boltdesignsystem.com ./node_modules/.bin/nightwatch --config packages/testing/testing-nightwatch/nightwatch.js --env chrome,firefox,ie11",
     "test:e2e:full-local": "NOW_URL=http://localhost:3000 ./node_modules/.bin/nightwatch --config packages/testing/testing-nightwatch/nightwatch.local.js --env chrome,safari",
     "test:e2e:full-master": " NOW_URL=https://master.boltdesignsystem.com ./node_modules/.bin/nightwatch --config packages/testing/testing-nightwatch/nightwatch.js --env chrome,firefox,ie11",
+    "test:e2e:quick": "./node_modules/.bin/nightwatch --config packages/testing/testing-nightwatch/nightwatch.js --env chrome,ie11",
     "test:e2e:quick-live": " NOW_URL=https://boltdesignsystem.com ./node_modules/.bin/nightwatch --config packages/testing/testing-nightwatch/nightwatch.local.js",
     "test:e2e:quick-local": "NOW_URL=http://localhost:3000 ./node_modules/.bin/nightwatch --config packages/testing/testing-nightwatch/nightwatch.local.js",
     "test:e2e:quick-master": " NOW_URL=https://master.boltdesignsystem.com ./node_modules/.bin/nightwatch --config packages/testing/testing-nightwatch/nightwatch.local.js",
     "pretest:js": "npm run setup:php",
-    "jest": "jest --maxWorkers=3 --all --colors",
     "test:js": "NODE_ENV='test' jest --all --colors 'packages|scripts' --passWithNoTests ",
     "test:js:quick": "NODE_ENV='test' jest --colors \"$(bolt-list-pkg-paths-changed)\" --passWithNoTests",
     "test:js:update": "yarn run test:js -u",
     "test:monorepo": "jest ./__tests__/monorepo -c jest.config.quick.js --noStackTrace",
-    "test:build-tools": "cd packages/build-tools && yarn run test",
     "test:php": "cd packages/core-php -- composer run test",
     "test:pkgs": "lerna run test --ignore=@bolt/uikit-* --ignore=@bolt/build-tools--*",
-    "test:types": "tsc",
-    "postinstall": "patch-package && npx lerna run postbootstrap",
-    "release": "node ./auto-release.js"
+    "test:types": "tsc"
   },
   "husky": {
     "hooks": {
@@ -91,37 +91,49 @@
       "commitmsg": "commitlint -E $GIT_PARAMS"
     }
   },
-  "lint-staged": {
-    "*.js": ["eslint --fix", "git add"],
-    "*.scss": ["stylelint --config .stylelintrc --fix", "git add"],
-    "*.{md,html}": ["prettier --write", "git add"]
-  },
   "commitlint": {
     "extends": [
       "@commitlint/config-conventional"
     ]
   },
+  "lint-staged": {
+    "*.js": [
+      "eslint --fix",
+      "git add"
+    ],
+    "*.scss": [
+      "stylelint --config .stylelintrc --fix",
+      "git add"
+    ],
+    "*.{md,html}": [
+      "prettier --write",
+      "git add"
+    ],
+    "package.json": [
+      "sort-package-json",
+      "git add"
+    ]
+  },
   "config": {
-    "puppeteer_skip_chromium_download": false,
     "commitizen": {
       "path": "./node_modules/@instructure/cz-lerna-changelog"
-    }
+    },
+    "puppeteer_skip_chromium_download": false
   },
   "browserslist": [
     "extends @bolt/browserslist-config"
   ],
   "dependencies": {
-    "lint-staged": "^9.5.0",
-    "shelljs": "^0.8.3",
-    "@slack/webhook" : "^5.0.2",
-    "@auto-it/released": "^8.0.0",
     "@auto-it/npm": "^8.0.0",
     "@auto-it/omit-commits": "^8.0.0",
-    "auto": "^8.0.0",
+    "@auto-it/released": "^8.0.0",
+    "@bolt/testing-utils": "^2.8.0-beta.4",
     "@commitlint/cli": "^8.0.0",
     "@commitlint/config-conventional": "^8.0.0",
     "@instructure/cz-lerna-changelog": "^6.6.0",
     "@open-wc/testing-helpers": "^1.0.10",
+    "@slack/webhook": "^5.0.2",
+    "auto": "^8.0.0",
     "ci-utils": "^0.6.0",
     "commitizen": "^3.1.1",
     "conf": "^5.0.0",
@@ -130,15 +142,15 @@
     "eslint": "^6.0.1",
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-react": "^7.14.2",
-    "globby": "^10.0.1",
-    "@bolt/testing-utils": "^2.8.0-beta.4",
     "find-pkg": "^2.0.0",
     "get-port": "^5.0.0",
+    "globby": "^10.0.1",
     "haunted": "^4.4.0",
     "husky": "^3.0.0",
     "jest": "^24.8.0",
     "jsonwebtoken": "^8.5.1",
     "lerna": "^3.15.0",
+    "lint-staged": "^9.5.0",
     "lit-element": "^2.2.0",
     "lit-html": "^1.1.1",
     "npm-run-all": "^4.1.5",
@@ -147,16 +159,18 @@
     "proxy-polyfill": "^0.3.0",
     "release-it": "^12.3.2",
     "semantic-release": "^15.13.18",
+    "shelljs": "^0.8.3",
+    "sort-package-json": "^1.31.0",
     "typescript": "^3.5.3"
-  },
-  "publishConfig": {
-    "access": "public"
   },
   "devDependencies": {
     "@types/jest": "^24.0.15",
+    "@types/skatejs": "^5.0.1",
     "stylelint": "^10.1.0",
     "stylelint-order": "^3.0.1",
-    "stylelint-scss": "^3.9.2",
-    "@types/skatejs": "^5.0.1"
+    "stylelint-scss": "^3.9.2"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1185,9 +1185,9 @@
     sleep-promise "^8.0.1"
 
 "@bolt/components-page-footer@file:packages/components/bolt-page-footer":
-  version "2.12.0"
+  version "2.13.0"
   dependencies:
-    "@bolt/core" "^2.12.0"
+    "@bolt/core" "^2.13.0"
 
 "@ckeditor/ckeditor5-build-classic@^12.1.0":
   version "12.4.0"
@@ -7282,6 +7282,11 @@ detect-libc@^1.0.2, detect-libc@^1.0.3:
   resolved "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
+detect-newline@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
+  integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
+
 detect-newline@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
@@ -9846,7 +9851,7 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, gl
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@~7.1.4:
+glob@^7.1.6, glob@~7.1.4:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -20043,6 +20048,16 @@ sort-package-json@^1.20.0:
   integrity sha512-uVINQraFQvnlzNHFnQOT4MYy0qonIEzKwhrI2yrTiQjNo5QF4h3ffrnCk7a95QAwoK/RdkO/w8W9tJIcaOWC7g==
   dependencies:
     detect-indent "^5.0.0"
+    sort-object-keys "^1.1.2"
+
+sort-package-json@^1.31.0:
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/sort-package-json/-/sort-package-json-1.31.0.tgz#778c652b1ee88c15337b258d3ae7e47576e4fb88"
+  integrity sha512-zBdnTpMCJNZszbPcAbGIAgfRQ0A0dF/ZOsQdUHICZ6XLuIQK1Mcwp8zfkF3ySg2lT2oKxU4dVhh/9tZxGLBU0A==
+  dependencies:
+    detect-indent "^6.0.0"
+    detect-newline "3.1.0"
+    glob "^7.1.6"
     sort-object-keys "^1.1.2"
 
 sorted-object@~2.0.1:


### PR DESCRIPTION
## Jira
N/A

## Summary
Auto-format + re-order any `package.json` files that get updated.

## Details
Uses https://www.npmjs.com/package/sort-package-json + our new super fast commit hooks to automatically take care of everything!

## How to test
It just works + only applies to the monorepo. Super low risk quality of life improvement! 😉