### PR TITLE
Hotfix/wwwd 4533 web component icon background match twig

### DIFF
--- a/packages/components/bolt-icon/src/icon.standalone.js
+++ b/packages/components/bolt-icon/src/icon.standalone.js
@@ -97,10 +97,10 @@ class BoltIcon extends withPreact {
         ? `c-bolt-icon--${size}`
         : '',
       name ? `c-bolt-icon--${name}` : '',
-      background && schema.properties.background.enum.includes(background)
+      background && background !== 'none' && schema.properties.background.enum.includes(background)
         ? `has-background`
         : '',
-      background && schema.properties.background.enum.includes(background)
+      background && background !== 'none' && schema.properties.background.enum.includes(background)
         ? `has-${background}-background`
         : '',
       color && schema.properties.color.enum.includes(color)

--- a/packages/components/bolt-icon/src/icon.standalone.js
+++ b/packages/components/bolt-icon/src/icon.standalone.js
@@ -155,7 +155,7 @@ class BoltIcon extends withPreact {
             fgColor={secondaryColor}
           />
         )}
-        {background && <span className={backgroundClasses} />}
+        {background && background !== 'none' && <span className={backgroundClasses} />}
       </span>
     );
   }


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/WWWD-4533

## Summary

Removes background on web component icons when background="none"

## Details

This fixes a regression (see http://vjira2:8080/browse/WWWD-4533) where a background="none" prop actually resulted in a background being added.  

## How to test

### Confirm the bug
- On master, add this icon in pattern lab (as a web component): `<bolt-icon name="chevron-right" background="none"></bolt-icon>`
- Confirm that a background is added

### Confirm the fix
- On this branch, confirm that the same behavior results in no background being added.
