### PR TITLE
WWWD-4219 schema docs fixes

### DIFF
--- a/docs-site/src/components/pattern-lab-utils/schema-docs.twig
+++ b/docs-site/src/components/pattern-lab-utils/schema-docs.twig
@@ -41,39 +41,41 @@
           [<em>items</em>]:
           <ul class="c-bds-docs-list__child">
             <li>Type: <code>{{ printableType }}</code>{{ macros.titleAndDescription(prop.items.title, prop.items.description, prop.minimum, prop.maximum) }}</li>
-            <li>Properties:
-              <ul class="c-bds-docs-list__child c-bds-docs-list__child--level-2">
-                {% for key, property in prop.items.properties %}
-                  <li><code>{{ key }}</code>
-                    {{ macros.titleAndDescription(property.title, property.description, prop.minimum, prop.maximum) }}
-                    {% if property.type %}
-                      <ul class="c-bds-docs-list__child c-bds-docs-list__child--level-3">
-                        <li>
-                          Type:
-                          {% if property.type is iterable %}
-                            {% for type in property.type %}
-                              <code>{{ type }}</code>{% if not loop.last %}, {% endif %}
-                            {% endfor %}
-                          {% else %}
-                            <code>{{ property.type }}</code>
+            {% if prop.items.properties is not empty %}
+              <li>Properties:
+                <ul class="c-bds-docs-list__child c-bds-docs-list__child--level-2">
+                  {% for key, property in prop.items.properties %}
+                    <li><code>{{ key }}</code>
+                      {{ macros.titleAndDescription(property.title, property.description, prop.minimum, prop.maximum) }}
+                      {% if property.type %}
+                        <ul class="c-bds-docs-list__child c-bds-docs-list__child--level-3">
+                          <li>
+                            Type:
+                            {% if property.type is iterable %}
+                              {% for type in property.type %}
+                                <code>{{ type }}</code>{% if not loop.last %}, {% endif %}
+                              {% endfor %}
+                            {% else %}
+                              <code>{{ property.type }}</code>
+                            {% endif %}
+                          </li>
+                          {% if property.enum %}
+                          <li>
+                            Enum:
+                            {{ macros.loopThroughEnums(property) }}
+                          </li>
                           {% endif %}
-                        </li>
-                        {% if property.enum %}
-                        <li>
-                          Enum:
-                          {{ macros.loopThroughEnums(property) }}
-                        </li>
-                        {% endif %}
-                        {% if property.type == "object" and property.properties %}
-                          <li>Properties:</li>
-                          {{ macros.object(property.properties) }}
-                        {% endif %}
-                      </ul>
-                    {% endif %}
-                  </li>
-                {% endfor %}
-              </ul>
-            </li>
+                          {% if property.type == "object" and property.properties %}
+                            <li>Properties:</li>
+                            {{ macros.object(property.properties) }}
+                          {% endif %}
+                        </ul>
+                      {% endif %}
+                    </li>
+                  {% endfor %}
+                </ul>
+              </li>
+            {% endif %}
           </ul>
         {% endif %}
       {% elseif not prop.enum %}

--- a/docs-site/src/components/pattern-lab-utils/schema-docs.twig
+++ b/docs-site/src/components/pattern-lab-utils/schema-docs.twig
@@ -150,7 +150,9 @@
       <li>
         <code>{{ key }}</code>
         {{ macros.titleAndDescription(prop.title, prop.description, prop.minimum, prop.maximum) }}
-        {% if isRef %}<br />Type: {{ prop.type is iterable ? prop.type|join(", ") : prop.type }} {% endif %}
+        {% if isRef %}
+          <p>Type: {{ prop.type is iterable ? prop.type|join(", ") : prop.type }}</p>
+        {% endif %}
         {{ macros.schemaProps(prop) }}
       </li>
     {% endfor %}

--- a/docs-site/src/components/pattern-lab-utils/schema-docs.twig
+++ b/docs-site/src/components/pattern-lab-utils/schema-docs.twig
@@ -36,10 +36,11 @@
           {{ macros.object(prop.properties) }}
         {% endif %}
       {% elseif prop.type == "array" and prop.items %}
-        {% if prop.items.type == "object" or prop.items.type == "any" %}
+        {% if prop.items.type == "object" or prop.items.type == "any" or prop.items.type is iterable %}
+          {% set printableType = prop.items.type is iterable ? prop.items.type|join(', ') : prop.items.type %}
           [<em>items</em>]:
           <ul class="c-bds-docs-list__child">
-            <li>Type: <code>{{ prop.items.type }}</code>{{ macros.titleAndDescription(prop.items.title, prop.items.description, prop.minimum, prop.maximum) }}</li>
+            <li>Type: <code>{{ printableType }}</code>{{ macros.titleAndDescription(prop.items.title, prop.items.description, prop.minimum, prop.maximum) }}</li>
             <li>Properties:
               <ul class="c-bds-docs-list__child c-bds-docs-list__child--level-2">
                 {% for key, property in prop.items.properties %}

--- a/docs-site/src/components/schema-table/schema-table.scss
+++ b/docs-site/src/components/schema-table/schema-table.scss
@@ -5,7 +5,6 @@
 
   ul {
     p {
-      display: inline;
       margin: 0;
     }
 


### PR DESCRIPTION
## Summary

Schema docs fixes

## Details

This fixes schema docs problems found while working on #1701.  Specifically:
- When `type` in the schema was an array, it was not printed.  For example, here's the breadcrumb component (https://boltdesignsystem.com/pattern-lab/?p=viewall-components-breadcrumb) before and after this PR:
    Before:
    <img width="1091" alt="Screen Shot 2020-02-07 at 2 15 41 PM" src="https://user-images.githubusercontent.com/677668/74058748-b18d7480-49b4-11ea-818b-9cb854fd0d56.png">
    After:
    <img width="1218" alt="Screen Shot 2020-02-07 at 2 15 54 PM" src="https://user-images.githubusercontent.com/677668/74058750-b3573800-49b4-11ea-83ce-a768f4f8df55.png">
- When `type` was an array but each item did not have properties, an empty "Properties" label was printed.  For example, here's the content items row of the buttons group component (https://boltdesignsystem.com/pattern-lab/?p=viewall-components-buttons-group) before and after this PR:
    Before:
    <img width="842" alt="Screen Shot 2020-02-07 at 2 20 36 PM" src="https://user-images.githubusercontent.com/677668/74058983-28c30880-49b5-11ea-9ec0-920e9ee92f15.png">
    After:
    <img width="829" alt="Screen Shot 2020-02-07 at 2 20 13 PM" src="https://user-images.githubusercontent.com/677668/74058990-2a8ccc00-49b5-11ea-9090-65ae2ba36820.png">

## How to test

Compare the two links above between master and this branch and confirm that the issues are fixed.
