### PR TITLE
Feature: Add bolt-shadow-toggle component

### DIFF
--- a/docs-site/.boltrc.js
+++ b/docs-site/.boltrc.js
@@ -75,7 +75,10 @@ const config = {
 
   components: {
     global: [
+      // helper components that are only used internally
+      '@bolt/shadow-toggle',
       '@bolt/theme-switcher',
+
       '@bolt/components-radio-switch',
       '@bolt/components-carousel',
       '@bolt/global',

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -86,7 +86,7 @@
     "@bolt/critical-path-polyfills": "^2.12.0",
     "@bolt/global": "^2.13.0",
     "@bolt/micro-journeys": "^2.13.1",
-    "@bolt/shadow-toggle": "^2.11.0",
+    "@bolt/shadow-toggle": "0.0.0",
     "@bolt/theme-switcher": "^2.13.0",
     "@bolt/twig-renderer": "^2.13.0",
     "@ckeditor/ckeditor5-build-classic": "^12.1.0",

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -86,6 +86,7 @@
     "@bolt/critical-path-polyfills": "^2.12.0",
     "@bolt/global": "^2.13.0",
     "@bolt/micro-journeys": "^2.13.1",
+    "@bolt/shadow-toggle": "^2.11.0",
     "@bolt/theme-switcher": "^2.13.0",
     "@bolt/twig-renderer": "^2.13.0",
     "@ckeditor/ckeditor5-build-classic": "^12.1.0",

--- a/docs-site/src/components/shadow-toggle/index.js
+++ b/docs-site/src/components/shadow-toggle/index.js
@@ -1,0 +1,10 @@
+import { polyfillLoader } from '@bolt/core/polyfills';
+
+polyfillLoader.then(res => {
+  import(
+    /*
+    webpackMode: 'eager',
+    webpackChunkName: 'bolt-shadow-toggle'
+  */ './shadow-toggle.js'
+  );
+});

--- a/docs-site/src/components/shadow-toggle/package.json
+++ b/docs-site/src/components/shadow-toggle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bolt/shadow-toggle",
-  "version": "2.11.0",
+  "version": "0.0.0",
   "private": true,
   "description": "A toggle switch for the Bolt Design System that allows developers to globally enable / disable Shadow DOM rendering in web components for easier debugging & development",
   "keywords": [

--- a/docs-site/src/components/shadow-toggle/package.json
+++ b/docs-site/src/components/shadow-toggle/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@bolt/shadow-toggle",
+  "version": "2.11.0",
+  "private": true,
+  "description": "A toggle switch for the Bolt Design System that allows developers to globally enable / disable Shadow DOM rendering in web components for easier debugging & development",
+  "keywords": [
+    "bolt design system",
+    "bolt",
+    "design system",
+    "web components",
+    "shadow dom"
+  ],
+  "homepage": "https://boltdesignsystem.com",
+  "bugs": "https://github.com/boltdesignsystem/bolt/issues",
+  "license": "MIT",
+  "main": "index.js",
+  "style": "shadow-toggle.scss",
+  "dependencies": {
+    "@bolt/core": "^2.11.0",
+    "@bolt/element": "^2.11.0"
+  },
+  "maintainers": [
+    {
+      "name": "Salem Ghoweri",
+      "email": "me@salemghoweri.com",
+      "web": "https://github.com/sghoweri"
+    }
+  ]
+}

--- a/docs-site/src/components/shadow-toggle/package.json
+++ b/docs-site/src/components/shadow-toggle/package.json
@@ -16,8 +16,8 @@
   "main": "index.js",
   "style": "shadow-toggle.scss",
   "dependencies": {
-    "@bolt/core": "^2.11.0",
-    "@bolt/element": "^2.11.0"
+    "@bolt/core-v3.x": "^2.13.0",
+    "@bolt/element": "^2.13.0"
   },
   "maintainers": [
     {

--- a/docs-site/src/components/shadow-toggle/shadow-toggle.js
+++ b/docs-site/src/components/shadow-toggle/shadow-toggle.js
@@ -83,7 +83,6 @@ class BoltShadowToggle extends BoltElement {
   }
 
   render() {
-    // ${this.addStyles([styles])}
     return html`
       <div class="c-bolt-shadow-toggle__wrapper" @click=${this.onClick}>
         <ul

--- a/docs-site/src/components/shadow-toggle/shadow-toggle.js
+++ b/docs-site/src/components/shadow-toggle/shadow-toggle.js
@@ -1,0 +1,188 @@
+/* --------------------------------
+  NOTE: This is a fork of our upcoming <bolt-radio-switch> component!
+  @todo: Once <bolt-radio-switch> is more fully baked, the majority of this code should be able to be cleared out
+-------------------------------- */
+
+import { html, BoltElement, customElement, unsafeCSS } from '@bolt/element';
+import shadowToggleStyles from './shadow-toggle.scss';
+
+@customElement('bolt-shadow-toggle')
+class BoltShadowToggle extends BoltElement {
+  static get styles() {
+    return [unsafeCSS(shadowToggleStyles)];
+  }
+
+  static get properties() {
+    return {
+      isIndeterminate: Boolean,
+      isEnabled: Boolean,
+      isDisabled: Boolean,
+    };
+  }
+
+  constructor() {
+    super();
+    this.onFormChange = this.onFormChange.bind(this);
+    this.onClick = this.onClick.bind(this);
+    this.onReset = this.onReset.bind(this);
+
+    this.isIndeterminate = window.localStorage.getItem('bolt-debug')
+      ? false
+      : true;
+    this.isEnabled = window.localStorage.getItem('bolt-enable-shadow')
+      ? true
+      : null;
+    this.isDisabled = window.localStorage.getItem('bolt-disable-shadow')
+      ? true
+      : null;
+  }
+
+  onReset() {
+    this.isIndeterminate = true;
+    this.isEnabled = null;
+    this.isDisabled = null;
+
+    window.localStorage.removeItem('bolt-debug');
+    window.localStorage.removeItem('bolt-enable-shadow');
+    window.localStorage.removeItem('bolt-disable-shadow');
+
+    setTimeout(() => {
+      document.location.search = '';
+    }, 500);
+  }
+
+  onClick() {
+    if (this.isIndeterminate === true) {
+      this.isIndeterminate = false;
+    }
+  }
+
+  onFormChange(value) {
+    if (value === 'enable-shadow') {
+      this.isEnabled = true;
+      this.isDisabled = false;
+      window.localStorage.setItem('bolt-debug', true);
+      window.localStorage.setItem('bolt-enable-shadow', true);
+      window.localStorage.removeItem('bolt-disable-shadow');
+
+      setTimeout(() => {
+        window.location.reload();
+      }, 500);
+    } else if (value === 'disable-shadow') {
+      this.isEnabled = false;
+      this.isDisabled = true;
+
+      window.localStorage.setItem('bolt-debug', true);
+      window.localStorage.setItem('bolt-disable-shadow', true);
+      window.localStorage.removeItem('bolt-enable-shadow');
+
+      setTimeout(() => {
+        window.location.reload();
+      }, 500);
+    }
+  }
+
+  render() {
+    // ${this.addStyles([styles])}
+    return html`
+      <div class="c-bolt-shadow-toggle__wrapper" @click=${this.onClick}>
+        <ul
+          class="c-bolt-shadow-toggle ${this.isIndeterminate === false
+            ? 'is-enabled'
+            : ''} ${this.isEnabled === true ? 'has-shadow-enabled' : ''} ${this
+            .isDisabled === true
+            ? 'has-shadow-disabled'
+            : ''}"
+        >
+          <li class="c-bolt-shadow-toggle__item">
+            <input
+              value="enable-shadow"
+              class="c-bolt-shadow-toggle__input reset"
+              type="radio"
+              ?checked=${this.isEnabled}
+              name="shadowToggle"
+              id="radio1"
+              @change=${e => this.onFormChange(e.target.value)}
+            />
+            <label class="c-bolt-shadow-toggle__label" for="radio1">
+              <svg viewBox="0 0 24 24" height="32" width="32">
+                <title>Enable Shadow DOM</title>
+                <path
+                  d="M12 20.863c-0.38-0.215-0.972-0.57-1.655-1.049-0.679-0.476-1.442-1.068-2.175-1.761-0.849-0.803-1.641-1.725-2.22-2.739-0.079-0.137-0.153-0.276-0.223-0.417-0.248-0.496-0.441-1.009-0.566-1.536-0.104-0.442-0.161-0.895-0.161-1.361v-6.307l7-2.625 7 2.625v6.307c0 0.466-0.057 0.919-0.161 1.361-0.124 0.527-0.317 1.040-0.566 1.536-0.070 0.14-0.145 0.279-0.223 0.417-0.579 1.014-1.371 1.936-2.22 2.739-0.733 0.693-1.495 1.286-2.175 1.761-0.684 0.478-1.275 0.833-1.655 1.049zM12.447 22.894c0.028-0.014 1.041-0.522 2.355-1.442 0.74-0.518 1.583-1.171 2.402-1.947 0.945-0.894 1.878-1.967 2.582-3.2 0.096-0.168 0.188-0.34 0.276-0.515 0.309-0.618 0.559-1.276 0.723-1.971 0.138-0.582 0.215-1.19 0.215-1.819v-7c0-0.426-0.267-0.79-0.649-0.936l-8-3c-0.236-0.089-0.485-0.082-0.702 0l-8 3c-0.399 0.149-0.646 0.527-0.649 0.936v7c0 0.629 0.077 1.237 0.214 1.82 0.164 0.695 0.414 1.353 0.723 1.971 0.087 0.175 0.179 0.346 0.276 0.515 0.704 1.233 1.637 2.306 2.582 3.2 0.82 0.776 1.663 1.429 2.402 1.947 1.314 0.92 2.327 1.428 2.355 1.442 0.292 0.146 0.62 0.136 0.894 0z"
+                  fill="currentColor"
+                ></path>
+              </svg>
+            </label>
+          </li>
+
+          <li class="c-bolt-shadow-toggle__item">
+            <input
+              value="disable-shadow"
+              class="c-bolt-shadow-toggle__input reset"
+              type="radio"
+              name="shadowToggle"
+              ?checked=${this.isDisabled}
+              id="radio2"
+              @change=${e => this.onFormChange(e.target.value)}
+            />
+            <label class="c-bolt-shadow-toggle__label" for="radio2">
+              <svg viewBox="0 0 24 24" height="32" width="32">
+                <title>Disable Shadow DOM</title>
+                <path
+                  d="M20.645 14.296c0.241-0.776 0.358-1.567 0.355-2.3v-6.996c0-0.426-0.267-0.79-0.649-0.936l-8-3c-0.236-0.088-0.484-0.082-0.701 0l-3.16 1.18c-0.517 0.192-0.78 0.768-0.587 1.286s0.769 0.78 1.287 0.587l2.809-1.049 7.001 2.625v6.311c0.002 0.522-0.082 1.111-0.265 1.7-0.164 0.527 0.131 1.088 0.659 1.251s1.088-0.131 1.251-0.659zM5 6.414l11.231 11.231c-1.181 1.2-2.612 2.306-4.232 3.217-0.38-0.216-0.971-0.57-1.654-1.048-0.679-0.476-1.442-1.068-2.175-1.761-0.849-0.803-1.641-1.725-2.22-2.739-0.079-0.137-0.153-0.276-0.223-0.417-0.248-0.496-0.441-1.009-0.566-1.536-0.104-0.442-0.161-0.895-0.161-1.361zM0.293 1.707l2.824 2.825c-0.075 0.142-0.116 0.302-0.117 0.468v7c0 0.629 0.077 1.237 0.214 1.82 0.164 0.695 0.414 1.353 0.723 1.971 0.087 0.175 0.179 0.346 0.276 0.515 0.704 1.233 1.637 2.306 2.582 3.2 0.82 0.776 1.663 1.429 2.402 1.947 1.314 0.92 2.327 1.428 2.355 1.442 0.298 0.149 0.636 0.135 0.914-0.010 1.985-1.047 3.74-2.366 5.178-3.825l4.648 4.648c0.391 0.391 1.024 0.391 1.414 0s0.391-1.024 0-1.414l-21.999-22.001c-0.391-0.391-1.024-0.391-1.414 0-0.39 0.39-0.391 1.023 0 1.414z"
+                  fill="currentColor"
+                ></path></svg
+            ></label>
+            <div aria-hidden="true" class="c-bolt-shadow-toggle__toggle">
+              <span class="c-bolt-shadow-toggle__marker"></span>
+            </div>
+          </li>
+        </ul>
+
+        <div
+          class="c-bolt-shadow-toggle__reset ${this.isIndeterminate === true
+            ? 'is-enabled'
+            : ''}"
+        >
+          <bolt-button
+            color="text"
+            size="xsmall"
+            @click=${e => this.onReset(e.target.value)}
+          >
+            ${this.isIndeterminate
+              ? 'Click to Override Shadow DOM'
+              : this.isEnabled === true || this.isDisabled === true
+              ? 'Reset Shadow DOM Overrides'
+              : 'Choose An Override'}
+          </bolt-button>
+        </div>
+      </div>
+    `;
+  }
+
+  firstUpdated() {
+    if (!this._wasInitiallyRendered) {
+      this._wasInitiallyRendered = true;
+      if (
+        window.localStorage.getItem('bolt-enable-shadow') ||
+        window.localStorage.getItem('bolt-disable-shadow')
+      ) {
+        this.isEnabled = window.localStorage.getItem('bolt-enable-shadow')
+          ? true
+          : false;
+        this.isDisabled = window.localStorage.getItem('bolt-disable-shadow')
+          ? true
+          : false;
+      } else {
+        var inputs = this.renderRoot.querySelector('input');
+
+        for (var i = 0; i < inputs.length; i++) {
+          inputs[i].indeterminate = true;
+        }
+      }
+    }
+    super.firstUpdated && super.firstUpdated();
+  }
+}
+
+export { BoltShadowToggle };

--- a/docs-site/src/components/shadow-toggle/shadow-toggle.scss
+++ b/docs-site/src/components/shadow-toggle/shadow-toggle.scss
@@ -1,0 +1,160 @@
+/* --------------------------------
+  NOTE: This is a fork of our upcoming <bolt-radio-switch> component!
+  @todo: Once <bolt-radio-switch> is more fully baked, the majority of this code should be able to be cleared out
+-------------------------------- */
+@import '@bolt/core';
+
+bolt-shadow-toggle {
+  display: block;
+  text-align: center;
+}
+
+:root {
+  // style
+  --shadow-toggle-width: 52px;
+  --shadow-toggle-height: 30px;
+  --shadow-toggle-padding: 4px;
+  --shadow-toggle-radius: 50em;
+  --shadow-toggle-animation-duration: 0.3s;
+}
+
+.c-bolt-shadow-toggle:not(.is-enabled) {
+  opacity: 0.5;
+  cursor: pointer;
+
+  .c-bolt-shadow-toggle__item {
+    pointer-events: none;
+  }
+}
+
+.c-bolt-shadow-toggle__reset.is-enabled {
+  opacity: 0.5;
+  pointer-events: none;
+  transition: all 0.3s ease;
+}
+
+.c-bolt-shadow-toggle {
+  display: inline-block; // flexbox fallback
+  display: inline-flex;
+  position: relative;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  transition: all 0.3s ease;
+}
+
+.c-bolt-shadow-toggle__item {
+  position: relative;
+  float: left; // flexbox fallback
+  height: var(--shadow-toggle-height);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.c-bolt-shadow-toggle__input {
+  opacity: 0;
+  position: relative;
+  transform: scaleX(
+    2
+  ); // scale up the input element so that it covers the entire switch
+  z-index: 2;
+  width: calc(var(--shadow-toggle-width) * 0.5);
+  height: 100%;
+  cursor: pointer;
+  transform-origin: 0 0;
+
+  .c-bolt-shadow-toggle__item:last-of-type & {
+    transform-origin: 100% 100%;
+  }
+
+  .c-bolt-shadow-toggle__item:first-of-type & {
+    order: 1; // input follows label
+  }
+
+  &:checked {
+    z-index: -1; // make sure the unchecked input is the only one clickable
+  }
+}
+
+.c-bolt-shadow-toggle__label {
+  display: block;
+  position: relative;
+  z-index: 2;
+  cursor: pointer;
+  @include bolt-no-select;
+  @include bolt-font-size(small);
+  transition: color var(--shadow-toggle-animation-duration);
+
+  .c-bolt-shadow-toggle__item:first-of-type & {
+    float: left; // flexbox fallback
+    @include bolt-margin-right(xsmall);
+  }
+
+  .c-bolt-shadow-toggle__item:last-of-type & {
+    float: right; // flexbox fallback
+    @include bolt-margin-left(xsmall);
+  }
+
+  .c-bolt-shadow-toggle__input:checked ~ & {
+    color: bolt-theme(primary);
+  }
+
+  .c-bolt-shadow-toggle__input:focus ~ & {
+    // focus effect if :focus-within is not supported
+    outline: 2px solid bolt-theme(primary, 0.2);
+    outline-offset: 2px;
+  }
+
+  :not(*):focus-within,
+  .c-bolt-shadow-toggle__input:focus ~ & {
+    // reset focus style for browsers supporting :focus-within
+    outline: none;
+  }
+}
+
+.c-bolt-shadow-toggle__toggle {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: translateX(-50%);
+  z-index: 1;
+  width: var(--shadow-toggle-width);
+  height: var(--shadow-toggle-height);
+  border-radius: var(--shadow-toggle-radius);
+  box-shadow: 0 0 0 1px bolt-color(gray);
+
+  .c-bolt-shadow-toggle:focus-within &,
+  .c-bolt-shadow-toggle:active & {
+    box-shadow: 0 0 0 1px bolt-color(gray), 0 0 0 3px bolt-color(gray, dark); // focus effect if :focus-within is supported
+  }
+}
+
+.c-bolt-shadow-toggle__marker {
+  opacity: 0;
+  position: absolute;
+  top: var(--shadow-toggle-padding);
+  left: var(--shadow-toggle-padding);
+  z-index: 1;
+  width: calc(var(--shadow-toggle-height) - var(--shadow-toggle-padding) * 2);
+  height: calc(var(--shadow-toggle-height) - var(--shadow-toggle-padding) * 2);
+  border-radius: 50%;
+  background-color: bolt-theme(primary);
+  will-change: left;
+  transition: opacity var(--shadow-toggle-animation-duration),
+    left var(--shadow-toggle-animation-duration);
+
+  .has-shadow-enabled &,
+  .has-shadow-disabled & {
+    opacity: 1;
+  }
+}
+
+.c-bolt-shadow-toggle__input:checked
+  ~ .c-bolt-shadow-toggle__toggle
+  .c-bolt-shadow-toggle__marker {
+  left: calc(
+    var(--shadow-toggle-width) - var(--shadow-toggle-height) +
+      var(--shadow-toggle-padding)
+  );
+}

--- a/docs-site/src/components/shadow-toggle/shadow-toggle.twig
+++ b/docs-site/src/components/shadow-toggle/shadow-toggle.twig
@@ -1,0 +1,28 @@
+{#
+/* --------------------------------
+  NOTE: This is a fork of our upcoming <bolt-radio-switch> component!
+  @todo: Once <bolt-radio-switch> is more fully baked, the majority of this code should be able to be cleared out
+-------------------------------- */
+#}
+
+<bolt-button size="small" color="secondary" on-click="show" on-click-target="js-bolt-modal-debug-panel" icon-only style="position: fixed; bottom: 0.5rem; right: 0.5rem;" border-radius="full">
+  <replace-with-children class="u-bolt-visuallyhidden">Debug Panel</replace-with-children>
+  <bolt-icon slot="before" name="java"></bolt-icon>
+</bolt-button>
+
+<bolt-modal scroll="overall" class="js-bolt-modal-debug-panel" width="auto">
+  <bolt-shadow-toggle>
+    <ul class="c-bolt-shadow-toggle">
+      <li class="c-bolt-shadow-toggle__item">
+        <input class="c-bolt-shadow-toggle__input reset" type="radio" value="enable-shadow" name="radioSwitch" id="radio1">
+        <label class="c-bolt-shadow-toggle__label" for="radio1">Enable Shadow DOM</label>
+      </li>
+
+      <li class="c-bolt-shadow-toggle__item">
+        <input class="c-bolt-shadow-toggle__input reset" type="radio" name="radioSwitch" id="radio2" value="disable-shadow">
+        <label class="c-bolt-shadow-toggle__label" for="radio2">Disable Shadow DOM</label>
+        <div aria-hidden="true" class="c-bolt-shadow-toggle__toggle"><span class="c-bolt-shadow-toggle__marker"></span></div>
+      </li>
+    </ul>
+  </bolt-shadow-toggle>
+</bolt-modal>

--- a/docs-site/src/templates/_site-footer.twig
+++ b/docs-site/src/templates/_site-footer.twig
@@ -33,5 +33,7 @@
     <script>console.log('Bolt Global Twig variable. In Twig, you can tap into the `bolt` global var to access all sorts of helpful information about the Bolt Design System, such as colors, spacing, and more. Most is exported from Sass; to add more, add this to any Sass file: `@include export-data("myVariables.bolt.json", $my-variables-in-a-sass-map);`, and then you can access it in Twig via `bolt.data.myVariables`. Here is all the data available to the current templates, including the `bolt` var:');</script>
   {% endif %} #}
 
+    {# @todo: refactor once additional debug panel items are available #}
+    {% include "@bolt/shadow-toggle.twig" only %}
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
       "docs-site/src/components/theme-switcher",
       "docs-site/src/components/docs-search",
       "docs-site/src/components/radio-switch",
+      "docs-site/src/components/shadow-toggle",
       "packages/*",
       "packages/*/*",
       "packages/build-tools/__tests__/*",

--- a/packages/base-element/index.js
+++ b/packages/base-element/index.js
@@ -10,8 +10,8 @@ export {
 } from './src/lib/utils';
 
 export { convertInitialTags } from './src/lib/decorators';
-export { unsafeCSS } from 'lit-element';
-export { render, html } from 'lit-html';
+export { html, unsafeCSS } from 'lit-element';
+export { render } from 'lit-html';
 export { ifDefined } from 'lit-html/directives/if-defined';
 export { classMap } from 'lit-html/directives/class-map.js';
 export { styleMap } from 'lit-html/directives/style-map.js';

--- a/packages/base-element/src/lib/utils.js
+++ b/packages/base-element/src/lib/utils.js
@@ -6,20 +6,23 @@ export function findParentTag(el, tag) {
   return null;
 }
 
-export function shouldUseShadowDom(elem) {
-  if (
-    elem.useShadow === false ||
-    elem.noShadow === true ||
-    findParentTag(elem, 'FORM') ||
-    elem.hasAttribute('no-shadow') === true
-  ) {
-    return false;
-  } else {
-    return hasNativeShadowDomSupport;
-  }
+// global URL query flags & overrides for debugging & testing
+const isDebugMode =
+  (window.localStorage && window.localStorage.getItem('bolt-debug')) || false;
+let globallyUseShadowDom = supportsShadowDom();
+
+if (window.localStorage && window.localStorage.getItem('bolt-enable-shadow')) {
+  globallyUseShadowDom = true;
+} else if (
+  window.localStorage &&
+  window.localStorage.getItem('bolt-disable-shadow')
+) {
+  globallyUseShadowDom = false;
 }
 
-export const hasNativeShadowDomSupport = supportsShadowDom();
+export const hasNativeShadowDomSupport = isDebugMode
+  ? globallyUseShadowDom
+  : supportsShadowDom();
 
 // Helper util to check if the browser supports shadow DOM for conditional shimming / progressive rendering
 export function supportsShadowDom() {
@@ -31,6 +34,19 @@ export function supportsShadowDom() {
     return true;
   } else {
     return false;
+  }
+}
+
+export function shouldUseShadowDom(elem) {
+  if (
+    elem.useShadow === false ||
+    elem.noShadow === true ||
+    findParentTag(elem, 'FORM') ||
+    elem.hasAttribute('no-shadow') === true
+  ) {
+    return false;
+  } else {
+    return hasNativeShadowDomSupport;
   }
 }
 


### PR DESCRIPTION
## Jira
n/a

## Summary
Adds a new `<bolt-shadow-toggle>` helper component (based off of the upcoming `<bolt-radio-switch>`) that allows devs to globally enable / disable Shadow DOM rendering while developing in Bolt.

## Details 
Replaces #1538 which got out of sync with `master`.

Adds a new feature flag to @bolt/core to carefully allow the default Shadow DOM feature detection check results to be overwritten while debugging / testing. 

Uses Modal to tuck away the config options while not in use.

## How to test
Try the new helper component out!