### PR TITLE
debug(editor): twig render is failing for editor... why?

### DIFF
--- a/packages/experimental/editor/__tests__/editor.js
+++ b/packages/experimental/editor/__tests__/editor.js
@@ -1,0 +1,30 @@
+import { html, render, stopServer } from '@bolt/testing-helpers';
+
+const timeout = 120000;
+
+describe('GrapesJS Editor', () => {
+  let page;
+
+  beforeEach(async () => {
+    await page.evaluate(() => {
+      document.body.innerHTML = '';
+    });
+  }, timeout);
+
+  beforeAll(async () => {
+    page = await global.__BROWSER__.newPage();
+    await page.goto('http://127.0.0.1:4444/', {
+      timeout: 0,
+    });
+  }, timeout);
+
+  afterAll(async () => {
+    await stopServer();
+    await page.close();
+  }, timeout);
+
+  test('basic editor', async () => {
+    const results = await render('@bolt-components-editor/editor.twig', {});
+    expect(results.html).toContain('Edit');
+  });
+});


### PR DESCRIPTION
I've copied a test structure directly from `packages/components/bolt-accordion/__tests__/accordion.js` and my test looks identical.

But when I run `npx jest packages/experimental/editor/__tests__/editor.js`

I get:

```
    expect(received).toContain(expected) // indexOf

    Expected substring: "Edit"
    Received string:    "<pre><code>Error trying to render \"@bolt-components-editor/editor.twig\". Template \"@bolt-components-editor/editor.twig\" is not defined.</code></pre>"

      26 |   test('basic editor', async () => {
      27 |     const results = await render('@bolt-components-editor/editor.twig', {});
    > 28 |     expect(results.html).toContain('Edit');
         |                          ^
      29 |   });
      30 | });
      31 |

      at Object.<anonymous> (packages/experimental/editor/__tests__/editor.js:28:26)
```

I can't figure out why the twig renderer is not finding the file.

It's exactly the same as accordion, and the `package`s`.json` seem the same as well.

```
  test('basic usage', async () => {
    const results = await render('@bolt-components-accordion/accordion.twig', {
      items: accordionTwigItems,
    });
    expect(results.ok).toBe(true);
    expect(results.html).toMatchSnapshot();
  });
```