### PR TITLE
Fix popover double-focus

### DIFF
--- a/packages/components/bolt-popover/src/popover.js
+++ b/packages/components/bolt-popover/src/popover.js
@@ -120,8 +120,8 @@ class BoltPopover extends BoltElement {
       }
     };
 
-    this.slotMap.get('content') &&
-      this.slotMap.get('content').forEach(e => {
+    this.slotMap.get('default') &&
+      this.slotMap.get('default').forEach(e => {
         // Sorts through the content slot, figure out what kind of nodes it
         // contains, and sets variables accordingly
         recursivelySort(e);


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1986

## Summary

Fix popover double-focus.

## Details

We were checking the wrong slot for focusable content. Now we're checking the "default" slot which contains the trigger, the content we actually want to inspect. With that change, it's working as expected.

## How to test

- Review code change.
- Test this demo on PL: `/pattern-lab/patterns/02-components-popover-20-popover-use-case-menu/02-components-popover-20-popover-use-case-menu.html`. You should only have to tab once to focus on the Popover trigger.
