### PR TITLE
Update Slotify Internal `templateMap` API

### DIFF
--- a/packages/base-element/src/Slotify.js
+++ b/packages/base-element/src/Slotify.js
@@ -2,7 +2,7 @@
 import { LitElement } from 'lit-element';
 
 export class Slotify extends LitElement {
-  templateMap = new Map();
+  slotMap = new Map();
 
   assignSlotToContent(child) {
     return child.getAttribute
@@ -14,13 +14,13 @@ export class Slotify extends LitElement {
     return child && (!child.textContent || !child.textContent.trim());
   }
 
-  addChildToTemplateMap(slot, child) {
+  addChildToSlotMap(slot, child) {
     if (!slot) return;
 
-    if (!this.templateMap.has(slot)) {
-      this.templateMap.set(slot, [child]);
+    if (!this.slotMap.has(slot)) {
+      this.slotMap.set(slot, [child]);
     } else {
-      this.templateMap.set(slot, [...this.templateMap.get(slot), child]);
+      this.slotMap.set(slot, [...this.slotMap.get(slot), child]);
     }
   }
 
@@ -30,9 +30,9 @@ export class Slotify extends LitElement {
       const slot = this.assignSlotToContent(child);
 
       if (!child.textContent || child.textContent.trim().length > 0) {
-        this.addChildToTemplateMap(slot, child);
+        this.addChildToSlotMap(slot, child);
       } else if (slot && child instanceof HTMLElement) {
-        this.addChildToTemplateMap(slot, child);
+        this.addChildToSlotMap(slot, child);
       }
     });
   }
@@ -46,7 +46,7 @@ export class Slotify extends LitElement {
   }
 
   slotify(slot = 'default', defaultContent) {
-    const slotContent = this.templateMap.get(slot);
+    const slotContent = this.slotMap.get(slot);
 
     // render actualy slots if Shadow DOM supported + getting used
     // @todo: what's a better way to allow customizing the checks to perform?

--- a/packages/components/bolt-button/src/button.js
+++ b/packages/components/bolt-button/src/button.js
@@ -89,7 +89,7 @@ class BoltButton extends BoltActionElement {
           `}${this.slotify('default') &&
           html`
             <span class="${itemClasses}">${this.slotify('default')}</span>
-          `}${this.slotify('after') &&
+          `}${this.slotMap.get('after') &&
           html`
             <span class="${iconClasses}"
               ><span class="${sizerClasses}"

--- a/packages/components/bolt-link/src/link.js
+++ b/packages/components/bolt-link/src/link.js
@@ -71,13 +71,13 @@ class BoltLink extends BoltActionElement {
     // prettier-ignore
 
     const innerSlots = html`${
-      this.templateMap.get('before')
+      this.slotMap.get('before')
         ? html`<span class="${cx(`c-bolt-link__icon`)}">&#xfeff;${this.slotify('before')}</span>`
         : html`<slot name="before" />`}${
-      this.templateMap.get('default')
+      this.slotMap.get('default')
         ? html`<span class="${cx(`c-bolt-link__text`)}">${this.slotify('default')}</span>`
         : html`<slot />`}${
-      this.templateMap.get('after')
+      this.slotMap.get('after')
         ? html`<span class="${cx(`c-bolt-link__icon`)}">&#xfeff;${this.slotify('after')}</span>`
         : html`<slot name="after" />`}`;
 


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/BDS-1964?filter=-1

## Summary
Renames the internal map used in Slotify from being named `templateMap` to `slotMap` (note: was originally used by the new Card component so an update might be needed after merging this in).

This also requires us to update the Slotify API referenced in a handful of new components (Button and Link).

## How to test
- Confirm tests pass as expected
