### PR TITLE
hotfix: Remove cache-loader from webpack fonts rule

### DIFF
--- a/packages/build-tools/create-webpack-config.js
+++ b/packages/build-tools/create-webpack-config.js
@@ -336,7 +336,6 @@ async function createWebpackConfig(buildConfig) {
         {
           test: /\.(woff|woff2)$/,
           use: [
-            'cache-loader',
             {
               loader: 'url-loader',
               options: {


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/WWWD-4467

## Summary

Restores font files when creating multiple builds at once

## Details

### Steps to reproduce the problem
- Check out the [bolt-release-build repo](http://vstash:7990/projects/BOLT/repos/bolt-release-build/browse)
- Run `npx gulp --bolt-version=v2.13.1 --additional-components="@bolt/components-icon"` (FYI, the additional-components option is a temporary workaround for a separate problem)
- Observe that there is a `builds/v2.13.1/builds/en--dev/fonts` directory, but not a `builds/v2.13.1/builds/en/fonts` directory.

Note: it's possible this is an intermittent bug and may not always be reproducible the same way

### Discussion

The fix in this PR is based on the discussion in https://github.com/webpack-contrib/cache-loader/issues/82

Why it works, I'm less sure.  The comments there mention a few things:

> it should not be placed before any loader that has side effects like emitFile

I believe that's the case in our config, though I don't understand why it should be avoided.

> You don't need cache-loader on file-loader, why you do this?

This brings up a bigger question-- are we even using cache-loader correctly?  Specifically, is there any benefit to using cache-loader before something like file-loader or url-loader (as opposed to, for example, babel-loader which has potentially heavy transpiling work to do?)

## How to test

Confirm that the change in this PR resolves the bug described in "Steps to reproduce", above