### PR TITLE
fix: address HTML rendering / escaping issue w/ Card Replacement Body in Drupal

### DIFF
--- a/packages/components/bolt-card-replacement/src/card-replacement-body/_card-replacement-body.twig
+++ b/packages/components/bolt-card-replacement/src/card-replacement-body/_card-replacement-body.twig
@@ -11,7 +11,7 @@
     {% block body %}
       {% if card_replacement_body_content %}
         {# @todo: The replace function is a hack to get around the utf-8 bug. #}
-        {{ card_replacement_body_content | join | replace({"UTF-8": ""}) }}
+        {{ card_replacement_body_content | join | replace({"UTF-8": ""}) | raw }}
       {% else %}
         {% set card_replacement_eyebrow = body.eyebrow %}
         {% set card_replacement_headline = body.headline %}


### PR DESCRIPTION
## Jira
N/A

## Summary
Implements a small Twig update to the new Card component's Body template to address an auto-escaping / HTML encoding issue identified in Drupal. 

## Details
This update (confirmed locally in Drupal after troubleshooting with the Academy team) fixes HTML content passed into the Card Body from rendering as plain text (vs actually rendering HTML).

## How to Test
N/A -  already tested the fix in Drupal + spot checked in Pattern Lab to ensure everything on our end continues to render as expected.