### PR TITLE
fix: whole-card clickability

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/card-replacement/00-card-replacement-docs.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/card-replacement/00-card-replacement-docs.twig
@@ -1,8 +1,7 @@
 {% set usage %}
 {% verbatim %}
-  // Standard card-replacement
-
-  {% include "@bolt-components-card-replacement/card-replacement.twig" with {
+// Standard card-replacement
+{% include "@bolt-components-card-replacement/card-replacement.twig" with {
   media: {
     image: {
       src: "/images/placeholders/landscape-16x9-mountains.jpg",
@@ -22,9 +21,8 @@
   ],
 } only %}
 
-  // Custom Content
-
-  {% include "@bolt-components-card-replacement/card-replacement.twig" with {
+// Custom section content
+{% include "@bolt-components-card-replacement/card-replacement.twig" with {
   media: {
     content: "Pass custom content to the card-replacement media.",
   },
@@ -33,7 +31,8 @@
   },
 } only %}
 
-  {% include "@bolt-components-card-replacement/card-replacement.twig" with {
+// Custom overall content
+{% include "@bolt-components-card-replacement/card-replacement.twig" with {
   content: "Pass completely custom content to the card-replacement, without the styles of the card-replacement body.",
 } only %}
 {% endverbatim %}

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/card-replacement/30-card-replacement-link-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/card-replacement/30-card-replacement-link-variations.twig
@@ -1,3 +1,8 @@
+{% set link %}{% spaceless %}{% include "@bolt-components-link/link.twig" with {
+  text: "like this",
+  url: "https://yahoo.com",
+} only %}{% endspaceless %}{% endset %}
+
 {% grid "o-bolt-grid--flex o-bolt-grid--matrix o-bolt-grid--center" %}
   {% cell "u-bolt-width-6/12 u-bolt-width-4/12@small" %}
     {% include "@bolt-components-card-replacement/card-replacement.twig" with {
@@ -14,7 +19,7 @@
       actions: [
         {
           text: "This is a button",
-          url: "http://pega.com",
+          url: "https://pega.com",
         }
       ],
     } only %}
@@ -23,7 +28,7 @@
   {% cell "u-bolt-width-6/12 u-bolt-width-4/12@small" %}
     {% include "@bolt-components-card-replacement/card-replacement.twig" with {
       link: {
-        url: "http://pega.com",
+        url: "https://pega.com",
         text: "Go to pega.com"
       },
       media: {
@@ -34,12 +39,12 @@
       },
       body: {
         headline: "With link",
-        paragraph: "This card has a link, which makes the whole card clickable, but you can still have the action button to link somewhere else if needed.",
+        paragraph: "This card has a url, which makes the whole card clickable, but you can still have text links in the body (" ~ link ~ ") or the action button to link somewhere else if needed.",
       },
       actions: [
         {
           text: "This button has a diffent link",
-          url: "http://google.com",
+          url: "https://google.com",
         }
       ],
     } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/card-replacement/999-card-replacement-with-web-component.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/card-replacement/999-card-replacement-with-web-component.twig
@@ -7,71 +7,72 @@
     {% endgrid %}
   </div>
   <div class="u-bolt-margin-bottom-large">
-    <bolt-code-snippet syntax="dark" lang="html">{% spaceless %}{{ code | replace({
+    <bolt-code-snippet syntax="dark" lang="html">{% spaceless %}
+      {{ code | replace({
         '<': '&lt;',
         '>': '&gt;',
-      }) | trim | raw }}{% endspaceless %}
-    </bolt-code-snippet>
+      }) | trim | raw }}
+    {% endspaceless %}</bolt-code-snippet>
   </div>
 {% endmacro %}
 
 {% import _self as card_replacement_code %}
 
 {% macro video() %}
-<bolt-card-replacement-media>
-  <bolt-ratio aspect-ratio-height="9" aspect-ratio-width="16">
-    <bolt-video data-setup='{"techOrder": ["Html5"], "resizeManager": false}' video-id="3861325118001" account-id="1900410236" show-meta show-meta-title player-id="r1CAdLzTW" controls></bolt-video>
-  </bolt-ratio>
-</bolt-card-replacement-media>
+  <bolt-card-replacement-media>
+    <bolt-ratio aspect-ratio-height="9" aspect-ratio-width="16">
+      <bolt-video data-setup='{"techOrder": ["Html5"], "resizeManager": false}' video-id="3861325118001" account-id="1900410236" show-meta show-meta-title player-id="r1CAdLzTW" controls></bolt-video>
+    </bolt-ratio>
+  </bolt-card-replacement-media>
 {% endmacro %}
 
 {% macro image() %}
-<bolt-card-replacement-media>
-  <bolt-image src="/images/placeholders/landscape-16x9-mountains.jpg" alt="card-replacement media."></bolt-image>
-</bolt-card-replacement-media>
+  <bolt-card-replacement-media>
+    <bolt-image src="/images/placeholders/landscape-16x9-mountains.jpg" alt="card-replacement media."></bolt-image>
+  </bolt-card-replacement-media>
 {% endmacro %}
 
 {% macro body() %}
-<bolt-card-replacement-body>
-  <bolt-text eyebrow>This is an eyebrow</bolt-text>
-  <bolt-text headline>This is a headline</bolt-text>
-  <bolt-text>This is a paragraph.</bolt-text>
-</bolt-card-replacement-body>
+  <bolt-card-replacement-body>
+    <bolt-text eyebrow>This is an eyebrow</bolt-text>
+    <bolt-text headline>This is a headline</bolt-text>
+    <bolt-text>This is a paragraph.</bolt-text>
+  </bolt-card-replacement-body>
 {% endmacro %}
 
 {% macro body_clickable() %}
-<bolt-card-replacement-body>This is a card-replacement with an overall link that makes the whole card-replacement clickable.</bolt-card-replacement-body>
+  <bolt-card-replacement-body>This is a card-replacement with an overall link that makes the whole card-replacement clickable.</bolt-card-replacement-body>
 {% endmacro %}
 
 {% macro body_with_link() %}
-<bolt-card-replacement-body>
-  This is a card-replacement with an overall link that makes the whole card-replacement clickable, while the body can still have <bolt-link target="_blank" url="https://boltdesignsystem.com/docs">text links</bolt-link> that would go somewhere else.
-</bolt-card-replacement-body>
+  <bolt-card-replacement-body>
+    This is a card-replacement with an overall link that makes the whole card-replacement clickable, while the body can still have <bolt-link target="_blank" url="https://boltdesignsystem.com/docs">text links</bolt-link> that would go somewhere else.
+  </bolt-card-replacement-body>
 {% endmacro %}
 
 {% macro actions() %}
-<bolt-card-replacement-actions>
-  <bolt-card-replacement-action url="https://pega.com">
-    Internal link
-  </bolt-card-replacement-action>
-  <bolt-card-replacement-action url="https://yahoo.com" external>
-    External link
-  </bolt-card-replacement-action>
-</bolt-card-replacement-actions>
+  <bolt-card-replacement-actions>
+    <bolt-card-replacement-action url="https://pega.com">
+      Internal link
+    </bolt-card-replacement-action>
+    <bolt-card-replacement-action url="https://yahoo.com" external>
+      External link
+    </bolt-card-replacement-action>
+  </bolt-card-replacement-actions>
 {% endmacro %}
 
 {% set card_replacement_web_component_demo %}
 <bolt-card-replacement>
-  {% include card_replacement_code.image() %}
-  {% include card_replacement_code.body() %}
-  {% include card_replacement_code.actions() %}
+{% include card_replacement_code.image() %}
+{% include card_replacement_code.body() %}
+{% include card_replacement_code.actions() %}
 </bolt-card-replacement>
 {% endset %}
 
 {% set simple_link_demo %}
 <bolt-card-replacement url="https://google.com" url-text="Go to google.com">
-  {% include card_replacement_code.image() %}
-  {% include card_replacement_code.body_clickable() %}
+{% include card_replacement_code.image() %}
+{% include card_replacement_code.body_clickable() %}
 </bolt-card-replacement>
 {% endset %}
 
@@ -80,16 +81,16 @@
   <bolt-card-replacement-link custom-attribute="foo" html-attribute="bar">
     <a href="http://google.com" target="_blank">Go to google.com</a>
   </bolt-card-replacement-link>
-  {% include card_replacement_code.image() %}
-  {% include card_replacement_code.body_clickable() %}
+{% include card_replacement_code.image() %}
+{% include card_replacement_code.body_clickable() %}
 </bolt-card-replacement>
 {% endset %}
 
 {% set nested_links_demo %}
 <bolt-card-replacement url="https://google.com">
-  {% include card_replacement_code.video() %}
-  {% include card_replacement_code.body_with_link() %}
-  {% include card_replacement_code.actions() %}
+{% include card_replacement_code.video() %}
+{% include card_replacement_code.body_with_link() %}
+{% include card_replacement_code.actions() %}
 </bolt-card-replacement>
 {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/card-replacement/999-card-replacement-with-web-component.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/card-replacement/999-card-replacement-with-web-component.twig
@@ -7,13 +7,10 @@
     {% endgrid %}
   </div>
   <div class="u-bolt-margin-bottom-large">
-    <bolt-code-snippet syntax="dark" lang="html">
-      {% spaceless %}
-        {{ code | replace({
+    <bolt-code-snippet syntax="dark" lang="html">{% spaceless %}{{ code | replace({
         '<': '&lt;',
         '>': '&gt;',
-      }) | trim | raw }}
-      {% endspaceless %}
+      }) | trim | raw }}{% endspaceless %}
     </bolt-code-snippet>
   </div>
 {% endmacro %}
@@ -21,46 +18,46 @@
 {% import _self as card_replacement_code %}
 
 {% macro video() %}
-  <bolt-card-replacement-media>
-    <bolt-ratio aspect-ratio-height="9" aspect-ratio-width="16">
-      <bolt-video data-setup='{"techOrder": ["Html5"], "resizeManager": false}' video-id="3861325118001" account-id="1900410236" show-meta show-meta-title player-id="r1CAdLzTW" controls></bolt-video>
-    </bolt-ratio>
-  </bolt-card-replacement-media>
+<bolt-card-replacement-media>
+  <bolt-ratio aspect-ratio-height="9" aspect-ratio-width="16">
+    <bolt-video data-setup='{"techOrder": ["Html5"], "resizeManager": false}' video-id="3861325118001" account-id="1900410236" show-meta show-meta-title player-id="r1CAdLzTW" controls></bolt-video>
+  </bolt-ratio>
+</bolt-card-replacement-media>
 {% endmacro %}
 
 {% macro image() %}
-  <bolt-card-replacement-media>
-    <bolt-image src="/images/placeholders/landscape-16x9-mountains.jpg" alt="card-replacement media."></bolt-image>
-  </bolt-card-replacement-media>
+<bolt-card-replacement-media>
+  <bolt-image src="/images/placeholders/landscape-16x9-mountains.jpg" alt="card-replacement media."></bolt-image>
+</bolt-card-replacement-media>
 {% endmacro %}
 
 {% macro body() %}
-  <bolt-card-replacement-body>
-    <bolt-text eyebrow>This is an eyebrow</bolt-text>
-    <bolt-text headline>This is a headline</bolt-text>
-    <bolt-text>This is a paragraph.</bolt-text>
-  </bolt-card-replacement-body>
+<bolt-card-replacement-body>
+  <bolt-text eyebrow>This is an eyebrow</bolt-text>
+  <bolt-text headline>This is a headline</bolt-text>
+  <bolt-text>This is a paragraph.</bolt-text>
+</bolt-card-replacement-body>
 {% endmacro %}
 
 {% macro body_clickable() %}
-  <bolt-card-replacement-body>This is a card-replacement with an overall link that makes the whole card-replacement clickable.</bolt-card-replacement-body>
+<bolt-card-replacement-body>This is a card-replacement with an overall link that makes the whole card-replacement clickable.</bolt-card-replacement-body>
 {% endmacro %}
 
 {% macro body_with_link() %}
-  <bolt-card-replacement-body>This is a card-replacement with an overall link that makes the whole card-replacement clickable, while the body can still have
-    <bolt-link target="_blank" url="https://boltdesignsystem.com/docs">text links</bolt-link>
-    that would go somewhere else.</bolt-card-replacement-body>
+<bolt-card-replacement-body>
+  This is a card-replacement with an overall link that makes the whole card-replacement clickable, while the body can still have <bolt-link target="_blank" url="https://boltdesignsystem.com/docs">text links</bolt-link> that would go somewhere else.
+</bolt-card-replacement-body>
 {% endmacro %}
 
 {% macro actions() %}
-  <bolt-card-replacement-actions>
-    <bolt-card-replacement-action url="https://pega.com">
-      Internal link
-    </bolt-card-replacement-action>
-    <bolt-card-replacement-action url="https://yahoo.com" external>
-      External link
-    </bolt-card-replacement-action>
-  </bolt-card-replacement-actions>
+<bolt-card-replacement-actions>
+  <bolt-card-replacement-action url="https://pega.com">
+    Internal link
+  </bolt-card-replacement-action>
+  <bolt-card-replacement-action url="https://yahoo.com" external>
+    External link
+  </bolt-card-replacement-action>
+</bolt-card-replacement-actions>
 {% endmacro %}
 
 {% set card_replacement_web_component_demo %}

--- a/packages/components/bolt-card-replacement/src/_card-replacement-settings-and-tools.scss
+++ b/packages/components/bolt-card-replacement/src/_card-replacement-settings-and-tools.scss
@@ -8,8 +8,9 @@ $bolt-card-replacement-border-width: $bolt-border-width;
 $bolt-card-replacement-border-style: $bolt-border-style;
 $bolt-card-replacement-border-color: bolt-theme(text, 0.15);
 $bolt-card-replacement-border-radius: 4px;
-$bolt-card-replacement-link-z-index: 1;
-$bolt-card-replacement-individual-link-z-index: 2;
+$bolt-card-replacement-link-z-index: 3;
+$bolt-card-replacement-individual-link-z-index: 4;
+$bolt-card-replacement-body-z-index: 2; // Must be at least 2 to layer over card-replacement-background, and these elements can appear in any order
 $bolt-card-replacement-video-z-index: $bolt-card-replacement-individual-link-z-index;
 
 

--- a/packages/components/bolt-card-replacement/src/_card-replacement-settings-and-tools.scss
+++ b/packages/components/bolt-card-replacement/src/_card-replacement-settings-and-tools.scss
@@ -8,11 +8,12 @@ $bolt-card-replacement-border-width: $bolt-border-width;
 $bolt-card-replacement-border-style: $bolt-border-style;
 $bolt-card-replacement-border-color: bolt-theme(text, 0.15);
 $bolt-card-replacement-border-radius: 4px;
-$bolt-card-replacement-link-z-index: 3;
-$bolt-card-replacement-individual-link-z-index: 4;
-$bolt-card-replacement-body-z-index: 2; // Must be at least 2 to layer over card-replacement-background, and these elements can appear in any order
-$bolt-card-replacement-video-z-index: $bolt-card-replacement-individual-link-z-index;
 
+// Don't set z-index on body, because body can have links that need to set its own z-index. We'd want to keep z-index usage at a minimum to avoid endless conflicts. Background should be set to 0 because it's the lowest in the stacking order and 0 will not cover up body as long as body is set to position:relative.
+// @todo: also note, setting inner link to 2 is prone to conflicts, but there's no other way currently.
+$bolt-card-replacement-z-index-background: 0;
+$bolt-card-replacement-z-index-outer-link: 1;
+$bolt-card-replacement-z-index-inner-link: 2;
 
 // Tools
 
@@ -25,22 +26,24 @@ $bolt-card-replacement-video-z-index: $bolt-card-replacement-individual-link-z-i
 @mixin bolt-card-replacement-content-conditions {
   // [Mai] Only the card-replacement body should not have hidden overflow and border radius because its background is transparent. This also catches any kind of free-form content being passed, making sure they don't poke outside the card-replacement (which has rounded corners and box shadows). The reason the card-replacement itself shouldn't have hidden overflow is because the card-replacement body can contain some kind of tooltip bubble or dropdown ui, they can poke out of the card-replacement naturally.
   > * {
-
     &:first-child {
-      border-radius: $bolt-card-replacement-border-radius $bolt-card-replacement-border-radius 0 0;
+      border-radius: $bolt-card-replacement-border-radius
+        $bolt-card-replacement-border-radius 0 0;
     }
 
     &:last-child {
-      border-radius: 0 0 $bolt-card-replacement-border-radius $bolt-card-replacement-border-radius;
+      border-radius: 0 0 $bolt-card-replacement-border-radius
+        $bolt-card-replacement-border-radius;
     }
 
-    &:only-child{
+    &:only-child {
       border-radius: $bolt-card-replacement-border-radius;
     }
   }
 
   > bolt-card-replacement-link + * {
-    border-radius: $bolt-card-replacement-border-radius $bolt-card-replacement-border-radius 0 0;
+    border-radius: $bolt-card-replacement-border-radius
+      $bolt-card-replacement-border-radius 0 0;
 
     &:last-child {
       border-radius: $bolt-card-replacement-border-radius;

--- a/packages/components/bolt-card-replacement/src/card-replacement-actions/_card-replacement-actions.scss
+++ b/packages/components/bolt-card-replacement/src/card-replacement-actions/_card-replacement-actions.scss
@@ -15,7 +15,7 @@ bolt-card-replacement-actions {
   display: flex;
   flex-wrap: wrap;
   position: relative;
-  z-index: $bolt-card-replacement-individual-link-z-index;
+  z-index: $bolt-card-replacement-z-index-inner-link;
   width: 100%;
   margin-top: auto;
 }

--- a/packages/components/bolt-card-replacement/src/card-replacement-background/_card-replacement-background.scss
+++ b/packages/components/bolt-card-replacement/src/card-replacement-background/_card-replacement-background.scss
@@ -11,14 +11,6 @@ bolt-card-replacement-background {
   right: 0;
   bottom: 0;
   left: 0;
-  z-index: 1;
-  overflow: hidden;
-  pointer-events: none;
-  border-radius: 4px;
-
-  [rounded] & {
-    @include bolt-border-radius(large);
-  }
 
   & + bolt-card-replacement-body {
     margin-bottom: auto;
@@ -27,11 +19,13 @@ bolt-card-replacement-background {
 
 .c-bolt-card_replacement__background {
   position: relative;
-  z-index: 1;
+  z-index: $bolt-card-replacement-z-index-background;
   width: 100%;
   height: 100%;
   overflow: hidden;
-  border-radius: 4px;
+  pointer-events: none;
+  user-select: none;
+  border-radius: $bolt-card-replacement-border-radius;
 
   [rounded] & {
     @include bolt-border-radius(large);

--- a/packages/components/bolt-card-replacement/src/card-replacement-body/_card-replacement-body.scss
+++ b/packages/components/bolt-card-replacement/src/card-replacement-body/_card-replacement-body.scss
@@ -7,7 +7,7 @@
 
 bolt-card-replacement-body {
   position: relative; // this + z-index needed in order to handle a background layer
-  z-index: 2;
+  z-index: $bolt-card-replacement-body-z-index;
   width: 100%;
 }
 

--- a/packages/components/bolt-card-replacement/src/card-replacement-body/_card-replacement-body.scss
+++ b/packages/components/bolt-card-replacement/src/card-replacement-body/_card-replacement-body.scss
@@ -5,13 +5,7 @@
 @import '@bolt/core-v3.x';
 @import '../_card-replacement-settings-and-tools.scss';
 
-bolt-card-replacement-body {
-  position: relative; // this + z-index needed in order to handle a background layer
-  z-index: $bolt-card-replacement-body-z-index;
-  width: 100%;
-}
-
-:host {
+@include bolt-repeat-rule(('bolt-card-replacement-body', ':host')) {
   width: 100%;
 }
 
@@ -20,16 +14,5 @@ bolt-card-replacement-body {
   @include bolt-padding(#{$bolt-card-replacement-body-spacing});
 
   display: block;
-}
-
-// automatically raise the default z-index of nested bolt-links in the bolt-card-replacement-body so they aren't covered by the bolt-card-replacement-link layer
-.c-bolt-card_replacement__body ::slotted(bolt-link) {
-  position: relative;
-  z-index: $bolt-card-replacement-individual-link-z-index;
-}
-
-// fallback version of the above styles -- used if shadow dom isn't supported or not getting used in certain situations
-.c-bolt-card_replacement__body bolt-link {
-  position: relative;
-  z-index: $bolt-card-replacement-individual-link-z-index;
+  position: relative; // Position is needed to bring body's stacking order above background.
 }

--- a/packages/components/bolt-card-replacement/src/card-replacement-link/_card-replacement-link.scss
+++ b/packages/components/bolt-card-replacement/src/card-replacement-link/_card-replacement-link.scss
@@ -14,7 +14,7 @@
   right: 0;
   bottom: 0;
   left: 0;
-  z-index: $bolt-card-replacement-link-z-index; // a small z-index is required here so the <bolt-card-replacement-link> covers most types of content used inside the card-replacement component, except for a few exceptions
+  z-index: $bolt-card-replacement-z-index-outer-link;
   cursor: pointer;
 }
 

--- a/packages/components/bolt-card-replacement/src/card-replacement-media/_card-replacement-media.scss
+++ b/packages/components/bolt-card-replacement/src/card-replacement-media/_card-replacement-media.scss
@@ -46,5 +46,5 @@ bolt-card-replacement-media {
 
 .c-bolt-card_replacement__media--video {
   position: relative;
-  z-index: $bolt-card-replacement-video-z-index;
+  z-index: $bolt-card-replacement-z-index-inner-link;
 }

--- a/packages/components/bolt-card-replacement/src/card-replacement/card-replacement.scss
+++ b/packages/components/bolt-card-replacement/src/card-replacement/card-replacement.scss
@@ -139,3 +139,11 @@ bolt-card-replacement {
   flex-grow: 1;
   flex-shrink: 1;
 }
+
+// This catches all links and button inside the card (inner links) and increases their z-index to make them higher than the outer link. Reference the _card-replacement-settings-and-tools.scss to see the full stacking order.
+@include bolt-repeat-rule(
+  ('::slotted(bolt-link)', 'bolt-link', '::slotted(bolt-button)', 'bolt-button')
+) {
+  position: relative;
+  z-index: $bolt-card-replacement-z-index-inner-link;
+}

--- a/packages/components/bolt-card-replacement/src/card-replacement/card-replacement.scss
+++ b/packages/components/bolt-card-replacement/src/card-replacement/card-replacement.scss
@@ -142,7 +142,12 @@ bolt-card-replacement {
 
 // This catches all links and button inside the card (inner links) and increases their z-index to make them higher than the outer link. Reference the _card-replacement-settings-and-tools.scss to see the full stacking order.
 @include bolt-repeat-rule(
-  ('::slotted(bolt-link)', 'bolt-link', '::slotted(bolt-button)', 'bolt-button')
+  (
+    '::slotted(bolt-link)',
+    'bolt-card-replacement bolt-link',
+    '::slotted(bolt-button)',
+    'bolt-card-replacement bolt-button'
+  )
 ) {
   position: relative;
   z-index: $bolt-card-replacement-z-index-inner-link;


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-1985

## Summary

Fixes whole-card clickability which is currently broken because card-body element has greater z-index.

## Details

Z-index was added to card-body ([see commit](https://github.com/boltdesignsystem/bolt/commit/37d427863c60e793a6cae34df0777e2852baa5fa)) so that it layers above the new card-background element. This inadvertently blocks the card-link element from being clickable. This PR resorts the z-indexes to fix the bug.

## How to test
- Review code changes.
- See broken whole-card clickability [on master](https://master.boltdesignsystem.com/pattern-lab/?p=components-card-replacement-link-variations) and verify it's fixed on feature branch.