### PR TITLE
TOC | JS | Add smooth scroll and scroll-spy behavior

### DIFF
--- a/packages/components/bolt-toc/__tests__/__snapshots__/toc.js.snap
+++ b/packages/components/bolt-toc/__tests__/__snapshots__/toc.js.snap
@@ -3,6 +3,7 @@
 exports[`<bolt-toc> Component Basic usage 1`] = `
 <bolt-toc ssr-id="12345">
   <replace-with-children class="c-bolt-toc"
+                         role="navigation"
                          aria-labelledby="js-bolt-toc-12345"
   >
     <h2 class="c-bolt-toc__header c-bolt-toc__header--hidden"
@@ -56,6 +57,7 @@ exports[`<bolt-toc> Component Basic usage 1`] = `
 exports[`<bolt-toc> Component Manuualy set the current item 1`] = `
 <bolt-toc ssr-id="12345">
   <replace-with-children class="c-bolt-toc"
+                         role="navigation"
                          aria-labelledby="js-bolt-toc-12345"
   >
     <h2 class="c-bolt-toc__header c-bolt-toc__header--hidden"
@@ -112,6 +114,7 @@ exports[`<bolt-toc> Component Table of content with a header 1`] = `
           ssr-id="12345"
 >
   <replace-with-children class="c-bolt-toc"
+                         role="navigation"
                          aria-labelledby="js-bolt-toc-12345"
   >
     <h2 class="c-bolt-toc__header"

--- a/packages/components/bolt-toc/__tests__/__snapshots__/toc.js.snap
+++ b/packages/components/bolt-toc/__tests__/__snapshots__/toc.js.snap
@@ -1,18 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<bolt-toc> Component Basic usage 1`] = `
-<bolt-toc>
-  <nav class="c-bolt-toc"
-       aria-labelledby="js-bolt-toc-12345"
+<bolt-toc ssr-id="12345">
+  <replace-with-children class="c-bolt-toc"
+                         aria-labelledby="js-bolt-toc-12345"
   >
     <h2 class="c-bolt-toc__header c-bolt-toc__header--hidden"
         id="js-bolt-toc-12345"
+        ssr-for="12345"
+        ssr-type="remove"
     >
       Table of Content
     </h2>
-    <ssr-keep for="bolt-toc"
-              class="c-bolt-toc__list"
-              role="list"
+    <replace-with-children class="c-bolt-toc__list"
+                           role="list"
     >
       <bolt-toc-item url="#section-one"
                      role="presentation"
@@ -47,24 +48,25 @@ exports[`<bolt-toc> Component Basic usage 1`] = `
           </a>
         </replace-with-grandchildren>
       </bolt-toc-item>
-    </ssr-keep>
-  </nav>
+    </replace-with-children>
+  </replace-with-children>
 </bolt-toc>
 `;
 
 exports[`<bolt-toc> Component Manuualy set the current item 1`] = `
-<bolt-toc>
-  <nav class="c-bolt-toc"
-       aria-labelledby="js-bolt-toc-12345"
+<bolt-toc ssr-id="12345">
+  <replace-with-children class="c-bolt-toc"
+                         aria-labelledby="js-bolt-toc-12345"
   >
     <h2 class="c-bolt-toc__header c-bolt-toc__header--hidden"
         id="js-bolt-toc-12345"
+        ssr-for="12345"
+        ssr-type="remove"
     >
       Table of Content
     </h2>
-    <ssr-keep for="bolt-toc"
-              class="c-bolt-toc__list"
-              role="list"
+    <replace-with-children class="c-bolt-toc__list"
+                           role="list"
     >
       <bolt-toc-item url="#section-one"
                      role="presentation"
@@ -100,24 +102,27 @@ exports[`<bolt-toc> Component Manuualy set the current item 1`] = `
           </a>
         </replace-with-grandchildren>
       </bolt-toc-item>
-    </ssr-keep>
-  </nav>
+    </replace-with-children>
+  </replace-with-children>
 </bolt-toc>
 `;
 
 exports[`<bolt-toc> Component Table of content with a header 1`] = `
-<bolt-toc header="This is the header">
-  <nav class="c-bolt-toc"
-       aria-labelledby="js-bolt-toc-12345"
+<bolt-toc header="This is the header"
+          ssr-id="12345"
+>
+  <replace-with-children class="c-bolt-toc"
+                         aria-labelledby="js-bolt-toc-12345"
   >
     <h2 class="c-bolt-toc__header"
         id="js-bolt-toc-12345"
+        ssr-for="12345"
+        ssr-type="remove"
     >
       This is the header
     </h2>
-    <ssr-keep for="bolt-toc"
-              class="c-bolt-toc__list"
-              role="list"
+    <replace-with-children class="c-bolt-toc__list"
+                           role="list"
     >
       <bolt-toc-item url="#section-one"
                      role="presentation"
@@ -152,7 +157,7 @@ exports[`<bolt-toc> Component Table of content with a header 1`] = `
           </a>
         </replace-with-grandchildren>
       </bolt-toc-item>
-    </ssr-keep>
-  </nav>
+    </replace-with-children>
+  </replace-with-children>
 </bolt-toc>
 `;

--- a/packages/components/bolt-toc/package.json
+++ b/packages/components/bolt-toc/package.json
@@ -17,7 +17,8 @@
   "main": "index.js",
   "style": "index.scss",
   "dependencies": {
-    "@bolt/core-v3.x": "^2.14.0"
+    "@bolt/core-v3.x": "^2.14.0",
+    "wc-context": "^0.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/components/bolt-toc/src/_toc-item.js
+++ b/packages/components/bolt-toc/src/_toc-item.js
@@ -66,8 +66,8 @@ class BoltTocItem extends withContext(BoltElement) {
   }
 
   contextChangedCallback(name, oldValue, value) {
-    if (name === 'activeItem') {
-      if (this === value) {
+    if (name === 'activeItem' && value) {
+      if (value === this) {
         this.active = true;
       } else {
         this.active = false;

--- a/packages/components/bolt-toc/src/_toc-item.js
+++ b/packages/components/bolt-toc/src/_toc-item.js
@@ -57,6 +57,7 @@ class BoltTocItem extends withContext(BoltElement) {
     super.connectedCallback && super.connectedCallback();
 
     if (this.url && this.url.indexOf('#') === 0) {
+      // todo: update `this.target` when url prop changes
       this.target = document.querySelector(this.url);
     }
   }

--- a/packages/components/bolt-toc/src/_toc-item.js
+++ b/packages/components/bolt-toc/src/_toc-item.js
@@ -2,12 +2,17 @@ import {
   customElement,
   BoltElement,
   html,
-  styleMap,
   ifDefined,
   unsafeCSS,
 } from '@bolt/element';
-import classNames from 'classnames/dedupe';
+import classNames from 'classnames/bind';
 import { withContext } from 'wc-context';
+import {
+  smoothScroll,
+  scrollOptions,
+  getScrollTarget,
+} from '@bolt/components-smooth-scroll';
+
 import tocItemStyles from './_toc-item.scss';
 import schema from '../toc.schema';
 
@@ -44,6 +49,60 @@ class BoltTocItem extends withContext(BoltElement) {
     return [unsafeCSS(tocItemStyles)];
   }
 
+  static get observedContexts() {
+    return ['activeItem'];
+  }
+
+  connectedCallback() {
+    super.connectedCallback && super.connectedCallback();
+
+    if (this.url && this.url.indexOf('#') === 0) {
+      this.target = document.querySelector(this.url);
+    }
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback && super.disconnectedCallback();
+  }
+
+  contextChangedCallback(name, oldValue, value) {
+    if (name === 'activeItem') {
+      if (this === value) {
+        this.active = true;
+      } else {
+        this.active = false;
+      }
+    }
+  }
+
+  onClick(event) {
+    try {
+      if (this.target) {
+        event.preventDefault();
+        smoothScroll.animateScroll(this.target, this.shadowLink, scrollOptions);
+      }
+    } catch (err) {
+      console.log(err);
+    }
+
+    this.dispatchEvent(
+      new CustomEvent('toc:activate', {
+        detail: {
+          activeItem: this,
+          onClick: true,
+        },
+        bubbles: true,
+      }),
+    );
+  }
+
+  firstUpdated() {
+    // `smoothScroll` needs the anchor as its second argument, does not
+    // appear to do anything but throws an error if missing
+    // https://github.com/cferdinandi/smooth-scroll#animatescroll
+    this.shadowLink = this.renderRoot.querySelector('a');
+  }
+
   render() {
     const classes = cx('c-bolt-toc-item', {
       [`c-bolt-toc-item--current`]: this.active,
@@ -54,6 +113,7 @@ class BoltTocItem extends withContext(BoltElement) {
         <a
           class="${classes}"
           href="${ifDefined(this.url ? this.url : undefined)}"
+          @click="${this.onClick}"
         >
           ${this.slotify('default')}
         </a>

--- a/packages/components/bolt-toc/src/_toc-item.js
+++ b/packages/components/bolt-toc/src/_toc-item.js
@@ -61,10 +61,6 @@ class BoltTocItem extends withContext(BoltElement) {
     }
   }
 
-  disconnectedCallback() {
-    super.disconnectedCallback && super.disconnectedCallback();
-  }
-
   contextChangedCallback(name, oldValue, value) {
     if (name === 'activeItem' && value) {
       if (value === this) {

--- a/packages/components/bolt-toc/src/toc.js
+++ b/packages/components/bolt-toc/src/toc.js
@@ -50,11 +50,6 @@ class BoltToc extends withContext(BoltElement) {
     // These are fixed for now, make into props if necessary
     this.boundaryTop = 0;
     this.boundaryBottom = '75%';
-
-    // Dislay waypoint boundaries on screen if debug is `true` (only ever IN_DEV!)
-    if (IS_DEV && BoltToc.debug && !BoltToc.debuggerAdded) {
-      this.addWaypointDebugger();
-    }
   }
 
   static get styles() {
@@ -94,6 +89,11 @@ class BoltToc extends withContext(BoltElement) {
     document.addEventListener('scrollStart', this.logScrollEvent, false);
     document.addEventListener('scrollStop', this.logScrollEvent, false);
     document.addEventListener('scrollCancel', this.logScrollEvent, false);
+
+    // Dislay waypoint boundaries on screen if debug is `true` (only ever IN_DEV!)
+    if (IS_DEV && BoltToc.debug && !BoltToc.debuggerAdded) {
+      this.addWaypointDebugger();
+    }
   }
 
   disconnectedCallback() {

--- a/packages/components/bolt-toc/src/toc.js
+++ b/packages/components/bolt-toc/src/toc.js
@@ -269,6 +269,10 @@ class BoltToc extends withContext(BoltElement) {
     // @todo: add mutation observer if we want this to update when items added or removed
     this.waypointData = this.itemData;
     this.updateWaypoints();
+
+    // Returns first active item or undefined
+    this.activeItem = Array.from(this.items).find(item => item.active);
+    this.updateProvidedContext('activeItem', this.activeItem);
   }
 
   render() {

--- a/packages/components/bolt-toc/src/toc.js
+++ b/packages/components/bolt-toc/src/toc.js
@@ -1,16 +1,30 @@
-import {
-  customElement,
-  BoltElement,
-  html,
-  styleMap,
-  unsafeCSS,
-} from '@bolt/element';
-import classNames from 'classnames/dedupe';
+import { customElement, BoltElement, html, unsafeCSS } from '@bolt/element';
+import { IS_DEV } from '@bolt/core-v3.x/utils';
+import classNames from 'classnames/bind';
 import { withContext } from 'wc-context';
+import { getBounds, getCurrentPosition } from './waypoint';
 import tocStyles from './toc.scss';
 import schema from '../toc.schema';
 
 let cx = classNames.bind(tocStyles);
+
+// @todo: refactor into core-v3
+let passiveIfSupported = false;
+
+// https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Improving_scrolling_performance_with_passive_listeners
+try {
+  window.addEventListener(
+    'test',
+    null,
+    Object.defineProperty({}, 'passive', {
+      // eslint-disable-next-line getter-return
+      get() {
+        // @ts-ignore
+        passiveIfSupported = { passive: true };
+      },
+    }),
+  );
+} catch (err) {}
 
 /*
  * 1. @todo: remove SSR Hydration from this file, move to base
@@ -29,7 +43,30 @@ class BoltToc extends withContext(BoltElement) {
 
   constructor() {
     super();
+
     this.uuid = this.uuid || Math.floor(10000 + Math.random() * 90000);
+
+    // These are fixed for now, make into props if necessary
+    this.boundaryTop = 0;
+    this.boundaryBottom = '75%';
+
+    // Dislay waypoint boundaries on screen if debug is `true` (only ever IN_DEV!)
+    if (IS_DEV && BoltToc.debug && !BoltToc.debuggerAdded) {
+      this.addWaypointDebugger();
+    }
+  }
+
+  static get styles() {
+    return [unsafeCSS(tocStyles)];
+  }
+
+  // Set to `true` to display waypoint boundary on screen
+  static debug = false;
+
+  static get providedContexts() {
+    return {
+      activeItem: { value: null },
+    };
   }
 
   /* [1] */
@@ -40,6 +77,39 @@ class BoltToc extends withContext(BoltElement) {
     if (this.ssrKeep && !this.ssrPrepped) {
       this.ssrHydrationPrep();
     }
+
+    this.addEventListener('toc:activate', this.onActivate);
+
+    this.updateWaypoints = this.updateWaypoints.bind(this);
+    window.addEventListener('scroll', this.updateWaypoints, passiveIfSupported);
+    window.addEventListener('resize', this.updateWaypoints, passiveIfSupported);
+
+    // Listen for smooth-scroll events
+    this.logScrollEvent = this.logScrollEvent.bind(this);
+    document.addEventListener('scrollStart', this.logScrollEvent, false);
+    document.addEventListener('scrollStop', this.logScrollEvent, false);
+    document.addEventListener('scrollCancel', this.logScrollEvent, false);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback && super.disconnectedCallback();
+
+    this.removeEventListener('toc:activate', this.onActivate);
+
+    window.removeEventListener(
+      'scroll',
+      this.updateWaypoints,
+      passiveIfSupported,
+    );
+    window.removeEventListener(
+      'resize',
+      this.updateWaypoints,
+      passiveIfSupported,
+    );
+
+    document.removeEventListener('scrollStart', this.logScrollEvent, false);
+    document.removeEventListener('scrollStop', this.logScrollEvent, false);
+    document.removeEventListener('scrollCancel', this.logScrollEvent, false);
   }
 
   /* [1] */
@@ -64,8 +134,140 @@ class BoltToc extends withContext(BoltElement) {
     this.ssrPrepped = true;
   }
 
-  static get styles() {
-    return [unsafeCSS(tocStyles)];
+  addWaypointDebugger() {
+    const marker = document.createElement('div');
+    marker.setAttribute(
+      'style',
+      `position: fixed; bottom: ${this.boundaryBottom}; top: ${this.boundaryTop}; width: 100%; border: 1px solid red; opacity: 0.5`,
+    );
+    document.body.appendChild(marker);
+    BoltToc.debuggerAdded = true;
+  }
+
+  get items() {
+    return this.querySelectorAll('bolt-toc-item');
+  }
+
+  get itemData() {
+    let triggers = [];
+    let targets = [];
+
+    this.items.forEach(item => {
+      if (item.target) {
+        triggers.push(item);
+        targets.push(item.target);
+      }
+    });
+    return {
+      triggers,
+      targets,
+    };
+  }
+
+  logScrollEvent(event) {
+    if (event.type === 'scrollStart') {
+      this.scrolling = true;
+    } else if (event.type === 'scrollStop' || event.type === 'scrollCancel') {
+      this.scrolling = false;
+    }
+  }
+
+  onActivate(event) {
+    if (event?.detail?.activeItem) {
+      this.activeItem = event.detail.activeItem;
+      this.updateProvidedContext('activeItem', this.activeItem);
+    }
+  }
+
+  updateWaypoints() {
+    const update = target => {
+      if (!target || this.scrolling) return;
+
+      const trigger = this.getMatchingItem(target);
+      const bounds = getBounds(
+        target,
+        window,
+        this.boundaryTop,
+        this.boundaryBottom,
+      );
+      const currentPosition = getCurrentPosition(bounds);
+
+      // store data on `trigger` not `target`, `trigger` is a Bolt component and `target` could be anything
+      const previousPosition = trigger._previousPosition;
+
+      // Save previous position as early as possible to prevent cycles
+      trigger._previousPosition = currentPosition;
+
+      // We could return here if we were listening on each item rather than iterating over an array of items.
+      // The latter, while reducing scroll jank, can cause a race condition when scrolling rapidly where the
+      // `activeItem` is not properly set. So, let the code below always execute to avoid that race condition.
+      // if (previousPosition === currentPosition) return;
+
+      const callbackArg = {
+        target,
+        currentPosition,
+        previousPosition,
+        waypointTop: bounds.waypointTop,
+        waypointBottom: bounds.waypointBottom,
+        viewportTop: bounds.viewportTop,
+        viewportBottom: bounds.viewportBottom,
+      };
+
+      this.onPositionChange(callbackArg);
+
+      if (currentPosition === 'inside') {
+        this.onEnter(callbackArg);
+      } else if (previousPosition === 'inside') {
+        this.onLeave(callbackArg);
+      }
+    };
+
+    this.waypointData?.targets.forEach(target => {
+      update(target);
+    });
+  }
+
+  getMatchingItem(target, shift = 0) {
+    const index = this.waypointData.targets.indexOf(target) + shift;
+
+    if (index !== -1) {
+      return this.waypointData.triggers[index];
+    }
+  }
+
+  onEnter({ target }) {
+    // Fires when waypoint enters the boundary
+    const item = this.getMatchingItem(target);
+
+    if (item && item !== this.activeItem) {
+      this.activeItem = item;
+      this.updateProvidedContext('activeItem', this.activeItem);
+    }
+  }
+
+  onLeave({ target, currentPosition, previousPosition }) {
+    // Fires when waypoint leaves the boundary
+  }
+
+  onPositionChange({ target, currentPosition, previousPosition }) {
+    // If `activeItem` is undefined (could be first load), use the first item
+    // with position 'below' to get the previous item, which is assumed to be
+    // the most visible section
+    if (!this.activeItem) {
+      if (currentPosition === 'below') {
+        let item = this.getMatchingItem(target, -1);
+        if (item) {
+          this.activeItem = item;
+          this.updateProvidedContext('activeItem', this.activeItem);
+        }
+      }
+    }
+  }
+
+  firstUpdated() {
+    // @todo: add mutation observer if we want this to update when items added or removed
+    this.waypointData = this.itemData;
+    this.updateWaypoints();
   }
 
   render() {

--- a/packages/components/bolt-toc/src/toc.js
+++ b/packages/components/bolt-toc/src/toc.js
@@ -1,5 +1,5 @@
 import { customElement, BoltElement, html, unsafeCSS } from '@bolt/element';
-import { IS_DEV } from '@bolt/core-v3.x/utils';
+import { getUniqueId, IS_DEV } from '@bolt/core-v3.x/utils';
 import classNames from 'classnames/bind';
 import { withContext } from 'wc-context';
 import { getBounds, getCurrentPosition } from './waypoint';
@@ -44,7 +44,8 @@ class BoltToc extends withContext(BoltElement) {
   constructor() {
     super();
 
-    this.uuid = this.uuid || Math.floor(10000 + Math.random() * 90000);
+    this.uuid =
+      this.uuid || bolt.config.env === 'test' ? '12345' : getUniqueId();
 
     // These are fixed for now, make into props if necessary
     this.boundaryTop = 0;

--- a/packages/components/bolt-toc/src/toc.twig
+++ b/packages/components/bolt-toc/src/toc.twig
@@ -41,7 +41,7 @@
   {{ this.props|without("items")|without("class") }}
   ssr-id="{{ uuid }}"
 >
-  <replace-with-children {% if inner_classes %} class="{{ inner_classes|join(' ') }}" {% endif %} aria-labelledby="{{ "js-bolt-toc-#{uuid}" }}">
+  <replace-with-children {% if inner_classes %} class="{{ inner_classes|join(' ') }}" {% endif %} role="navigation" aria-labelledby="{{ "js-bolt-toc-#{uuid}" }}">
     <h2
       {% if header %}
         class="c-bolt-toc__header"

--- a/packages/components/bolt-toc/src/toc.twig
+++ b/packages/components/bolt-toc/src/toc.twig
@@ -39,8 +39,9 @@
 <bolt-toc
   {% if outer_classes %} class="{{ outer_classes|join(' ') }}" {% endif %}
   {{ this.props|without("items")|without("class") }}
+  ssr-id="{{ uuid }}"
 >
-  <nav {% if inner_classes %} class="{{ inner_classes|join(' ') }}" {% endif %} aria-labelledby="{{ "js-bolt-toc-#{uuid}" }}">
+  <replace-with-children {% if inner_classes %} class="{{ inner_classes|join(' ') }}" {% endif %} aria-labelledby="{{ "js-bolt-toc-#{uuid}" }}">
     <h2
       {% if header %}
         class="c-bolt-toc__header"
@@ -48,6 +49,8 @@
         class="c-bolt-toc__header c-bolt-toc__header--hidden"
       {% endif %}
       id="{{ "js-bolt-toc-#{uuid}" }}"
+      ssr-for="{{ uuid }}"
+      ssr-type="remove"
     >
       {% if header %}
         {{ header }}
@@ -55,12 +58,12 @@
         Table of Content
       {% endif %}
     </h2>
-    <ssr-keep for="bolt-toc" class="c-bolt-toc__list" role="list">
+    <replace-with-children class="c-bolt-toc__list" role="list">
       {% for item in items %}
         {% if item %}
           {% include "@bolt-components-toc/_toc-item.twig" with item only %}
         {% endif %}
       {% endfor %}
-    </ssr-keep>
-  </nav>
+    </replace-with-children>
+  </replace-with-children>
 </bolt-toc>

--- a/packages/components/bolt-toc/src/waypoint/computeOffsetPixels.js
+++ b/packages/components/bolt-toc/src/waypoint/computeOffsetPixels.js
@@ -1,0 +1,22 @@
+import parseOffsetAsPercentage from './parseOffsetAsPercentage';
+import parseOffsetAsPixels from './parseOffsetAsPixels';
+
+/**
+ * @param {string|number} offset
+ * @param {number} contextHeight
+ * @return {number} A number representing `offset` converted into pixels.
+ */
+export function computeOffsetPixels(offset, contextHeight) {
+  const pixelOffset = parseOffsetAsPixels(offset);
+
+  if (typeof pixelOffset === 'number') {
+    return pixelOffset;
+  }
+
+  const percentOffset = parseOffsetAsPercentage(offset);
+  if (typeof percentOffset === 'number') {
+    return percentOffset * contextHeight;
+  }
+
+  return undefined;
+}

--- a/packages/components/bolt-toc/src/waypoint/getBounds.js
+++ b/packages/components/bolt-toc/src/waypoint/getBounds.js
@@ -1,0 +1,34 @@
+import { computeOffsetPixels } from './computeOffsetPixels';
+
+/**
+ * @param {Element} element The waypoint element to be tracked
+ * @param {Element} context The scrollable context in which the element may appear
+ * @param {string|number} topOffset An offset amount for the top boundary, use `px or %`
+ * @param {string|number} bottomOffset An offset amount for the bottom boundary, use `px or %`
+ * @return {object} An object with bounds data for the waypoint and scrollable parent
+ */
+export function getBounds(
+  element,
+  context = window,
+  topOffset = 0,
+  bottomOffset = 0,
+) {
+  if (!element) return;
+
+  const { top, bottom } = element.getBoundingClientRect();
+
+  // Only tested with `window` context so far
+  let contextHeight = context.innerHeight;
+  let contextScrollTop = 0;
+
+  const topOffsetPx = computeOffsetPixels(topOffset, contextHeight);
+  const bottomOffsetPx = computeOffsetPixels(bottomOffset, contextHeight);
+  const contextBottom = contextScrollTop + contextHeight;
+
+  return {
+    waypointTop: top,
+    waypointBottom: bottom,
+    viewportTop: contextScrollTop + topOffsetPx,
+    viewportBottom: contextBottom - bottomOffsetPx,
+  };
+}

--- a/packages/components/bolt-toc/src/waypoint/getCurrentPosition.js
+++ b/packages/components/bolt-toc/src/waypoint/getCurrentPosition.js
@@ -1,0 +1,46 @@
+/**
+ * @param {object} bounds An object with bounds data for the waypoint and
+ *   scrollable parent
+ * @return {string} The current position of the waypoint in relation to the
+ *   visible portion of the scrollable parent. One of the constants `above`,
+ *   `below`, `inside` or `invisible`.
+ */
+export function getCurrentPosition(bounds) {
+  if (bounds.viewportBottom - bounds.viewportTop === 0) {
+    return 'invisible';
+  }
+
+  // top is within the viewport
+  if (
+    bounds.viewportTop <= bounds.waypointTop &&
+    bounds.waypointTop <= bounds.viewportBottom
+  ) {
+    return 'inside';
+  }
+
+  // bottom is within the viewport
+  if (
+    bounds.viewportTop <= bounds.waypointBottom &&
+    bounds.waypointBottom <= bounds.viewportBottom
+  ) {
+    return 'inside';
+  }
+
+  // top is above the viewport and bottom is below the viewport
+  if (
+    bounds.waypointTop <= bounds.viewportTop &&
+    bounds.viewportBottom <= bounds.waypointBottom
+  ) {
+    return 'inside';
+  }
+
+  if (bounds.viewportBottom < bounds.waypointTop) {
+    return 'below';
+  }
+
+  if (bounds.waypointTop < bounds.viewportTop) {
+    return 'above';
+  }
+
+  return 'invisible';
+}

--- a/packages/components/bolt-toc/src/waypoint/index.js
+++ b/packages/components/bolt-toc/src/waypoint/index.js
@@ -1,0 +1,4 @@
+// Adapted from https://github.com/civiccc/react-waypoint
+export { getBounds } from './getBounds';
+export { getCurrentPosition } from './getCurrentPosition';
+export { computeOffsetPixels } from './computeOffsetPixels';

--- a/packages/components/bolt-toc/src/waypoint/parseOffsetAsPercentage.js
+++ b/packages/components/bolt-toc/src/waypoint/parseOffsetAsPercentage.js
@@ -1,0 +1,19 @@
+/**
+ * Attempts to parse the offset provided as a prop as a percentage. For
+ * instance, if the component has been provided with the string "20%" as
+ * a value of one of the offset props. If the value matches, then it returns
+ * a numeric version of the prop. For instance, "20%" would become `0.2`.
+ * If `str` isn't a percentage, then `undefined` will be returned.
+ *
+ * @param {string} str The value of an offset prop to be converted to a
+ *   number.
+ * @return {number|undefined} The numeric version of `str`. Undefined if `str`
+ *   was not a percentage.
+ */
+export default function parseOffsetAsPercentage(str) {
+  if (str.slice(-1) === '%') {
+    return parseFloat(str.slice(0, -1)) / 100;
+  }
+
+  return undefined;
+}

--- a/packages/components/bolt-toc/src/waypoint/parseOffsetAsPixels.js
+++ b/packages/components/bolt-toc/src/waypoint/parseOffsetAsPixels.js
@@ -1,0 +1,24 @@
+/**
+ * Attempts to parse the offset provided as a prop as a pixel value. If
+ * parsing fails, then `undefined` is returned. Three examples of values that
+ * will be successfully parsed are:
+ * `20`
+ * "20px"
+ * "20"
+ *
+ * @param {string|number} str A string of the form "{number}" or "{number}px",
+ *   or just a number.
+ * @return {number|undefined} The numeric version of `str`. Undefined if `str`
+ *   was neither a number nor string ending in "px".
+ */
+export default function parseOffsetAsPixels(str) {
+  // eslint-disable-next-line no-restricted-globals
+  if (!isNaN(parseFloat(str)) && isFinite(str)) {
+    return parseFloat(str);
+  }
+  if (str.slice(-2) === 'px') {
+    return parseFloat(str.slice(0, -2));
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1975

## Summary

Add smooth scroll and scroll-spy behavior to Table of Contents component.

## Details

- Uses an adapted version of [React Waypoint](https://github.com/civiccc/react-waypoint) for scroll-spy behavior (i.e. update active item as you scroll). For now, Waypoint-specific code lives with the component in `./waypoint`. This could easily be refactored into Core and used with Nav Priority later on.
- Updates component to use `getUniqueId` helper
- Makes sure only one active item at a time and initial active item is taken into account.
- Fix SSR hydration prep issues in IE11 by switching from `<ssr-keep>` to a new method, avoids the race conditions caused by `<ssr-keep>` loading late in IE11.

## How to test

- Review code changes
- Test TOC demos, especially "Use Case Sticky" for scroll spy behavior