### PR TITLE
Fix block() and include() autoescaping

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/01-atoms/forms/_checkbox.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/01-atoms/forms/_checkbox.twig
@@ -1,7 +1,9 @@
 {% extends "@bolt-components-form/form-element.twig" %}
 
+{% import "@bolt-blueprints/macros.twig" as macros %}
+
 {% set label %}
-  {% include("@bolt-components-form/form-label.twig") with {
+  {% macros.include("@bolt-components-form/form-label.twig") with {
     "title": labelTitle,
     "displayType": "inline-checkbox",
     "attributes": {
@@ -11,7 +13,7 @@
 {% endset %}
 
 {% set children %}
-  {% include("@bolt-components-form/form-input.twig") with {
+  {% macros.include("@bolt-components-form/form-input.twig") with {
     "attributes": {
       "type": "checkbox",
       "id": elementId

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/01-atoms/forms/_custom-select.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/01-atoms/forms/_custom-select.twig
@@ -1,6 +1,8 @@
+{% import "@bolt-blueprints/macros.twig" as macros %}
+
 {% set children %}
   <bolt-select should-sort-items="true" item-select-text="">
-    {% include("@bolt-components-form/form-select.twig") with {
+    {% macros.include("@bolt-components-form/form-select.twig") with {
       options: [
         {
           label: "Pega Platform 8.4",
@@ -31,7 +33,7 @@
   </bolt-select>
 {% endset %}
 
-{% include("@bolt-components-form/form-element.twig") with {
+{% macros.include("@bolt-components-form/form-element.twig") with {
   children: children,
 } only %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/01-atoms/forms/_select.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/01-atoms/forms/_select.twig
@@ -1,16 +1,18 @@
 {% extends "@bolt-components-form/form-element.twig" %}
 
+{% import "@bolt-blueprints/macros.twig" as macros %}
+
 {% set label_display = 'after' %}
 
 {% set label %}
-  {% include("@bolt-components-form/form-label.twig") with {
+  {% macros.include("@bolt-components-form/form-label.twig") with {
     "title": title,
     "displayType": "floating"
   } %}
 {% endset %}
 
 {% set children %}
-  {% include("@bolt-components-form/form-select.twig") with {
+  {% macros.include("@bolt-components-form/form-select.twig") with {
     "attributes": selectAttributes,
     "options": options
   } %}

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/01-atoms/forms/toolbar-buttons/_share.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/01-atoms/forms/toolbar-buttons/_share.twig
@@ -1,62 +1,64 @@
 {% extends "@bolt-blueprints/toolbar-buttons/_toolbar-button.twig" %}
 
+{% import "@bolt-blueprints/macros.twig" as macros %}
+
 {% set iconName = "share" %}
 {% set popover %}
   {% include "@bolt-components-menu/menu.twig" with {
     items: [
       {
-        content: include("@bolt-components-headline/text.twig", {
+        content: macros.include("@bolt-components-headline/text.twig", {
           text: "Facebook",
           size: "medium",
           icon: {
             name: "facebook-solid",
             position: "before"
           }
-        }, with_context = false),
+        }, false),
         url: "#!"
       },
       {
-        content: include("@bolt-components-headline/text.twig", {
+        content: macros.include("@bolt-components-headline/text.twig", {
           text: "Twitter",
           size: "medium",
           icon: {
             name: "twitter",
             position: "before"
           }
-        }, with_context = false),
+        }, false),
         url: "#!"
       },
       {
-        content: include("@bolt-components-headline/text.twig", {
+        content: macros.include("@bolt-components-headline/text.twig", {
           text: "LinkedIn",
           size: "medium",
           icon: {
             name: "linkedin",
             position: "before"
           }
-        }, with_context = false),
+        }, false),
         url: "#!"
       },
       {
-        content: include("@bolt-components-headline/text.twig", {
+        content: macros.include("@bolt-components-headline/text.twig", {
           text: "Email",
           size: "medium",
           icon: {
             name: "email",
             position: "before"
           }
-        }, with_context = false),
+        }, false),
         url: "#!"
       },
       {
-        content: include("@bolt-components-headline/text.twig", {
+        content: macros.include("@bolt-components-headline/text.twig", {
           text: "Link",
           size: "medium",
           icon: {
             name: "asset-link",
             position: "before"
           }
-        }, with_context = false),
+        }, false),
         url: "#!"
       },
     ]

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/01-atoms/macros.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/01-atoms/macros.twig
@@ -1,0 +1,7 @@
+{% macro include(path, args = {}, with_context = true) %}
+  {% if with_context %}
+    {% include path with args %}
+  {% else %}
+    {% include path with args only %}
+  {% endif %}
+{% endmacro %}

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/h5p-embed/h5p-embed.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/h5p-embed/h5p-embed.twig
@@ -1,11 +1,13 @@
+{% import "@bolt-blueprints/macros.twig" as macros %}
+
 {% grid "o-bolt-grid--flex o-bolt-grid--center o-bolt-grid--matrix" %}
     {% cell "u-bolt-width-1/1 u-bolt-width-10/12@small u-bolt-width-10/12@medium" %}
       {% include "@bolt-components-card-replacement/card-replacement.twig" with {
         rounded: true,
         body: {
-          content: embedContent | default(include("@bolt-components-ratio/ratio.twig", {
+          content: embedContent | default(macros.include("@bolt-components-ratio/ratio.twig", {
             ratio: "16/9",
-            children: include("@bolt-components-placeholder/placeholder.twig", {
+            children: macros.include("@bolt-components-placeholder/placeholder.twig", {
               size: "large",
               text: "H5P Placeholder"
             }),

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/search-and-filtereing/_chips--search-filter.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/search-and-filtereing/_chips--search-filter.twig
@@ -1,3 +1,5 @@
+{% import "@bolt-blueprints/macros.twig" as macros %}
+
 {% set clear_filters_link %}
   {% include "@bolt-components-link/link.twig" with {
     text: "Clear filters"
@@ -7,7 +9,7 @@
 {% include "@bolt-components-list/list.twig" with {
   display: "inline",
   items: [
-    include("@bolt-components-chip/chip.twig", {
+    macros.include("@bolt-components-chip/chip.twig", {
       text: "Challenge",
       url: "#!",
       size: "xsmall",
@@ -16,7 +18,7 @@
         position: "after"
       }
     }),
-    include("@bolt-components-headline/text.twig", {
+    macros.include("@bolt-components-headline/text.twig", {
       text: "(" ~ clear_filters_link|trim ~ ")",
       tag: "span",
       size: "small"

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/search-and-filtereing/_hide-show-completed.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/search-and-filtereing/_hide-show-completed.twig
@@ -1,24 +1,26 @@
 {% extends "@bolt-components-form/form-element.twig" %}
 
+{% import "@bolt-blueprints/macros.twig" as macros %}
+
 {% set label %}
-  {% include("@bolt-components-form/form-label.twig") with {
+  {{ macros.include("@bolt-components-form/form-label.twig", {
     "title": "Hide Completed",
     "displayType": "inline-checkbox",
     "attributes": {
       "for": "hide-completed"
     }
-  } %}
+  }) }}
 {% endset %}
 
 {% set children %}
-  {% include("@bolt-components-form/form-input.twig") with {
+  {{ macros.include("@bolt-components-form/form-input.twig", {
     "attributes": {
       "type": "checkbox",
       "id": ["hide-completed"],
       "checked": hideCompleted,
       "data-demo-url": hideCompleted ? link["blueprints-t1-mission-landing"] : link["blueprints-t1-mission-landing-hide-completed"]
-    },
-  } %}
+    }
+  }) }}
 
   <!-- Super simple demo for PL to go back and forth between page examples -->
   <script>

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/user-actions/_toolbar-actions.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/user-actions/_toolbar-actions.twig
@@ -1,13 +1,15 @@
 {% set shareButton = shareButton | default(true) %}
 
+{% import "@bolt-blueprints/macros.twig" as macros %}
+
 {% include "@bolt-components-list/list.twig" with {
   display: "flex",
   align: "end",
   spacing: "xsmall",
   nowrap: true,
   items: [
-    shareButton ? include("@bolt-blueprints/toolbar-buttons/_share.twig", with_context = false) : '',
-    favoriteButton ? include("@bolt-components-button/button.twig", {
+    shareButton ? macros.include("@bolt-blueprints/toolbar-buttons/_share.twig", {}, false) : '',
+    favoriteButton ? macros.include("@bolt-components-button/button.twig", {
       text: "Favorite",
       size: "small",
       style: "secondary",
@@ -15,8 +17,8 @@
       icon: {
         name: "heart",
       }
-    }, with_context = false) : '',
-    addButton ? include("@bolt-components-button/button.twig", {
+    }, false) : '',
+    addButton ? macros.include("@bolt-components-button/button.twig", {
       text: "Add",
       size: "small",
       style: "secondary",
@@ -24,9 +26,9 @@
       icon: {
         name: "add",
       }
-    }, with_context = false) : '',
-    removeButton ? include("@bolt-blueprints/toolbar-buttons/_remove.twig", with_context = false) : '',
-    downloadButton ? include("@bolt-components-button/button.twig", {
+    }, false) : '',
+    removeButton ? macros.include("@bolt-blueprints/toolbar-buttons/_remove.twig", {}, false) : '',
+    downloadButton ? macros.include("@bolt-components-button/button.twig", {
       text: "Download",
       size: "small",
       style: "secondary",
@@ -34,6 +36,6 @@
       icon: {
         name: "download",
       }
-    }, with_context = false) : '',
+    }, false) : '',
   ]
 } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/collections/dashboard/_dashboard-band--in-progress.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/collections/dashboard/_dashboard-band--in-progress.twig
@@ -1,3 +1,5 @@
+{% import "@bolt-blueprints/macros.twig" as macros %}
+
 {% include "@bolt-blueprints/_dashboard-band.twig" with {
   sectionTitle: "In Progress",
   contentItems: [
@@ -6,25 +8,25 @@
       cardSubtitle: "Module",
       cardTitle: bolt.faker.sentence(3),
       cardMetaItems: [
-        include("@bolt-components-headline/text.twig", {
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "#{bolt.faker.numberBetween(2,10)} Topics",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "40 mins remaining",
           attributes: {
             class: ["u-bolt-color-orange"]
           }
-        }, with_context = false)
+        }, false)
       ],
       cardGradient: "teal",
       cardIcon: "orbit",
       cardDescription: bolt.faker.paragraph(2),
       cardUtilityItems: [
-        include("@bolt-components-button/button.twig", {
+        macros.include("@bolt-components-button/button.twig", {
           text: "Share",
           size: "xsmall",
           style: "text",
@@ -33,16 +35,16 @@
             size: "small"
           },
           iconOnly: true
-        }, with_context = false )
+        }, false )
       ],
       cardStatusItems: [
-        include("@bolt-components-headline/eyebrow.twig", {
+        macros.include("@bolt-components-headline/eyebrow.twig", {
           text: "Last activity: 3 days ago",
           align: "center",
           attributes: {
             class: ["u-bolt-padding-small"]
           }
-        }, with_context = false)
+        }, false)
       ]
     },
     {
@@ -50,25 +52,25 @@
       cardSubtitle: "Module",
       cardTitle: bolt.faker.sentence(3),
       cardMetaItems: [
-        include("@bolt-components-headline/text.twig", {
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "#{bolt.faker.numberBetween(2,10)} Topics",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "In progress",
           attributes: {
             class: ["u-bolt-color-orange"]
           }
-        }, with_context = false)
+        }, false)
       ],
       cardGradient: "orange",
       cardIcon: "meteor",
       cardDescription: bolt.faker.paragraph(2),
       cardUtilityItems: [
-        include("@bolt-components-button/button.twig", {
+        macros.include("@bolt-components-button/button.twig", {
           text: "Share",
           size: "xsmall",
           style: "text",
@@ -77,16 +79,16 @@
             size: "small"
           },
           iconOnly: true
-        }, with_context = false )
+        }, false )
       ],
       cardStatusItems: [
-        include("@bolt-components-headline/eyebrow.twig", {
+        macros.include("@bolt-components-headline/eyebrow.twig", {
           text: "Last activity: 12/21/19",
           align: "center",
           attributes: {
             class: ["u-bolt-padding-small"]
           }
-        }, with_context = false)
+        }, false)
       ]
     }
   ]

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/collections/dashboard/_dashboard-band--my-missions.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/collections/dashboard/_dashboard-band--my-missions.twig
@@ -1,40 +1,42 @@
+{% import "@bolt-blueprints/macros.twig" as macros %}
+
 {% set cardContentItems = [
     {
       cardUrl: "#!",
       cardSubtitle: "Mission",
       cardTitle: bolt.faker.sentence(3),
       cardMetaItems: [
-        include("@bolt-components-headline/text.twig", {
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "#{bolt.faker.numberBetween(2,10)} Modules",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "1 Challenge",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "25% complete",
           attributes: {
             class: ["u-bolt-color-orange"]
           }
-        }, with_context = false)
+        }, false)
       ],
       cardGradient: "purple",
       cardIcon: "rocket",
       cardDescription: bolt.faker.paragraph(2),
       removeButton: true,
       cardStatusItems: [
-        include("@bolt-components-headline/eyebrow.twig", {
+        macros.include("@bolt-components-headline/eyebrow.twig", {
           text: "Last activity: 3 days ago",
           align: "center",
           attributes: {
             class: ["u-bolt-padding-small"]
           }
-        }, with_context = false)
+        }, false)
       ]
     },
     {
@@ -42,44 +44,44 @@
       cardSubtitle: "Mission",
       cardTitle: bolt.faker.sentence(3),
       cardMetaItems: [
-        include("@bolt-components-headline/text.twig", {
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "#{bolt.faker.numberBetween(2,10)} Modules",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "1 Challenge",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "10% complete",
           attributes: {
             class: ["u-bolt-color-orange"]
           }
-        }, with_context = false)
+        }, false)
       ],
       cardGradient: "purple",
       cardIcon: "rocket",
       cardDescription: bolt.faker.paragraph(2),
       removeButton: true,
       cardStatusItems: [
-        include("@bolt-components-headline/eyebrow.twig", {
+        macros.include("@bolt-components-headline/eyebrow.twig", {
           text: "Last activity: 12/21/19",
           align: "center",
           attributes: {
             class: ["u-bolt-padding-small"]
           }
-        }, with_context = false),
-        include("@bolt-components-headline/eyebrow.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/eyebrow.twig", {
           text: "Assigned",
           align: "center",
           attributes: {
             class: ["u-bolt-padding-small"]
           }
-        }, with_context = false)
+        }, false)
       ]
     },
     {
@@ -87,37 +89,37 @@
       cardSubtitle: "Mission",
       cardTitle: bolt.faker.sentence(3),
       cardMetaItems: [
-        include("@bolt-components-headline/text.twig", {
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "#{bolt.faker.numberBetween(2,10)} Modules",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "1 Challenge",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "10% complete",
           attributes: {
             class: ["u-bolt-color-orange"]
           }
-        }, with_context = false)
+        }, false)
       ],
       cardGradient: "purple",
       cardIcon: "rocket",
       cardDescription: bolt.faker.paragraph(2),
       removeButton: true,
       cardStatusItems: [
-        include("@bolt-components-headline/eyebrow.twig", {
+        macros.include("@bolt-components-headline/eyebrow.twig", {
           text: "Last activity: 12/21/19",
           align: "center",
           attributes: {
             class: ["u-bolt-padding-small"]
           }
-        }, with_context = false)
+        }, false)
       ]
     },
     {
@@ -125,30 +127,30 @@
       cardSubtitle: "Mission",
       cardTitle: bolt.faker.sentence(3),
       cardMetaItems: [
-        include("@bolt-components-headline/text.twig", {
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "#{bolt.faker.numberBetween(2,10)} Modules",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "1 Challenge",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "25% complete",
           attributes: {
             class: ["u-bolt-color-orange"]
           }
-        }, with_context = false)
+        }, false)
       ],
       cardGradient: "purple",
       cardIcon: "rocket",
       cardDescription: bolt.faker.paragraph(2),
       cardUtilityItems: [
-        include("@bolt-components-button/button.twig", {
+        macros.include("@bolt-components-button/button.twig", {
           text: "Share",
           size: "xsmall",
           style: "text",
@@ -157,8 +159,8 @@
             size: "small"
           },
           iconOnly: true
-        }, with_context = false ),
-        include("@bolt-components-button/button.twig", {
+        }, false ),
+        macros.include("@bolt-components-button/button.twig", {
           text: "Remove from Dashboard",
           size: "xsmall",
           style: "text",
@@ -167,16 +169,16 @@
             size: "small"
           },
           iconOnly: true
-        }, with_context = false )
+        }, false )
       ],
       cardStatusItems: [
-        include("@bolt-components-headline/eyebrow.twig", {
+        macros.include("@bolt-components-headline/eyebrow.twig", {
           text: "Last activity: 3 days ago",
           align: "center",
           attributes: {
             class: ["u-bolt-padding-small"]
           }
-        }, with_context = false)
+        }, false)
       ]
     },
     {
@@ -184,30 +186,30 @@
       cardSubtitle: "Mission",
       cardTitle: bolt.faker.sentence(3),
       cardMetaItems: [
-        include("@bolt-components-headline/text.twig", {
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "#{bolt.faker.numberBetween(2,10)} Modules",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "1 Challenge",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "10% complete",
           attributes: {
             class: ["u-bolt-color-orange"]
           }
-        }, with_context = false)
+        }, false)
       ],
       cardGradient: "purple",
       cardIcon: "rocket",
       cardDescription: bolt.faker.paragraph(2),
       cardUtilityItems: [
-        include("@bolt-components-button/button.twig", {
+        macros.include("@bolt-components-button/button.twig", {
           text: "Share",
           size: "xsmall",
           style: "text",
@@ -216,8 +218,8 @@
             size: "small"
           },
           iconOnly: true
-        }, with_context = false ),
-        include("@bolt-components-button/button.twig", {
+        }, false ),
+        macros.include("@bolt-components-button/button.twig", {
           text: "Remove from Dashboard",
           size: "xsmall",
           style: "text",
@@ -227,23 +229,23 @@
           },
           iconOnly: true,
           disabled: true
-        }, with_context = false )
+        }, false )
       ],
       cardStatusItems: [
-        include("@bolt-components-headline/eyebrow.twig", {
+        macros.include("@bolt-components-headline/eyebrow.twig", {
           text: "Last activity: 12/21/19",
           align: "center",
           attributes: {
             class: ["u-bolt-padding-small"]
           }
-        }, with_context = false),
-        include("@bolt-components-headline/eyebrow.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/eyebrow.twig", {
           text: "Assigned",
           align: "center",
           attributes: {
             class: ["u-bolt-padding-small"]
           }
-        }, with_context = false)
+        }, false)
       ]
     },
     {
@@ -251,30 +253,30 @@
       cardSubtitle: "Mission",
       cardTitle: bolt.faker.sentence(3),
       cardMetaItems: [
-        include("@bolt-components-headline/text.twig", {
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "#{bolt.faker.numberBetween(2,10)} Modules",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "1 Challenge",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "10% complete",
           attributes: {
             class: ["u-bolt-color-orange"]
           }
-        }, with_context = false)
+        }, false)
       ],
       cardGradient: "purple",
       cardIcon: "rocket",
       cardDescription: bolt.faker.paragraph(2),
       cardUtilityItems: [
-        include("@bolt-components-button/button.twig", {
+        macros.include("@bolt-components-button/button.twig", {
           text: "Share",
           size: "xsmall",
           style: "text",
@@ -283,8 +285,8 @@
             size: "small"
           },
           iconOnly: true
-        }, with_context = false ),
-        include("@bolt-components-button/button.twig", {
+        }, false ),
+        macros.include("@bolt-components-button/button.twig", {
           text: "Remove from Dashboard",
           size: "xsmall",
           style: "text",
@@ -293,16 +295,16 @@
             size: "small"
           },
           iconOnly: true,
-        }, with_context = false )
+        }, false )
       ],
       cardStatusItems: [
-        include("@bolt-components-headline/eyebrow.twig", {
+        macros.include("@bolt-components-headline/eyebrow.twig", {
           text: "Last activity: 12/21/19",
           align: "center",
           attributes: {
             class: ["u-bolt-padding-small"]
           }
-        }, with_context = false)
+        }, false)
       ]
     },
     {
@@ -310,30 +312,30 @@
       cardSubtitle: "Mission",
       cardTitle: bolt.faker.sentence(3),
       cardMetaItems: [
-        include("@bolt-components-headline/text.twig", {
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "#{bolt.faker.numberBetween(2,10)} Modules",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "1 Challenge",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "25% complete",
           attributes: {
             class: ["u-bolt-color-orange"]
           }
-        }, with_context = false)
+        }, false)
       ],
       cardGradient: "purple",
       cardIcon: "rocket",
       cardDescription: bolt.faker.paragraph(2),
       cardUtilityItems: [
-        include("@bolt-components-button/button.twig", {
+        macros.include("@bolt-components-button/button.twig", {
           text: "Share",
           size: "xsmall",
           style: "text",
@@ -342,8 +344,8 @@
             size: "small"
           },
           iconOnly: true
-        }, with_context = false ),
-        include("@bolt-components-button/button.twig", {
+        }, false ),
+        macros.include("@bolt-components-button/button.twig", {
           text: "Remove from Dashboard",
           size: "xsmall",
           style: "text",
@@ -352,16 +354,16 @@
             size: "small"
           },
           iconOnly: true
-        }, with_context = false )
+        }, false )
       ],
       cardStatusItems: [
-        include("@bolt-components-headline/eyebrow.twig", {
+        macros.include("@bolt-components-headline/eyebrow.twig", {
           text: "Last activity: 3 days ago",
           align: "center",
           attributes: {
             class: ["u-bolt-padding-small"]
           }
-        }, with_context = false)
+        }, false)
       ]
     },
     {
@@ -369,30 +371,30 @@
       cardSubtitle: "Mission",
       cardTitle: bolt.faker.sentence(3),
       cardMetaItems: [
-        include("@bolt-components-headline/text.twig", {
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "#{bolt.faker.numberBetween(2,10)} Modules",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "1 Challenge",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "10% complete",
           attributes: {
             class: ["u-bolt-color-orange"]
           }
-        }, with_context = false)
+        }, false)
       ],
       cardGradient: "purple",
       cardIcon: "rocket",
       cardDescription: bolt.faker.paragraph(2),
       cardUtilityItems: [
-        include("@bolt-components-button/button.twig", {
+        macros.include("@bolt-components-button/button.twig", {
           text: "Share",
           size: "xsmall",
           style: "text",
@@ -401,8 +403,8 @@
             size: "small"
           },
           iconOnly: true
-        }, with_context = false ),
-        include("@bolt-components-button/button.twig", {
+        }, false ),
+        macros.include("@bolt-components-button/button.twig", {
           text: "Remove from Dashboard",
           size: "xsmall",
           style: "text",
@@ -412,23 +414,23 @@
           },
           iconOnly: true,
           disabled: true
-        }, with_context = false )
+        }, false )
       ],
       cardStatusItems: [
-        include("@bolt-components-headline/eyebrow.twig", {
+        macros.include("@bolt-components-headline/eyebrow.twig", {
           text: "Last activity: 12/21/19",
           align: "center",
           attributes: {
             class: ["u-bolt-padding-small"]
           }
-        }, with_context = false),
-        include("@bolt-components-headline/eyebrow.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/eyebrow.twig", {
           text: "Assigned",
           align: "center",
           attributes: {
             class: ["u-bolt-padding-small"]
           }
-        }, with_context = false)
+        }, false)
       ]
     },
     {
@@ -436,30 +438,30 @@
       cardSubtitle: "Mission",
       cardTitle: bolt.faker.sentence(3),
       cardMetaItems: [
-        include("@bolt-components-headline/text.twig", {
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "#{bolt.faker.numberBetween(2,10)} Modules",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "1 Challenge",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "10% complete",
           attributes: {
             class: ["u-bolt-color-orange"]
           }
-        }, with_context = false)
+        }, false)
       ],
       cardGradient: "purple",
       cardIcon: "rocket",
       cardDescription: bolt.faker.paragraph(2),
       cardUtilityItems: [
-        include("@bolt-components-button/button.twig", {
+        macros.include("@bolt-components-button/button.twig", {
           text: "Share",
           size: "xsmall",
           style: "text",
@@ -468,8 +470,8 @@
             size: "small"
           },
           iconOnly: true
-        }, with_context = false ),
-        include("@bolt-components-button/button.twig", {
+        }, false ),
+        macros.include("@bolt-components-button/button.twig", {
           text: "Remove from Dashboard",
           size: "xsmall",
           style: "text",
@@ -478,16 +480,16 @@
             size: "small"
           },
           iconOnly: true,
-        }, with_context = false )
+        }, false )
       ],
       cardStatusItems: [
-        include("@bolt-components-headline/eyebrow.twig", {
+        macros.include("@bolt-components-headline/eyebrow.twig", {
           text: "Last activity: 12/21/19",
           align: "center",
           attributes: {
             class: ["u-bolt-padding-small"]
           }
-        }, with_context = false)
+        }, false)
       ]
     },
     {
@@ -495,30 +497,30 @@
       cardSubtitle: "Mission",
       cardTitle: bolt.faker.sentence(3),
       cardMetaItems: [
-        include("@bolt-components-headline/text.twig", {
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "#{bolt.faker.numberBetween(2,10)} Modules",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "1 Challenge",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "25% complete",
           attributes: {
             class: ["u-bolt-color-orange"]
           }
-        }, with_context = false)
+        }, false)
       ],
       cardGradient: "purple",
       cardIcon: "rocket",
       cardDescription: bolt.faker.paragraph(2),
       cardUtilityItems: [
-        include("@bolt-components-button/button.twig", {
+        macros.include("@bolt-components-button/button.twig", {
           text: "Share",
           size: "xsmall",
           style: "text",
@@ -527,8 +529,8 @@
             size: "small"
           },
           iconOnly: true
-        }, with_context = false ),
-        include("@bolt-components-button/button.twig", {
+        }, false ),
+        macros.include("@bolt-components-button/button.twig", {
           text: "Remove from Dashboard",
           size: "xsmall",
           style: "text",
@@ -537,16 +539,16 @@
             size: "small"
           },
           iconOnly: true
-        }, with_context = false )
+        }, false )
       ],
       cardStatusItems: [
-        include("@bolt-components-headline/eyebrow.twig", {
+        macros.include("@bolt-components-headline/eyebrow.twig", {
           text: "Last activity: 3 days ago",
           align: "center",
           attributes: {
             class: ["u-bolt-padding-small"]
           }
-        }, with_context = false)
+        }, false)
       ]
     },
     {
@@ -554,30 +556,30 @@
       cardSubtitle: "Mission",
       cardTitle: bolt.faker.sentence(3),
       cardMetaItems: [
-        include("@bolt-components-headline/text.twig", {
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "#{bolt.faker.numberBetween(2,10)} Modules",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "1 Challenge",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "10% complete",
           attributes: {
             class: ["u-bolt-color-orange"]
           }
-        }, with_context = false)
+        }, false)
       ],
       cardGradient: "purple",
       cardIcon: "rocket",
       cardDescription: bolt.faker.paragraph(2),
       cardUtilityItems: [
-        include("@bolt-components-button/button.twig", {
+        macros.include("@bolt-components-button/button.twig", {
           text: "Share",
           size: "xsmall",
           style: "text",
@@ -586,8 +588,8 @@
             size: "small"
           },
           iconOnly: true
-        }, with_context = false ),
-        include("@bolt-components-button/button.twig", {
+        }, false ),
+        macros.include("@bolt-components-button/button.twig", {
           text: "Remove from Dashboard",
           size: "xsmall",
           style: "text",
@@ -597,23 +599,23 @@
           },
           iconOnly: true,
           disabled: true
-        }, with_context = false )
+        }, false )
       ],
       cardStatusItems: [
-        include("@bolt-components-headline/eyebrow.twig", {
+        macros.include("@bolt-components-headline/eyebrow.twig", {
           text: "Last activity: 12/21/19",
           align: "center",
           attributes: {
             class: ["u-bolt-padding-small"]
           }
-        }, with_context = false),
-        include("@bolt-components-headline/eyebrow.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/eyebrow.twig", {
           text: "Assigned",
           align: "center",
           attributes: {
             class: ["u-bolt-padding-small"]
           }
-        }, with_context = false)
+        }, false)
       ]
     },
     {
@@ -621,30 +623,30 @@
       cardSubtitle: "Mission",
       cardTitle: bolt.faker.sentence(3),
       cardMetaItems: [
-        include("@bolt-components-headline/text.twig", {
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "#{bolt.faker.numberBetween(2,10)} Modules",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "1 Challenge",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "10% complete",
           attributes: {
             class: ["u-bolt-color-orange"]
           }
-        }, with_context = false)
+        }, false)
       ],
       cardGradient: "purple",
       cardIcon: "rocket",
       cardDescription: bolt.faker.paragraph(2),
       cardUtilityItems: [
-        include("@bolt-components-button/button.twig", {
+        macros.include("@bolt-components-button/button.twig", {
           text: "Share",
           size: "xsmall",
           style: "text",
@@ -653,8 +655,8 @@
             size: "small"
           },
           iconOnly: true
-        }, with_context = false ),
-        include("@bolt-components-button/button.twig", {
+        }, false ),
+        macros.include("@bolt-components-button/button.twig", {
           text: "Remove from Dashboard",
           size: "xsmall",
           style: "text",
@@ -663,16 +665,16 @@
             size: "small"
           },
           iconOnly: true,
-        }, with_context = false )
+        }, false )
       ],
       cardStatusItems: [
-        include("@bolt-components-headline/eyebrow.twig", {
+        macros.include("@bolt-components-headline/eyebrow.twig", {
           text: "Last activity: 12/21/19",
           align: "center",
           attributes: {
             class: ["u-bolt-padding-small"]
           }
-        }, with_context = false)
+        }, false)
       ]
     },
 ] %}
@@ -770,13 +772,13 @@
   sectionTitle: sectionTitle|default("My Missions"),
   theme: "light",
   sectionButtons: sectionButtons ?? [
-    include("@bolt-components-button/button.twig", {
+    macros.include("@bolt-components-button/button.twig", {
       style: "secondary",
       size: "small",
       border_radius: "full",
       text: "Show all (12)"
-    }, with_context = false),
-    include("@bolt-components-button/button.twig", {
+    }, false),
+    macros.include("@bolt-components-button/button.twig", {
       style: "text",
       size: "large",
       text: "Add Missions",
@@ -784,7 +786,7 @@
         name: "add-open",
         position: "before"
       }
-    }, with_context = false)
+    }, false)
   ],
   useCarousel: useCarousel,
   contentItems: cardContentItems

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/collections/dashboard/_dashboard-band--new-training.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/collections/dashboard/_dashboard-band--new-training.twig
@@ -1,3 +1,5 @@
+{% import "@bolt-blueprints/macros.twig" as macros %}
+
 {% include "@bolt-blueprints/_dashboard-band.twig" with {
   sectionTitle: "New Training",
   contentItems: [
@@ -6,30 +8,30 @@
       cardSubtitle: "Mission",
       cardTitle: bolt.faker.sentence(3),
       cardMetaItems: [
-        include("@bolt-components-headline/text.twig", {
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "#{bolt.faker.numberBetween(2,10)} Modules",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "1 Challenge",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "25% complete",
           attributes: {
             class: ["u-bolt-color-orange"]
           }
-        }, with_context = false)
+        }, false)
       ],
       cardGradient: "purple",
       cardIcon: "rocket",
       cardDescription: bolt.faker.paragraph(2),
       cardUtilityItems: [
-        include("@bolt-components-button/button.twig", {
+        macros.include("@bolt-components-button/button.twig", {
           text: "Share",
           size: "xsmall",
           style: "text",
@@ -38,8 +40,8 @@
             size: "small"
           },
           iconOnly: true
-        }, with_context = false ),
-        include("@bolt-components-button/button.twig", {
+        }, false ),
+        macros.include("@bolt-components-button/button.twig", {
           text: "Remove from Dashboard",
           size: "xsmall",
           style: "text",
@@ -48,7 +50,7 @@
             size: "small"
           },
           iconOnly: true
-        }, with_context = false )
+        }, false )
       ]
     },
     {
@@ -56,25 +58,25 @@
       cardSubtitle: "Module",
       cardTitle: bolt.faker.sentence(3),
       cardMetaItems: [
-        include("@bolt-components-headline/text.twig", {
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "#{bolt.faker.numberBetween(2,10)} Topics",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "In progress",
           attributes: {
             class: ["u-bolt-color-orange"]
           }
-        }, with_context = false)
+        }, false)
       ],
       cardGradient: "orange",
       cardIcon: "meteor",
       cardDescription: bolt.faker.paragraph(2),
       cardUtilityItems: [
-        include("@bolt-components-button/button.twig", {
+        macros.include("@bolt-components-button/button.twig", {
           text: "Share",
           size: "xsmall",
           style: "text",
@@ -83,7 +85,7 @@
             size: "small"
           },
           iconOnly: true
-        }, with_context = false )
+        }, false )
       ]
     },
     {
@@ -91,25 +93,25 @@
       cardSubtitle: "Module",
       cardTitle: bolt.faker.sentence(3),
       cardMetaItems: [
-        include("@bolt-components-headline/text.twig", {
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "#{bolt.faker.numberBetween(2,10)} Topics",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "40 mins remaining",
           attributes: {
             class: ["u-bolt-color-orange"]
           }
-        }, with_context = false)
+        }, false)
       ],
       cardGradient: "teal",
       cardIcon: "orbit",
       cardDescription: bolt.faker.paragraph(2),
       cardUtilityItems: [
-        include("@bolt-components-button/button.twig", {
+        macros.include("@bolt-components-button/button.twig", {
           text: "Share",
           size: "xsmall",
           style: "text",
@@ -118,7 +120,7 @@
             size: "small"
           },
           iconOnly: true
-        }, with_context = false )
+        }, false )
       ]
     }
   ]

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/collections/dashboard/_dashboard-band--recommended.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/collections/dashboard/_dashboard-band--recommended.twig
@@ -1,3 +1,5 @@
+{% import "@bolt-blueprints/macros.twig" as macros %}
+
 {% include "@bolt-blueprints/_dashboard-band.twig" with {
   sectionTitle: "Recommended Missions",
   theme: "light",
@@ -7,30 +9,30 @@
       cardSubtitle: "Mission",
       cardTitle: bolt.faker.sentence(3),
       cardMetaItems: [
-        include("@bolt-components-headline/text.twig", {
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "#{bolt.faker.numberBetween(2,10)} Modules",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "1 Challenge",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "25% complete",
           attributes: {
             class: ["u-bolt-color-orange"]
           }
-        }, with_context = false)
+        }, false)
       ],
       cardGradient: "purple",
       cardIcon: "rocket",
       cardDescription: bolt.faker.paragraph(2),
       cardUtilityItems: [
-        include("@bolt-components-button/button.twig", {
+        macros.include("@bolt-components-button/button.twig", {
           text: "Share",
           size: "xsmall",
           style: "text",
@@ -39,8 +41,8 @@
             size: "small"
           },
           iconOnly: true
-        }, with_context = false ),
-        include("@bolt-components-button/button.twig", {
+        }, false ),
+        macros.include("@bolt-components-button/button.twig", {
           text: "Remove from Dashboard",
           size: "xsmall",
           style: "text",
@@ -49,7 +51,7 @@
             size: "small"
           },
           iconOnly: true
-        }, with_context = false )
+        }, false )
       ]
     },
     {
@@ -57,30 +59,30 @@
       cardSubtitle: "Mission",
       cardTitle: bolt.faker.sentence(3),
       cardMetaItems: [
-        include("@bolt-components-headline/text.twig", {
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "#{bolt.faker.numberBetween(2,10)} Modules",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "1 Challenge",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "25% complete",
           attributes: {
             class: ["u-bolt-color-orange"]
           }
-        }, with_context = false)
+        }, false)
       ],
       cardGradient: "purple",
       cardIcon: "rocket",
       cardDescription: bolt.faker.paragraph(2),
       cardUtilityItems: [
-        include("@bolt-components-button/button.twig", {
+        macros.include("@bolt-components-button/button.twig", {
           text: "Share",
           size: "xsmall",
           style: "text",
@@ -89,8 +91,8 @@
             size: "small"
           },
           iconOnly: true
-        }, with_context = false ),
-        include("@bolt-components-button/button.twig", {
+        }, false ),
+        macros.include("@bolt-components-button/button.twig", {
           text: "Remove from Dashboard",
           size: "xsmall",
           style: "text",
@@ -100,7 +102,7 @@
           },
           iconOnly: true,
           disabled: true
-        }, with_context = false )
+        }, false )
       ]
     },
     {
@@ -108,30 +110,30 @@
       cardSubtitle: "Mission",
       cardTitle: bolt.faker.sentence(3),
       cardMetaItems: [
-        include("@bolt-components-headline/text.twig", {
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "#{bolt.faker.numberBetween(2,10)} Modules",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "1 Challenge",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "25% complete",
           attributes: {
             class: ["u-bolt-color-orange"]
           }
-        }, with_context = false)
+        }, false)
       ],
       cardGradient: "purple",
       cardIcon: "rocket",
       cardDescription: bolt.faker.paragraph(2),
       cardUtilityItems: [
-        include("@bolt-components-button/button.twig", {
+        macros.include("@bolt-components-button/button.twig", {
           text: "Share",
           size: "xsmall",
           style: "text",
@@ -140,8 +142,8 @@
             size: "small"
           },
           iconOnly: true
-        }, with_context = false ),
-        include("@bolt-components-button/button.twig", {
+        }, false ),
+        macros.include("@bolt-components-button/button.twig", {
           text: "Remove from Dashboard",
           size: "xsmall",
           style: "text",
@@ -150,7 +152,7 @@
             size: "small"
           },
           iconOnly: true,
-        }, with_context = false )
+        }, false )
       ]
     }
   ]

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/collections/dashboard/_dashboard-band.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/collections/dashboard/_dashboard-band.twig
@@ -1,3 +1,5 @@
+{% import "@bolt-blueprints/macros.twig" as macros %}
+
 {% set useCarousel = useCarousel ?? true %}
 
 {% set content %}
@@ -31,7 +33,7 @@
         {% for item in contentItems %}
           {# @todo: why do we do this check? #}
           {% if item.cardTitle %}
-            {% set slides = slides|merge([include("@bolt-blueprints/_vertical-card.twig", item)]) %}
+            {% set slides = slides|merge([macros.include("@bolt-blueprints/_vertical-card.twig", item)]) %}
           {% else %}
             {% set slides = slides|merge([item]) %}
           {% endif %}

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/heros/_hero-partials/_hero-primary-content.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/heros/_hero-partials/_hero-primary-content.twig
@@ -1,3 +1,5 @@
+{% import "@bolt-blueprints/macros.twig" as macros %}
+
 {% if heroSubTitle %}
   {% include "@bolt-components-headline/eyebrow.twig" with {
     text: heroSubTitle,
@@ -35,11 +37,11 @@
         "u-bolt-margin-bottom-small",
       ]
     },
-    items: heroMetaItems | map(item => item.text ? include("@bolt-components-headline/text.twig", {
+    items: heroMetaItems | map(item => item.text ? macros.include("@bolt-components-headline/text.twig", {
       text: item.text,
       size: "small",
       weight: "bold",
-    }, with_context = false) : item )
+    }, false) : item )
   } only %}
       {# include("@bolt-blueprints/_custom-select.twig", with_context = false), #}
 {% endif %}

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/heros/_hero-partials/_hero-secondary-content.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/heros/_hero-partials/_hero-secondary-content.twig
@@ -32,6 +32,6 @@
       {# include("@bolt-blueprints/_custom-select.twig", with_context = false), #}
 {% endif %}
 
-{% if heroSupplementalContent %}
-  {{ heroSupplementalContent }}
+{% if heroSupplementalContentBlock %}
+  {{ heroSupplementalContentBlock }}
 {% endif %}

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/heros/_hero-partials/_hero-secondary-content.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/heros/_hero-partials/_hero-secondary-content.twig
@@ -1,3 +1,5 @@
+{% import "@bolt-blueprints/macros.twig" as macros %}
+
 {% if heroDescription %}
   {% include "@bolt-components-headline/text.twig" with {
     text: heroDescription,
@@ -21,11 +23,11 @@
         "u-bolt-negative-margin-top-xsmall",
       ]
     },
-    items: heroTags | map(item => item.text ? include("@bolt-components-chip/chip.twig", {
+    items: heroTags | map(item => item.text ? macros.include("@bolt-components-chip/chip.twig", {
       text: item.text,
       url: item.url | default(false),
       size: "xsmall",
-    }, with_context = false) : item )
+    }, false) : item )
   } only %}
       {# include("@bolt-blueprints/_custom-select.twig", with_context = false), #}
 {% endif %}

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/heros/dashboard-page-hero/dashboard-page-hero.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/heros/dashboard-page-hero/dashboard-page-hero.twig
@@ -1,4 +1,8 @@
-{% set heroButtonRow = block('heroButtonRow') %}
+{% if block('heroButtonRow') %}
+  {% set heroButtonRowBlock %}
+    {{ block('heroButtonRow') }}
+  {% endset %}
+{% endif %}
 
 {% embed "@bolt-components-band/band.twig" with {
   theme: "xdark",
@@ -46,9 +50,9 @@
         {% endif %}
       {% endcell %}
 
-      {% if heroButtonRow %}
+      {% if heroButtonRowBlock %}
         {% cell "u-bolt-flex-shrink u-bolt-margin-top-auto" %}
-          {{ heroButtonRow }}
+          {{ heroButtonRowBlock }}
         {% endcell %}
       {% endif %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/heros/homepage-heros/_hero--hp-missions.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/heros/homepage-heros/_hero--hp-missions.twig
@@ -1,3 +1,5 @@
+{% import "@bolt-blueprints/macros.twig" as macros %}
+
 {% set content %}
   {% grid "o-bolt-grid--flex o-bolt-grid--matrix o-bolt-grid--xlarge" %}
     {% cell "u-bolt-width-12/12" %}
@@ -56,14 +58,14 @@
               valign: "middle",
               url: item.url,
               figure: {
-                content: include("@bolt-components-icon/icon.twig", {
+                content: macros.include("@bolt-components-icon/icon.twig", {
                   name: item.icon,
                   size: "medium",
                   background: "circle",
                 }),
               },
-              content: include("@bolt-components-headline/text.twig", {
-                text: include("@bolt-components-link/link.twig", {
+              content: macros.include("@bolt-components-headline/text.twig", {
+                text: macros.include("@bolt-components-link/link.twig", {
                   isHeadline: true,
                   text: item.text,
                   url: item.url,
@@ -138,14 +140,14 @@
               url: item.url,
               valign: "middle",
               figure: {
-                content: include("@bolt-components-icon/icon.twig", {
+                content: macros.include("@bolt-components-icon/icon.twig", {
                   name: item.icon,
                   size: "medium",
                   background: "circle",
                 }),
               },
-              content: include("@bolt-components-headline/text.twig", {
-                text: include("@bolt-components-link/link.twig", {
+              content: macros.include("@bolt-components-headline/text.twig", {
+                text: macros.include("@bolt-components-link/link.twig", {
                   text: item.text,
                   url: item.url,
                   isHeadline: true,
@@ -172,14 +174,14 @@
         valign: "top",
         size: "medium",
         figure: {
-          content: include("@bolt-components-image/image.twig", {
+          content: macros.include("@bolt-components-image/image.twig", {
             src: "/images/homepage-promo-alt.jpg",
             max_width: "300px",
           }),
         },
         content: [
-          include("@bolt-components-headline/headline.twig", {
-            text: include("@bolt-components-link/link.twig", {
+          macros.include("@bolt-components-headline/headline.twig", {
+            text: macros.include("@bolt-components-link/link.twig", {
               text: "Technical Paths",
               url: "/",
               isHeadline: true,
@@ -187,11 +189,11 @@
             size: "xlarge",
             weight: "bold",
           }),
-          include("@bolt-components-headline/text.twig", {
+          macros.include("@bolt-components-headline/text.twig", {
             text: "Build strategic applications to help solve real-world problems for today’s fast-paced business environment.",
             size: "large",
           }),
-          include("@bolt-components-button/button.twig", {
+          macros.include("@bolt-components-button/button.twig", {
             style: "secondary",
             size: "small",
             border_radius: "full",
@@ -210,14 +212,14 @@
         valign: "top",
         size: "medium",
         figure: {
-          content: include("@bolt-components-image/image.twig", {
+          content: macros.include("@bolt-components-image/image.twig", {
             src: "/images/homepage-promo.jpg",
             max_width: "300px",
           }),
         },
         content: [
-          include("@bolt-components-headline/headline.twig", {
-            text: include("@bolt-components-link/link.twig", {
+          macros.include("@bolt-components-headline/headline.twig", {
+            text: macros.include("@bolt-components-link/link.twig", {
               text: "Business Paths",
               url: "/",
               isHeadline: true,
@@ -225,11 +227,11 @@
             size: "xlarge",
             weight: "bold",
           }),
-          include("@bolt-components-headline/text.twig", {
+          macros.include("@bolt-components-headline/text.twig", {
             text: "Ensure that business users align their strategic business goals with IT initiatives to ensure project success.",
             size: "large",
           }),
-          include("@bolt-components-button/button.twig", {
+          macros.include("@bolt-components-button/button.twig", {
             style: "secondary",
             size: "small",
             border_radius: "full",

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/heros/landing-page-hero/landing-page-hero.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/heros/landing-page-hero/landing-page-hero.twig
@@ -1,5 +1,14 @@
-{% set heroTopicList = block('heroTopicList') %}
-{% set heroSupplementalContent = block('heroSupplementalContent') %}
+{% if block('heroTopicList') %}
+  {% set heroTopicListBlock %}
+    {{ block('heroTopicList') }}
+  {% endset %}
+{% endif %}
+
+{% if block('heroSupplementalContent') %}
+  {% set heroSupplementalContentBlock %}
+    {{ block('heroSupplementalContent') }}
+  {% endset %}
+{% endif %}
 
 {% embed "@bolt-components-band/band.twig" with {
   theme: "none",
@@ -24,9 +33,9 @@
             {% include "@bolt-blueprints/_hero-secondary-content.twig" %}
           {% endcell %}
 
-            {% if heroTopicList %}
+            {% if heroTopicListBlock %}
               {% cell "u-bolt-width-1/1 u-bolt-width-1/2@medium" %}
-                {{ heroTopicList }}
+                {{ heroTopicListBlock }}
               {% endcell %}
             {% endif %}
           {% endgrid %}

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/heros/wip-heros/_hero--request-feedback.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/heros/wip-heros/_hero--request-feedback.twig
@@ -3,6 +3,8 @@
   size: "small"
 } %}
   {% block band_content %}
+    {% import "@bolt-blueprints/macros.twig" as macros %}
+
     <div class="u-bolt-overflow-hidden">
       {% grid "o-bolt-grid--flex o-bolt-grid--matrix o-bolt-grid--border o-bolt-grid--middle" %}
         {% cell "u-bolt-width-12/12 u-bolt-width-7/12@small" %}
@@ -32,7 +34,7 @@
                     ]
                   },
                   items: [
-                    include("@bolt-components-button/button.twig", {
+                    macros.include("@bolt-components-button/button.twig", {
                       text: "Yes",
                       style: "text",
                       size: "small",
@@ -41,8 +43,8 @@
                         position: "before",
                         name: "add-open"
                       }
-                    }, with_context = false),
-                    include("@bolt-components-button/button.twig", {
+                    }, false),
+                    macros.include("@bolt-components-button/button.twig", {
                       text: "No",
                       style: "text",
                       size: "xsmall",
@@ -51,11 +53,11 @@
                         position: "before",
                         name: "minus-open"
                       }
-                    }, with_context = false),
-                    include("@bolt-components-headline/text.twig", {
+                    }, false),
+                    macros.include("@bolt-components-headline/text.twig", {
                       text: "<strong>28%</strong> found this useful",
                       size: "xsmall"
-                    }, with_context = false),
+                    }, false),
                   ]
                 } only %}
               {% endcell %}

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/modals/_test-completed-modal.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/modals/_test-completed-modal.twig
@@ -1,4 +1,5 @@
 {% set modalContent %}
+  {% import "@bolt-blueprints/macros.twig" as macros %}
 
   {% include "@bolt-components-card-replacement/card-replacement.twig" with {
     theme: "dark",
@@ -23,7 +24,7 @@
       },
       content: [
 
-        include("@bolt-components-headline/headline.twig", {
+        macros.include("@bolt-components-headline/headline.twig", {
           size: "xxlarge",
           text: "Congratulations #{userFirstName}!",
           align: "center",
@@ -36,7 +37,7 @@
             ]
           }
         }),
-        include("@bolt-components-headline/subheadline.twig", {
+        macros.include("@bolt-components-headline/subheadline.twig", {
           text: "You’ve completed the #{missionName} and earned a new badge!",
           align: "center",
           size: "xlarge",
@@ -49,9 +50,9 @@
             ]
           }
         }),
-        include("@bolt-components-ratio/ratio.twig", {
+        macros.include("@bolt-components-ratio/ratio.twig", {
           ratio: "140/160",
-          children: include("@bolt-components-placeholder/placeholder.twig", {
+          children: macros.include("@bolt-components-placeholder/placeholder.twig", {
             text: "FPO",
           }),
           attributes: {
@@ -63,7 +64,7 @@
             ]
           }
         }),
-        include("@bolt-components-headline/text.twig", {
+        macros.include("@bolt-components-headline/text.twig", {
           text: "<strong>NOTE:</strong> Please allow 24-48 hours for the badge to appear on your Achievements page.",
           size: "xxsmall",
           style: "italic",
@@ -77,12 +78,12 @@
             ]
           }
         }),
-        include("@bolt-components-list/list.twig", {
+        macros.include("@bolt-components-list/list.twig", {
           display: "inline",
           spacing: "small",
           align: "center",
           items: [
-            include("@bolt-components-button/button.twig", {
+            macros.include("@bolt-components-button/button.twig", {
               text: "Return to Mission",
               size: "small",
               border_radius: "full",
@@ -91,7 +92,7 @@
                 "on-click-target": "js-modal-advanced-auto-open",
               },
             }),
-            include("@bolt-components-button/button.twig", {
+            macros.include("@bolt-components-button/button.twig", {
               text: "View Achievements",
               size: "small",
               style: "secondary",

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/search/_search-bar.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/search/_search-bar.twig
@@ -1,8 +1,10 @@
+{% import "@bolt-blueprints/macros.twig" as macros %}
+
 {% set content %}
   {% grid "o-bolt-grid o-bolt-grid--center" %}
     {% cell "u-bolt-width-12/12 u-bolt-width-10/12@large" %}
       {% include "@bolt-components-form/form.twig" with {
-        children: include("@bolt-components-typeahead/typeahead.twig", {
+        children: macros.include("@bolt-components-typeahead/typeahead.twig", {
           attributes: {
             class: [
               "js-typeahead-hook--exact-result"

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/toolbar/_toolbar.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/toolbar/_toolbar.twig
@@ -11,13 +11,15 @@
 } %}
   {% if breadcrumbs %}
     {% block content_before %}
+      {% import "@bolt-blueprints/macros.twig" as macros %}
+
       {% include "@bolt-components-breadcrumb/breadcrumb.twig" with {
-        "contentItems": breadcrumbs | map(breadcrumb => breadcrumb.text and breadcrumb.url ? include("@bolt-components-link/link.twig", {
+        "contentItems": breadcrumbs | map(breadcrumb => breadcrumb.text and breadcrumb.url ? macros.include("@bolt-components-link/link.twig", {
           text: breadcrumb.text,
           url: breadcrumb.url,
           isHeadline: true
-        }, with_context = false) : (breadcrumb.text ?
-          include("@bolt-components-headline/text.twig", {
+        }, false) : (breadcrumb.text ?
+          macros.include("@bolt-components-headline/text.twig", {
             text: breadcrumb.text,
             size: "small",
             weight: "bold",
@@ -27,7 +29,7 @@
                 "u-bolt-inline"
               ]
             }
-          }, with_context = false) : breadcrumb))
+          }, false) : breadcrumb))
       } only %}
     {% endblock %}
   {% endif %}

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/04-templates/_detail-page-template.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/04-templates/_detail-page-template.twig
@@ -6,7 +6,6 @@
     {% endcell %}
   {% endgrid %}
 {% endset %}
-{% set backgroundBlock = block("page_background") %}
 
 <div class="c-bolt-site">
   {% block global_header %}

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/04-templates/_landing-page-template.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/04-templates/_landing-page-template.twig
@@ -1,6 +1,8 @@
 {% set mainContentBlock = block("page_content") %}
 {% set backgroundBlock = block("page_background") %}
 
+{% import "@bolt-blueprints/macros.twig" as macros %}
+
 <div class="c-bolt-site">
   {% block global_header %}
     {% include "@bolt/page-header.twig" %}
@@ -16,12 +18,12 @@
       background: {
         overlay: "disabled",
         contentItems: [
-          include('@bolt-components-background/background-overlay.twig', {
+          macros.include('@bolt-components-background/background-overlay.twig', {
             fill: "color",
             fillColor: "black",
             overlay: "enabled",
-          }, with_context = false),
-          include('@bolt-components-image/image.twig', {
+          }, false),
+          macros.include('@bolt-components-image/image.twig', {
             placeholder_color: "#000000",
             src: "/images/mission-hero.jpg",
             cover: false,

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/04-templates/_landing-page-template.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/04-templates/_landing-page-template.twig
@@ -1,5 +1,14 @@
-{% set mainContentBlock = block("page_content") %}
-{% set backgroundBlock = block("page_background") %}
+{% if block("page_background") %}
+  {% set backgroundBlock %}
+    {{ block("page_background") }}
+  {% endset %}
+{% endif %}
+
+{% if block("page_content") %}
+  {% set mainContentBlock %}
+    {{ block("page_content") }}
+  {% endset %}
+{% endif %}
 
 {% import "@bolt-blueprints/macros.twig" as macros %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/05-pages/t1-landing-pages/certification-exam/certification-exam-page.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/05-pages/t1-landing-pages/certification-exam/certification-exam-page.twig
@@ -11,6 +11,8 @@
 {% block page_content %}
   {% embed "@bolt-blueprints/landing-page-hero.twig" %}
     {% block heroSupplementalContent %}
+      {% import "@bolt-blueprints/macros.twig" as macros %}
+
       {% include "@bolt-components-headline/headline.twig" with {
         size: "xlarge",
         text: "Prerequisites:",
@@ -23,7 +25,7 @@
         display: "block",
         spacing: "none",
         items: [
-          include("@bolt-components-link/link.twig", {
+          macros.include("@bolt-components-link/link.twig", {
             url: "https://www.google.com",
             text: "Name of Mission will go here"
           }),
@@ -35,7 +37,7 @@
 
       {% include "@bolt-components-headline/headline.twig" with {
         size: "xlarge",
-        text: "Exam Topics " ~ include("@bolt-components-headline/text.twig", {
+        text: "Exam Topics " ~ macros.include("@bolt-components-headline/text.twig", {
           weight: "regular",
           tag: "span",
           size: "medium",
@@ -66,6 +68,7 @@
     {% endblock %}
 
     {% block heroTopicList %}
+      {% import "@bolt-blueprints/macros.twig" as macros %}
 
       {% include "@bolt-components-card-replacement/card-replacement.twig" with {
         theme: "xlight",
@@ -78,15 +81,15 @@
         },
         body: {
           content: [
-            include("@bolt-blueprints/_headline-with-logo.twig", {
-              headline: include("@bolt-components-headline/headline.twig", {
+            macros.include("@bolt-blueprints/_headline-with-logo.twig", {
+              headline: macros.include("@bolt-components-headline/headline.twig", {
                 size: "xlarge",
                 text: "Before you begin...",
                 attributes: {
                   class: "u-bolt-margin-bottom-none",
                 }
               }),
-              logo: include("@bolt-components-image/image.twig", {
+              logo: macros.include("@bolt-components-image/image.twig", {
                 src: "/images/pearson-logo.svg",
                 attributes: {
                   style: "max-width: 170px;",
@@ -96,7 +99,7 @@
                 }
               }),
             }),
-            include("@bolt-components-headline/text.twig", {
+            macros.include("@bolt-components-headline/text.twig", {
               size: "medium",
               text: "The <strong>Certified System Architect Test</strong> is proctored by Pearson VUE. Users must create a Pearson VUE account if you do not already have one and register for the exam through the Pearson VUE site. There are two exam delivery options:",
               attributes: {
@@ -105,10 +108,10 @@
                 ]
               }
             }),
-            include("@bolt-components-ul/ul.twig", {
+            macros.include("@bolt-components-ul/ul.twig", {
               items: [
                 "Take an exam at a test center, or",
-                "Take an exam via Online Proctored delivery" ~ include("@bolt-components-headline/text.twig", {
+                "Take an exam via Online Proctored delivery" ~ macros.include("@bolt-components-headline/text.twig", {
                   text: "(e.g., in a quiet, uninterrupted room in your home or office, proctored via webcam).",
                   size: "xxsmall",
                   style: "italic",
@@ -116,7 +119,7 @@
                 }),
               ]
             }),
-            include("@bolt-components-list/list.twig", {
+            macros.include("@bolt-components-list/list.twig", {
               display: "inline",
               spacing: "small",
               align: "start",
@@ -126,14 +129,14 @@
                 ]
               },
               items: [
-                include("@bolt-components-button/button.twig", {
+                macros.include("@bolt-components-button/button.twig", {
                   text: "Create Pearson VUE Account",
                   size: "small",
                   style: "secondary",
                   border_radius: "full",
                   url: "https://www.google.com",
                 }),
-                include("@bolt-components-button/button.twig", {
+                macros.include("@bolt-components-button/button.twig", {
                   text: "Register for Exam",
                   size: "small",
                   border_radius: "full",

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/05-pages/t1-landing-pages/mission-landing/_mission-landing.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/05-pages/t1-landing-pages/mission-landing/_mission-landing.twig
@@ -1,6 +1,7 @@
 {% extends "@bolt-blueprints/_landing-page-template.twig" %}
 
 {% block page_content %}
+  {% import "@bolt-blueprints/macros.twig" as macros %}
   {% include "@bolt-blueprints/landing-page-hero.twig" %}
 
   {% grid "o-bolt-grid--flex o-bolt-grid--center o-bolt-grid--matrix" %}
@@ -28,7 +29,7 @@
                 {% else %}
                   {% if numberOfCompletedItems != 0 %}
                     {% set contentItemsConsolidated = contentItemsConsolidated | merge([
-                      include("@bolt-blueprints/_horizontal-divider.twig", { dividerText: "Completed (" ~ numberOfCompletedItems ~ ")" })
+                      macros.include("@bolt-blueprints/_horizontal-divider.twig", { dividerText: "Completed (" ~ numberOfCompletedItems ~ ")" })
                     ]) %}
                     {% set numberOfCompletedItems = 0 %}
                   {% endif %}

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/05-pages/t1-landing-pages/mission-landing/t1-mission-landing.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/05-pages/t1-landing-pages/mission-landing/t1-mission-landing.twig
@@ -1,15 +1,17 @@
+{% import "@bolt-blueprints/macros.twig" as macros %}
+
 {% include "@bolt-blueprints/_mission-landing.twig" with {
   contentItems: [
     {
       cardSubtitle: "Mission",
       cardTitle: bolt.faker.sentence(3),
       cardMetaItems: [
-        include("@bolt-components-headline/text.twig", {
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "#{bolt.faker.numberBetween(2,30)} topics",
-        }, with_context = false),
-        include("@bolt-components-headline/text.twig", {
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
           size: "small",
           weight: "bold",
           text: "Completed",
@@ -22,7 +24,7 @@
               'color: #3C9439;'
             ]
           }
-        }, with_context = false),
+        }, false),
       ],
       cardGradient: "orange",
       cardIcon: "meteor",
@@ -87,6 +89,6 @@
       cardIcon: "atom",
       cardDescription: bolt.faker.paragraph(3),
     },
-    include("@bolt-blueprints/_badge.twig"),
+    macros.include("@bolt-blueprints/_badge.twig"),
   ]
 } %}

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/05-pages/t1-landing-pages/module-landing/t1-module-landing-page.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/05-pages/t1-landing-pages/module-landing/t1-module-landing-page.twig
@@ -3,6 +3,8 @@
 {% block page_content %}
   {% embed "@bolt-blueprints/landing-page-hero.twig" %}
     {% block heroSupplementalContent %}
+      {% import "@bolt-blueprints/macros.twig" as macros %}
+
       {% include "@bolt-components-headline/headline.twig" with {
         size: "medium",
         text: "After completing this module, you should be able to:",
@@ -36,15 +38,15 @@
         display: "block",
         spacing: "none",
         items: [
-          include("@bolt-components-link/link.twig", {
+          macros.include("@bolt-components-link/link.twig", {
             url: "https://www.google.com",
             text: "Name of Mission will go here"
           }),
-          include("@bolt-components-link/link.twig", {
+          macros.include("@bolt-components-link/link.twig", {
             url: "https://www.google.com",
             text: "Name of Mission"
           }),
-          include("@bolt-components-link/link.twig", {
+          macros.include("@bolt-components-link/link.twig", {
             url: "https://www.google.com",
             text: "Adding another mission here"
           }),
@@ -53,6 +55,7 @@
     {% endblock %}
 
     {% block heroTopicList %}
+      {% import "@bolt-blueprints/macros.twig" as macros %}
 
       {% include "@bolt-components-card-replacement/card-replacement.twig" with {
         theme: "xlight",
@@ -65,14 +68,14 @@
         },
         body: {
           content: [
-            include("@bolt-components-headline/headline.twig", {
+            macros.include("@bolt-components-headline/headline.twig", {
               size: "xlarge",
               text: "Topics",
               attributes: {
                 class: "u-bolt-margin-bottom-small",
               }
             }),
-            include("@bolt-components-list/list.twig", {
+            macros.include("@bolt-components-list/list.twig", {
               separator: "solid",
               attributes: {
                 class: [
@@ -81,29 +84,29 @@
                 ],
               },
               items: [
-                include("@bolt-blueprints/_module-topic-item.twig", {
+                macros.include("@bolt-blueprints/_module-topic-item.twig", {
                   text: "Data types",
                   duration: "10 mins",
                   viewed: true,
                 }),
-                include("@bolt-blueprints/_module-topic-item.twig", {
+                macros.include("@bolt-blueprints/_module-topic-item.twig", {
                   text: "Creating a data type",
                   duration: "5 mins",
                 }),
-                include("@bolt-blueprints/_module-topic-item.twig", {
+                macros.include("@bolt-blueprints/_module-topic-item.twig", {
                   text: "Creating a data type",
                   duration: "5 mins",
                 }),
-                include("@bolt-blueprints/_module-quiz-item.twig", {
+                macros.include("@bolt-blueprints/_module-quiz-item.twig", {
                   text: "Module Quiz",
                   numberOfQuestionsText: "3 Questions",
                 }),
-                include("@bolt-blueprints/_module-quiz-item.twig", {
+                macros.include("@bolt-blueprints/_module-quiz-item.twig", {
                   text: "Module Quiz",
                   numberOfQuestionsText: "3 Questions",
                   status: "passed"
                 }),
-                include("@bolt-blueprints/_module-quiz-item.twig", {
+                macros.include("@bolt-blueprints/_module-quiz-item.twig", {
                   text: "Module Quiz",
                   numberOfQuestionsText: "3 Questions",
                   status: "failed"

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/05-pages/t2-inner-pages/challenge-details/t2-challenge-detail-page.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/05-pages/t2-inner-pages/challenge-details/t2-challenge-detail-page.twig
@@ -1,6 +1,8 @@
 {% extends "@bolt-blueprints/_detail-page-template.twig" %}
 
 {% block page_content %}
+  {% import "@bolt-blueprints/macros.twig" as macros %}
+
   {% include "@bolt-components-headline/headline.twig" with {
     tag: "h2",
     size: "xxlarge",
@@ -43,7 +45,7 @@
 
   {% include "@bolt-components-figure/figure.twig" with {
     media: {
-      content: include("@bolt-components-image/image.twig", {
+      content: macros.include("@bolt-components-image/image.twig", {
         src: "/images/placeholders/500x500.jpg",
       }),
     },

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/05-pages/wip-pages/mission-exercise/_t2-mission-exercise-detail-page.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/05-pages/wip-pages/mission-exercise/_t2-mission-exercise-detail-page.twig
@@ -1,5 +1,7 @@
 {% extends "@bolt-blueprints/_default-page-template.twig" %}
 
+{% import "@bolt-blueprints/macros.twig" as macros %}
+
 {% block main_content %}
   {# Toolbar #}
   {% set icon %}
@@ -185,7 +187,7 @@
         } only %}
         {% include "@bolt-components-figure/figure.twig" with {
           media: {
-            content: include("@bolt-components-image/image.twig", {
+            content: macros.include("@bolt-components-image/image.twig", {
               src: "/images/placeholders/500x500.jpg",
             }),
           },

--- a/packages/components/bolt-card-replacement/src/card-replacement-media/_card-replacement-media.twig
+++ b/packages/components/bolt-card-replacement/src/card-replacement-media/_card-replacement-media.twig
@@ -4,8 +4,6 @@
 
 {% set card_replacement_media_content = media.content %}
 
-{% set media_block = block("media") %}
-
 {% if horizontal and card_replacement_image %}
   {% set card_replacement_image = card_replacement_image | merge({
     ratio: false,
@@ -17,13 +15,13 @@
   {# @todo: The replace function is a hack to get around the utf-8 bug. #}
   {{ card_replacement_media_content | join | replace({"UTF-8": ""}) }}
 {% else %}
-  {% if card_replacement_image or media_block %}
+  {% if card_replacement_image or block("media") %}
     <bolt-card-replacement-media {{ attributes }}>
       <replace-with-children class="c-bolt-card_replacement__media">
         {% if card_replacement_image %}
           {% include "@bolt-components-image/image.twig" with card_replacement_image only %}
-        {% elseif media_block %}
-          {{ media_block }}
+        {% elseif block("media") %}
+          {{ block("media") }}
         {% endif %}
       </replace-with-children>
     </bolt-card-replacement-media>

--- a/packages/components/bolt-card-replacement/src/card-replacement/card-replacement.twig
+++ b/packages/components/bolt-card-replacement/src/card-replacement/card-replacement.twig
@@ -29,7 +29,6 @@
 {% set background_block = block("background") %}
 {% set media_block = block("media") %}
 {% set body_block = block("body") %}
-{% set actions_block = block("actions") %}
 
 {# card-replacement component's custom element wrapper #}
 <bolt-card-replacement

--- a/packages/components/bolt-card-replacement/src/card-replacement/card-replacement.twig
+++ b/packages/components/bolt-card-replacement/src/card-replacement/card-replacement.twig
@@ -26,9 +26,23 @@
   {% set link_attributes = create_attribute(link.attributes) %}
 {% endif %}
 
-{% set background_block = block("background") %}
-{% set media_block = block("media") %}
-{% set body_block = block("body") %}
+{% if block("background") %}
+  {% set background_block %}
+    {{ block("background") }}
+  {% endset %}
+{% endif %}
+
+{% if block("media") %}
+  {% set media_block %}
+    {{ block("media") }}
+  {% endset %}
+{% endif %}
+
+{% if block("body") %}
+  {% set body_block %}
+    {{ block("body") }}
+  {% endset %}
+{% endif %}
 
 {# card-replacement component's custom element wrapper #}
 <bolt-card-replacement

--- a/packages/components/bolt-toolbar/toolbar.twig
+++ b/packages/components/bolt-toolbar/toolbar.twig
@@ -11,19 +11,32 @@
             </div>
           {% endif %}
 
-          {{ block('toolbar_before') | default(content_before) }}
+          {%  if block("toolbar_before") %}
+            {{ block("toolbar_before") }}
+          {% else %}
+            {{ toolbar_before }}
+          {% endif %}
+
         </div>
       {% endif %}
 
       {% if block("content") or content %}
         <div class="c-bolt-toolbar__item c-bolt-toolbar__item--center">
-          {{ block("content") | default(content) }}
+          {%  if block("content") %}
+            {{ block("content") }}
+          {% else %}
+            {{ content }}
+          {% endif %}
         </div>
       {% endif %}
 
       {% if block("content_after") or content_after %}
         <div class="c-bolt-toolbar__item c-bolt-toolbar__item--after">
-          {{ block("content_after") | default(content_after) }}
+          {% if block("content_after") %}
+            {{ block("content_after") }}
+          {% else %}
+            {{ content_after }}
+          {% endif %}
         </div>
       {% endif %}
     </div>

--- a/packages/components/bolt-toolbar/toolbar.twig
+++ b/packages/components/bolt-toolbar/toolbar.twig
@@ -1,7 +1,7 @@
 <div class="t-bolt-xdark c-bolt-toolbar c-bolt-toolbar--{{ gradientName | default('purple') }}">
   <div class="c-bolt-toolbar__inner">
     <div class="c-bolt-toolbar__items">
-      {% if title or block('toolbar_before') or content_before %}
+      {% if title or block('content_before') or content_before %}
         <div class="c-bolt-toolbar__item c-bolt-toolbar__item--before">
           {% if title %}
             <div class="c-bolt-toolbar__title">
@@ -11,10 +11,10 @@
             </div>
           {% endif %}
 
-          {%  if block("toolbar_before") %}
-            {{ block("toolbar_before") }}
+          {%  if block("content_before") %}
+            {{ block("content_before") }}
           {% else %}
-            {{ toolbar_before }}
+            {{ content_before }}
           {% endif %}
 
         </div>

--- a/packages/components/bolt-toolbar/toolbar.twig
+++ b/packages/components/bolt-toolbar/toolbar.twig
@@ -1,11 +1,7 @@
-{% set toolbar_content_before = block("content_before") %}
-{% set toolbar_content = block("content") %}
-{% set toolbar_content_after = block("content_after") %}
-
 <div class="t-bolt-xdark c-bolt-toolbar c-bolt-toolbar--{{ gradientName | default('purple') }}">
   <div class="c-bolt-toolbar__inner">
     <div class="c-bolt-toolbar__items">
-      {% if title or toolbar_content_before or content_before %}
+      {% if title or block('toolbar_before') or content_before %}
         <div class="c-bolt-toolbar__item c-bolt-toolbar__item--before">
           {% if title %}
             <div class="c-bolt-toolbar__title">
@@ -15,19 +11,19 @@
             </div>
           {% endif %}
 
-          {{ toolbar_content_before | default(content_before) | raw }}
+          {{ block('toolbar_before') | default(content_before) }}
         </div>
       {% endif %}
 
-      {% if toolbar_content or content %}
+      {% if block("content") or content %}
         <div class="c-bolt-toolbar__item c-bolt-toolbar__item--center">
-          {{ toolbar_content | default(content) | raw }}
+          {{ block("content") | default(content) }}
         </div>
       {% endif %}
 
-      {% if toolbar_content_after or content_after %}
+      {% if block("content_after") or content_after %}
         <div class="c-bolt-toolbar__item c-bolt-toolbar__item--after">
-          {{ toolbar_content_after | default(content_after) | raw }}
+          {{ block("content_after") | default(content_after) }}
         </div>
       {% endif %}
     </div>


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1988

## Summary

Fix twig `block()` and `include()` function usage to work with autoescaping

## Details
This PR has two parts:
1. Replace the twig `include()` function in the blueprints package with a macro that prints the contents of the include in order to play nice with autoescaping (credit goes to @sghoweri, thanks!)
2. Update places where the twig `block()` syntax is used to ensure that the block is always printed before setting its contents to a variable (also to play nice with autoescaping and remove the need for the `|raw` filter).  This can take several forms:
    - Most simply, ensuring that where the block contents is printed, the ` {{ block('block-name') }}` syntax (and not a printed variable) is used.
    - In more complex cases-- especially when embeds result in multiple layers of blocks, potentially with conflicting names-- setting a variable representing the block and its contents using the following syntax:
```
{% if block("body") %}
  {% set body_block %}
    {{ block("body") }}
  {% endset %}
{% endif %}
```

## How to test
- Confirm that replacement card, toolbar, and all blueprint patterns can be printed with autoescaping enabled (in particular, in Drupal) without raw markup displaying.  Unfortunately, Drupal lab needs some updates to be functional, which I omitted from this PR for clarity (but will work on in separate PRs).
- Confirm no regressions in pattern lab.  In particular, confirm that when a block is either not present or empty, any conditional wrappers do not print.  For example, both the following should result in cards that do not have a `<bolt-card-replacement-media>` element within them

```
{% embed "@bolt-components-card-replacement/card-replacement.twig"  only %}
  {% block body %}
    hello world
  {% endblock %}
{% endembed %}
```
```
{% embed "@bolt-components-card-replacement/card-replacement.twig" only %}
  {% block media %}{% endblock %}

  {% block body %}
    hello world
  {% endblock %}
{% endembed %}
```
