### PR TITLE
Fix: add missing role attributes to menu component

### DIFF
--- a/packages/components/bolt-menu/__tests__/__snapshots__/menu.js.snap
+++ b/packages/components/bolt-menu/__tests__/__snapshots__/menu.js.snap
@@ -2,13 +2,15 @@
 
 exports[`<bolt-menu> Component basic usage 1`] = `
 <bolt-menu role="menu">
-  <replace-with-children class="c-bolt-menu">
+  <replace-with-children role="presentation"
+                         class="c-bolt-menu"
+  >
     <replace-with-children class="c-bolt-menu__title c-bolt-menu__title--spacing-small">
       <span slot="title">
         Menu title
       </span>
     </replace-with-children>
-    <bolt-menu-item>
+    <bolt-menu-item role="presentation">
       <bolt-trigger role="menuitem"
                     display="block"
                     no-outline
@@ -25,7 +27,9 @@ exports[`<bolt-menu> Component basic usage 1`] = `
         </button>
       </bolt-trigger>
     </bolt-menu-item>
-    <bolt-menu-item url="https://pega.com">
+    <bolt-menu-item url="https://pega.com"
+                    role="presentation"
+    >
       <bolt-trigger role="menuitem"
                     url="https://pega.com"
                     display="block"
@@ -43,7 +47,7 @@ exports[`<bolt-menu> Component basic usage 1`] = `
         </a>
       </bolt-trigger>
     </bolt-menu-item>
-    <bolt-menu-item>
+    <bolt-menu-item role="presentation">
       <bolt-trigger role="menuitem"
                     display="block"
                     no-outline
@@ -68,8 +72,10 @@ exports[`<bolt-menu> Component menu item spacing: medium 1`] = `
 <bolt-menu spacing="medium"
            role="menu"
 >
-  <replace-with-children class="c-bolt-menu">
-    <bolt-menu-item>
+  <replace-with-children role="presentation"
+                         class="c-bolt-menu"
+  >
+    <bolt-menu-item role="presentation">
       <bolt-trigger role="menuitem"
                     display="block"
                     no-outline
@@ -86,7 +92,7 @@ exports[`<bolt-menu> Component menu item spacing: medium 1`] = `
         </button>
       </bolt-trigger>
     </bolt-menu-item>
-    <bolt-menu-item>
+    <bolt-menu-item role="presentation">
       <bolt-trigger role="menuitem"
                     display="block"
                     no-outline
@@ -103,7 +109,7 @@ exports[`<bolt-menu> Component menu item spacing: medium 1`] = `
         </button>
       </bolt-trigger>
     </bolt-menu-item>
-    <bolt-menu-item>
+    <bolt-menu-item role="presentation">
       <bolt-trigger role="menuitem"
                     display="block"
                     no-outline
@@ -128,8 +134,10 @@ exports[`<bolt-menu> Component menu item spacing: small 1`] = `
 <bolt-menu spacing="small"
            role="menu"
 >
-  <replace-with-children class="c-bolt-menu">
-    <bolt-menu-item>
+  <replace-with-children role="presentation"
+                         class="c-bolt-menu"
+  >
+    <bolt-menu-item role="presentation">
       <bolt-trigger role="menuitem"
                     display="block"
                     no-outline
@@ -146,7 +154,7 @@ exports[`<bolt-menu> Component menu item spacing: small 1`] = `
         </button>
       </bolt-trigger>
     </bolt-menu-item>
-    <bolt-menu-item>
+    <bolt-menu-item role="presentation">
       <bolt-trigger role="menuitem"
                     display="block"
                     no-outline
@@ -163,7 +171,7 @@ exports[`<bolt-menu> Component menu item spacing: small 1`] = `
         </button>
       </bolt-trigger>
     </bolt-menu-item>
-    <bolt-menu-item>
+    <bolt-menu-item role="presentation">
       <bolt-trigger role="menuitem"
                     display="block"
                     no-outline
@@ -188,8 +196,10 @@ exports[`<bolt-menu> Component menu item spacing: xsmall 1`] = `
 <bolt-menu spacing="xsmall"
            role="menu"
 >
-  <replace-with-children class="c-bolt-menu">
-    <bolt-menu-item>
+  <replace-with-children role="presentation"
+                         class="c-bolt-menu"
+  >
+    <bolt-menu-item role="presentation">
       <bolt-trigger role="menuitem"
                     display="block"
                     no-outline
@@ -206,7 +216,7 @@ exports[`<bolt-menu> Component menu item spacing: xsmall 1`] = `
         </button>
       </bolt-trigger>
     </bolt-menu-item>
-    <bolt-menu-item>
+    <bolt-menu-item role="presentation">
       <bolt-trigger role="menuitem"
                     display="block"
                     no-outline
@@ -223,7 +233,7 @@ exports[`<bolt-menu> Component menu item spacing: xsmall 1`] = `
         </button>
       </bolt-trigger>
     </bolt-menu-item>
-    <bolt-menu-item>
+    <bolt-menu-item role="presentation">
       <bolt-trigger role="menuitem"
                     display="block"
                     no-outline

--- a/packages/components/bolt-menu/src/_menu-item.js
+++ b/packages/components/bolt-menu/src/_menu-item.js
@@ -23,6 +23,10 @@ class BoltMenuItem extends withContext(BoltElement) {
     return {
       url: String,
       spacing: String,
+      role: {
+        type: String,
+        reflect: true,
+      },
     };
   }
 
@@ -36,6 +40,7 @@ class BoltMenuItem extends withContext(BoltElement) {
 
   constructor() {
     super();
+    this.role = 'presentation';
   }
 
   static get styles() {
@@ -97,6 +102,7 @@ class BoltMenuItem extends withContext(BoltElement) {
         display="block"
         no-outline
         url="${ifDefined(this.url ? this.url : undefined)}"
+        role="menuitem"
       >
         <div class="${classes}">
           ${this.slotify('default')}

--- a/packages/components/bolt-menu/src/_menu-item.twig
+++ b/packages/components/bolt-menu/src/_menu-item.twig
@@ -20,6 +20,7 @@
 
 <bolt-menu-item
   {{ this.props|without("content")|without("class") }}
+  role="presentation"
 >
   {% set menu_item %}
     <ssr-keep

--- a/packages/components/bolt-menu/src/menu.js
+++ b/packages/components/bolt-menu/src/menu.js
@@ -18,6 +18,10 @@ class BoltMenu extends withContext(BoltElement) {
   static get properties() {
     return {
       spacing: String,
+      role: {
+        type: String,
+        reflect: true,
+      },
     };
   }
 
@@ -29,6 +33,7 @@ class BoltMenu extends withContext(BoltElement) {
 
   constructor() {
     super();
+    this.role = 'menu';
   }
 
   static get styles() {
@@ -54,7 +59,7 @@ class BoltMenu extends withContext(BoltElement) {
     });
 
     return html`
-      <div class="${cx(`c-bolt-menu`)}">
+      <div class="${cx(`c-bolt-menu`)}" role="presentation">
         ${this.slotMap.get('title') &&
           html`
             <div class="${classes}">

--- a/packages/components/bolt-menu/src/menu.twig
+++ b/packages/components/bolt-menu/src/menu.twig
@@ -35,7 +35,7 @@
   {{ this.props|without("content")|without("title")|without("class") }}
   role="menu"
 >
-  <replace-with-children {% if inner_classes %} class="{{ inner_classes|join(' ') }}" {% endif %}>
+  <replace-with-children role="presentation" {% if inner_classes %} class="{{ inner_classes|join(' ') }}" {% endif %}>
     {% if title %}
       {% set title_class = base_class ~ "__title" %}
       {% set title_classes = [


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1986

## Summary

Adds the proper `role` attributes to indicate `menu` and `menuitem`.

## Details

1. `role="menu"` added to parent container.
2. `role="menuitem"` added to each trigger.
3. `role="presentation"` added to any containers in between the menu and menu item to remove any native semantics.

## How to test

Run the branch locally and check the markup in the Menu docs. Make sure the `role` attributes are in the right places, with or without JS.