### PR TITLE
Improve Initial SSR Rendering (Especially in IE 11)

### DIFF
--- a/docs-site/src/templates/_site-footer.twig
+++ b/docs-site/src/templates/_site-footer.twig
@@ -30,9 +30,8 @@
 
   <script type="module">
     if (!sessionStorage.fontsLoadedCriticalFoftPreloadPolyfill){
-      {% if fileExists("@bolt-assets/bolt-components-critical-css.js") %}
-        {{ inline( legacyAssets["bolt-components-critical-fonts.js"] | default("") ) }}
-      {% endif %}
+      document.documentElement.classList.add('js-fonts-loaded');
+      sessionStorage.fontsLoadedCriticalFoftPreloadPolyfill = true;
     }
   </script>
 

--- a/docs-site/src/templates/_site-footer.twig
+++ b/docs-site/src/templates/_site-footer.twig
@@ -20,12 +20,27 @@
   {% endif %}
 
   {% if bolt.data.config.esModules %}
+    <script nomodule src="{{ legacyAssets["bolt-global.js"] | default("/build/bolt-global.js") }}?cacheBuster={{ cacheBuster }}" async></script>
+
     <script type="module" src="{{ modernAssets["bolt-global.js"] | default("/build/bolt-global.modern.js") }}" async></script>
 
-    <script nomodule src="{{ legacyAssets["bolt-global.js"] | default("/build/bolt-global.js") }}?cacheBuster={{ cacheBuster }}" async></script>
   {% else %}
     <script src="{{ legacyAssets["bolt-global.js"] | default("/build/bolt-global.js") }}?cacheBuster={{ cacheBuster }}" async></script>
   {% endif %}
+
+  <script type="module">
+    if (!sessionStorage.fontsLoadedCriticalFoftPreloadPolyfill){
+      {% if fileExists("@bolt-assets/bolt-components-critical-css.js") %}
+        {{ inline( legacyAssets["bolt-components-critical-fonts.js"] | default("") ) }}
+      {% endif %}
+    }
+  </script>
+
+  <script nomodule>
+    document.documentElement.classList.add('js-fonts-loaded');
+  </script>
+
+  <script src="https://www.google-analytics.com/analytics.js" async></script>
 
   {{ patternLabFoot | raw }}
 

--- a/docs-site/src/templates/_site-head.twig
+++ b/docs-site/src/templates/_site-head.twig
@@ -51,10 +51,12 @@
       {% endif %}
 
       {% if fileExists("@bolt-assets/bolt-components-critical-css.js") %}
-        {{ inline( legacyAssets["bolt-components-critical-css.js"] | default("") ) }}
         {{ inline( legacyAssets["bolt-components-critical-css-vars.js"] | default("") ) }}
-        {{ inline( legacyAssets["bolt-components-critical-fonts.js"] | default("") ) }}
       {% endif %}
+
+      if (sessionStorage.fontsLoadedCriticalFoftPreloadPolyfill){
+        document.documentElement.classList.add('js-fonts-loaded');
+      }
 
       window.drupalSettings = {
         google_analytics: {
@@ -82,8 +84,6 @@
         {{ inline( legacyAssets["bolt-components-critical-fonts.css"] | default("") ) }}
       {% endif %}
     </style>
-
-    <script src="https://www.google-analytics.com/analytics.js" defer></script>
 
     <link rel="image_src" href="/images/bolt-logo-480.png">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=LbyzAXRqNz">

--- a/docs-site/src/templates/_site-head.twig
+++ b/docs-site/src/templates/_site-head.twig
@@ -81,7 +81,7 @@
     {# @TODO: wire this up to use Critical CSS #}
     <style>
       {% if fileExists("@bolt-assets/bolt-components-critical-fonts.css") %}
-        {{ inline( legacyAssets["bolt-components-critical-fonts.css"] | default("") ) }}
+        {# {{ inline( legacyAssets["bolt-components-critical-fonts.css"] | default("") ) }} #}
       {% endif %}
     </style>
 


### PR DESCRIPTION
## Jira
N/A

## Summary
Tweaks the critical path assets in the header / footer to speed up the initial rendering + reduce the jumpiness seen on master.

![image](https://user-images.githubusercontent.com/1617209/71751272-07687d00-2e49-11ea-987f-30fdcb77b55a.png)


## Details
I'm not 100% sure if the order of the `<script>` tags really matters here (haven't spent enough time on this to measure all the different combos) however I know that clearing up much of the `<head>` / virtually eliminating the inline Critical Font code should help quite a bit on this front.

Further updates to our async font loader might further help us here however in the interim we're going super lightweight here to reduce the amount of render blocking code getting run.

### Before vs After in IE 11

https://www.webpagetest.org/video/view.php?id=200103_3429bc8b8293e6df31a9a750ba377979bdf96894

> Note: the long "visually complete" bit of the video is sometimes finicky due to our animated background!

## How to test
- Compare perceived performance on master compared to the updates on this branch
