### PR TITLE
Chore/schema cleanup

### DIFF
--- a/packages/components/bolt-logo/logo.schema.yml
+++ b/packages/components/bolt-logo/logo.schema.yml
@@ -6,4 +6,3 @@ properties:
   invert:
     type: boolean
     description: Set to true to invert the logo colors.
-additionalProperties: true

--- a/packages/components/bolt-pagination/pagination.schema.yml
+++ b/packages/components/bolt-pagination/pagination.schema.yml
@@ -14,11 +14,11 @@ properties:
       - end
       - center
   total:
-    type: number
+    type: integer
     title: Total pages
     description: Total pages within the pagination
   current:
-    type: number
+    type: integer
     title: Current page
     description: Current page selected
   pages:

--- a/packages/components/bolt-share/share.schema.yml
+++ b/packages/components/bolt-share/share.schema.yml
@@ -61,8 +61,8 @@ properties:
     type: object
     ref: '@bolt-components-copy-to-clipboard/copy-to-clipboard.schema.yml'
   inline:
-    title: DPRECATED.
+    title: DEPRECATED.
     description: Button version has been removed so this prop is no longer needed.
   copyToClipboard:
-    title: DPRECATED.
+    title: DEPRECATED.
     description: Please use copy_to_clipboard.

--- a/packages/components/bolt-tabs/tabs.schema.yml
+++ b/packages/components/bolt-tabs/tabs.schema.yml
@@ -47,8 +47,8 @@ properties:
     default: auto
     enum:
       - auto
-      - 'on'
-      - 'off'
+      - on
+      - off
   selected_tab:
     type: integer
     description: Set selected tab by number. To select the second tab, set to 2.


### PR DESCRIPTION
## Jira

Schema cleanup (no ticket)

## Summary

Fix typo or consistency errors I found when surveying schema files.

## Details

 -  Remove `additionalProperties: true` from `logo.schema.yml`. @remydenton  says this is the default.
 - `pagination.schema.yml` has `total` and `current` pages as `number`, but that would include floating point. Moved to `integer`. https://json-schema.org/understanding-json-schema/reference/numeric.html#number I can't find `number` in `YAML` spec: https://yaml.org/spec/1.2/spec.html
 -  Fix`share.schema.yml` properties `inline` and `copyToClipboard` titles set to `DPRECATED` rather than `DEPRECATED`.
 - Anal retentive fix.`tabs.schema.yml` does not quote `auto` while `on` and `off` are quoted. I unquoted `on` and `off`

## How to test

