### PR TITLE
fix(editor): step removal event not completing when parent bolt-anima…

### DIFF
--- a/packages/experimental/editor/src/editor.js
+++ b/packages/experimental/editor/src/editor.js
@@ -459,14 +459,17 @@ export function enableEditor({ space, uiWrapper, config }) {
   editor.on('component:remove', (/** @type {grapesjs.Component} */ model) => {
     // Editor removes all components in order on save/cleanup. Don't check then.
     if (!editor.isSaving) {
-      const parent = model.parent();
-      // Remove empty parent `bolt-animate`s
-      if (parent && parent.attributes.tagName === 'bolt-animate') {
-        if (parent && parent.view.el.assignedSlot) {
-          parent.view.el.assignedSlot.remove();
+      // Timeout so cleanup and layer re-render happens on parent before removal.
+      setTimeout(() => {
+        const parent = model.parent();
+        // Remove empty parent `bolt-animate`s
+        if (parent && parent.attributes.tagName === 'bolt-animate') {
+          if (parent && parent.view.el.assignedSlot) {
+            parent.view.el.assignedSlot.remove();
+          }
+          parent.remove();
         }
-        parent.remove();
-      }
+      }, 0);
     }
   });
 


### PR DESCRIPTION
…te removed also

## Jira

http://vjira2:8080/browse/WWWD-4535

## Summary

Fix Step removal event not firing due to removal of Animate parent

## Details

The removal of empty `bolt-animate`s on `component:remove` caused the other `bolt-interactive-step` removal event not to fire.

I fixed this by pushing the removal of `bolt-animate`s to the end of the call stack, after other queued removal events.

## How to test

-   Go to editor
-    Click to 'Clear Canvas' and then drag-and-drop the 'Two-Character Pathway' into the Stage
-    Within the Layers interface, hilight the fifth and sixth 'Bolt-interactive-step' layers and then click to 'Delete' each - note that these layers no longer disappear from the Layers stack
-    Click to 'Save & Close' the MJ editor and see that the fifth and sixth Steps were in fact removed
-    Next, repeat the same initial process, but drag-and-drop the 'Two-character Pathways' Starter into the Stage
-    Attempt to 'Delete' the fifth and sixth Pathways - note these also don't disppear
-    Finally, click to 'Save & Close' the MJ editor and see that the fifth and sixth Pathways were in fact removed
