### PR TITLE
feat(editor): add prop schema descriptions underneath traits

### DIFF
--- a/packages/experimental/editor/src/editor.js
+++ b/packages/experimental/editor/src/editor.js
@@ -426,6 +426,29 @@ export function enableEditor({ space, uiWrapper, config }) {
     render(content, editorSlots.slotControls);
   }
 
+  /**
+   * Add prop schema descriptions underneath traits on select if not present.
+   *
+   * @param {grapesjs.Component} model
+   * @return {void}
+   */
+  editor.on('component:selected', model => {
+    model.attributes.traits.models.forEach(trait => {
+      if (trait.attributes.description) {
+        // setTimeout because view hasn't yet been created for trait in component:selected.
+        setTimeout(() => {
+          const traitDescClass = 'trait-description';
+          if (trait.view.el.lastElementChild.getAttribute('class') !== traitDescClass) {
+            const template = document.createElement('template');
+            template.innerHTML = `<div class="${traitDescClass}" style="font-size: smaller"><i>${trait.attributes.description}</i></div>`;
+            trait.view.el.appendChild(template.content.firstChild);
+          }
+        }, 0);
+      }
+
+    });
+  });
+
   editor.on('component:selected', (/** @type {grapesjs.Component} */ model) => {
     const name = model.getName().toLowerCase();
     const slotControls = model.getSlotControls && model.getSlotControls();

--- a/packages/experimental/editor/src/utils.js
+++ b/packages/experimental/editor/src/utils.js
@@ -42,6 +42,7 @@ export function convertSchemaPropToTrait({ name, prop }) {
     label: prop.title || name,
     name: kebabCase(name),
     type: 'text',
+    description: prop.description ? prop.description : '',
   };
 
   if (prop.default) trait.default = prop.default;


### PR DESCRIPTION
## Jira

https://app.asana.com/0/1126340469288208/1157449394066073/f

## Summary

Add prop schema descriptions underneath traits.

## Details
I chose the approach I did (appending our own div to existing traits at runtime) because otherwise we would have to create custom traits from scratch, and traits are extendible, so we'd have had to create them all from scratch.

Before:
<img width="135" alt="image" src="https://user-images.githubusercontent.com/1361104/72556622-a12a2400-3864-11ea-9bb9-2f4aa03966fc.png">

After:
<img width="148" alt="image" src="https://user-images.githubusercontent.com/1361104/72556563-82c42880-3864-11ea-9c3d-ba62445acc70.png">

## How to test

Edit components. See that the descriptions from their prop schema are added underneath the traits in editor. Make sure editor still works.
