### PR TITLE
Twig rendering fixes for Toolbar + Icon; fix for docs site visual regression w/ CSS vars fallback

### DIFF
--- a/docs-site/src/templates/_site-head.twig
+++ b/docs-site/src/templates/_site-head.twig
@@ -46,7 +46,15 @@
     <meta name="viewport" content="width=device-width" />
     <title>Bolt Design System</title>
 
-    <script>
+    <link rel="preconnect" href="https://www.google-analytics.com">
+    <link rel="preconnect dns-prefetch" href="https://www.google-analytics.com"/>
+
+    <!-- async load PL's CSS -->
+    <link rel="stylesheet" href="{{ legacyAssets["bolt-global.css"] | default("/build/bolt-global.css") }}" media="all" />
+    <link rel="preload" href="/pattern-lab/styleguide/css/pattern-lab.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+
+    {# critical path scripts for non-ES Module browsers #}
+    <script nomodule>
       {% if fileExists("@bolt-assets/bolt-critical-path-polyfills.cjs.js") %}
         {{ inline(legacyAssets["bolt-critical-path-polyfills.cjs.js"] | default("")) }}
       {% endif %}
@@ -54,7 +62,10 @@
       {% if fileExists("@bolt-assets/bolt-components-critical-css.js") %}
         {{ inline( legacyAssets["bolt-components-critical-css-vars.js"] | default("") ) }}
       {% endif %}
+    </script>
 
+    {# shared critical path scripts #}
+    <script>
       if (sessionStorage.fontsLoadedCriticalFoftPreloadPolyfill){
         document.documentElement.classList.add('js-fonts-loaded');
       }
@@ -70,10 +81,6 @@
       window.bolt.data.fullManifest = window.bolt.data.fullManifest || {};
       window.bolt.data.fullManifest.version = window.bolt.data.fullManifest.version || {{ bolt.data.fullManifest.version|json_encode|raw }};
     </script>
-
-    <!-- async load PL's CSS -->
-    <link rel="stylesheet" href="{{ legacyAssets["bolt-global.css"] | default("/build/bolt-global.css") }}" media="all" />
-    <link rel="preload" href="/pattern-lab/styleguide/css/pattern-lab.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
 
     <noscript>
       <link href="/pattern-lab/styleguide/css/pattern-lab.css" rel="stylesheet">

--- a/packages/components/bolt-icon/src/icon.twig
+++ b/packages/components/bolt-icon/src/icon.twig
@@ -38,7 +38,7 @@
         "<svg ": '<svg class="' ~ svg_classes|join(" ")|trim ~ '" '
       }) %}
 
-      {{ svg_source }}
+      {{ svg_source | raw }}
 
     {% else %}
      <svg class="{{ svg_classes|join(' ')|trim }}">

--- a/packages/components/bolt-toolbar/toolbar.twig
+++ b/packages/components/bolt-toolbar/toolbar.twig
@@ -15,19 +15,19 @@
             </div>
           {% endif %}
 
-          {{ toolbar_content_before | default(content_before) }}
+          {{ toolbar_content_before | default(content_before) | raw }}
         </div>
       {% endif %}
 
       {% if toolbar_content or content %}
         <div class="c-bolt-toolbar__item c-bolt-toolbar__item--center">
-          {{ toolbar_content | default(content) }}
+          {{ toolbar_content | default(content) | raw }}
         </div>
       {% endif %}
 
       {% if toolbar_content_after or content_after %}
         <div class="c-bolt-toolbar__item c-bolt-toolbar__item--after">
-          {{ toolbar_content_after | default(content_after) }}
+          {{ toolbar_content_after | default(content_after) | raw }}
         </div>
       {% endif %}
     </div>


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/BDS-1987?filter=-1

## Summary
Adds 3 small Twig template updates to smooth over some issues with the v2.16.1 release.

## Details
1. Updates the Icon component's Twig-only fallback (used to display SVG icons before JS kicks in) to use the `raw` Twig filter + escape HTML correctly.
2. Updates the Toolbar component's main template to also add the raw filter (fixes HTML displaying that isn't rendered)   
3. Updates the internal docs site + Pattern Lab `<head>` Twig file to address an internal visual regression with the CSS variable fallback styles.

## How to test
- Confirm that the buttons on [this demo page](https://boltdesignsystem.com/pattern-lab/?p=components-button-style-variations) (using the deploy URL) now looks correct in IE 11
- Very quick smoke test to confirm that the Toolbar + Icon components still render as expected 