### PR TITLE
Fix failing Lighthouse job

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -10,6 +10,7 @@
         "dom-size": "warn",
         "external-anchors-use-rel-noopener": "warn",
         "image-alt": "warn",
+        "is-crawlable": "warn",
         "label": "warn",
         "link-name": "warn",
         "list": "warn",


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-2048

## Summary

Updates Lighthouse assertions to "warn" not "error" on pages that are not crawlable.

## Details

Lighthouse Travis job was failing when it hit pages that weren't crawlable, and these are indeed pages we do not want to be crawled. So, the assertion has been updated to only "warn" when a page is not crawlable. It was not specified before, so I assume it was defaulting to "error" as part of the "minScore" assertion.

I also tested a branch with additional feature changes ([fix/test-lighthouse-with-feature](https://travis-ci.com/boltdesignsystem/bolt/builds/150747790)) and it's passing.

## How to test

- Review files changed
- Verify passing builds