### PR TITLE
Webpack DLL / Polyfill Workaround

### DIFF
--- a/packages/base-element/index.js
+++ b/packages/base-element/index.js
@@ -1,3 +1,5 @@
+// temp workaround to auto-injected polyfills not getting bundled when Webpack DLL plugin is run outside of the Bolt Build tools
+import '@bolt/polyfills';
 export { BoltElement } from './src/BoltElement';
 export { BoltActionElement } from './src/BoltActionElement';
 export { Slotify } from './src/Slotify';

--- a/packages/base-element/package.json
+++ b/packages/base-element/package.json
@@ -6,6 +6,7 @@
   "main": "index.js",
   "dependencies": {
     "@bolt/core-v3.x": "^2.14.0",
+    "@bolt/polyfills": "^2.14.0",
     "lit-element": "2.2.1"
   },
   "publishConfig": {


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/AC-382

## Summary
Temporary workaround to address a Babel regenerator runtime JS error getting thrown after running the  Bolt Build Tools externally with the Webpack DLL plugin added on top.

## How to test
Testing this within Bolt isn't currently possible until the Webpack DLL plugin work is folded within the design system itself; our next best thing would be to retest a new build after this goes out the door.