### PR TITLE
Upgrade Execa / Twig Renderer Patch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,8 +73,6 @@ jobs:
       name: 'Build + Deploy Website + Lighthouse CLI'
       if: (NOT tag =~ ^v) AND (NOT branch =~ /(master|release|bug|fix)/)
       install:
-        - npx json -I -f package.json -e 'delete this.dependencies'
-        - npx json -I -f package.json -e 'delete this.scripts.postinstall'
         - yarn run setup
         - npx lerna run postbootstrap
         - yarn global add @lhci/cli@0.3.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,8 @@ jobs:
       name: 'Build + Deploy Website + Lighthouse CLI'
       if: (NOT tag =~ ^v) AND (NOT branch =~ /(master|release|bug|fix)/)
       install:
+        - npx json -I -f package.json -e 'delete this.dependencies'
+        - npx json -I -f package.json -e 'delete this.scripts.postinstall'
         - yarn run setup
         - npx lerna run postbootstrap
         - yarn global add @lhci/cli@0.3.x

--- a/package.json
+++ b/package.json
@@ -165,6 +165,9 @@
     "stylelint-order": "^3.0.1",
     "stylelint-scss": "^3.9.2"
   },
+  "resolutions": {
+    "execa": "^4.0.0"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/build-tools/utils/package.json
+++ b/packages/build-tools/utils/package.json
@@ -19,7 +19,7 @@
     "convert-hrtime": "^3.0.0",
     "cosmiconfig": "^5.2.1",
     "del": "^4.1.1",
-    "execa": "^1.0.0",
+    "execa": "^4.0.0",
     "js-yaml": "^3.13.1",
     "jsonschema": "^1.2.4",
     "node-cache": "^4.2.0",

--- a/packages/testing/testing-helpers/package.json
+++ b/packages/testing/testing-helpers/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "main": "index.js",
   "dependencies": {
-    "@basalt/twig-renderer": "^0.12.0",
+    "@basalt/twig-renderer": "^0.13.0",
     "@bolt/build-tools": "^2.14.0",
     "@bolt/drupal-twig-extensions": "^2.14.0",
     "json-schema-ref-parser": "^7.1.0",

--- a/packages/testing/testing-utils/cli/list-pkg-paths-changed.js
+++ b/packages/testing/testing-utils/cli/list-pkg-paths-changed.js
@@ -31,7 +31,7 @@ if (process.env.TRAVIS === 'true') {
     },
   ].forEach(step => {
     process.stderr.write(`${step.label}\n`);
-    const results = execa.shellSync(step.cmd);
+    const results = execa.sync(step.cmd);
     if (results.failed) {
       process.stderr.write(`Uh oh, this Travis git step failed:\n`);
       process.stderr.write(`${results.stderr}\n`);

--- a/packages/testing/testing-utils/package.json
+++ b/packages/testing/testing-utils/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "find-pkg": "^2.0.0",
     "fs-extra": "^8.1.0",
-    "globby": "^9.2.0"
+    "globby": "^9.2.0",
+    "execa": "^4.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/testing/testing-utils/test-utils.js
+++ b/packages/testing/testing-utils/test-utils.js
@@ -22,7 +22,7 @@ const lernaCli = join(repoRoot, 'node_modules/.bin/lerna');
  */
 function runLernaCmd(cmd) {
   try {
-    const results = execa.shellSync([lernaCli, cmd, '--json'].join(' '), {
+    const results = execa.commandSync(`${lernaCli} ${cmd} --json`, {
       cwd: repoRoot,
     });
     return JSON.parse(results.stdout);
@@ -138,7 +138,7 @@ function getFilesChanged({ from = 'HEAD', base = 'master', inDir } = {}) {
   const cmds = ['git', 'diff', '--name-only', `${base}...${from}`];
   if (inDir) cmds.push(inDir);
   try {
-    const results = execa.shellSync(cmds.join(' '), {
+    const results = execa.sync(cmds.join(' '), {
       cwd: repoRoot,
     });
     const files = results.stdout.split('\n');

--- a/packages/twig-integration/twig-renderer/package.json
+++ b/packages/twig-integration/twig-renderer/package.json
@@ -17,7 +17,7 @@
     "setup": "composer run setup"
   },
   "dependencies": {
-    "@basalt/twig-renderer": "0.13.0",
+    "@basalt/twig-renderer": "^0.13.0",
     "@bolt/build-utils": "^2.14.0",
     "@bolt/drupal-twig-extensions": "^2.14.0",
     "sleep-promise": "^8.0.1"

--- a/patches/@basalt+twig-renderer+0.13.0.patch
+++ b/patches/@basalt+twig-renderer+0.13.0.patch
@@ -1,0 +1,192 @@
+diff --git a/node_modules/@basalt/twig-renderer/dist/twig-renderer.js b/node_modules/@basalt/twig-renderer/dist/twig-renderer.js
+index 6aee6e8..b1f1924 100644
+--- a/node_modules/@basalt/twig-renderer/dist/twig-renderer.js
++++ b/node_modules/@basalt/twig-renderer/dist/twig-renderer.js
+@@ -206,7 +206,7 @@ class TwigRenderer {
+    */
+   constructor(userConfig) {
+     try {
+-      execa.shellSync('php --version');
++      execa.sync('php', ['--version']);
+     } catch (err) {
+       console.error('Error: php cli required. ', err.message);
+       process.exit(1);
+@@ -342,22 +342,18 @@ class TwigRenderer {
+   }
+
+   async getOpenPort() {
+-    let portSelected = await getPort({
+-      host: '127.0.0.1' // helps ensure the host being checked matches the PHP server being spun up
+-
+-    }); // pick another port if the one selected has already been taken
+-
+-    while (this.configStore.has(`ports.${portSelected}`)) {
+-      // eslint-disable-next-line no-await-in-loop
+-      portSelected = await getPort({
+-        host: '127.0.0.1' // helps ensure the host being checked matches the PHP server being spun up
++    this.portSelected = await getPort({
++      host: '127.0.0.1'
++    });
+
++    while (this.configStore.has(`ports.${this.portSelected}`)) {
++      this.portSelected = await getPort({
++        host: '127.0.0.1'
+       });
+-    } // remember which ports have been assigned to avoid giving out the same port twice
+-
++    }
+
+-    this.configStore.set(`ports.${portSelected}`, true);
+-    return portSelected;
++    this.configStore.set(`ports.${this.portSelected}`, true);
++    return this.portSelected;
+   }
+
+   async init() {
+@@ -379,14 +375,14 @@ class TwigRenderer {
+     this.phpServerPort = await this.getOpenPort();
+     this.phpServerUrl = `http://127.0.0.1:${this.phpServerPort}`; // @todo Pass config to PHP server a better way than writing JSON file, then reading in PHP
+
+-    const sharedConfigPath = path__default.join(__dirname, `shared-config--${this.phpServerPort}.json`);
+-    await fs.writeFile(sharedConfigPath, JSON.stringify(this.config, null, '  '));
++    this.sharedConfigPath = path__default.join(__dirname, `shared-config--${this.phpServerPort}.json`);
++    await fs.writeFile(this.sharedConfigPath, JSON.stringify(this.config, null, '  '));
+     const phpMemoryLimit = '4048M'; // @todo make user configurable
+
+-    const params = ['-d', `memory_limit=${phpMemoryLimit}`, path__default.join(__dirname, 'server--async.php'), this.phpServerPort, sharedConfigPath];
++    const params = ['-d', `memory_limit=${phpMemoryLimit}`, path__default.join(__dirname, 'server--async.php'), this.phpServerPort, this.sharedConfigPath];
+     this.phpServer = execa('php', params, {
+       cleanup: true,
+-      detached: false
++      detached: true
+     }); // the PHP close event appears to happen first, THEN the exit event
+
+     this.phpServer.on('close', async () => {
+@@ -395,7 +391,7 @@ class TwigRenderer {
+     });
+     this.phpServer.on('exit', async () => {
+       // console.log(`Server ${this.phpServerPort} event: 'exit'`);
+-      await fs.unlink(sharedConfigPath);
++      this.stop();
+       this.serverState = serverStates.STOPPED;
+     });
+     this.phpServer.on('disconnect', () => {// console.log(`Server ${this.phpServerPort} event: 'disconnect'`);
+@@ -414,8 +410,16 @@ class TwigRenderer {
+
+   stop() {
+     // console.log(`stopping server with port ${this.phpServerPort}`);
++    // remove old config file when we're done
++    try {
++      fs.accessSync(this.sharedConfigPath, fs.constants.R_OK | fs.constants.W_OK);
++      fs.unlinkSync(this.sharedConfigPath);
++    } catch (err) {// console.error('no access!');
++    }
++
++    this.configStore.delete(`ports.${this.portSelected}`);
+     this.serverState = serverStates.STOPPED;
+-    this.phpServer.kill(); // ↓ not 100% sure if we need this w/ execa; other exec examples seem to do this for cleanup
++    this.phpServer.cancel(); // ↓ not 100% sure if we need this w/ execa; other exec examples seem to do this for cleanup
+
+     this.phpServer.removeAllListeners();
+   }
+diff --git a/node_modules/@basalt/twig-renderer/dist/twig-renderer.mjs.js b/node_modules/@basalt/twig-renderer/dist/twig-renderer.mjs.js
+index 7eb62bf..3611549 100644
+--- a/node_modules/@basalt/twig-renderer/dist/twig-renderer.mjs.js
++++ b/node_modules/@basalt/twig-renderer/dist/twig-renderer.mjs.js
+@@ -201,7 +201,7 @@ class TwigRenderer {
+    */
+   constructor(userConfig) {
+     try {
+-      execa.shellSync('php --version');
++      execa.sync('php', ['--version']);
+     } catch (err) {
+       console.error('Error: php cli required. ', err.message);
+       process.exit(1);
+@@ -337,22 +337,18 @@ class TwigRenderer {
+   }
+
+   async getOpenPort() {
+-    let portSelected = await getPort({
+-      host: '127.0.0.1' // helps ensure the host being checked matches the PHP server being spun up
+-
+-    }); // pick another port if the one selected has already been taken
+-
+-    while (this.configStore.has(`ports.${portSelected}`)) {
+-      // eslint-disable-next-line no-await-in-loop
+-      portSelected = await getPort({
+-        host: '127.0.0.1' // helps ensure the host being checked matches the PHP server being spun up
++    this.portSelected = await getPort({
++      host: '127.0.0.1'
++    });
+
++    while (this.configStore.has(`ports.${this.portSelected}`)) {
++      this.portSelected = await getPort({
++        host: '127.0.0.1'
+       });
+-    } // remember which ports have been assigned to avoid giving out the same port twice
+-
++    }
+
+-    this.configStore.set(`ports.${portSelected}`, true);
+-    return portSelected;
++    this.configStore.set(`ports.${this.portSelected}`, true);
++    return this.portSelected;
+   }
+
+   async init() {
+@@ -374,14 +370,14 @@ class TwigRenderer {
+     this.phpServerPort = await this.getOpenPort();
+     this.phpServerUrl = `http://127.0.0.1:${this.phpServerPort}`; // @todo Pass config to PHP server a better way than writing JSON file, then reading in PHP
+
+-    const sharedConfigPath = path.join(__dirname, `shared-config--${this.phpServerPort}.json`);
+-    await fs.writeFile(sharedConfigPath, JSON.stringify(this.config, null, '  '));
++    this.sharedConfigPath = path.join(__dirname, `shared-config--${this.phpServerPort}.json`);
++    await fs.writeFile(this.sharedConfigPath, JSON.stringify(this.config, null, '  '));
+     const phpMemoryLimit = '4048M'; // @todo make user configurable
+
+-    const params = ['-d', `memory_limit=${phpMemoryLimit}`, path.join(__dirname, 'server--async.php'), this.phpServerPort, sharedConfigPath];
++    const params = ['-d', `memory_limit=${phpMemoryLimit}`, path.join(__dirname, 'server--async.php'), this.phpServerPort, this.sharedConfigPath];
+     this.phpServer = execa('php', params, {
+       cleanup: true,
+-      detached: false
++      detached: true
+     }); // the PHP close event appears to happen first, THEN the exit event
+
+     this.phpServer.on('close', async () => {
+@@ -390,7 +386,7 @@ class TwigRenderer {
+     });
+     this.phpServer.on('exit', async () => {
+       // console.log(`Server ${this.phpServerPort} event: 'exit'`);
+-      await fs.unlink(sharedConfigPath);
++      this.stop();
+       this.serverState = serverStates.STOPPED;
+     });
+     this.phpServer.on('disconnect', () => {// console.log(`Server ${this.phpServerPort} event: 'disconnect'`);
+@@ -409,8 +405,16 @@ class TwigRenderer {
+
+   stop() {
+     // console.log(`stopping server with port ${this.phpServerPort}`);
++    // remove old config file when we're done
++    try {
++      fs.accessSync(this.sharedConfigPath, fs.constants.R_OK | fs.constants.W_OK);
++      fs.unlinkSync(this.sharedConfigPath);
++    } catch (err) {// console.error('no access!');
++    }
++
++    this.configStore.delete(`ports.${this.portSelected}`);
+     this.serverState = serverStates.STOPPED;
+-    this.phpServer.kill(); // ↓ not 100% sure if we need this w/ execa; other exec examples seem to do this for cleanup
++    this.phpServer.cancel(); // ↓ not 100% sure if we need this w/ execa; other exec examples seem to do this for cleanup
+
+     this.phpServer.removeAllListeners();
+   }
+diff --git a/node_modules/@basalt/twig-renderer/index.d.ts b/node_modules/@basalt/twig-renderer/index.d.ts
+index 7ad1aae..8474394 100644
+--- a/node_modules/@basalt/twig-renderer/index.d.ts
++++ b/node_modules/@basalt/twig-renderer/index.d.ts
+@@ -1,4 +1,4 @@
+-interface TwigRendererConfig {
++export interface TwigRendererConfig {
+   src: {
+     /** Root directories for Twig Loader */
+     roots: string[];

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@zeit/fetch-retry": "^3.0.0",
     "ci-utils": "^0.5.0",
-    "execa": "^1.0.0",
+    "execa": "^4.0.0",
     "git-semver-tags": "^2.0.2",
     "jsonwebtoken": "^8.4.0",
     "lodash": "^4.17.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1154,7 +1154,7 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@basalt/twig-renderer@0.13.0":
+"@basalt/twig-renderer@^0.13.0":
   version "0.13.0"
   resolved "https://registry.yarnpkg.com/@basalt/twig-renderer/-/twig-renderer-0.13.0.tgz#24a084d7bb046c9159f3795ba8f7840cd8ddcb88"
   integrity sha512-mEKiwHPTyZvyIcwM6GtA6iG7GBXekEiJ9PnvsfgjGkIDRv/80GiHlMeZmvnAmVJa25db7HbBuh0H6P4Zmmf32g==
@@ -1169,25 +1169,10 @@
     node-fetch "^2.1.2"
     sleep-promise "^8.0.1"
 
-"@basalt/twig-renderer@^0.12.0":
-  version "0.12.1"
-  resolved "https://registry.npmjs.org/@basalt/twig-renderer/-/twig-renderer-0.12.1.tgz#a7719a21d403f9bd3909eadd8df1c2f5ccebcf3e"
-  integrity sha512-RhGMEfLoQEFh6rCBMRV8VGausSrUjvWCDcqpjJwd1UiB09zR8+kUUFaOGVOzM4sllkSDZ+YIPW10T8MDxAuEBA==
-  dependencies:
-    "@babel/core" "^7.2.0"
-    "@babel/preset-env" "^7.2.0"
-    ajv "^6.5.2"
-    conf "^5.0.0"
-    execa "^1.0.0"
-    fs-extra "^7.0.1"
-    get-port "^5.0.0"
-    node-fetch "^2.1.2"
-    sleep-promise "^8.0.1"
-
 "@bolt/components-page-footer@file:packages/components/bolt-page-footer":
-  version "2.13.0"
+  version "2.14.0"
   dependencies:
-    "@bolt/core-v3.x" "^2.13.0"
+    "@bolt/core-v3.x" "^2.14.0"
 
 "@ckeditor/ckeditor5-build-classic@^12.1.0":
   version "12.4.0"
@@ -6753,15 +6738,7 @@ cross-env@^5.2.0:
   dependencies:
     cross-spawn "^6.0.5"
 
-cross-spawn-async@^2.1.1:
-  version "2.2.5"
-  resolved "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz#845ff0c0834a3ded9d160daca6d390906bb288cc"
-  integrity sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=
-  dependencies:
-    lru-cache "^4.0.0"
-    which "^1.2.8"
-
-cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
+cross-spawn@6.0.5, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
@@ -6780,14 +6757,14 @@ cross-spawn@^3.0.0:
     lru-cache "^4.0.1"
     which "^1.2.9"
 
-cross-spawn@^5.0.1:
-  version "5.1.0"
-  resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
-  integrity sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=
+cross-spawn@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
+  integrity sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==
   dependencies:
-    lru-cache "^4.0.1"
-    shebang-command "^1.2.0"
-    which "^1.2.9"
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
 
 crypto-browserify@^3.11.0:
   version "3.12.0"
@@ -8667,78 +8644,18 @@ exec-sh@^0.3.2:
   resolved "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.2.tgz#6738de2eb7c8e671d0366aea0b0db8c6f7d7391b"
   integrity sha512-9sLAvzhI5nc8TpuQUh4ahMdCrWT00wPWz7j47/emR5+2qEfoZP5zzUXvx+vdx+H6ohhnsYC31iX04QLYJK8zTg==
 
-execa@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.npmjs.org/execa/-/execa-0.1.1.tgz#b09c2a9309bc0ef0501479472db3180f8d4c3edd"
-  integrity sha1-sJwqkwm8DvBQFHlHLbMYD41MPt0=
+execa@^0.1.1, execa@^0.4.0, execa@^0.6.0, execa@^0.7.0, execa@^1.0.0, execa@^2.0.2, execa@^2.0.3, execa@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-4.0.0.tgz#7f37d6ec17f09e6b8fc53288611695b6d12b9daf"
+  integrity sha512-JbDUxwV3BoT5ZVXQrSVbAiaXhXUkIwvbhPIwZ0N13kX+5yCzOhUNdocxB/UQRuYOHRYYwAxKYwJYc0T4D12pDA==
   dependencies:
-    cross-spawn-async "^2.1.1"
-    object-assign "^4.0.1"
-    strip-eof "^1.0.0"
-
-execa@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz#4eb6467a36a095fabb2970ff9d5e3fb7bce6ebc3"
-  integrity sha1-TrZGejaglfq7KXD/nV4/t7zm68M=
-  dependencies:
-    cross-spawn-async "^2.1.1"
-    is-stream "^1.1.0"
-    npm-run-path "^1.0.0"
-    object-assign "^4.0.1"
-    path-key "^1.0.0"
-    strip-eof "^1.0.0"
-
-execa@^0.6.0:
-  version "0.6.3"
-  resolved "https://registry.npmjs.org/execa/-/execa-0.6.3.tgz#57b69a594f081759c69e5370f0d17b9cb11658fe"
-  integrity sha1-V7aaWU8IF1nGnlNw8NF7nLEWWP4=
-  dependencies:
-    cross-spawn "^5.0.1"
-    get-stream "^3.0.0"
-    is-stream "^1.1.0"
-    npm-run-path "^2.0.0"
-    p-finally "^1.0.0"
-    signal-exit "^3.0.0"
-    strip-eof "^1.0.0"
-
-execa@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
-  integrity sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=
-  dependencies:
-    cross-spawn "^5.0.1"
-    get-stream "^3.0.0"
-    is-stream "^1.1.0"
-    npm-run-path "^2.0.0"
-    p-finally "^1.0.0"
-    signal-exit "^3.0.0"
-    strip-eof "^1.0.0"
-
-execa@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
-  integrity sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==
-  dependencies:
-    cross-spawn "^6.0.0"
-    get-stream "^4.0.0"
-    is-stream "^1.1.0"
-    npm-run-path "^2.0.0"
-    p-finally "^1.0.0"
-    signal-exit "^3.0.0"
-    strip-eof "^1.0.0"
-
-execa@^2.0.2, execa@^2.0.3:
-  version "2.0.4"
-  resolved "https://registry.npmjs.org/execa/-/execa-2.0.4.tgz#2f5cc589c81db316628627004ea4e37b93391d8e"
-  integrity sha512-VcQfhuGD51vQUQtKIq2fjGDLDbL6N1DTQVpYzxZ7LPIXw3HqTuIz6uxRmpV1qf8i31LHf2kjiaGI+GdHwRgbnQ==
-  dependencies:
-    cross-spawn "^6.0.5"
+    cross-spawn "^7.0.0"
     get-stream "^5.0.0"
+    human-signals "^1.1.1"
     is-stream "^2.0.0"
     merge-stream "^2.0.0"
-    npm-run-path "^3.0.0"
+    npm-run-path "^4.0.0"
     onetime "^5.1.0"
-    p-finally "^2.0.0"
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
@@ -11167,6 +11084,11 @@ https-proxy-agent@^4.0.0:
   dependencies:
     agent-base "5"
     debug "4"
+
+human-signals@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
+  integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
 humanize-ms@^1.2.1:
   version "1.2.1"
@@ -14396,7 +14318,7 @@ lowercase-keys@^2.0.0:
   resolved "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
   integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
 
-lru-cache@^4.0.0, lru-cache@^4.0.1, lru-cache@^4.1.5:
+lru-cache@^4.0.1, lru-cache@^4.1.5:
   version "4.1.5"
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
   integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
@@ -15891,24 +15813,10 @@ npm-run-all@^4.1.5:
     shell-quote "^1.6.1"
     string.prototype.padend "^3.0.0"
 
-npm-run-path@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz#f5c32bf595fe81ae927daec52e82f8b000ac3c8f"
-  integrity sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=
-  dependencies:
-    path-key "^1.0.0"
-
-npm-run-path@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
-  integrity sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=
-  dependencies:
-    path-key "^2.0.0"
-
-npm-run-path@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz#7f91be317f6a466efed3c9f2980ad8a4ee8b0fa5"
-  integrity sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==
+npm-run-path@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
+  integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
 
@@ -16576,11 +16484,6 @@ p-finally@^1.0.0:
   resolved "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
 
-p-finally@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz#bd6fcaa9c559a096b680806f4d657b3f0f240561"
-  integrity sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==
-
 p-is-promise@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz#9c9456989e9f6588017b0434d56097675c3da05e"
@@ -17100,12 +17003,7 @@ path-is-inside@^1.0.1, path-is-inside@^1.0.2, path-is-inside@~1.0.2:
   resolved "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
   integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
 
-path-key@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz#5d53d578019646c0d68800db4e146e6bdc2ac7af"
-  integrity sha1-XVPVeAGWRsDWiADbThRua9wqx68=
-
-path-key@^2.0.0, path-key@^2.0.1:
+path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
@@ -17114,6 +17012,11 @@ path-key@^3.0.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz#99a10d870a803bdd5ee6f0470e58dfcd2f9a54d3"
   integrity sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==
+
+path-key@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
 path-parse@^1.0.6:
   version "1.0.6"
@@ -20262,10 +20165,22 @@ shebang-command@^1.2.0:
   dependencies:
     shebang-regex "^1.0.0"
 
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  dependencies:
+    shebang-regex "^3.0.0"
+
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 shell-quote@^1.6.1:
   version "1.7.2"
@@ -21169,11 +21084,6 @@ strip-comments@^1.0.2:
   dependencies:
     babel-extract-comments "^1.0.0"
     babel-plugin-transform-object-rest-spread "^6.26.0"
-
-strip-eof@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
-  integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
 
 strip-final-newline@^2.0.0:
   version "2.0.0"
@@ -23379,10 +23289,17 @@ which-pm-runs@^1.0.0:
   resolved "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
   integrity sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
 
-which@1, which@1.3.1, which@^1.0.5, which@^1.2.12, which@^1.2.14, which@^1.2.8, which@^1.2.9, which@^1.3.0, which@^1.3.1:
+which@1, which@1.3.1, which@^1.0.5, which@^1.2.12, which@^1.2.14, which@^1.2.9, which@^1.3.0, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.npmjs.org/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
+
+which@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
 


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/BDS-1969 and http://vjira2:8080/browse/BDS-1933

## Summary
Globally updates the version of `execa` used + implements a related temp patch to the Twig renderer.

## Details
- Updated root monorepo `package.json` file resolution
- Updated the dependency version used in build tools utils package.json + scripts/package.json
- Updated execa function calls in `packages/testing/testing-utils/cli/list-pkg-paths-changed.js` and `packages/testing/testing-utils/test-utils.js`
- Upgrades Twig renderer to v0.13 in our testing helpers library + `packages/twig-integration/twig-renderer/package.json`
- Add Twig Renderer patch to fix unavailable port errors
  - Updates our Travis CI config to make sure patch-package is run on every CI task

## How to test
- Confirm tests passing
- Review changes
