### PR TITLE
`@bolt/element` conditional Shadow DOM fix; add `css` export

### DIFF
--- a/packages/base-element/index.js
+++ b/packages/base-element/index.js
@@ -12,7 +12,7 @@ export {
 } from './src/lib/utils';
 
 export { convertInitialTags } from './src/lib/decorators';
-export { html, unsafeCSS } from 'lit-element';
+export { css, html, unsafeCSS } from 'lit-element';
 export { render } from 'lit-html';
 export { ifDefined } from 'lit-html/directives/if-defined';
 export { classMap } from 'lit-html/directives/class-map.js';

--- a/packages/base-element/src/lib/decorators.js
+++ b/packages/base-element/src/lib/decorators.js
@@ -96,6 +96,17 @@ const conditionalShadowDomClass = clazz => {
     createRenderRoot() {
       this.useShadow = shouldUseShadowDom(this);
 
+      // @todo: look into adding fallback style loader
+      // if (this.constructor && this.useShadow === false && this.constructor.styles){
+      //   this.constructor.styles.map(item => {
+      //     if (item.cssText){
+      //       const stylesheet = new CSSStyleSheet();
+      //       stylesheet.replaceSync(item.cssText);
+      //       document.adoptedStyleSheets = [stylesheet];
+      //     }
+      //   });
+      // }
+
       if (this.useShadow) {
         return this.attachShadow({ mode: 'open' });
       } else {

--- a/packages/base-element/src/lib/utils.js
+++ b/packages/base-element/src/lib/utils.js
@@ -39,6 +39,8 @@ export function supportsShadowDom() {
 
 export function shouldUseShadowDom(elem) {
   if (
+    (elem.constructor && elem.constructor.useShadow === false) || // aka static useShadow = false;
+    (elem.constructor && elem.constructor.noShadow === true) ||
     elem.useShadow === false ||
     elem.noShadow === true ||
     findParentTag(elem, 'FORM') ||

--- a/packages/components/bolt-button/src/button.js
+++ b/packages/components/bolt-button/src/button.js
@@ -21,6 +21,8 @@ class BoltButton extends BoltActionElement {
     return [unsafeCSS(buttonStyles)];
   }
 
+  // static useShadow = false; example of manually disabling Shadow DOM w/ BoltElement
+
   static get properties() {
     return {
       ...BoltActionElement.properties, // Provides: disabled, onClick, onClickTarget, target, url


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/BDS-1981

## Summary
`@bolt/element` related updates from https://github.com/boltdesignsystem/bolt/pull/1711

## Details
- Exposes the `css` lit-element export to `@bolt/element`
- Fixes / addresses the  need for BoltElement components to be able to optionally disable Shadow DOM rendering (regardless of cross-browser support) via a static Class property that can be defined.

Ex.
```
@customElement('bolt-button')
class BoltButton extends BoltElement {
 constructor() {
    this.useShadow = false; // --> this does NOT work! (and might not ever work) 
  }

  static useShadow = false; // --> however THIS now works!

```