### PR TITLE
fix(editor): rearrange step w content

### DIFF
--- a/packages/experimental/editor/src/editor.js
+++ b/packages/experimental/editor/src/editor.js
@@ -56,7 +56,7 @@ export function enableEditor({ space, uiWrapper, config }) {
    *
    * @param opt {Object}
    * @param opt.editor {grapesjs.Editor}
-   * @param opt.isUp {[boolean = true]}: If true, move direction is up. If false, direction is down.
+   * @param opt.isUp {boolean} If true, move direction is up. If false, direction is down.
    * @returns {Promise<void>}
    */
   function moveElement({ editor, isUp = true }) {
@@ -145,7 +145,11 @@ export function enableEditor({ space, uiWrapper, config }) {
         }
 
         if (isPathway) {
-          newEl.parentElement.beginItAll();
+          /** @type {import('@bolt/micro-journeys/src/interactive-pathways').BoltInteractivePathways} */
+          const pathway = newEl.parentElement;
+          if (pathway && pathway.beginItAll) {
+            pathway.beginItAll();
+          }
           newEl.dispatchEvent(
             new CustomEvent('bolt-interactive-pathway:title-updated', {
               bubbles: true,
@@ -165,6 +169,7 @@ export function enableEditor({ space, uiWrapper, config }) {
    * @param opt {Object}
    * @param opt.editor {grapesjs.Editor}
    * @param opt.buttonId {string} i.e. `move-up`, `move-down`, etc
+   * @param [opt.panelId='buttons'] {string}
    * @param opt.disable {boolean}
    * @returns {void}
    */

--- a/packages/experimental/micro-journeys/src/interactive-pathway.js
+++ b/packages/experimental/micro-journeys/src/interactive-pathway.js
@@ -60,7 +60,32 @@ class BoltInteractivePathway extends withLitContext {
     self.addEventListener('bolt-interactive-step:change-active-step', event => {
       const steps = self.getSteps();
       const stepId = steps.findIndex(step => step.el === event.target);
-      self.setActiveStep(stepId);
+      if (stepId > 0) {
+        self.setActiveStep(stepId);
+      } else {
+        console.warn('uh oh! could not find active step', { event, steps });
+      }
+    });
+
+    self.addEventListener('bolt-interactive-step:change-active-step-to-index', event => {
+      const { index } = event.detail || {};
+      if (typeof index !== 'number') {
+        console.warn(`Uh oh! "bolt-interactive-step:change-active-step-to-index" event was fired without an "index" in "event.detail"`, event);
+        return;
+      }
+
+      const steps = self.getSteps();
+      const totalSteps = steps.length;
+      if (totalSteps < index) {
+        console.warn(`Uh oh! "bolt-interactive-step:change-active-step-to-index" event was fired with an "index" that is bigger than our list of steps total items`, {
+          event,
+          totalSteps,
+          index,
+        });
+        return;
+      }
+
+      self.setActiveStep(index);
     });
 
     self.addEventListener('bolt-interactive-step:title-updated', () => {

--- a/packages/experimental/micro-journeys/src/interactive-pathway.js
+++ b/packages/experimental/micro-journeys/src/interactive-pathway.js
@@ -67,26 +67,35 @@ class BoltInteractivePathway extends withLitContext {
       }
     });
 
-    self.addEventListener('bolt-interactive-step:change-active-step-to-index', event => {
-      const { index } = event.detail || {};
-      if (typeof index !== 'number') {
-        console.warn(`Uh oh! "bolt-interactive-step:change-active-step-to-index" event was fired without an "index" in "event.detail"`, event);
-        return;
-      }
+    self.addEventListener(
+      'bolt-interactive-step:change-active-step-to-index',
+      event => {
+        const { index } = event.detail || {};
+        if (typeof index !== 'number') {
+          console.warn(
+            `Uh oh! "bolt-interactive-step:change-active-step-to-index" event was fired without an "index" in "event.detail"`,
+            event,
+          );
+          return;
+        }
 
-      const steps = self.getSteps();
-      const totalSteps = steps.length;
-      if (totalSteps < index) {
-        console.warn(`Uh oh! "bolt-interactive-step:change-active-step-to-index" event was fired with an "index" that is bigger than our list of steps total items`, {
-          event,
-          totalSteps,
-          index,
-        });
-        return;
-      }
+        const steps = self.getSteps();
+        const totalSteps = steps.length;
+        if (totalSteps < index) {
+          console.warn(
+            `Uh oh! "bolt-interactive-step:change-active-step-to-index" event was fired with an "index" that is bigger than our list of steps total items`,
+            {
+              event,
+              totalSteps,
+              index,
+            },
+          );
+          return;
+        }
 
-      self.setActiveStep(index);
-    });
+        self.setActiveStep(index);
+      },
+    );
 
     self.addEventListener('bolt-interactive-step:title-updated', () => {
       self.checkChildrenAndRender();

--- a/packages/experimental/micro-journeys/src/interactive-step.js
+++ b/packages/experimental/micro-journeys/src/interactive-step.js
@@ -119,6 +119,13 @@ class BoltInteractiveStep extends withLitContext {
         );
       });
     }
+
+    this.dispatchEvent(
+      new CustomEvent(`${BoltInteractiveStep.is}:trigger-anim-ins`, {
+        bubbles: true,
+      }),
+    );
+
     return triggerAnims({
       animEls,
       stage: 'IN',


### PR DESCRIPTION
## Tasks

- Asana: [Move up/down buttons breaks when applied to pathway steps](https://app.asana.com/0/1126340469288208/1160381693199881/f)
- JIRA: [WWWD-4544](http://vjira2:8080/browse/WWWD-4544)

## Summary

Fixes Editor re-arrangement of Micro Journey Steps

## Details

(Explain the changes in enough detail fo reviewers to understand.  Raise any questions for reviewers to consider.)

## How to test

- Go to https://boltdesignsystem.com/pattern-lab/?p=experiments-micro-journeys and click 'Edit'
- Select one of the `bolt-interactive-step` elements in the layers palette
- Click the `move up` or `move down` button in the editor

**Resolved**: After doing this, the contents of the step you moved will be gone (and won't come back after saving).

# WIP Remaining

- [x] Fix core bug involving Steps moving up & down & retaining content
- [x] Editor UI feedback for first/last items
- [x] Ensure pathway re-arranging is smooth too