### PR TITLE
Debug/html files not imported in tests

### DIFF
--- a/packages/experimental/micro-journeys/__tests__/character-layouts.js
+++ b/packages/experimental/micro-journeys/__tests__/character-layouts.js
@@ -1,0 +1,78 @@
+import * as starters from '@bolt/micro-journeys/starters';
+import { stopServer, html } from '../../../testing/testing-helpers';
+
+const timeout = 992000;
+jest.setTimeout(timeout);
+
+describe('Character layouts', () => {
+  let page;
+
+  beforeEach(async () => {
+    await page.evaluate(() => {
+      document.body.innerHTML = '';
+    });
+  }, timeout);
+
+  beforeAll(async () => {
+    page = await global.__BROWSER__.newPage();
+    await page.goto('http://127.0.0.1:4444/', {
+      timeout: 0,
+    });
+    page.on('console', msg => console.log('PAGE LOG:', msg.text()));
+  }, timeout);
+
+  afterAll(async () => {
+    await stopServer();
+    await page.close();
+  }, timeout);
+
+  test('<bolt-character> animates in on <bolt-step>', async function() {
+    // Await character rendered.
+    await page.evaluate(async () => {
+      return new Promise((resolve, reject) => {
+        document.addEventListener('rendered', e => {
+          if (e.target.nodeName.toLowerCase() === 'bolt-character') {
+            resolve();
+          }
+        });
+        document.addEventListener('error', reject);
+        const wrapper = document.createElement('div');
+        wrapper.innerHTML = starters.oneCharacterLorem;
+        document.body.appendChild(wrapper);
+      });
+    });
+
+    // await page.evaluate(async () => {
+    //   const wrapper = document.createElement('div');
+    //   wrapper.innerHTML = starters.oneCharacterLorem;
+    //   document.body.appendChild(wrapper);
+    //   const animateElCount = document.querySelectorAll('bolt-animate').length;
+    //   console.log('animateElCount', animateElCount);
+    //   await document.addEventListener('rendered', el => {
+    //     if (el.target.nodeName === 'BOLT-CHARACTER') {
+    //     }
+    //   });
+    //   let animateEndEventCount = 0;
+    //   return new Promise((resolve, reject) => {
+    //     step.addEventListener('bolt-animate:end:out', e => {
+    //       debugger;
+    //       animateEndEventCount++;
+    //       console.log('animateEndEventCount', animateEndEventCount);
+    //       if (animateEndEventCount >= animateElCount) {
+    //         resolve();
+    //       }
+    //     });
+    //     debugger;
+    //     step.triggerAnimIns();
+    //     step.addEventListener('error', reject);
+    //   });
+    // });
+    //
+    // const stepShadowRoot = await page.evaluate(async () => {
+    //   return document.querySelector('bolt-interactive-step').renderRoot
+    //     .innerHTML;
+    // });
+
+    // expect(stepShadowRoot).toContain('My step title');
+  });
+});


### PR DESCRIPTION
I'm having a problem in tests because I want to import my .html starters, but it’s breaking on import:
`npx  ./node_modules/.bin/jest packages/experimental/micro-journeys/__tests__/character-layouts.js`
```
    /Users/jeremy/www/bolt/packages/experimental/micro-journeys/starters/cta-text-lorem.html:1
    ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){<bolt-text>
                                                                                             ^
    SyntaxError: Unexpected token '<'
    > 1 | import ctaTextLorem from './cta-text-lorem.html';

```
Digging around, I see this in the config: https://github.com/boltdesignsystem/bolt/blob/195444752b480c40ac01b94ea6bfee30da955c2f/packages/build-tools/create-webpack-config.js#L302

And it appears to be added to the config (see debugging screenshot):
![image](https://user-images.githubusercontent.com/1361104/73001269-ccae9080-3dc7-11ea-9f78-0e0ca7670a71.png)


…but why the error then? Workaround is copy/pasting the starter HTML into tests, but that’s won’t capture future changes.

Happy to use the workaround, but just thought I'd raise this.