### PR TITLE
Fix wrapping links in Safari

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/collections/dashboard/_dashboard-band.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/collections/dashboard/_dashboard-band.twig
@@ -3,7 +3,7 @@
 {% set useCarousel = useCarousel ?? true %}
 
 {% set content %}
-  {% grid "o-bolt-grid--flex o-bolt-grid--matrix" %}
+  {% grid "o-bolt-grid--flex o-bolt-grid--matrix o-bolt-grid--middle" %}
     {% if sectionTitle %}
       {% cell "u-bolt-width-1/1 #{sectionButtons ? 'u-bolt-width-1/2@small' : 'u-bolt-width-3/4@small'} u-bolt-flex-grow" %}
         {% include "@bolt-components-headline/headline.twig" with {
@@ -15,13 +15,14 @@
     {% endif %}
 
     {% if sectionButtons %}
-      {% cell "u-bolt-flex-shrink u-bolt-margin-top-auto" %}
-        {% include "@bolt-components-list/list.twig" with {
-          display: "inline",
-          tag: "ul",
-          spacing: "xxsmall",
-          items: sectionButtons
-        } %}
+      {% cell %}
+        {% grid "o-bolt-grid--flex o-bolt-grid--matrix o-bolt-grid--middle o-bolt-grid--xsmall" %}
+          {% for button in sectionButtons %}
+            {% cell %}
+              {{ button }}
+            {% endcell %}
+          {% endfor %}
+        {% endgrid %}
       {% endcell %}
     {% endif %}
   {% endgrid %}
@@ -43,10 +44,7 @@
           {% include "@bolt-components-carousel/carousel.twig" with {
             slides_per_view: "auto",
             nav_button_position: "outside",
-            slides: slides,
-            attributes: {
-              class: ["u-bolt-padding-top-medium"]
-            }
+            slides: slides
           } only %}
         {% endcell %}
       {% else %}


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-2010

## Summary

Fixes links in a list that are wrapping when they should not be.

## Details
### Underlying issue
There is a bug in Safari with our `bolt-list` component that occurs when an inline list is placed inside certain containers. So far we've observed it happening when placed inside a flex grid cell and nested inside `bolt-list`. The bug causes inline elements to wrap to a new line when they have space to fit on a single line.

It appears to be a sub-pixel rounding issue because when we pad the list `width` by 1 pixel (add `+ 1px` to [this](https://github.com/boltdesignsystem/bolt/blob/master/packages/components/bolt-list/src/list.scss#L80-L96) calc function) it fixes itself. However, it causes a separate problem in FF where it's then 1px too wide and can cause scroll bars to appear if the list sits inside a container with overflow `auto` on it.

### Workaround
We couldn't find a fix to the root problem ([made a ticket](http://vjira2:8080/browse/BDS-2024)), so for now this is a workaround. Simply switch to a nested grid instead of using `bolt-list`. Change that and it works fine.

I also adjusted the padding around the cell below the grid to reduce overall spacing.

## How to test

- Review files changed
- See Dashboard template in Safari (and Chrome and FF) and verify the "Show all" and "Add Missions" buttons are not wrapping.
  - `/pattern-lab/patterns/03-blueprints-05-pages-dashboard-dashboard-dashboard/03-blueprints-05-pages-dashboard-dashboard-dashboard.html`