### PR TITLE
Restore -none- option for icons in dialog bar

### DIFF
--- a/packages/experimental/micro-journeys/src/status-dialogue-bar.schema.js
+++ b/packages/experimental/micro-journeys/src/status-dialogue-bar.schema.js
@@ -14,7 +14,7 @@ module.exports = {
       type: 'string',
       description: 'Icon name.',
       default: 'mobility',
-      enum: ['', ...iconSchema.properties.name.anyOf[0].enum],
+      enum: ['-none-', ...iconSchema.properties.name.anyOf[0].enum],
     },
     isAlertMessage: {
       type: 'boolean',


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/WWWD-4536

## Summary

Restore -none- option for icons in dialog bar

## Details

This restores the functionality introduced in cc58925 that was later lost in a merge conflict with cba55e55.

## How to test

- Go to `/pattern-lab/?p=experiments-editor-with-two-character-layout`
- Click edit
- Select the dialog bar above the second character
- In the icon dropdown for that character, select "-none-"
- Save.  There should be no icon or funky spacing in the dialog bar you just edited.
