### PR TITLE
Ship new Banner component originally slated for v2.15.0

### DIFF
--- a/docs-site/.boltrc.js
+++ b/docs-site/.boltrc.js
@@ -106,6 +106,7 @@ const config = {
       '@bolt/components-background',
       '@bolt/components-background-shapes',
       '@bolt/components-band',
+      '@bolt/components-banner',
       '@bolt/components-block-list',
       '@bolt/components-blockquote',
       '@bolt/components-breadcrumb',

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -37,6 +37,7 @@
     "@bolt/components-background": "^2.15.0",
     "@bolt/components-background-shapes": "^2.15.0",
     "@bolt/components-band": "^2.15.0",
+    "@bolt/components-banner": "^0.0.0",
     "@bolt/components-block-list": "^2.15.0",
     "@bolt/components-blockquote": "^2.15.0",
     "@bolt/components-breadcrumb": "^2.15.0",

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/banner/00-banner-docs.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/banner/00-banner-docs.twig
@@ -1,0 +1,10 @@
+{% set usage %}{% verbatim %}
+{% include "@bolt-components-banner/banner.twig" with {
+  content: "This is the banner content."
+} only %}
+{% endverbatim %}{% endset %}
+
+{% include "@utils/docs.twig" with {
+  componentName: "banner",
+  usage: usage
+} only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/banner/05-banner.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/banner/05-banner.twig
@@ -1,0 +1,5 @@
+{# Start component specific code #}
+{% include "@bolt-components-banner/banner.twig" with {
+  content: "This is a banner",
+} only %}
+{# End component specific code #}

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/banner/10-banner-status-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/banner/10-banner-status-variations.twig
@@ -1,0 +1,14 @@
+{# Setting variables for demo purposes #}
+{% set schema = bolt.data.components["@bolt-components-banner"].schema %}
+
+<bolt-text headline>
+  Status
+</bolt-text>
+{% for status in schema.properties.status.enum %}
+  {# Start component specific code #}
+  {% include "@bolt-components-banner/banner.twig" with {
+    content: "This banner is trying to convey " ~ status,
+    status: status,
+  } only %}
+  {# End component specific code #}
+{% endfor %}

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/banner/15-banner-align-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/banner/15-banner-align-variations.twig
@@ -1,0 +1,14 @@
+{# Setting variables for demo purposes #}
+{% set schema = bolt.data.components["@bolt-components-banner"].schema %}
+
+<bolt-text headline>
+  Text alignment
+</bolt-text>
+{% for align in schema.properties.align.enum %}
+  {# Start component specific code #}
+  {% include "@bolt-components-banner/banner.twig" with {
+    content: "This banner's text is aligned to the " ~ align,
+    align: align,
+  } only %}
+  {# End component specific code #}
+{% endfor %}

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/banner/20-banner-use-case-status-report.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/banner/20-banner-use-case-status-report.twig
@@ -1,0 +1,22 @@
+{# Setting variables for demo purposes #}
+{% set link %}
+{% include "@bolt-components-link/link.twig" with {
+  text: "View Details",
+  url: "https://pega.com",
+} only %}
+{% endset %}
+
+<bolt-text headline>
+  Academy Challenge Status
+</bolt-text>
+{# Start component specific code #}
+{% include "@bolt-components-banner/banner.twig" with {
+  content: "You passed this challenge on <strong>May 21, 2020</strong>. " ~ link,
+  status: "success"
+} only %}
+
+{% include "@bolt-components-banner/banner.twig" with {
+  content: "You failed this challenge on <strong>May 21, 2020</strong>. " ~ link,
+  status: "error"
+} only %}
+{# End component specific code #}

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/banner/999-banner-with-web-component.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/banner/999-banner-with-web-component.twig
@@ -1,0 +1,43 @@
+{% macro code_example(code) %}
+  <div class="t-bolt-light u-bolt-margin-bottom-small u-bolt-padding-medium">
+    {% grid %}
+      {% cell "u-bolt-width-12/12" %}
+        {{ code }}
+      {% endcell %}
+    {% endgrid %}
+  </div>
+  <div class="u-bolt-margin-bottom-large">
+    <bolt-code-snippet syntax="dark" lang="html">{% spaceless %}
+      {{ code | replace({
+        '<': '&lt;',
+        '>': '&gt;',
+      }) | trim | raw }}
+    {% endspaceless %}</bolt-code-snippet>
+  </div>
+{% endmacro %}
+
+{% import _self as banner_example %}
+
+{% set banner_demo %}
+<bolt-banner>
+  This is a banner
+</bolt-banner>
+{% endset %}
+
+{% set banner_prop_demo %}
+<bolt-banner status="success" align="start">
+  You passed this challenge on <strong>May 21, 2020</strong>. <bolt-link url="https://pega.com">View Details</bolt-link>
+</bolt-banner>
+{% endset %}
+
+<bolt-text headline>Web Component Usage</bolt-text>
+<bolt-text>
+  Bolt Banner is a web component, you can simply use <bolt-code-snippet display="inline" lang="html">&lt;bolt-banner&gt;</bolt-code-snippet> in the markup to make it render.
+</bolt-text>
+{% include banner_example.code_example(banner_demo) %}
+
+<bolt-text headline>Prop Usage</bolt-text>
+<bolt-text>
+  Configure the banner with the properties specified in the schema.
+</bolt-text>
+{% include banner_example.code_example(banner_prop_demo) %}

--- a/packages/components/bolt-banner/README.md
+++ b/packages/components/bolt-banner/README.md
@@ -1,0 +1,7 @@
+Banner component. Part of the Bolt “Components” CSS framework that powers the [Bolt Design System](https://www.boltdesignsystem.com).
+
+###### Install via NPM
+
+```
+npm install @bolt/components-banner
+```

--- a/packages/components/bolt-banner/__tests__/__snapshots__/banner.js.snap
+++ b/packages/components/bolt-banner/__tests__/__snapshots__/banner.js.snap
@@ -1,0 +1,81 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<bolt-banner> Component Basic usage 1`] = `
+<bolt-banner>
+  <replace-with-grandchildren>
+    <div class="c-bolt-banner c-bolt-banner--status-information   c-bolt-banner--align-center c-bolt-banner--full">
+      This is a banner
+    </div>
+  </replace-with-grandchildren>
+</bolt-banner>
+`;
+
+exports[`<bolt-banner> Component Status of the banner message: error 1`] = `
+<bolt-banner status="error">
+  <replace-with-grandchildren>
+    <div class="c-bolt-banner c-bolt-banner--status-error t-bolt-dark  c-bolt-banner--align-center c-bolt-banner--full">
+      This banner is trying to convey error
+    </div>
+  </replace-with-grandchildren>
+</bolt-banner>
+`;
+
+exports[`<bolt-banner> Component Status of the banner message: information 1`] = `
+<bolt-banner status="information">
+  <replace-with-grandchildren>
+    <div class="c-bolt-banner c-bolt-banner--status-information   c-bolt-banner--align-center c-bolt-banner--full">
+      This banner is trying to convey information
+    </div>
+  </replace-with-grandchildren>
+</bolt-banner>
+`;
+
+exports[`<bolt-banner> Component Status of the banner message: success 1`] = `
+<bolt-banner status="success">
+  <replace-with-grandchildren>
+    <div class="c-bolt-banner c-bolt-banner--status-success  t-bolt-dark c-bolt-banner--align-center c-bolt-banner--full">
+      This banner is trying to convey success
+    </div>
+  </replace-with-grandchildren>
+</bolt-banner>
+`;
+
+exports[`<bolt-banner> Component Status of the banner message: warning 1`] = `
+<bolt-banner status="warning">
+  <replace-with-grandchildren>
+    <div class="c-bolt-banner c-bolt-banner--status-warning   c-bolt-banner--align-center c-bolt-banner--full">
+      This banner is trying to convey warning
+    </div>
+  </replace-with-grandchildren>
+</bolt-banner>
+`;
+
+exports[`<bolt-banner> Component Text alignment: center 1`] = `
+<bolt-banner align="center">
+  <replace-with-grandchildren>
+    <div class="c-bolt-banner c-bolt-banner--status-information   c-bolt-banner--align-center c-bolt-banner--full">
+      The text is aligned to the center
+    </div>
+  </replace-with-grandchildren>
+</bolt-banner>
+`;
+
+exports[`<bolt-banner> Component Text alignment: end 1`] = `
+<bolt-banner align="end">
+  <replace-with-grandchildren>
+    <div class="c-bolt-banner c-bolt-banner--status-information   c-bolt-banner--align-end c-bolt-banner--full">
+      The text is aligned to the end
+    </div>
+  </replace-with-grandchildren>
+</bolt-banner>
+`;
+
+exports[`<bolt-banner> Component Text alignment: start 1`] = `
+<bolt-banner align="start">
+  <replace-with-grandchildren>
+    <div class="c-bolt-banner c-bolt-banner--status-information   c-bolt-banner--align-start c-bolt-banner--full">
+      The text is aligned to the start
+    </div>
+  </replace-with-grandchildren>
+</bolt-banner>
+`;

--- a/packages/components/bolt-banner/__tests__/banner.js
+++ b/packages/components/bolt-banner/__tests__/banner.js
@@ -1,0 +1,48 @@
+import {
+  isConnected,
+  render,
+  renderString,
+  stopServer,
+  html,
+} from '../../../testing/testing-helpers';
+import schema from '../banner.schema';
+const { status, align } = schema.properties;
+const timeout = 120000;
+
+describe('<bolt-banner> Component', () => {
+  afterAll(async () => {
+    await stopServer();
+  }, 100);
+
+  // Basic Usage
+  test('Basic usage', async () => {
+    const results = await render('@bolt-components-banner/banner.twig', {
+      content: 'This is a banner',
+    });
+    expect(results.ok).toBe(true);
+    expect(results.html).toMatchSnapshot();
+  });
+
+  // Props
+  status.enum.forEach(async statusChoice => {
+    test(`Status of the banner message: ${statusChoice}`, async () => {
+      const results = await render('@bolt-components-banner/banner.twig', {
+        content: `This banner is trying to convey ${statusChoice}`,
+        status: statusChoice,
+      });
+      expect(results.ok).toBe(true);
+      expect(results.html).toMatchSnapshot();
+    });
+  });
+
+  align.enum.forEach(async alignChoice => {
+    test(`Text alignment: ${alignChoice}`, async () => {
+      const results = await render('@bolt-components-banner/banner.twig', {
+        content: `The text is aligned to the ${alignChoice}`,
+        align: alignChoice,
+      });
+      expect(results.ok).toBe(true);
+      expect(results.html).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/components/bolt-banner/banner.schema.js
+++ b/packages/components/bolt-banner/banner.schema.js
@@ -1,0 +1,38 @@
+module.exports = {
+  $schema: 'http://json-schema.org/draft-04/schema#',
+  title: 'Banner',
+  description:
+    'A content container that delivers important messages to the user.',
+  type: 'object',
+  required: ['content'],
+  properties: {
+    attributes: {
+      type: 'object',
+      description:
+        'A Drupal attributes object. Applies extra HTML attributes to the outer &lt;bolt-menu&gt; tag.',
+    },
+    content: {
+      type: 'any',
+      description:
+        'Renders the content of the banner. While any element can be passed, only text and links are recommended because banner messages are supposed to be concise.',
+    },
+    status: {
+      type: 'string',
+      description: 'Sets the status that the banner is trying to convey.',
+      enum: ['error', 'warning', 'success', 'information'],
+      default: 'information',
+    },
+    align: {
+      type: 'string',
+      description: 'Sets the text alignment of the content.',
+      enum: ['start', 'center', 'end'],
+      default: 'center',
+    },
+    full: {
+      type: 'boolean',
+      description:
+        'Sets the width of the banner to take up 100% of the screen width.',
+      default: false,
+    },
+  },
+};

--- a/packages/components/bolt-banner/index.js
+++ b/packages/components/bolt-banner/index.js
@@ -1,0 +1,7 @@
+import { polyfillLoader } from '@bolt/core-v3.x/polyfills';
+
+polyfillLoader.then(res => {
+  import(
+    /* webpackMode: 'eager', webpackChunkName: 'bolt-banner' */ './src/banner'
+  );
+});

--- a/packages/components/bolt-banner/index.scss
+++ b/packages/components/bolt-banner/index.scss
@@ -1,0 +1,1 @@
+@import 'src/banner';

--- a/packages/components/bolt-banner/package.json
+++ b/packages/components/bolt-banner/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@bolt/components-banner",
+  "version": "0.0.0",
+  "description": "A content container that delivers important messages to the user.",
+  "keywords": [
+    "bolt design system",
+    "bolt",
+    "css framework",
+    "design system",
+    "components",
+    "banner"
+  ],
+  "homepage": "https://boltdesignsystem.com",
+  "bugs": "https://github.com/bolt-design-system/bolt/issues",
+  "repository": "https://github.com/bolt-design-system/bolt/tree/master/packages/components/bolt-banner",
+  "license": "MIT",
+  "main": "index.js",
+  "style": "index.scss",
+  "dependencies": {
+    "@bolt/core-v3.x": "^2.14.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "gitHead": "d41aa75ae3d195d9d7fb3952eed5e0ae80988133",
+  "maintainers": [
+    {
+      "name": "Salem Ghoweri",
+      "email": "me@salemghoweri.com",
+      "web": "https://github.com/sghoweri"
+    },
+    {
+      "name": "Mike Mai",
+      "email": "boss@mikemai.net",
+      "web": "http://mikemai.net/"
+    },
+    {
+      "name": "Dan Morse",
+      "web": "https://github.com/danielamorse"
+    }
+  ],
+  "schema": "banner.schema.js",
+  "twig": "src/banner.twig"
+}

--- a/packages/components/bolt-banner/src/banner.js
+++ b/packages/components/bolt-banner/src/banner.js
@@ -1,0 +1,50 @@
+import { customElement, BoltElement, html, unsafeCSS } from '@bolt/element';
+import classNames from 'classnames/dedupe';
+import bannerStyles from './banner.scss';
+import schema from '../banner.schema';
+
+let cx = classNames.bind(bannerStyles);
+
+@customElement('bolt-banner')
+class BoltBanner extends BoltElement {
+  static get properties() {
+    return {
+      status: String,
+      align: String,
+      full: {
+        type: Boolean,
+        reflect: true,
+      },
+    };
+  }
+
+  constructor() {
+    super();
+  }
+
+  static get styles() {
+    return [unsafeCSS(bannerStyles)];
+  }
+
+  render() {
+    const status = this.status || schema.properties.status.default;
+    const align = this.align || schema.properties.align.default;
+    const full = this.full || schema.properties.full.default;
+
+    const classes = cx('c-bolt-banner', {
+      [`c-bolt-banner--status-${status}`]: status,
+      [`t-bolt-dark`]:
+        (status && status === 'error') || (status && status === 'success'),
+      [`c-bolt-banner--align-${align}`]: align,
+      [`c-bolt-banner--full`]: full,
+    });
+
+    return html`
+      <div class="${classes}">
+        ${this.slotify('default')}
+      </div>
+    `;
+  }
+}
+
+export { BoltBanner };

--- a/packages/components/bolt-banner/src/banner.scss
+++ b/packages/components/bolt-banner/src/banner.scss
@@ -1,0 +1,105 @@
+/* ------------------------------------ *\
+   Banner
+\* ------------------------------------ */
+@import '@bolt/core-v3.x';
+
+/**
+ * Register custom element
+ */
+@include bolt-repeat-rule(('bolt-banner', ':host')) {
+  display: block;
+
+  &:not(:last-child) {
+    @include bolt-margin-bottom(medium);
+  }
+}
+
+.c-bolt-banner {
+  @include bolt-padding(medium, squished);
+  display: block;
+
+  &--full {
+    @include bolt-full-bleed;
+  }
+}
+
+/**
+ * Status prop
+ * @todo: we don't have a good way to create more themes on the fly. We should consider creating 'Light Mode' and 'Dark Mode', then background-color can be set separately.
+ * 1. Hacking the colors in modern browsers.
+ * 2. Hacking the colors in IE.
+ */
+.c-bolt-banner--status-error,
+.c-bolt-banner--status-success {
+  --bolt-theme-headline-link: bolt-color(black); /* [1] */
+  --bolt-theme-headline: bolt-color(black); /* [1] */
+  --bolt-theme-link: bolt-color(black); /* [1] */
+  --bolt-theme-text: bolt-color(black); /* [1] */
+
+  color: bolt-color(white);
+}
+
+.c-bolt-banner--status-error {
+  background-color: bolt-color(error);
+
+  &[class*='t-bolt-dark'] {
+    background-color: bolt-color(error); /* [2] */
+  }
+}
+
+.c-bolt-banner--status-warning {
+  color: bolt-color(black);
+  background-color: bolt-color(warning);
+}
+
+.c-bolt-banner--status-success {
+  background-color: bolt-color(success);
+
+  &[class*='t-bolt-dark'] {
+    background-color: bolt-color(success); /* [2] */
+  }
+}
+
+.c-bolt-banner--status-information {
+  position: relative;
+  color: bolt-theme(text);
+  border-left-color: bolt-theme(link);
+  border-left-style: $bolt-border-style;
+  border-left-width: $bolt-border-width * 3;
+  box-shadow: 0 0 bolt-spacing(xxsmall) bolt-theme(neutral, bolt-opacity(20));
+  background-color: bolt-theme(background);
+
+  @include bolt-ie11-only {
+    box-shadow: 0 0 bolt-spacing(xsmall) bolt-theme(neutral, bolt-opacity(40));
+  }
+
+  &:before {
+    content: '';
+    display: block;
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    pointer-events: none;
+    user-select: none;
+    background-color: rgba(bolt-color(white), bolt-opacity(20));
+  }
+}
+
+/**
+ * Align prop
+ */
+.c-bolt-banner--align-start {
+  text-align: left;
+  text-align: start;
+}
+
+.c-bolt-banner--align-center {
+  text-align: center;
+}
+
+.c-bolt-banner--align-end {
+  text-align: right;
+  text-align: end;
+}

--- a/packages/components/bolt-banner/src/banner.twig
+++ b/packages/components/bolt-banner/src/banner.twig
@@ -1,0 +1,47 @@
+{% set schema = bolt.data.components["@bolt-components-banner"].schema %}
+
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(schema, _self) | raw }}
+{% endif %}
+
+{# Variables #}
+{% set base_class = "c-bolt-banner" %}
+{% set this = init(schema) %}
+{% set inner_attributes = create_attribute({}) %}
+
+{# Array of classes based on the defined + default props #}
+{% set classes = [
+  base_class,
+  this.data.status ? base_class ~ "--status-" ~ this.data.status.value,
+  this.data.status.value == "error" ? "t-bolt-dark",
+  this.data.status.value == "success" ? "t-bolt-dark",
+  this.data.align ? base_class ~ "--align-" ~ this.data.align.value,
+  this.data.full ? base_class ~ "--full",
+] %}
+
+{#
+  Sort classes passed in via attributes into two groups:
+  1. Those that should be applied to the inner tag (namely, "is-" and "has-" classes)
+  2. Those that should be applied to the outer custom element (everything else EXCEPT c-bolt-* classes, which should never be passed in via attributes)
+#}
+{% set outer_classes = [] %}
+{% set inner_classes = classes %}
+
+{% for class in this.props.class %}
+  {% if class starts with "is-" or class starts with "has-" %}
+    {% set inner_classes = inner_classes|merge([class]) %}
+  {% elseif class starts with "c-bolt-" == false %}
+    {% set outer_classes = outer_classes|merge([class]) %}
+  {% endif %}
+{% endfor %}
+
+<bolt-banner
+  {% if outer_classes %} class="{{ outer_classes|join(' ') }}" {% endif %}
+  {{ this.props|without("content")|without("class") }}
+>
+  <replace-with-grandchildren>
+    <div {% if inner_classes %} class="{{ inner_classes|join(' ') }}" {% endif %}>
+      {{ content }}
+    </div>
+  </replace-with-grandchildren>
+</bolt-banner>


### PR DESCRIPTION
Shipping the new Banner component work from https://github.com/boltdesignsystem/bolt/pull/1693 that didn't get merged down to the correct branch before the release was cut!

## Jira

http://vjira2:8080/browse/BDS-1891

## Summary

Introduces a new component called Banner: a content container that delivers important messages to the user.

## Details

1. `status` prop indicates what kind of message.
2. `align` prop controls text-alignment.
3. Fully built out the JS and Twig.
4. Documented all props and existing use cases (mainly used on Academy Challenge Details page).

## How to test

Pull down the branch and run locally. Review the code and the docs.
