### PR TITLE
feat(button): add a proposed slot property to button schema to docume…

### DIFF
--- a/packages/components/bolt-button/button.schema.js
+++ b/packages/components/bolt-button/button.schema.js
@@ -31,16 +31,16 @@ module.exports = {
   },
   slots: {
     default: {
-      type: 'object',
+      type: 'string',
       description: 'Button title text.',
     },
     before: {
-      type: 'object',
+      type: 'string',
       description:
         'Anything passed to this slot will go before the button text.',
     },
     after: {
-      type: 'object',
+      type: 'string',
       description:
         'Anything passed to this slot will go after the button text.',
     },

--- a/packages/components/bolt-button/button.schema.js
+++ b/packages/components/bolt-button/button.schema.js
@@ -29,6 +29,22 @@ module.exports = {
       },
     ],
   },
+  slots: {
+    default: {
+      type: 'object',
+      description: 'Button title text.',
+    },
+    before: {
+      type: 'object',
+      description:
+        'Anything passed to this slot will go before the button text.',
+    },
+    after: {
+      type: 'object',
+      description:
+        'Anything passed to this slot will go after the button text.',
+    },
+  },
   properties: {
     attributes: {
       type: 'object',


### PR DESCRIPTION
…nt slots

## Jira

https://app.asana.com/0/1126340469288208/1156288417263591/f

## Summary

Add a proposed `slot` property to button schema.

## Details

Currently, the Editor [manually adds slots, non-programmatically](https://github.com/boltdesignsystem/bolt/blob/master/packages/experimental/editor/src/setup-bolt.js#L500). This means that if a `slot` is added to a component or changed, it would need to be added also to the Editor. To fix that, I'm proposing that we add at `slots` property to our schema files. This will allow us to programmatically add slots in the Editor based on schema and will also auto-detect slots on components like Button (we currently don't support slots on Button, but if slots were in schema, it would happen automatically).

This is just a proposal for what a `slots` property would look like, using Button as an example.

Thoughts?