### PR TITLE
Hotfix for Twig escaping / rendering issues in Drupal

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/01-atoms/forms/toolbar-buttons/_toolbar-button.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/01-atoms/forms/toolbar-buttons/_toolbar-button.twig
@@ -33,6 +33,6 @@
     }
   } only %}
 {% else %}
-  {{ button }}
+  {{ button|raw }}
 {% endif %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/display/_horizontal-divider.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/display/_horizontal-divider.twig
@@ -1,7 +1,7 @@
 <div class="c-bolt-horizontal-divider">
   <div class="c-bolt-horizontal-divider__border"></div>
   {% if dividerText %}
-    <div class="c-bolt-horizontal-divider__text">{{ dividerText }}</div>
+    <div class="c-bolt-horizontal-divider__text">{{ dividerText|raw }}</div>
   {% endif %}
   <div class="c-bolt-horizontal-divider__border"></div>
 </div>

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/typography/_headline-with-logo.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/typography/_headline-with-logo.twig
@@ -1,10 +1,10 @@
 {% grid "o-bolt-grid--flex o-bolt-grid--small o-bolt-grid--matrix o-bolt-grid--middle" %}
   {% cell "u-bolt-width-12/12 u-bolt-width-6/12@small" %}
-    {{ headline }}
+    {{ headline|raw }}
   {% endcell %}
 
   {% cell "u-bolt-width-12/12 u-bolt-width-6/12@small" %}
-    {{ logo }}
+    {{ logo|raw }}
   {% endcell %}
 {% endgrid %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/collections/dashboard/_dashboard-band.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/collections/dashboard/_dashboard-band.twig
@@ -51,7 +51,7 @@
             {% if item.cardTitle %}
               {% include "@bolt-blueprints/_vertical-card.twig" with item %}
             {% else %}
-              {{ item }}
+              {{ item|raw }}
             {% endif %}
           {% endcell %}
         {% endfor %}

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/heros/_hero-partials/_hero-secondary-content.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/heros/_hero-partials/_hero-secondary-content.twig
@@ -31,5 +31,5 @@
 {% endif %}
 
 {% if heroSupplementalContent %}
-  {{ heroSupplementalContent }}
+  {{ heroSupplementalContent|raw }}
 {% endif %}

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/heros/dashboard-page-hero/dashboard-page-hero.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/heros/dashboard-page-hero/dashboard-page-hero.twig
@@ -48,7 +48,7 @@
 
       {% if heroButtonRow %}
         {% cell "u-bolt-flex-shrink u-bolt-margin-top-auto" %}
-          {{ heroButtonRow }}
+          {{ heroButtonRow|raw }}
         {% endcell %}
       {% endif %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/heros/landing-page-hero/landing-page-hero.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/heros/landing-page-hero/landing-page-hero.twig
@@ -26,7 +26,7 @@
 
             {% if heroTopicList %}
               {% cell "u-bolt-width-1/1 u-bolt-width-1/2@medium" %}
-                {{ heroTopicList }}
+                {{ heroTopicList|raw }}
               {% endcell %}
             {% endif %}
           {% endgrid %}

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/04-templates/_landing-page-template.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/04-templates/_landing-page-template.twig
@@ -45,7 +45,7 @@
     } %}
       {% block band_background %}
         {% if backgroundBlock is not empty %}
-          {{ backgroundBlock }}
+          {{ backgroundBlock|raw }}
         {% else %}
           {{ parent() }}
         {% endif %}

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/05-pages/t1-landing-pages/mission-landing/_mission-landing.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/05-pages/t1-landing-pages/mission-landing/_mission-landing.twig
@@ -44,7 +44,7 @@
                 {% if item.cardTitle %}
                   {% include "@bolt-blueprints/_horizontal-card.twig" with item %}
                 {% else %}
-                  {{ item }}
+                  {{ item|raw }}
                 {% endif %}
               {% endcell %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/05-pages/wip-pages/mission-exercise/_t2-mission-exercise-detail-page.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/05-pages/wip-pages/mission-exercise/_t2-mission-exercise-detail-page.twig
@@ -87,10 +87,10 @@
   {% set content %}
     {% grid "o-bolt-grid--flex o-bolt-grid--middle o-bolt-grid--matrix" %}
       {% cell "u-bolt-flex-grow" %}
-        {{ title }}
+        {{ title|raw }}
       {% endcell %}
       {% cell "u-bolt-flex-shrink" %}
-        {{ tools }}
+        {{ tools|raw }}
       {% endcell %}
     {% endgrid %}
   {% endset %}

--- a/packages/components/bolt-accordion/src/AccordionItem/accordion-item.twig
+++ b/packages/components/bolt-accordion/src/AccordionItem/accordion-item.twig
@@ -83,24 +83,24 @@
       <{{ trigger_tag }} {{ label_attributes.addClass(label_classes) }}>
         <div class="c-bolt-accordion-item__trigger-content">
           <ssr-keep for="bolt-accordion-item">
-            <div slot="trigger">{{ trigger }}</div>
+            <div slot="trigger">{{ trigger|raw }}</div>
           </ssr-keep>
         </div>
       </{{ trigger_tag }}>
 
       <a href="#{{ primary_uuid }}" class="c-bolt-accordion-item__trigger-link c-bolt-accordion-item__trigger-link--open {{ trigger_spacing_class }}">
-        <span class="c-bolt-accordion-item__toggle-text">{{ this.data.open_label.value }}</span>
+        <span class="c-bolt-accordion-item__toggle-text">{{ this.data.open_label.value|raw }}</span>
       </a>
 
       <a href="#{{ secondary_uuid }}" class="c-bolt-accordion-item__trigger-link c-bolt-accordion-item__trigger-link--close {{ trigger_spacing_class }}">
-        <span class="c-bolt-accordion-item__toggle-text">{{ this.data.close_label.value }}</span>
+        <span class="c-bolt-accordion-item__toggle-text">{{ this.data.close_label.value|raw }}</span>
       </a>
     </div>
 
     <div class="c-bolt-accordion-item__content">
       <div {{ content_attributes.addClass(content_classes) }}>
         <ssr-keep for="bolt-accordion-item">
-          {{ content }}
+          {{ content|raw }}
         </ssr-keep>
       </div>
     </div>

--- a/packages/components/bolt-action-blocks/src/_action-blocks-item.twig
+++ b/packages/components/bolt-action-blocks/src/_action-blocks-item.twig
@@ -18,7 +18,7 @@
 
     {% if text %}
       <div class="{{ "#{action_block_base_class}__item #{action_block_base_class}__text" }}">
-        {{ text }}
+        {{ text|raw }}
       </div>
     {% endif %}
   </a>

--- a/packages/components/bolt-action-blocks/src/action-blocks.twig
+++ b/packages/components/bolt-action-blocks/src/action-blocks.twig
@@ -73,7 +73,7 @@
 >
   <ul {{ inner_attributes.addClass(inner_classes) }}>
     {% if children %}
-      {{ children }}
+      {{ children|raw }}
     {% else %}
       {% for item in contentItems %}
         <li class="{{ "#{base_class}__item" }}">

--- a/packages/components/bolt-background/src/background-item.twig
+++ b/packages/components/bolt-background/src/background-item.twig
@@ -26,8 +26,8 @@
   </div>
 {% elseif (item is iterable) %}
   <div class="{{ "#{baseClass}__item" }}">
-    {{ item }}
+    {{ item|raw }}
   </div>
 {% else %}
-  {{ item }}
+  {{ item|raw }}
 {% endif %}

--- a/packages/components/bolt-band/src/_band-items-adapter.twig
+++ b/packages/components/bolt-band/src/_band-items-adapter.twig
@@ -9,7 +9,7 @@
         ] %}
 
         <div {{ attributes.addClass(item_classes) }}>
-          {{ item.content }}
+          {{ item.content|raw }}
         </div>
       {% endfor %}
     </div>

--- a/packages/components/bolt-band/src/band.twig
+++ b/packages/components/bolt-band/src/band.twig
@@ -80,7 +80,7 @@
     {% set regular_content_block %}
       {# Setting a block so it doesn't break legacy embeds #}
       {% block band_content %}
-        {{ content }}
+        {{ content|raw }}
       {% endblock %}
     {% endset %}
     {% set regular_content %}
@@ -113,7 +113,7 @@
                 ] %}
 
                 <div {{ attributes.addClass(item_classes) }}>
-                  {{ item.content }}
+                  {{ item.content|raw }}
                 </div>
               {% endfor %}
             </div>
@@ -125,7 +125,7 @@
         </div>
       {% endif %}
 
-      {{ regular_content }}
+      {{ regular_content|raw }}
 
       {% if pinned_content_lower %}
         <div class="{{ "#{base_class}__content #{base_class}__content--pinned #{base_class}__content--pinned-lower" }}">
@@ -133,7 +133,7 @@
             <div class="{{ "#{base_class}__pinned-items" }}">
               {% for item in pinned_content_lower %}
                 <div class="{{ "#{base_class}__pinned-item #{base_class}__pinned-item--#{item.align}" }}">
-                  {{ item.content }}
+                  {{ item.content|raw }}
                 </div>
               {% endfor %}
             </div>
@@ -147,7 +147,7 @@
     {% else %}
 
     {# Otherwise, render just the content #}
-      {{ regular_content }}
+      {{ regular_content|raw }}
     {% endif %}
   </{{ tag }}>
 </bolt-band>

--- a/packages/components/bolt-banner/src/banner.twig
+++ b/packages/components/bolt-banner/src/banner.twig
@@ -41,7 +41,7 @@
 >
   <replace-with-grandchildren>
     <div {% if inner_classes %} class="{{ inner_classes|join(' ') }}" {% endif %}>
-      {{ content }}
+      {{ content|raw }}
     </div>
   </replace-with-grandchildren>
 </bolt-banner>

--- a/packages/components/bolt-block-list/src/block-list.twig
+++ b/packages/components/bolt-block-list/src/block-list.twig
@@ -42,7 +42,7 @@
     {% for listItem in items %}
       <li class="{{ "#{baseClass}__item" }}">
         {% if listItem %}
-          {{ listItem }}
+          {{ listItem|raw }}
         {% endif %}
       </li>
     {% endfor %}

--- a/packages/components/bolt-breadcrumb/src/breadcrumb.twig
+++ b/packages/components/bolt-breadcrumb/src/breadcrumb.twig
@@ -16,7 +16,7 @@
     <ol class="{{ "#{baseClass}__list" }}">
       {% for item in contentItems %}
         <li class="{{ "#{baseClass}__item" }}">
-          {{ item }}
+          {{ item|raw }}
         </li>
       {% endfor %}
     </ol>

--- a/packages/components/bolt-button/src/button.twig
+++ b/packages/components/bolt-button/src/button.twig
@@ -162,7 +162,7 @@ Sort classes passed in via attributes into two groups:
     {% block slot_before %}
       {{ macros.slottedIcon(icon, icon_position, "before") }}
     {% endblock %}
-    <replace-with-children class="c-bolt-button__item">{{ text }}</replace-with-children>
+    <replace-with-children class="c-bolt-button__item">{{ text|raw }}</replace-with-children>
     {% block slot_after %}
       {{ macros.slottedIcon(icon, icon_position, 'after') }}
     {% endblock %}

--- a/packages/components/bolt-card-replacement/src/card-replacement-actions/_card-replacement-action-item.twig
+++ b/packages/components/bolt-card-replacement/src/card-replacement-actions/_card-replacement-action-item.twig
@@ -1,5 +1,5 @@
 {% extends "@bolt-components-card-replacement/_card-replacement-action.twig" %}
 
 {% block action_item %}
-  {{item}}
+  {{ item|raw }}
 {% endblock %}

--- a/packages/components/bolt-card-replacement/src/card-replacement-body/_card-replacement-body.twig
+++ b/packages/components/bolt-card-replacement/src/card-replacement-body/_card-replacement-body.twig
@@ -12,7 +12,7 @@
     {% block body %}
       {% if card_replacement_body_content %}
         {# @todo: The replace function is a hack to get around the utf-8 bug. #}
-        {{ card_replacement_body_content | join | replace({"UTF-8": ""}) | raw }}
+        {{ card_replacement_body_content | join | replace({"UTF-8": ""})|raw }}
       {% else %}
         {% set card_replacement_eyebrow = body.eyebrow %}
         {% set card_replacement_headline = body.headline %}

--- a/packages/components/bolt-card-replacement/src/card-replacement-media/_card-replacement-media.twig
+++ b/packages/components/bolt-card-replacement/src/card-replacement-media/_card-replacement-media.twig
@@ -23,7 +23,7 @@
         {% if card_replacement_image %}
           {% include "@bolt-components-image/image.twig" with card_replacement_image only %}
         {% elseif media_block %}
-          {{ media_block }}
+          {{ media_block|raw }}
         {% endif %}
       </replace-with-children>
     </bolt-card-replacement-media>

--- a/packages/components/bolt-card-replacement/src/card-replacement/card-replacement.twig
+++ b/packages/components/bolt-card-replacement/src/card-replacement/card-replacement.twig
@@ -62,7 +62,7 @@
       {% if background_block %}
         {% embed "@bolt-components-card-replacement/_card-replacement-background.twig" %}
           {% block background %}
-            {{ background_block }}
+            {{ background_block|raw }}
           {% endblock %}
         {% endembed %}
       {% else %}
@@ -72,14 +72,14 @@
 
     {% if content %}
       {# @todo: The replace function is a hack to get around the utf-8 bug. #}
-      {{ content | join | replace({"UTF-8": ""}) }}
+      {{ content | join | replace({"UTF-8": ""})|raw }}
     {% else %}
 
       {% if media or media_block %}
         {% if media_block %}
           {% embed "@bolt-components-card-replacement/_card-replacement-media.twig" %}
             {% block media %}
-              {{ media_block }}
+              {{ media_block|raw }}
             {% endblock %}
           {% endembed %}
         {% else %}
@@ -92,7 +92,7 @@
         {% if body_block %}
           {% embed "@bolt-components-card-replacement/_card-replacement-body.twig" %}
             {% block body %}
-              {{ body_block }}
+              {{ body_block|raw }}
             {% endblock %}
           {% endembed %}
         {% else %}

--- a/packages/components/bolt-carousel/src/carousel.twig
+++ b/packages/components/bolt-carousel/src/carousel.twig
@@ -28,7 +28,7 @@
     {% for slide in slides %}
       {% embed "@bolt-components-carousel/_carousel-slide.twig" %}
         {% block default_slot %}
-          {{ slide }}
+          {{ slide|raw }}
         {% endblock %}
       {% endembed %}
     {% endfor %}

--- a/packages/components/bolt-chip/src/chip.twig
+++ b/packages/components/bolt-chip/src/chip.twig
@@ -74,7 +74,7 @@
     >
       {{ macros.slotted_icon(icon, icon_position, "before") }}
       <replace-with-children class="{{ "#{base_class}__text" }}">
-        {{ text }}
+        {{ text|raw }}
       </replace-with-children>
       {{ macros.slotted_icon(icon, icon_position, "after") }}
     </{{ tag }}>

--- a/packages/components/bolt-code-snippet/src/code-snippet.twig
+++ b/packages/components/bolt-code-snippet/src/code-snippet.twig
@@ -48,9 +48,9 @@
 >
   {% if display == "inline" %}
     {% spaceless %}
-      {{ code_content }}
+      {{ code_content|raw }}
     {% endspaceless %}
   {% else %}
-    <pre {{ attributes.addClass(classes) }}>{{ code_content }}</pre>
+    <pre {{ attributes.addClass(classes) }}>{{ code_content|raw }}</pre>
   {% endif %}
 </bolt-code-snippet>

--- a/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.twig
+++ b/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.twig
@@ -34,7 +34,7 @@
       size: iconSize
     } only %}
     <span class="{{ "#{base_class}__action-text" }}">
-      {{ trigger_text }}
+      {{ trigger_text|raw }}
     </span>
   </div>
 {% endset %}
@@ -67,15 +67,15 @@
   ] %}
   <span {{ inner_attributes.addClass(classes) }}>
     <button class="{{ "#{base_class}__trigger" }}" data-clipboard-text="{{ text_to_copy }}">
-      {{ custom_trigger|default(default_trigger) }}
+      {{ custom_trigger|default(default_trigger)|raw }}
     </button>
 
     <span class="{{ "#{base_class}__transition" }}">
-      {{ custom_transition|default(default_transition) }}
+      {{ custom_transition|default(default_transition)|raw }}
     </span>
 
     <span class="{{ "#{base_class}__confirmation" }}">
-      {{ custom_confirmation|default(default_confirmation) }}
+      {{ custom_confirmation|default(default_confirmation)|raw }}
     </span>
   </span>
 </bolt-copy-to-clipboard>

--- a/packages/components/bolt-figure/src/figure.twig
+++ b/packages/components/bolt-figure/src/figure.twig
@@ -50,7 +50,7 @@
             {% set table = media.table %}
 
             {% if content %}
-              {{ content }}
+              {{ content|raw }}
             {% elseif image %}
               {% include "@bolt-components-image/image.twig" with image only %}
             {% elseif icon %}
@@ -66,7 +66,7 @@
       {% if caption %}
         <replace-with-grandchildren>
           <figcaption class="{{ "#{base_class}__caption" }}">
-            {{ caption }}
+            {{ caption|raw }}
           </figcaption>
         </replace-with-grandchildren>
       {% endif %}

--- a/packages/components/bolt-form/src/elements/form-element.twig
+++ b/packages/components/bolt-form/src/elements/form-element.twig
@@ -18,24 +18,24 @@ Available variables:
 
 <div{{ attributes }}>
   {% if labelDisplay in ['before', 'invisible'] %}
-    {{ label }}
+    {{ label|raw }}
   {% endif %}
 
   {{ children }}
 
   {% if labelDisplay == 'after' %}
-    {{ label }}
+    {{ label|raw }}
   {% endif %}
 
   {% if errors %}
     <div class="c-bolt-input-message c-bolt-input-message--invalid">
-      {{ errors }}
+      {{ errors|raw }}
     </div>
   {% endif %}
 
   {% if descriptionText %}
     <div class="c-bolt-input-message">
-      {{ descriptionText }}
+      {{ descriptionText|raw }}
     </div>
   {% endif %}
 </div>

--- a/packages/components/bolt-form/src/elements/form-fieldset.twig
+++ b/packages/components/bolt-form/src/elements/form-fieldset.twig
@@ -28,17 +28,17 @@ Available variables:
   <div>
     {% if errors %}
       <div class="c-bolt-input-message c-bolt-input-message--invalid">
-        {{ errors }}
+        {{ errors|raw }}
       </div>
     {% endif %}
 
     {% if descriptionText %}
       <div class="c-bolt-input-message">
-        {{ descriptionText }}
+        {{ descriptionText|raw }}
       </div>
     {% endif %}
 
-    {{ children }}
+    {{ children|raw }}
 
   </div>
 </fieldset>

--- a/packages/components/bolt-form/src/elements/form-label.twig
+++ b/packages/components/bolt-form/src/elements/form-label.twig
@@ -25,4 +25,4 @@
   {% set _classes = ["c-bolt-label"] %}
 {% endif %}
 
-<label{{ attributes.addClass(_classes) }}>{{ title }}</label>
+<label{{ attributes.addClass(_classes) }}>{{ title|raw }}</label>

--- a/packages/components/bolt-form/src/form.twig
+++ b/packages/components/bolt-form/src/form.twig
@@ -1,5 +1,5 @@
 {% set attributes = create_attribute(attributes | default({})) %}
 
 <form{{ attributes }}>
-  {{ children }}
+  {{ children|raw }}
 </form>

--- a/packages/components/bolt-form/src/inputs/form-button.twig
+++ b/packages/components/bolt-form/src/inputs/form-button.twig
@@ -35,6 +35,6 @@
   {% endif %}
 
   <span class="c-bolt-button__item">
-    {{ text }}
+    {{ text|raw }}
   </span>
 </button>

--- a/packages/components/bolt-form/src/inputs/form-checkboxes.twig
+++ b/packages/components/bolt-form/src/inputs/form-checkboxes.twig
@@ -25,4 +25,4 @@
   'c-bolt-input-list--stack-spacing-none'
 ] %}
 
-<div{{ attributes.addClass(classes) }}>{{ children }}</div>
+<div{{ attributes.addClass(classes) }}>{{ children|raw }}</div>

--- a/packages/components/bolt-form/src/inputs/form-input.twig
+++ b/packages/components/bolt-form/src/inputs/form-input.twig
@@ -25,7 +25,7 @@ Available variables:
   {% set _classes = _classes|merge(['is-invalid']) %}
 {% endif %}
 
-<input{{ attributes.addClass(_classes) }} />{{ children }}
+<input{{ attributes.addClass(_classes) }} />{{ children|raw }}
 
 {#
 Some input types support icons, others don't.  Note that if icons are supported though, we'll always output

--- a/packages/components/bolt-form/src/inputs/form-select.twig
+++ b/packages/components/bolt-form/src/inputs/form-select.twig
@@ -9,11 +9,11 @@
       {% if option.type == 'optgroup' %}
         <optgroup label="{{ option.label }}">
           {% for sub_option in option.options %}
-            <option value="{{ sub_option.value }}"{{ sub_option.selected ? ' selected="selected"' }}>{{ sub_option.label }}</option>
+            <option value="{{ sub_option.value }}"{{ sub_option.selected ? ' selected="selected"' }}>{{ sub_option.label|raw }}</option>
           {% endfor %}
         </optgroup>
       {% elseif option.type == 'option' %}
-        <option value="{{ option.value }}"{{ option.selected ? ' selected="selected"' }}>{{ option.label }}</option>
+        <option value="{{ option.value }}"{{ option.selected ? ' selected="selected"' }}>{{ option.label|raw }}</option>
       {% endif %}
     {% endfor %}
   </select>

--- a/packages/components/bolt-form/src/inputs/form-textarea.twig
+++ b/packages/components/bolt-form/src/inputs/form-textarea.twig
@@ -17,4 +17,4 @@ Available variables:
   {% set _classes = _classes|merge(['is-invalid']) %}
 {% endif %}
 
-<textarea{{ attributes.addClass(_classes) }}>{{ value }}</textarea>
+<textarea{{ attributes.addClass(_classes) }}>{{ value|raw }}</textarea>

--- a/packages/components/bolt-grid/src/_grid-item.twig
+++ b/packages/components/bolt-grid/src/_grid-item.twig
@@ -28,5 +28,5 @@
   {% if valign %}valign="{{ valign }}"{% endif %}
   {{ item_attributes }}
 >
-  {{ content }}
+  {{ content|raw }}
 </bolt-grid-item>

--- a/packages/components/bolt-headline/src/_typography.twig
+++ b/packages/components/bolt-headline/src/_typography.twig
@@ -102,7 +102,7 @@
 
     {% include "@bolt/link.twig" with linkVars only %}
   {% else %}
-    {{ text }}
+    {{ text|raw }}
   {% endif %}
 
   {% if icon and not url and iconPosition != "before" %}

--- a/packages/components/bolt-image/src/image.twig
+++ b/packages/components/bolt-image/src/image.twig
@@ -147,7 +147,7 @@
 
   {% set children %}
     {{ is_jpg ? image_placeholder : "" }}
-    {{ image_tag }}
+    {{ image_tag|raw }}
   {% endset %}
 
   {% block image_content %}
@@ -158,9 +158,9 @@
       } only %}
     {% else %}
       {% if can_use_placeholder %}
-        {{ image_placeholder}}
+        {{ image_placeholder|raw }}
       {% endif %}
-      {{ image_tag }}
+      {{ image_tag|raw }}
     {% endif %}
   {% endblock %}
 </bolt-image>

--- a/packages/components/bolt-li/src/li.twig
+++ b/packages/components/bolt-li/src/li.twig
@@ -13,7 +13,7 @@
       <replace-with-grandchildren>
         <li class="{{ classes|join(" ") }}">
   {% endif %}
-  {{ children }}
+  {{ children|raw }}
   {% if length == index %}
         </li>
       </replace-with-grandchildren>
@@ -23,7 +23,7 @@
   <bolt-li {{ attributes }}>
     <replace-with-grandchildren>
       <li class="{{ classes|join(" ") }}">
-        {{ children }}
+        {{ children|raw }}
       </li>
     </replace-with-grandchildren>
   </bolt-li>

--- a/packages/components/bolt-link/src/link.twig
+++ b/packages/components/bolt-link/src/link.twig
@@ -95,7 +95,7 @@ Sort classes passed in via attributes into two groups:
   >
     {{ macros.slotted_icon(icon, icon_position, "before") }}
     <replace-with-children class="{{ "#{base_class}__text" }}">
-      {{- text | default(label) | default("Learn More") -}}
+      {{- text | default(label) | default("Learn More")|raw -}}
     </replace-with-children>
     {{ macros.slotted_icon(icon, icon_position, "after") }}
   </a>

--- a/packages/components/bolt-list/src/_list-item.twig
+++ b/packages/components/bolt-list/src/_list-item.twig
@@ -20,9 +20,9 @@
   <replace-with-grandchildren>
     <{{ tag }} {{ attributes.addClass(classes) }}>
       {% if item.content %}
-        {{ item.content }}
+        {{ item.content|raw }}
       {% else %}
-        {{ item }}
+        {{ item|raw }}
       {% endif %}
     </{{ tag }}>
   </replace-with-grandchildren>

--- a/packages/components/bolt-menu/src/_menu-item.twig
+++ b/packages/components/bolt-menu/src/_menu-item.twig
@@ -26,7 +26,7 @@
       for="bolt-menu-item"
       {% if classes %} class="{{ classes|join(' ') }}" {% endif %}
     >
-      {{ content }}
+      {{ content|raw }}
     </ssr-keep>
   {% endset %}
   {% set trigger_options = {

--- a/packages/components/bolt-modal/src/modal.twig
+++ b/packages/components/bolt-modal/src/modal.twig
@@ -20,5 +20,5 @@
   {{ this.props|without("content")|without("class") }}
   uuid="{{ uuid }}"
 >
-  {{ content }}
+  {{ content|raw }}
 </bolt-modal>

--- a/packages/components/bolt-navbar/src/_navbar-title.twig
+++ b/packages/components/bolt-navbar/src/_navbar-title.twig
@@ -13,16 +13,16 @@
     </div>
   {% endif %}
   <{{ tag }} class="c-bolt-navbar__title-text">
-    {{ text }}
+    {{ text|raw }}
   </{{ tag }}>
 {% endset %}
 
 {% if url %}
   <a class="c-bolt-navbar__title--link" {{ attributes }}>
-    {{ navbar_title }}
+    {{ navbar_title|raw }}
   </a>
 {% else %}
   <div class="c-bolt-navbar__title--static">
-    {{ navbar_title }}
+    {{ navbar_title|raw }}
   </div>
 {% endif %}

--- a/packages/components/bolt-navlink/navlink.twig
+++ b/packages/components/bolt-navlink/navlink.twig
@@ -43,7 +43,7 @@
     <a {{ attributes.addClass(navlink_classes) }}>
       {{ macros.slotted_icon(icon, icon_position, "before") }}
       <span class="c-bolt-navlink__text">
-        {{ text | default("Default Navlink") }}
+        {{ text | default("Default Navlink")|raw }}
       </span>
       {{ macros.slotted_icon(icon, icon_position, "after") }}
     </a>

--- a/packages/components/bolt-pagination/src/pagination.twig
+++ b/packages/components/bolt-pagination/src/pagination.twig
@@ -68,7 +68,7 @@
           <bolt-icon name="chevron-left" size="small"></bolt-icon>
         </span>
         <span class="{{ "#{baseClass}__text" }}">
-          {{ previousText }}
+          {{ previousText|raw }}
         </span>
       </a>
     {% endif %}
@@ -79,7 +79,7 @@
       <a {{ firstAttributes.addClass("#{baseClass}__item") }}>
       <span class="{{ "#{baseClass}__text" }}">
         <span class="u-bolt-visuallyhidden">
-          {{ "Navigate to first page"|t }}
+          {{ "Navigate to first page"|t|raw }}
         </span>
         1
       </span>
@@ -129,7 +129,7 @@
       <a {{ lastAttributes.addClass("#{baseClass}__item") }}>
         <span class="{{ "#{baseClass}__text" }}">
           <span class="u-bolt-visuallyhidden">
-            {{ "Navigate to last page"|t }}
+            {{ "Navigate to last page"|t|raw }}
           </span>
           {{ total }}
         </span>
@@ -141,7 +141,7 @@
       {% set nextAttributes = nextAttributes.setAttribute("href", nextAttributes.href|default(next.href)) %}
       <a {{ nextAttributes.addClass("#{baseClass}__item", "#{baseClass}__item--next") }}>
         <span class="{{ "#{baseClass}__text" }}">
-          {{ nextText }}
+          {{ nextText|raw }}
         </span>
         <span class="{{ "#{baseClass}__icon" }}">
           <bolt-icon name="chevron-right" size="small"></bolt-icon>

--- a/packages/components/bolt-placeholder/placeholder.twig
+++ b/packages/components/bolt-placeholder/placeholder.twig
@@ -47,7 +47,7 @@
       <replace-with-children class="c-bolt-placeholder__wrapper-y"></replace-with-children>
       <replace-with-children class="c-bolt-placeholder__wrapper-x"></replace-with-children>
       <replace-with-children class="{{ contentClasses|join(' ') }}">
-        {{ text }}
+        {{ text|raw }}
       </replace-with-children>
     </replace-with-children>
   </replace-with-children>

--- a/packages/components/bolt-popover/src/popover.twig
+++ b/packages/components/bolt-popover/src/popover.twig
@@ -54,13 +54,13 @@
         aria-describedby="{{ popover_uuid }}"
         aria-controls="{{ popover_uuid }}"
       >
-        {{ trigger }}
+        {{ trigger|raw }}
       </replace-with-children>
     {% endif %}
     {% if content %}
       <span slot="content">
         <replace-with-children class="{{ "#{base_class}__content" }}" id="{{ popover_uuid }}" aria-hidden="true">
-            {{ content }}
+            {{ content|raw }}
         </replace-with-children>
       </span>
     {% endif %}

--- a/packages/components/bolt-ratio/src/ratio.twig
+++ b/packages/components/bolt-ratio/src/ratio.twig
@@ -26,7 +26,7 @@
 <bolt-ratio {{ attributes }}>
   <replace-with-children class="c-bolt-ratio" style="{{ inline_styles | join(" ") }}">
     {% block ratio_content %}
-      {{ children }}
+      {{ children|raw }}
     {% endblock %}
   </replace-with-children>
 </bolt-ratio>

--- a/packages/components/bolt-search-filter/search-filter.twig
+++ b/packages/components/bolt-search-filter/search-filter.twig
@@ -31,7 +31,7 @@
     <div class="{{ "#{baseClass}__panel" }}" id="{{ panelId }}">
       <div class="c-bolt-search-filter__panel-content">
         {% block search_filter %}
-          {{ content }}
+          {{ content|raw }}
         {% endblock search_filter %}
       </div>
 

--- a/packages/components/bolt-share/src/share.twig
+++ b/packages/components/bolt-share/src/share.twig
@@ -87,7 +87,7 @@
         size: size,
       } only %}
       <span class="{{ "#{base_class}__link-text" }}">
-        {{ trigger_text }}
+        {{ trigger_text|raw }}
       </span>
     </span>
   {% endset %}
@@ -111,7 +111,7 @@
         size: size,
       } only %}
       <span class="{{ "#{base_class}__link-text" }}">
-        {{ confirmation_text }}
+        {{ confirmation_text|raw }}
       </span>
     </div>
   {% endset %}

--- a/packages/components/bolt-stack/src/stack.twig
+++ b/packages/components/bolt-stack/src/stack.twig
@@ -22,6 +22,6 @@
   {{ this.props|without("content")|without("class") }}
 >
   <div {{ inner_attributes.addClass(base_class) }} is="shadow-root">
-    {{ content }}
+    {{ content|raw }}
   </div>
 </bolt-stack>

--- a/packages/components/bolt-sticky/src/sticky.twig
+++ b/packages/components/bolt-sticky/src/sticky.twig
@@ -17,6 +17,6 @@
 
 <bolt-{{ componentName }} bolt-component {{ attributes.addClass(classes) }}>
   {% block sticky_content %}
-    {{ content }}
+    {{ content|raw }}
   {% endblock sticky_content %}
 </bolt-{{ componentName }}>

--- a/packages/components/bolt-table/src/table.twig
+++ b/packages/components/bolt-table/src/table.twig
@@ -51,9 +51,9 @@
             %}
             <th {{ cell_attributes.addClass(cell_classes) }} scope="col">
               {% if cell.content %}
-                {{ cell.content }}
+                {{ cell.content|raw }}
               {% else %}
-                {{ cell }}
+                {{ cell|raw }}
               {% endif %}
             </th>
           {% endfor %}
@@ -76,9 +76,9 @@
               {% if cell is not empty %}
                 <th {{ cell_attributes.addClass(cell_classes) }} scope="row">
                   {% if cell.content %}
-                    {{ cell.content }}
+                    {{ cell.content|raw }}
                   {% else %}
-                    {{ cell }}
+                    {{ cell|raw }}
                   {% endif %}
                 </th>
               {% endif %}
@@ -92,9 +92,9 @@
               %}
               <td {{ cell_attributes.addClass(cell_classes) }}>
                 {% if cell is iterable %}
-                  {{ cell.content }}
+                  {{ cell.content|raw }}
                 {% else %}
-                  {{ cell }}
+                  {{ cell|raw }}
                 {% endif %}
               </td>
             {% endfor %}
@@ -110,9 +110,9 @@
               {% if loop.last %}
                 <th class="{{ "#{base_class}__cell #{base_class}__cell--header" }}">
                   {% if cell.content %}
-                    {{ cell.content }}
+                    {{ cell.content|raw }}
                   {% else %}
-                    {{ cell }}
+                    {{ cell|raw }}
                   {% endif %}
                 </th>
               {% endif %}
@@ -127,9 +127,9 @@
             %}
             <td {{ cell_attributes.addClass(cell_classes) }}>
               {% if cell.content %}
-                {{ cell.content }}
+                {{ cell.content|raw }}
               {% else %}
-                {{ cell }}
+                {{ cell|raw }}
               {% endif %}
             </td>
           {% endfor %}

--- a/packages/components/bolt-tabs/src/TabPanel/tab-panel.twig
+++ b/packages/components/bolt-tabs/src/TabPanel/tab-panel.twig
@@ -46,7 +46,7 @@
 <label for="{{ panel_id }}" {{ label_attributes.addClass(label_classes) }}>
   <span class="c-bolt-tabs__label-inner">
     <span class="c-bolt-tabs__label-text">
-      {{ label }}
+      {{ label|raw }}
     </span>
   </span>
 </label>
@@ -54,12 +54,12 @@
   <ssr-keep for="bolt-tabs">
     <bolt-tab-panel {% if outer_classes %} class="{{ outer_classes|join(' ') }}" {% endif %} {{ this.props|without("label")|without("content")|without("class") }}>
       <ssr-keep for="bolt-tab-panel">
-        <div slot="label">{{ label }}</div>
+        <div slot="label">{{ label|raw }}</div>
       </ssr-keep>
       <div {{ inner_attributes.addClass(inner_classes) }}>
         <div role="tabpanel" class="c-bolt-tab-panel__content">
           <ssr-keep for="bolt-tab-panel">
-            {{ content }}
+            {{ content|raw }}
           </ssr-keep>
         </div>
       </div>

--- a/packages/components/bolt-text/src/text.twig
+++ b/packages/components/bolt-text/src/text.twig
@@ -162,4 +162,4 @@
   {% set attributes = attributes.setAttribute("util", util|join(',')) %}
 {% endif %}
 
-<bolt-text {{ attributes }}>{{ text }}</bolt-text>
+<bolt-text {{ attributes }}>{{ text|raw }}</bolt-text>

--- a/packages/components/bolt-toolbar/_toolbar-breadcrumbs.twig
+++ b/packages/components/bolt-toolbar/_toolbar-breadcrumbs.twig
@@ -13,16 +13,16 @@
     </div>
   {% endif %}
   <{{ tag }} class="c-bolt-toolbar__title-text">
-    {{ text }}
+    {{ text|raw }}
   </{{ tag }}>
 {% endset %}
 
 {% if url %}
   <a class="c-bolt-toolbar__title--link" {{ attributes }}>
-    {{ toolbar_title }}
+    {{ toolbar_title|raw }}
   </a>
 {% else %}
   <div class="c-bolt-toolbar__title--static">
-    {{ toolbar_title }}
+    {{ toolbar_title|raw }}
   </div>
 {% endif %}

--- a/packages/components/bolt-toolbar/_toolbar-title.twig
+++ b/packages/components/bolt-toolbar/_toolbar-title.twig
@@ -16,17 +16,17 @@
   {% endif %}
   {% if text %}
     <{{ tag }} class="c-bolt-toolbar__title-text">
-      {{ text }}
+      {{ text|raw }}
     </{{ tag }}>
   {% endif %}
 {% endset %}
 
 {% if url %}
   <a class="c-bolt-toolbar__title c-bolt-toolbar__title--link" {{ attributes }}>
-    {{ toolbar_title }}
+    {{ toolbar_title|raw }}
   </a>
 {% else %}
   <div class="c-bolt-toolbar__title c-bolt-toolbar__title--static">
-    {{ toolbar_title }}
+    {{ toolbar_title|raw }}
   </div>
 {% endif %}

--- a/packages/components/bolt-tooltip/src/tooltip.twig
+++ b/packages/components/bolt-tooltip/src/tooltip.twig
@@ -82,7 +82,7 @@
             {% include "@bolt-components-icon/icon.twig" with trigger.icon %}
           {% endif %}
           {% if trigger.text %}
-            {{ trigger.text }}
+            {{ trigger.text|raw }}
           {% endif %}
         </replace-with-children>
       {% elseif trigger.type == "button" %}
@@ -112,7 +112,7 @@
           aria-describedby="{{ tooltip_uuid }}"
           aria-controls="{{ tooltip_uuid }}"
         >
-          {{ trigger }}
+          {{ trigger|raw }}
         </replace-with-children>
       {% endif %}
       {# End new trigger #}
@@ -122,7 +122,7 @@
       <span slot="content">
         <replace-with-grandchildren id="{{ tooltip_uuid }}" class="{{ "#{base_class}__content" }}" role="tooltip" aria-hidden="true">
           <span class="{{ "#{base_class}__bubble" }}">
-            {{ content }}
+            {{ content|raw }}
           </span>
         </replace-with-grandchildren>
       </span>

--- a/packages/components/bolt-trigger/src/trigger.twig
+++ b/packages/components/bolt-trigger/src/trigger.twig
@@ -67,6 +67,6 @@
   {{ this.props|without("content")|without("class") }}
 >
   <{{ tag }} {{ inner_attributes|without("on-click")|without("on-click-target") }} is="shadow-root">
-    {{ content }}
+    {{ content|raw }}
   </{{ tag }}>
 </bolt-trigger>

--- a/packages/global/styles/05-objects/objects-wrapper/wrapper.twig
+++ b/packages/global/styles/05-objects/objects-wrapper/wrapper.twig
@@ -30,7 +30,7 @@
   <bolt-wrapper size="{{ size }}" full="{% if full == true %}true{% else %}false{% endif %}" bolt-object>
     <{{ tag }} {{ attributes.addClass(classes) }}>
       {% block wrapper_content %}
-        {{ content }}
+        {{ content|raw }}
       {% endblock wrapper_content %}
     </{{ tag }}>
   </bolt-wrapper>


### PR DESCRIPTION
## Jira
- http://vjira2:8080/browse/AC-67
- http://vjira2:8080/browse/AC-65
- http://vjira2:8080/browse/BDS-1988 --> especially this one.

## Summary
Adds `raw` Twig filters to Bolt templates that output text or nested content (ex. `{{ variable }}`) as a hotfix to address several different Twig rendering issues flagged in http://vjira2:8080/browse/BDS-1988.

## Details
This particular fix was a result of a day+ of debugging + hands on trial and error within Drupal Lab (using local Bolt Twig templates) to identify a viable solution for the Twig rendering issues. 

Side note: while at least some of the templates being updated here haven't been confirmed to have been breaking on Academy (ex. Accordion and Forms), at least most of these have been -- hence the across the board update to try and address this vs playing whack-a-mole every single time this pops up.

Once things have settled down, I have some Drupal Lab config updates + workflow updates to PR back to Bolt that should help simplify the debugging process for issues like these (plus some potential ways to prevent this specific type of issue moving forward). 

### Screenshots of Drupal Lab running locally with the fix in place:
![CleanShot 2020-01-29 at 16 17 19](https://user-images.githubusercontent.com/1617209/73399927-190d3b00-42b6-11ea-9718-1e783897ff1c.png)
![CleanShot 2020-01-29 at 16 17 05](https://user-images.githubusercontent.com/1617209/73399928-190d3b00-42b6-11ea-9359-39bff7e17bd3.png)


## How to test
- Sanity check on the Twig updates
- Quick smoke test in PL to make sure things generally seem to be working fine
- Confirm Twig rendering tests all pass