### PR TITLE
Preventing TypeError on emailSocialShare

### DIFF
--- a/packages/components/bolt-video/plugins/email-plugin.js
+++ b/packages/components/bolt-video/plugins/email-plugin.js
@@ -2,7 +2,7 @@ export const emailPlugin = player => {
   if (player.activePlugins_) {
     if (
       !player.activePlugins_.emailSocialShare &&
-      typeof emailSocialShare === "function"
+      typeof player.emailSocialShare === "function"
     ) {
       return player.emailSocialShare();
     }

--- a/packages/components/bolt-video/plugins/email-plugin.js
+++ b/packages/components/bolt-video/plugins/email-plugin.js
@@ -1,6 +1,9 @@
 export const emailPlugin = player => {
   if (player.activePlugins_) {
-    if (!player.activePlugins_.emailSocialShare) {
+    if (
+      !player.activePlugins_.emailSocialShare &&
+      typeof emailSocialShare === "function"
+    ) {
       return player.emailSocialShare();
     }
   }


### PR DESCRIPTION
Uncaught TypeError: player.emailSocialShare is not a function

## Jira

COMM-1617 (fixing console.log errors during Bolt upgrade)

## Summary

Site is throwing following error in console:
```
email-plugin.js?155c:4 Uncaught TypeError: player.emailSocialShare is not a function
    at Object.emailPlugin [as email] (email-plugin.js?155c:4)
    at eval (video.standalone.js?3c58:161)
    at Array.forEach (<anonymous>)
    at HTMLElement._setupPlugins (video.standalone.js?3c58:158)
    at a.handlePlayerReady (video.standalone.js?3c58:172)
    at a.eval (video.standalone.js?3c58:591)
    at e (index.min.js:1)
    at index.min.js:1
```

## Details

Added additional check to prevent TypeError

## How to test

1. Open Community homepage page before applying the fix. 
2. Check console - you'll see the error.
3. Apply the fix.
4. Check console again - there should be no error.
