### PR TITLE
Remove CSS workarounds for micro journeys in dark theme

### DIFF
--- a/packages/experimental/micro-journeys/src/interactive-pathway.scss
+++ b/packages/experimental/micro-journeys/src/interactive-pathway.scss
@@ -22,20 +22,11 @@ $bolt-interactive-step--dot-size: 1.2rem;
   &__nav-item {
     &:before {
       @include bolt-micro-journeys-nav-dot;
-
-      section.c-bolt-interactive-pathway.t-bolt-dark & {
-        background-color: bolt-color(indigo, light);
-      }
     }
 
     &--active {
       &:before {
         @include bolt-micro-journeys-nav-dot($active: true);
-
-        section.c-bolt-interactive-pathway.t-bolt-dark & {
-          border-color: bolt-color(white) !important;
-          background-color: bolt-color(yellow) !important;
-        }
       }
     }
   }
@@ -59,10 +50,6 @@ $bolt-interactive-step--dot-size: 1.2rem;
 
       &:after {
         @include bolt-micro-journeys-nav-line;
-
-        section.c-bolt-interactive-pathway.t-bolt-dark & {
-          background-color: bolt-color(indigo, light);
-        }
       }
 
       &--active {

--- a/packages/experimental/micro-journeys/src/interactive-step.scss
+++ b/packages/experimental/micro-journeys/src/interactive-step.scss
@@ -39,27 +39,14 @@ bolt-interactive-step {
     &:before {
       @include bolt-micro-journeys-nav-dot;
 
-      .c-bolt-interactive-step.t-bolt-dark & {
-        background-color: bolt-color(indigo, light);
-      }
-
       .c-bolt-interactive-step--active & {
         @include bolt-micro-journeys-nav-dot($active: true);
-      }
-
-      .c-bolt-interactive-step--active.t-bolt-dark & {
-        border-color: bolt-color(white);
-        background-color: bolt-color(yellow);
       }
     }
 
     // The nav line on mobile
     &:after {
       @include bolt-micro-journeys-nav-line;
-
-      .c-bolt-interactive-step.t-bolt-dark & {
-        background-color: bolt-color(indigo, light);
-      }
 
       .c-bolt-interactive-step--last & {
         display: none;
@@ -83,11 +70,6 @@ bolt-interactive-step {
 
     .c-bolt-interactive-step--active & {
       position: static;
-
-      .c-bolt-interactive-step.t-bolt-dark & {
-        border-color: bolt-color(white);
-        background-color: bolt-color(yellow);
-      }
     }
 
     .c-bolt-interactive-step--last & {

--- a/packages/experimental/micro-journeys/src/nav-shared.scss
+++ b/packages/experimental/micro-journeys/src/nav-shared.scss
@@ -13,7 +13,7 @@ $nav-circle-border-size: 2px;
     margin-top: calc(((#{$header-text-line-height} * #{$header-text-size}) - (#{$nav-circle-size--active} + (#{$nav-circle-border-size} * 2))) / 2);
     margin-left: -$nav-circle-size--active / 2 - $nav-circle-border-size;
     border: $nav-circle-border-size solid bolt-theme(primary);
-    background-color: bolt-theme(secondary);
+    background-color: bolt-theme(background);
   }
 
   @else {
@@ -30,7 +30,7 @@ $nav-circle-border-size: 2px;
     margin-right: bolt-spacing(small);
     margin-left: -$nav-circle-size / 2;
     border-radius: 50%;
-    background-color: bolt-theme(primary);
+    background-color: bolt-color(indigo, light);
   }
 }
 
@@ -44,7 +44,7 @@ $nav-circle-border-size: 2px;
   left: -$line-width / 2;
   width: $line-width;
   height: 100%;
-  background-color: bolt-theme(primary);
+  background-color: bolt-color(indigo, light);
 }
 
 @mixin bolt-micro-journeys-nav-title($active: false) {
@@ -52,10 +52,6 @@ $nav-circle-border-size: 2px;
     color: bolt-theme(primary);
     cursor: default;
     font-weight: bolder;
-
-    .t-bolt-dark & {
-      color: bolt-color(yellow);
-    }
   }
   @else {
     display: flex;


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/WWWD-4540

## Summary

Remove CSS workarounds for micro journeys in dark theme

## Details

- Removes all usages of the `.t-bolt-dark` class in micro journeys CSS.
- Updates dark theme behavior slightly.
Previously, active waypoints looked like this: 
![active waypoint comps](https://user-images.githubusercontent.com/677668/73849402-da1c3f80-47f7-11ea-81da-4fd5f064e537.png)
Now, they look like this:
![active waypoint background primary](https://user-images.githubusercontent.com/677668/73849405-db4d6c80-47f7-11ea-9dd6-165677a0caa5.png)

## How to test
- Go to /pattern-lab/?p=experiments-micro-journeys-solo and confirm micro journeys look as expected in both themes.
- Confirm no regressions