### PR TITLE
Add Overflow Hidden to "Site" Content Container

### DIFF
--- a/packages/components/bolt-site/site.scss
+++ b/packages/components/bolt-site/site.scss
@@ -55,7 +55,7 @@
   width: 100%;
   grid-column-start: 1;
   grid-column-end: 3;
-  // grid-column: 2 / -2;
+  overflow: hidden; // needed in order to crop off whitespace from negative vertical margins
 }
 
 .c-bolt-site__content--middle {


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/BDS-1959

## Summary
Small CSS update to the "Site" component to prevent negative margin offsets from adding extra whitespace on the bottom of the page + shadows from spilling out.

![image](https://user-images.githubusercontent.com/1617209/71852379-92927e80-30a6-11ea-8e7f-e9f421535aa9.png)

This update was originally required for Academy's homepage designs but could also be used in any places where we want to have Cards getting pulled up / over into neighboring sections.    

> Side note 1. I know `overflow: hidden;` might look scary but considering that anything that would normally overflow (ex. the global header / dropdown) is contained within a separate region, this PR should have a quite low risk.

> Side note 2. The original homepage build absolutely required this but the most recent iteration seems to tolerate not having this slightly more (although shadows still spill out). I'd still rather see us get this in given the extra whitespace problems probably will return elsewhere otherwise. 
 
## How to test
- ? Any thoughts?
