### PR TITLE
fix(micro-journeys): broaden desktop width of status bar

### DIFF
--- a/packages/micro-journeys/src/status-dialogue-bar.scss
+++ b/packages/micro-journeys/src/status-dialogue-bar.scss
@@ -15,7 +15,7 @@ $bolt-tooltip-bubble-triangle-width: 8px;
   &__content {
     display: flex;
     flex-direction: column;
-    max-width: 200px;
+    max-width: 125px;
     padding: bolt-spacing(xsmall) bolt-spacing(xsmall);
     color: bolt-color(black);
     border-radius: $bolt-border-radius;
@@ -25,7 +25,7 @@ $bolt-tooltip-bubble-triangle-width: 8px;
     @include bolt-mq(xsmall) {
       flex-direction: row;
       align-items: center;
-      max-width: 125px;
+      max-width: 175px;
     }
 
     @include bolt-mq(small) {


### PR DESCRIPTION
## Jira

https://app.asana.com/0/1126340469288208/1154819220959433/f

## Summary

Broaden desktop width of `bolt-status-dialog-bar`.

## How to test

View broadened status bar on micro journeys page.
