### PR TITLE
Hotfix: Fix IE11 Typeahead bugs

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/typeahead/_typeahead-demo.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/typeahead/_typeahead-demo.twig
@@ -5,7 +5,15 @@
 
 {{ typeahead_markdown_docs | markdown }}
 
-{% include twig_path %}
+{% set demo_content %}
+  {% include twig_path %}
+{% endset %}
+
+{% include "@bolt-components-band/band.twig" with {
+  content: demo_content,
+  theme: "none",
+  size: "none"
+} only %}
 
 <bolt-code-snippet syntax="light" lang="twig" class="u-bolt-block u-bolt-margin-top-medium">
   {% spaceless %}

--- a/packages/components/bolt-typeahead/__demos__/dynamically-fetch-data/typeahead.dynamically-fetch-data.js
+++ b/packages/components/bolt-typeahead/__demos__/dynamically-fetch-data/typeahead.dynamically-fetch-data.js
@@ -3,48 +3,54 @@ const dynamicTypeaheadDemo = document.querySelector(
   '.js-typeahead-hook--dynamically-fetch-data',
 );
 
-if (dynamicTypeaheadDemo) {
-  dynamicTypeaheadDemo.addEventListener('ready', function(e) {
-    if (e.detail.name === 'bolt-typeahead') {
-      // note: make sure to let Typeahead know when the data fetched is ready
-      dynamicTypeaheadDemo.on('getSuggestions', async value => {
-        return await new Promise(async resolve => {
-          await fetch('/build/data/typeahead.data.json')
-            .then(function(response) {
-              return response.json();
-            })
-            .then(function(data) {
-              return resolve(data);
-            });
+const setupEventHandlers = () => {
+  // note: make sure to let Typeahead know when the data fetched is ready
+  dynamicTypeaheadDemo.on('getSuggestions', async value => {
+    return await new Promise(async resolve => {
+      await fetch('/build/data/typeahead.data.json')
+        .then(function(response) {
+          return response.json();
+        })
+        .then(function(data) {
+          return resolve(data);
         });
-      });
+    });
+  });
 
-      dynamicTypeaheadDemo.on('onSelected', (element, event, suggestion) => {
-        const exactMatch = element.items.filter(
-          item => item.label === suggestion.suggestionValue,
-        )[0];
+  dynamicTypeaheadDemo.on('onSelected', (element, event, suggestion) => {
+    const exactMatch = element.items.filter(
+      item => item.label === suggestion.suggestionValue,
+    )[0];
 
-        function navigateTo(url) {
-          if (window.location !== window.parent.location) {
-            const win = window.open(url, '_blank');
-            win.focus();
-          } else {
-            window.location = url;
-          }
-        }
+    function navigateTo(url) {
+      if (window.location !== window.parent.location) {
+        const win = window.open(url, '_blank');
+        win.focus();
+      } else {
+        window.location = url;
+      }
+    }
 
-        if (exactMatch && exactMatch.url) {
-          if (exactMatch.url) {
-            navigateTo(exactMatch.url);
-          } else {
-            navigateTo(`https://www.pega.com/search?q=${itemSelected.label}`);
-          }
-        } else if (suggestion.suggestionValue !== '') {
-          navigateTo(
-            `https://www.pega.com/search?q=${suggestion.suggestionValue}`,
-          );
-        }
-      });
+    if (exactMatch && exactMatch.url) {
+      if (exactMatch.url) {
+        navigateTo(exactMatch.url);
+      } else {
+        navigateTo(`https://www.pega.com/search?q=${itemSelected.label}`);
+      }
+    } else if (suggestion.suggestionValue !== '') {
+      navigateTo(`https://www.pega.com/search?q=${suggestion.suggestionValue}`);
+    }
+  });
+};
+
+if (dynamicTypeaheadDemo) {
+  if (dynamicTypeaheadDemo._wasInitiallyRendered) {
+    setupEventHandlers();
+  }
+
+  dynamicTypeaheadDemo.addEventListener('ready', e => {
+    if (e.detail.name === 'bolt-typeahead') {
+      setupEventHandlers();
     }
   });
 }

--- a/packages/components/bolt-typeahead/__demos__/navigate-to-exact-result/typeahead.navigate-to-exact-result.js
+++ b/packages/components/bolt-typeahead/__demos__/navigate-to-exact-result/typeahead.navigate-to-exact-result.js
@@ -20,37 +20,43 @@ const typeaheadDemoItems = [
   },
 ];
 
+const setupEventHandlers = () => {
+  typeaheadDemo.items = typeaheadDemoItems;
+
+  typeaheadDemo.on('onSelected', (element, event, suggestion) => {
+    const exactMatch = element.items.filter(
+      item => item.label === suggestion.suggestionValue,
+    )[0];
+
+    function navigateTo(url) {
+      if (window.location !== window.parent.location) {
+        const win = window.open(url, '_blank');
+        win.focus();
+      } else {
+        window.location = url;
+      }
+    }
+
+    if (exactMatch && exactMatch.url) {
+      if (exactMatch.url) {
+        navigateTo(exactMatch.url);
+      } else {
+        navigateTo(`https://www.pega.com/search?q=${itemSelected.label}`);
+      }
+    } else if (suggestion.suggestionValue !== '') {
+      navigateTo(`https://www.pega.com/search?q=${suggestion.suggestionValue}`);
+    }
+  });
+};
+
 if (typeaheadDemo) {
-  typeaheadDemo.addEventListener('ready', function(e) {
+  if (typeaheadDemo._wasInitiallyRendered) {
+    setupEventHandlers();
+  }
+
+  typeaheadDemo.addEventListener('ready', e => {
     if (e.detail.name === 'bolt-typeahead') {
-      typeaheadDemo.items = typeaheadDemoItems;
-
-      typeaheadDemo.on('onSelected', (element, event, suggestion) => {
-        const exactMatch = element.items.filter(
-          item => item.label === suggestion.suggestionValue,
-        )[0];
-
-        function navigateTo(url) {
-          if (window.location !== window.parent.location) {
-            const win = window.open(url, '_blank');
-            win.focus();
-          } else {
-            window.location = url;
-          }
-        }
-
-        if (exactMatch && exactMatch.url) {
-          if (exactMatch.url) {
-            navigateTo(exactMatch.url);
-          } else {
-            navigateTo(`https://www.pega.com/search?q=${itemSelected.label}`);
-          }
-        } else if (suggestion.suggestionValue !== '') {
-          navigateTo(
-            `https://www.pega.com/search?q=${suggestion.suggestionValue}`,
-          );
-        }
-      });
+      setupEventHandlers();
     }
   });
 }

--- a/packages/components/bolt-typeahead/__demos__/navigate-to-search-results/typeahead.navigate-to-search-results.js
+++ b/packages/components/bolt-typeahead/__demos__/navigate-to-search-results/typeahead.navigate-to-search-results.js
@@ -56,30 +56,40 @@ const items = [
   },
 ];
 
-if (typeahead) {
-  typeahead.addEventListener('ready', function(e) {
-    if (e.detail.name === 'bolt-typeahead') {
-      typeahead.items = items;
-      typeahead.on('onSelected', (element, event, suggestion) => {
-        const itemSelected = element.items.filter(
-          item => item.label === suggestion.suggestionValue,
-        )[0];
+const setupEventHandlers = () => {
+  typeahead.items = items;
+  typeahead.on('onSelected', (element, event, suggestion) => {
+    const itemSelected = element.items.filter(
+      item => item.label === suggestion.suggestionValue,
+    )[0];
 
-        if (itemSelected) {
-          if (itemSelected.label) {
-            if (window.location !== window.parent.location) {
-              // const win = window.open(`${itemSelected.url}`, '_blank');
-              const win = window.open(
-                `https://www.pega.com/search?q=${itemSelected.label}`,
-                '_blank',
-              );
-              win.focus();
-            } else {
-              window.location = `https://www.pega.com/search?q=${itemSelected.label}`;
-            }
-          }
+    if (itemSelected) {
+      if (itemSelected.label) {
+        if (window.location !== window.parent.location) {
+          // const win = window.open(`${itemSelected.url}`, '_blank');
+          const win = window.open(
+            `https://www.pega.com/search?q=${itemSelected.label}`,
+            '_blank',
+          );
+          win.focus();
+        } else {
+          window.location = `https://www.pega.com/search?q=${itemSelected.label}`;
         }
-      });
+      }
     }
   });
+};
+
+if (typeahead) {
+  if (typeahead) {
+    if (typeahead._wasInitiallyRendered) {
+      setupEventHandlers();
+    }
+
+    typeahead.addEventListener('ready', e => {
+      if (e.detail.name === 'bolt-typeahead') {
+        setupEventHandlers();
+      }
+    });
+  }
 }

--- a/packages/components/bolt-typeahead/typeahead.autosuggest.js
+++ b/packages/components/bolt-typeahead/typeahead.autosuggest.js
@@ -108,6 +108,10 @@ class BoltAutosuggest extends withPreact() {
     super.disconnecting && super.disconnecting();
     // Keep an object of listener types mapped to callback functions
     this._listeners = {};
+
+    // hack so that "ready" event will fire next time component connects,
+    // and any external listeners will be re-added
+    this._wasInitiallyRendered = false;
   }
 
   // return the parent that's rendering <bolt-autosuggest> based on Shadow DOM usage

--- a/packages/components/bolt-typeahead/typeahead.autosuggest.js
+++ b/packages/components/bolt-typeahead/typeahead.autosuggest.js
@@ -371,7 +371,7 @@ class BoltAutosuggest extends withPreact() {
    * @param {{newValue: string}} newValue - the updated input value
    */
   onChange = (event, { newValue, method }) => {
-    this._fire('onChange', newValue, method);
+    this._fire('onChange', method, newValue);
 
     // @todo: replace this workaround with this.results.findIndex(findSelectedIndex) once `findIndex` can be safely polyfilled
     const suggestionIndex = this.results.indexOf(

--- a/packages/components/bolt-typeahead/typeahead.js
+++ b/packages/components/bolt-typeahead/typeahead.js
@@ -64,26 +64,25 @@ class BoltTypeahead extends withEvents(withLitHtml()) {
     this.autosuggest.clearSearch();
   }
 
-  submit() {
-    var evt = new KeyboardEvent('keypress', {
-      keyCode: 13,
-      which: 13,
-      key: 'Enter',
-    });
-    this.autosuggest.dispatchEvent(evt);
+  submit(e) {
+    this.handleSelected(e);
   }
 
   handleKeyPress(e) {
     if (e.target.value !== '') {
       if (e.key === 'Enter') {
-        this.autosuggest.onSelected(e, {
-          suggestionValue: this.inputValue,
-          suggestion: {
-            label: this.inputValue,
-          },
-        });
+        this.handleSelected(e);
       }
     }
+  }
+
+  handleSelected(e) {
+    this.autosuggest.onSelected(e, {
+      suggestionValue: this.inputValue,
+      suggestion: {
+        label: this.inputValue,
+      },
+    });
   }
 
   render() {

--- a/packages/components/bolt-typeahead/typeahead.js
+++ b/packages/components/bolt-typeahead/typeahead.js
@@ -51,6 +51,14 @@ class BoltTypeahead extends withEvents(withLitHtml()) {
     }
   }
 
+  disconnected() {
+    super.disconnected && super.disconnected();
+
+    // hack so that "ready" event will fire next time component connects,
+    // and any external listeners will be re-added
+    this._wasInitiallyRendered = false;
+  }
+
   clearSearch() {
     this.inputValue = '';
     this.autosuggest.clearSearch();

--- a/packages/components/bolt-typeahead/typeahead.js
+++ b/packages/components/bolt-typeahead/typeahead.js
@@ -66,6 +66,9 @@ class BoltTypeahead extends withEvents(withLitHtml()) {
 
   submit(e) {
     this.handleSelected(e);
+
+    // prevent default behavior or form submits multiple times
+    e.preventDefault();
   }
 
   handleKeyPress(e) {

--- a/packages/components/bolt-typeahead/typeahead.js
+++ b/packages/components/bolt-typeahead/typeahead.js
@@ -159,11 +159,11 @@ class BoltTypeahead extends withEvents(withLitHtml()) {
 
       if (this.autosuggest._wasInitiallyRendered) {
         setupEventHandlers();
-      } else {
-        this.autosuggest.addEventListener('ready', () => {
-          setupEventHandlers();
-        });
       }
+
+      this.autosuggest.addEventListener('ready', () => {
+        setupEventHandlers();
+      });
     }
   }
 }

--- a/packages/components/bolt-typeahead/typeahead.js
+++ b/packages/components/bolt-typeahead/typeahead.js
@@ -163,8 +163,10 @@ class BoltTypeahead extends withEvents(withLitHtml()) {
         setupEventHandlers();
       }
 
-      this.autosuggest.addEventListener('ready', () => {
-        setupEventHandlers();
+      this.autosuggest.addEventListener('ready', e => {
+        if (e.detail.name === 'bolt-autosuggest') {
+          setupEventHandlers();
+        }
       });
     }
   }

--- a/packages/components/bolt-typeahead/typeahead.js
+++ b/packages/components/bolt-typeahead/typeahead.js
@@ -136,17 +136,26 @@ class BoltTypeahead extends withEvents(withLitHtml()) {
   rendered() {
     super.rendered && super.rendered();
 
+    const setupEventHandlers = () => {
+      this.autosuggest.on('onInput', (element, event, newValue) => {
+        this.inputValue = newValue;
+      });
+
+      this.autosuggest.on('onChange', (element, event, newValue) => {
+        this.inputValue = newValue;
+      });
+    };
+
     if (!this.autosuggest) {
       this.autosuggest = this.renderRoot.querySelector('bolt-autosuggest');
-      this.autosuggest.addEventListener('ready', () => {
-        this.autosuggest.on('onInput', (element, event, newValue) => {
-          this.inputValue = newValue;
-        });
 
-        this.autosuggest.on('onChange', (element, event, newValue) => {
-          this.inputValue = newValue;
+      if (this.autosuggest._wasInitiallyRendered) {
+        setupEventHandlers();
+      } else {
+        this.autosuggest.addEventListener('ready', () => {
+          setupEventHandlers();
         });
-      });
+      }
     }
   }
 }


### PR DESCRIPTION
## Jira

- http://vjira2:8080/browse/BDS-1928
  - http://vjira2:8080/browse/BDS-1931
  - http://vjira2:8080/browse/BDS-1930

## Summary

Fixes IE11 Typeahead bug that prevents search terms from submitting, breaks autocomplete menu.

## Details

In IE11, when the Typeahead is inside a Band, the component connects and disconnects multiple times as the page renders. In our code, we are removing all external event listeners on disconnect to prevent duplicate event listeners from being added. This breaks IE11 because the event listeners are never re-added when the component re-connects. This PR adds a workaround so that every time Typeahead re-connects the "ready" event will fire, and any external event listeners added initially will be re-added.

**Key code changes:**
- Unset `_wasInitiallyRendered` on Typeahead and Autosuggest on disconnect so that the 'ready' event fires when they re-connect, and any external event listeners will be re-added. Fixes IE11 bug.
- Update the docs according to new suggested use.

While debugging this issue, I fixed a few other bugs that were making the job harder. I thought they were important enough to include them here:

**Additional bug fixes**
- Prevent multiple form submissions by setting `preventDefault` on submit button click.
- Fix IE11 JS error when you click submit button by removing `new KeyboardEvent`, which doesn't work in IE. Just call the `onSelected` method directly.
- Fix the order of arguments passed to the `onChange` event, was causing the event value (i.e. 'up', down') to be passed as the input value (i.e. the search term)

Along with this hotfix, there are minor changes required on the Drupal side so that the event listeners are added as shown in our updated Typeahead demos. I have made these changes locally and will share the code with the Drupal team.

## How to test
Check out branch locally. Open Typeahead demos one at a time in a new Tab. Test the following in Chrome, IE11 and Edge:
- Submit a search by pressing 'enter' key
- Submit a search by clicking submit button (search icon)
- Select an autosuggested result
> Open one demo at a time in a new tab, _not in Pattern Lab Iframe_. Close the Pattern Lab UI all together. Otherwise it may trigger multiple windows to open.