### PR TITLE
Headline Component Updates

### DIFF
--- a/packages/components/bolt-headline/headline.schema.yml
+++ b/packages/components/bolt-headline/headline.schema.yml
@@ -60,7 +60,7 @@ properties:
   # The default of `true` here goes against convention but it is forward thinking. [Salem] The goal is to have `autoshrink` to be an opt-in prop (Twig and JS), hence why I don't have this prop called `no-autoshrink` to help us future-proof those updates.
   autoshrink:
     type: boolean
-    description: Automatically shrink the font size used in the xxxlarge headline size  when 60 or more characters are used.
+    description: Automatically shrink the font size used in the `xxxlarge` headline size when 60 or more characters are used.
     default: true
   transform:
     type: string

--- a/packages/components/bolt-headline/headline.schema.yml
+++ b/packages/components/bolt-headline/headline.schema.yml
@@ -34,6 +34,7 @@ properties:
     description: Font weights.
     default: regular
     enum:
+      - light
       - bold
       - regular
       - semibold
@@ -56,6 +57,10 @@ properties:
       - xlarge
       - xxlarge
       - xxxlarge
+  autoshrink:
+    type: boolean
+    description: Automatically shrink the font size used in the xxxlarge headline size  when 60 or more characters are used.
+    default: true
   transform:
     type: string
     description: Text transformation.

--- a/packages/components/bolt-headline/headline.schema.yml
+++ b/packages/components/bolt-headline/headline.schema.yml
@@ -57,6 +57,7 @@ properties:
       - xlarge
       - xxlarge
       - xxxlarge
+  # The default of `true` here goes against convention but it is forward thinking. [Salem] The goal is to have `autoshrink` to be an opt-in prop (Twig and JS), hence why I don't have this prop called `no-autoshrink` to help us future-proof those updates.
   autoshrink:
     type: boolean
     description: Automatically shrink the font size used in the xxxlarge headline size  when 60 or more characters are used.

--- a/packages/components/bolt-headline/src/_tools.headlines.scss
+++ b/packages/components/bolt-headline/src/_tools.headlines.scss
@@ -48,6 +48,10 @@
   &--bold {
     @include bolt-font-weight(bold);
   }
+
+  &--light {
+    @include bolt-font-weight(light);
+  }
 }
 
 

--- a/packages/components/bolt-headline/src/_typography.twig
+++ b/packages/components/bolt-headline/src/_typography.twig
@@ -26,6 +26,7 @@
 {% set type = type in types ? type : "text" %}
 {% set size = size | default(schema.properties.size.default) %}
 
+{% set autoshrink = autoshrink is defined ? autoshrink : schema.properties.autoshrink.default %}
 
 {# For backwards compatibility only, setting icon to exactly 'false' is the same as specifying 'none'.  Deprecated. #}
 {% if icon is sameas(false) %}
@@ -60,7 +61,7 @@
 {% set baseClass = prefix ~ type %}
 {% set attributes = create_attribute(attributes|default({})) %}
 
-{% if (size == "xxxlarge") and (text|length >= 60) %}
+{% if (size == "xxxlarge") and (text|length >= 60) and autoshrink == true %}
   {% set longTitle = true %}
 {% endif %}
 

--- a/packages/components/bolt-headline/src/headline.scss
+++ b/packages/components/bolt-headline/src/headline.scss
@@ -18,6 +18,10 @@ $bolt-headline--plus-letter-spacing: 0.05rem;
 .c-bolt-eyebrow,
 .c-bolt-text {
   @include bolt-headline;
+
+  strong {
+    @include bolt-font-weight(bold);
+  }
 }
 
 .c-bolt-headline {


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/BDS-1954

## Summary
New options to our Headline component to better support the Academy designs

## Details
- Adds a new `light` font weight option
- Adds a new `autoshrink` prop to prevent text from automatically shrinking in size if over a certain letter count
- Makes `<strong>` tags used within eyebrows / text use a bold font weight

## How to test
- Review changes