### PR TITLE
fix: remove padding on last list item

### DIFF
--- a/packages/components/bolt-list/src/_list-item.scss
+++ b/packages/components/bolt-list/src/_list-item.scss
@@ -86,11 +86,11 @@ $bolt-list-separator-styles: solid, dashed;
         &.c-bolt-list-item--display-block {
           @include bolt-padding-bottom(#{$spacing-value-name});
         }
-      }
 
-      &.c-bolt-list-item--display-inline,
-      &.c-bolt-list-item--display-flex {
-        @include bolt-padding-right(#{$spacing-value-name});
+        &.c-bolt-list-item--display-inline,
+        &.c-bolt-list-item--display-flex {
+          @include bolt-padding-right(#{$spacing-value-name});
+        }
       }
     }
 


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1989

## Summary

Remove right padding on last list item.

## Details

CSS that should be removing this padding is not scoped properly. This fixes the scoping.

## How to test

- Review code changes.
- Check Inline List demo and verify last item has no right padding.
