### PR TITLE
Add new tertiary variant to the Button component

### DIFF
--- a/packages/build-tools/__tests__/multi-lang/__snapshots__/index.js.snap
+++ b/packages/build-tools/__tests__/multi-lang/__snapshots__/index.js.snap
@@ -93,8 +93,6 @@ bolt-button[type=\\"submit\\"] {
   vertical-align: middle;
   cursor: pointer;
   border-radius: 3px;
-  border-width: 1px;
-  border-style: solid;
   box-shadow: 0 1px 4px 1px rgba(6, 10, 36, 0.1),
     0 5px 10px 0 rgba(6, 10, 36, 0.08);
   transition: 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
@@ -105,6 +103,7 @@ bolt-button[type=\\"submit\\"] {
   );
   outline: 0;
   will-change: box-shadow;
+  border: 1px solid transparent;
 }
 .js-fonts-loaded .c-bolt-button {
   font-family: -apple-system, BlinkMacSystemFont, ヒラギノ角ゴ ProN,
@@ -140,63 +139,117 @@ bolt-button[type=\\"submit\\"] {
 }
 .c-bolt-button--primary {
   color: rgba(var(--bolt-theme-text-on-primary), 1);
-  border-color: rgba(var(--bolt-theme-primary), 1);
   background-color: rgba(var(--bolt-theme-primary), 1);
 }
 .c-bolt-button--primary.is-hover,
 .c-bolt-button--primary:hover {
   color: rgba(var(--bolt-theme-text-on-primary-lighten-15), 1);
-  border-color: rgba(var(--bolt-theme-primary-lighten-15), 1);
   background-color: rgba(var(--bolt-theme-primary-lighten-15), 1);
-  transform: translateY(-2px);
-  box-shadow: 0 1px 8px 1px rgba(6, 10, 36, 0.18),
-    0 5px 10px 1px rgba(6, 10, 36, 0.15), 0 15px 30px 0 rgba(6, 10, 36, 0.16);
 }
 .c-bolt-button--primary.is-focus:not([disabled]):not(.c-bolt-button--disabled):not(.c-bolt-button--inert),
 .c-bolt-button--primary:focus:not([disabled]):not(.c-bolt-button--disabled):not(.c-bolt-button--inert) {
   color: rgba(var(--bolt-theme-text-on-primary-darken-15), 1);
-  border-color: rgba(var(--bolt-theme-primary-darken-15), 1);
   background-color: rgba(var(--bolt-theme-primary-darken-15), 1);
 }
 .c-bolt-button--primary.is-active,
 .c-bolt-button--primary:active {
   color: rgba(var(--bolt-theme-text-on-primary-darken-25), 1);
-  border-color: rgba(var(--bolt-theme-primary-darken-25), 1);
   background-color: rgba(var(--bolt-theme-primary-darken-25), 1);
+}
+.c-bolt-button--primary.is-hover:not([disabled]),
+.c-bolt-button--primary:hover:not([disabled]) {
+  transform: translateY(-2px);
+  box-shadow: 0 1px 8px 1px rgba(6, 10, 36, 0.18),
+    0 5px 10px 1px rgba(6, 10, 36, 0.15), 0 15px 30px 0 rgba(6, 10, 36, 0.16);
+}
+.c-bolt-button--primary.is-active:not([disabled]),
+.c-bolt-button--primary:active:not([disabled]) {
   transform: translate3d(0, 1px, 0);
 }
 .c-bolt-button--secondary {
   color: rgba(var(--bolt-theme-text-on-secondary), 1);
-  border-color: rgba(var(--bolt-theme-secondary), 1);
   background-color: rgba(var(--bolt-theme-secondary), 1);
 }
 .c-bolt-button--secondary.is-hover,
 .c-bolt-button--secondary:hover {
   color: rgba(var(--bolt-theme-text-on-secondary-lighten-5), 1);
-  border-color: rgba(var(--bolt-theme-secondary-lighten-5), 1);
   background-color: rgba(var(--bolt-theme-secondary-lighten-5), 1);
-  transform: translateY(-2px);
-  box-shadow: 0 1px 8px 1px rgba(6, 10, 36, 0.18),
-    0 5px 10px 1px rgba(6, 10, 36, 0.15), 0 15px 30px 0 rgba(6, 10, 36, 0.16);
 }
 .c-bolt-button--secondary.is-focus:not([disabled]):not(.c-bolt-button--disabled):not(.c-bolt-button--inert),
 .c-bolt-button--secondary:focus:not([disabled]):not(.c-bolt-button--disabled):not(.c-bolt-button--inert) {
   color: rgba(var(--bolt-theme-text-on-secondary-darken-3), 1);
-  border-color: rgba(var(--bolt-theme-secondary-darken-3), 1);
   background-color: rgba(var(--bolt-theme-secondary-darken-3), 1);
 }
 .c-bolt-button--secondary.is-active,
 .c-bolt-button--secondary:active {
   color: rgba(var(--bolt-theme-text-on-secondary-darken-10), 1);
-  border-color: rgba(var(--bolt-theme-secondary-darken-10), 1);
   background-color: rgba(var(--bolt-theme-secondary-darken-10), 1);
+}
+.c-bolt-button--secondary.is-hover:not([disabled]),
+.c-bolt-button--secondary:hover:not([disabled]) {
+  transform: translateY(-2px);
+  box-shadow: 0 1px 8px 1px rgba(6, 10, 36, 0.18),
+    0 5px 10px 1px rgba(6, 10, 36, 0.15), 0 15px 30px 0 rgba(6, 10, 36, 0.16);
+}
+.c-bolt-button--secondary.is-active:not([disabled]),
+.c-bolt-button--secondary:active:not([disabled]) {
   transform: translate3d(0, 1px, 0);
+}
+.c-bolt-button--tertiary {
+  color: rgba(21, 22, 25, 0.9);
+  color: var(
+    --bolt-theme--tertiary--text-color--default,
+    rgba(21, 22, 25, 0.9)
+  );
+  background-color: rgba(141, 142, 153, 0.15);
+  background-color: var(
+    --bolt-theme--tertiary--background-color--default,
+    rgba(141, 142, 153, 0.15)
+  );
+  -webkit-backdrop-filter: saturate(105%) blur(20px);
+  backdrop-filter: saturate(105%) blur(20px);
+}
+.c-bolt-button--tertiary,
+.c-bolt-button--tertiary:before {
+  box-shadow: none;
+}
+.c-bolt-button--tertiary.is-hover,
+.c-bolt-button--tertiary:hover {
+  color: #151619;
+  color: var(--bolt-theme--tertiary--text-color--hover, #151619);
+  background-color: rgba(141, 142, 153, 0.3);
+  background-color: var(
+    --bolt-theme--tertiary--background-color--hover,
+    rgba(141, 142, 153, 0.3)
+  );
+}
+.c-bolt-button--tertiary.is-focus,
+.c-bolt-button--tertiary:active:focus,
+.c-bolt-button--tertiary:focus,
+.c-bolt-button--tertiary:focus:hover:not(:active) {
+  color: #151619;
+  color: var(--bolt-theme--tertiary--text-color--focus, #151619);
+  background-color: rgba(141, 142, 153, 0.4);
+  background-color: var(
+    --bolt-theme--tertiary--background-color--focus,
+    rgba(141, 142, 153, 0.4)
+  );
+}
+.c-bolt-button--tertiary.is-active,
+.c-bolt-button--tertiary:active,
+.c-bolt-button--tertiary:active:hover {
+  color: #151619;
+  color: var(--bolt-theme--tertiary--text-color--active, #151619);
+  background-color: rgba(141, 142, 153, 0.5);
+  background-color: var(
+    --bolt-theme--tertiary--background-color--active,
+    rgba(141, 142, 153, 0.5)
+  );
 }
 .c-bolt-button--text {
   opacity: 1;
   color: rgba(var(--bolt-theme-headline-link), 1);
   text-decoration: none;
-  border-color: transparent;
 }
 .c-bolt-button--text,
 .c-bolt-button--text.c-bolt-button--disabled,
@@ -220,75 +273,25 @@ bolt-button[type=\\"submit\\"] {
 .c-bolt-button--disabled,
 .c-bolt-button[disabled],
 [aria-disabled=\\"true\\"] .c-bolt-button {
-  cursor: not-allowed;
-}
-.c-bolt-button--disabled,
-.c-bolt-button--disabled.is-active,
-.c-bolt-button--disabled.is-hover,
-.c-bolt-button--disabled:active,
-.c-bolt-button--disabled:hover,
-.c-bolt-button--disabled:visited,
-.c-bolt-button[disabled],
-.c-bolt-button[disabled].is-active,
-.c-bolt-button[disabled].is-hover,
-.c-bolt-button[disabled]:active,
-.c-bolt-button[disabled]:hover,
-.c-bolt-button[disabled]:visited,
-[aria-disabled=\\"true\\"] .c-bolt-button,
-[aria-disabled=\\"true\\"] .c-bolt-button.is-active,
-[aria-disabled=\\"true\\"] .c-bolt-button.is-hover,
-[aria-disabled=\\"true\\"] .c-bolt-button:active,
-[aria-disabled=\\"true\\"] .c-bolt-button:hover,
-[aria-disabled=\\"true\\"] .c-bolt-button:visited {
-  color: rgba(var(--bolt-theme-text-disabled), 1);
-}
-.c-bolt-button--disabled:not(.c-bolt-button--text),
-.c-bolt-button--disabled:not(.c-bolt-button--text).is-active,
-.c-bolt-button--disabled:not(.c-bolt-button--text).is-hover,
-.c-bolt-button--disabled:not(.c-bolt-button--text):active,
-.c-bolt-button--disabled:not(.c-bolt-button--text):hover,
-.c-bolt-button--disabled:not(.c-bolt-button--text):visited,
-.c-bolt-button[disabled]:not(.c-bolt-button--text),
-.c-bolt-button[disabled]:not(.c-bolt-button--text).is-active,
-.c-bolt-button[disabled]:not(.c-bolt-button--text).is-hover,
-.c-bolt-button[disabled]:not(.c-bolt-button--text):active,
-.c-bolt-button[disabled]:not(.c-bolt-button--text):hover,
-.c-bolt-button[disabled]:not(.c-bolt-button--text):visited,
-[aria-disabled=\\"true\\"] .c-bolt-button:not(.c-bolt-button--text),
-[aria-disabled=\\"true\\"] .c-bolt-button:not(.c-bolt-button--text).is-active,
-[aria-disabled=\\"true\\"] .c-bolt-button:not(.c-bolt-button--text).is-hover,
-[aria-disabled=\\"true\\"] .c-bolt-button:not(.c-bolt-button--text):active,
-[aria-disabled=\\"true\\"] .c-bolt-button:not(.c-bolt-button--text):hover,
-[aria-disabled=\\"true\\"] .c-bolt-button:not(.c-bolt-button--text):visited {
-  box-shadow: 0 1px 4px 1px rgba(6, 10, 36, 0.1),
-    0 5px 10px 0 rgba(6, 10, 36, 0.08);
-  transition: 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
   opacity: 1;
   transform: none;
-  border-color: rgba(var(--bolt-theme-disabled), 1);
-  box-shadow: var(
-    --bolt-button-box-shadow,
-    0 1px 4px 1px rgba(6, 10, 36, 0.1),
-    0 5px 10px 0 rgba(6, 10, 36, 0.08)
-  );
-  background-color: rgba(var(--bolt-theme-disabled), 1);
-  will-change: box-shadow;
+  color: rgba(var(--bolt-theme-text-disabled), 1);
+  cursor: not-allowed;
 }
-.c-bolt-button--disabled.is-active:before,
-.c-bolt-button--disabled.is-hover:before,
-.c-bolt-button--disabled:active:before,
+.c-bolt-button--disabled *,
+.c-bolt-button[disabled] *,
+[aria-disabled=\\"true\\"] .c-bolt-button * {
+  pointer-events: none;
+}
+.c-bolt-button--disabled:not(.c-bolt-button--text),
+.c-bolt-button[disabled]:not(.c-bolt-button--text),
+[aria-disabled=\\"true\\"] .c-bolt-button:not(.c-bolt-button--text) {
+  background-color: rgba(var(--bolt-theme-disabled), 1);
+}
 .c-bolt-button--disabled:before,
-.c-bolt-button--disabled:hover:before,
-.c-bolt-button[disabled].is-active:before,
-.c-bolt-button[disabled].is-hover:before,
-.c-bolt-button[disabled]:active:before,
 .c-bolt-button[disabled]:before,
-.c-bolt-button[disabled]:hover:before,
-[aria-disabled=\\"true\\"] .c-bolt-button.is-active:before,
-[aria-disabled=\\"true\\"] .c-bolt-button.is-hover:before,
-[aria-disabled=\\"true\\"] .c-bolt-button:active:before,
-[aria-disabled=\\"true\\"] .c-bolt-button:before,
-[aria-disabled=\\"true\\"] .c-bolt-button:hover:before {
+[aria-disabled=\\"true\\"] .c-bolt-button:before {
+  content: \\"\\";
   display: none;
 }
 .c-bolt-button--uppercase {
@@ -1703,6 +1706,38 @@ bolt-inline-list:not(:last-child) {
 .t-bolt-xxdark {
   --bolt-theme-background: 0, 0, 0;
   background-color: #000;
+}
+.t-bolt-light,
+.t-bolt-xlight,
+:root {
+  --bolt-theme--tertiary--background-color--default: rgba(141, 142, 153, 0.15);
+  --bolt-theme--tertiary--background-color--hover: rgba(141, 142, 153, 0.3);
+  --bolt-theme--tertiary--background-color--focus: rgba(141, 142, 153, 0.4);
+  --bolt-theme--tertiary--background-color--active: rgba(141, 142, 153, 0.5);
+  --bolt-theme--tertiary--text-color--default: rgba(21, 22, 25, 0.9);
+  --bolt-theme--tertiary--text-color--hover: #151619;
+  --bolt-theme--tertiary--text-color--active: var(
+    --bolt-theme--tertiary--text-color--hover
+  );
+  --bolt-theme--tertiary--text-color--focus: var(
+    --bolt-theme--tertiary--text-color--hover
+  );
+}
+.t-bolt-dark,
+.t-bolt-xdark,
+.t-bolt-xxdark {
+  --bolt-theme--tertiary--background-color--default: hsla(0, 0%, 100%, 0.2);
+  --bolt-theme--tertiary--background-color--hover: hsla(0, 0%, 100%, 0.3);
+  --bolt-theme--tertiary--background-color--focus: hsla(0, 0%, 100%, 0.35);
+  --bolt-theme--tertiary--background-color--active: hsla(0, 0%, 100%, 0.4);
+  --bolt-theme--tertiary--text-color--default: hsla(0, 0%, 100%, 0.9);
+  --bolt-theme--tertiary--text-color--hover: #fff;
+  --bolt-theme--tertiary--text-color--active: var(
+    --bolt-theme--tertiary--text-color--hover
+  );
+  --bolt-theme--tertiary--text-color--focus: var(
+    --bolt-theme--tertiary--text-color--hover
+  );
 }
 .u-bolt-border-radius-small {
   border-radius: 3px !important;
@@ -18458,8 +18493,6 @@ bolt-button[type=\\"submit\\"] {
   vertical-align: middle;
   cursor: pointer;
   border-radius: 3px;
-  border-width: 1px;
-  border-style: solid;
   box-shadow: 0 1px 4px 1px rgba(6, 10, 36, 0.1),
     0 5px 10px 0 rgba(6, 10, 36, 0.08);
   transition: 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
@@ -18470,6 +18503,7 @@ bolt-button[type=\\"submit\\"] {
   );
   outline: 0;
   will-change: box-shadow;
+  border: 1px solid transparent;
 }
 .js-fonts-loaded .c-bolt-button {
   font-family: Open Sans, Helvetica Neue, sans-serif;
@@ -18502,63 +18536,117 @@ bolt-button[type=\\"submit\\"] {
 }
 .c-bolt-button--primary {
   color: rgba(var(--bolt-theme-text-on-primary), 1);
-  border-color: rgba(var(--bolt-theme-primary), 1);
   background-color: rgba(var(--bolt-theme-primary), 1);
 }
 .c-bolt-button--primary.is-hover,
 .c-bolt-button--primary:hover {
   color: rgba(var(--bolt-theme-text-on-primary-lighten-15), 1);
-  border-color: rgba(var(--bolt-theme-primary-lighten-15), 1);
   background-color: rgba(var(--bolt-theme-primary-lighten-15), 1);
-  transform: translateY(-2px);
-  box-shadow: 0 1px 8px 1px rgba(6, 10, 36, 0.18),
-    0 5px 10px 1px rgba(6, 10, 36, 0.15), 0 15px 30px 0 rgba(6, 10, 36, 0.16);
 }
 .c-bolt-button--primary.is-focus:not([disabled]):not(.c-bolt-button--disabled):not(.c-bolt-button--inert),
 .c-bolt-button--primary:focus:not([disabled]):not(.c-bolt-button--disabled):not(.c-bolt-button--inert) {
   color: rgba(var(--bolt-theme-text-on-primary-darken-15), 1);
-  border-color: rgba(var(--bolt-theme-primary-darken-15), 1);
   background-color: rgba(var(--bolt-theme-primary-darken-15), 1);
 }
 .c-bolt-button--primary.is-active,
 .c-bolt-button--primary:active {
   color: rgba(var(--bolt-theme-text-on-primary-darken-25), 1);
-  border-color: rgba(var(--bolt-theme-primary-darken-25), 1);
   background-color: rgba(var(--bolt-theme-primary-darken-25), 1);
+}
+.c-bolt-button--primary.is-hover:not([disabled]),
+.c-bolt-button--primary:hover:not([disabled]) {
+  transform: translateY(-2px);
+  box-shadow: 0 1px 8px 1px rgba(6, 10, 36, 0.18),
+    0 5px 10px 1px rgba(6, 10, 36, 0.15), 0 15px 30px 0 rgba(6, 10, 36, 0.16);
+}
+.c-bolt-button--primary.is-active:not([disabled]),
+.c-bolt-button--primary:active:not([disabled]) {
   transform: translate3d(0, 1px, 0);
 }
 .c-bolt-button--secondary {
   color: rgba(var(--bolt-theme-text-on-secondary), 1);
-  border-color: rgba(var(--bolt-theme-secondary), 1);
   background-color: rgba(var(--bolt-theme-secondary), 1);
 }
 .c-bolt-button--secondary.is-hover,
 .c-bolt-button--secondary:hover {
   color: rgba(var(--bolt-theme-text-on-secondary-lighten-5), 1);
-  border-color: rgba(var(--bolt-theme-secondary-lighten-5), 1);
   background-color: rgba(var(--bolt-theme-secondary-lighten-5), 1);
-  transform: translateY(-2px);
-  box-shadow: 0 1px 8px 1px rgba(6, 10, 36, 0.18),
-    0 5px 10px 1px rgba(6, 10, 36, 0.15), 0 15px 30px 0 rgba(6, 10, 36, 0.16);
 }
 .c-bolt-button--secondary.is-focus:not([disabled]):not(.c-bolt-button--disabled):not(.c-bolt-button--inert),
 .c-bolt-button--secondary:focus:not([disabled]):not(.c-bolt-button--disabled):not(.c-bolt-button--inert) {
   color: rgba(var(--bolt-theme-text-on-secondary-darken-3), 1);
-  border-color: rgba(var(--bolt-theme-secondary-darken-3), 1);
   background-color: rgba(var(--bolt-theme-secondary-darken-3), 1);
 }
 .c-bolt-button--secondary.is-active,
 .c-bolt-button--secondary:active {
   color: rgba(var(--bolt-theme-text-on-secondary-darken-10), 1);
-  border-color: rgba(var(--bolt-theme-secondary-darken-10), 1);
   background-color: rgba(var(--bolt-theme-secondary-darken-10), 1);
+}
+.c-bolt-button--secondary.is-hover:not([disabled]),
+.c-bolt-button--secondary:hover:not([disabled]) {
+  transform: translateY(-2px);
+  box-shadow: 0 1px 8px 1px rgba(6, 10, 36, 0.18),
+    0 5px 10px 1px rgba(6, 10, 36, 0.15), 0 15px 30px 0 rgba(6, 10, 36, 0.16);
+}
+.c-bolt-button--secondary.is-active:not([disabled]),
+.c-bolt-button--secondary:active:not([disabled]) {
   transform: translate3d(0, 1px, 0);
+}
+.c-bolt-button--tertiary {
+  color: rgba(21, 22, 25, 0.9);
+  color: var(
+    --bolt-theme--tertiary--text-color--default,
+    rgba(21, 22, 25, 0.9)
+  );
+  background-color: rgba(141, 142, 153, 0.15);
+  background-color: var(
+    --bolt-theme--tertiary--background-color--default,
+    rgba(141, 142, 153, 0.15)
+  );
+  -webkit-backdrop-filter: saturate(105%) blur(20px);
+  backdrop-filter: saturate(105%) blur(20px);
+}
+.c-bolt-button--tertiary,
+.c-bolt-button--tertiary:before {
+  box-shadow: none;
+}
+.c-bolt-button--tertiary.is-hover,
+.c-bolt-button--tertiary:hover {
+  color: #151619;
+  color: var(--bolt-theme--tertiary--text-color--hover, #151619);
+  background-color: rgba(141, 142, 153, 0.3);
+  background-color: var(
+    --bolt-theme--tertiary--background-color--hover,
+    rgba(141, 142, 153, 0.3)
+  );
+}
+.c-bolt-button--tertiary.is-focus,
+.c-bolt-button--tertiary:active:focus,
+.c-bolt-button--tertiary:focus,
+.c-bolt-button--tertiary:focus:hover:not(:active) {
+  color: #151619;
+  color: var(--bolt-theme--tertiary--text-color--focus, #151619);
+  background-color: rgba(141, 142, 153, 0.4);
+  background-color: var(
+    --bolt-theme--tertiary--background-color--focus,
+    rgba(141, 142, 153, 0.4)
+  );
+}
+.c-bolt-button--tertiary.is-active,
+.c-bolt-button--tertiary:active,
+.c-bolt-button--tertiary:active:hover {
+  color: #151619;
+  color: var(--bolt-theme--tertiary--text-color--active, #151619);
+  background-color: rgba(141, 142, 153, 0.5);
+  background-color: var(
+    --bolt-theme--tertiary--background-color--active,
+    rgba(141, 142, 153, 0.5)
+  );
 }
 .c-bolt-button--text {
   opacity: 1;
   color: rgba(var(--bolt-theme-headline-link), 1);
   text-decoration: none;
-  border-color: transparent;
 }
 .c-bolt-button--text,
 .c-bolt-button--text.c-bolt-button--disabled,
@@ -18582,75 +18670,25 @@ bolt-button[type=\\"submit\\"] {
 .c-bolt-button--disabled,
 .c-bolt-button[disabled],
 [aria-disabled=\\"true\\"] .c-bolt-button {
-  cursor: not-allowed;
-}
-.c-bolt-button--disabled,
-.c-bolt-button--disabled.is-active,
-.c-bolt-button--disabled.is-hover,
-.c-bolt-button--disabled:active,
-.c-bolt-button--disabled:hover,
-.c-bolt-button--disabled:visited,
-.c-bolt-button[disabled],
-.c-bolt-button[disabled].is-active,
-.c-bolt-button[disabled].is-hover,
-.c-bolt-button[disabled]:active,
-.c-bolt-button[disabled]:hover,
-.c-bolt-button[disabled]:visited,
-[aria-disabled=\\"true\\"] .c-bolt-button,
-[aria-disabled=\\"true\\"] .c-bolt-button.is-active,
-[aria-disabled=\\"true\\"] .c-bolt-button.is-hover,
-[aria-disabled=\\"true\\"] .c-bolt-button:active,
-[aria-disabled=\\"true\\"] .c-bolt-button:hover,
-[aria-disabled=\\"true\\"] .c-bolt-button:visited {
-  color: rgba(var(--bolt-theme-text-disabled), 1);
-}
-.c-bolt-button--disabled:not(.c-bolt-button--text),
-.c-bolt-button--disabled:not(.c-bolt-button--text).is-active,
-.c-bolt-button--disabled:not(.c-bolt-button--text).is-hover,
-.c-bolt-button--disabled:not(.c-bolt-button--text):active,
-.c-bolt-button--disabled:not(.c-bolt-button--text):hover,
-.c-bolt-button--disabled:not(.c-bolt-button--text):visited,
-.c-bolt-button[disabled]:not(.c-bolt-button--text),
-.c-bolt-button[disabled]:not(.c-bolt-button--text).is-active,
-.c-bolt-button[disabled]:not(.c-bolt-button--text).is-hover,
-.c-bolt-button[disabled]:not(.c-bolt-button--text):active,
-.c-bolt-button[disabled]:not(.c-bolt-button--text):hover,
-.c-bolt-button[disabled]:not(.c-bolt-button--text):visited,
-[aria-disabled=\\"true\\"] .c-bolt-button:not(.c-bolt-button--text),
-[aria-disabled=\\"true\\"] .c-bolt-button:not(.c-bolt-button--text).is-active,
-[aria-disabled=\\"true\\"] .c-bolt-button:not(.c-bolt-button--text).is-hover,
-[aria-disabled=\\"true\\"] .c-bolt-button:not(.c-bolt-button--text):active,
-[aria-disabled=\\"true\\"] .c-bolt-button:not(.c-bolt-button--text):hover,
-[aria-disabled=\\"true\\"] .c-bolt-button:not(.c-bolt-button--text):visited {
-  box-shadow: 0 1px 4px 1px rgba(6, 10, 36, 0.1),
-    0 5px 10px 0 rgba(6, 10, 36, 0.08);
-  transition: 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
   opacity: 1;
   transform: none;
-  border-color: rgba(var(--bolt-theme-disabled), 1);
-  box-shadow: var(
-    --bolt-button-box-shadow,
-    0 1px 4px 1px rgba(6, 10, 36, 0.1),
-    0 5px 10px 0 rgba(6, 10, 36, 0.08)
-  );
-  background-color: rgba(var(--bolt-theme-disabled), 1);
-  will-change: box-shadow;
+  color: rgba(var(--bolt-theme-text-disabled), 1);
+  cursor: not-allowed;
 }
-.c-bolt-button--disabled.is-active:before,
-.c-bolt-button--disabled.is-hover:before,
-.c-bolt-button--disabled:active:before,
+.c-bolt-button--disabled *,
+.c-bolt-button[disabled] *,
+[aria-disabled=\\"true\\"] .c-bolt-button * {
+  pointer-events: none;
+}
+.c-bolt-button--disabled:not(.c-bolt-button--text),
+.c-bolt-button[disabled]:not(.c-bolt-button--text),
+[aria-disabled=\\"true\\"] .c-bolt-button:not(.c-bolt-button--text) {
+  background-color: rgba(var(--bolt-theme-disabled), 1);
+}
 .c-bolt-button--disabled:before,
-.c-bolt-button--disabled:hover:before,
-.c-bolt-button[disabled].is-active:before,
-.c-bolt-button[disabled].is-hover:before,
-.c-bolt-button[disabled]:active:before,
 .c-bolt-button[disabled]:before,
-.c-bolt-button[disabled]:hover:before,
-[aria-disabled=\\"true\\"] .c-bolt-button.is-active:before,
-[aria-disabled=\\"true\\"] .c-bolt-button.is-hover:before,
-[aria-disabled=\\"true\\"] .c-bolt-button:active:before,
-[aria-disabled=\\"true\\"] .c-bolt-button:before,
-[aria-disabled=\\"true\\"] .c-bolt-button:hover:before {
+[aria-disabled=\\"true\\"] .c-bolt-button:before {
+  content: \\"\\";
   display: none;
 }
 .c-bolt-button--uppercase {
@@ -20028,6 +20066,38 @@ bolt-inline-list:not(:last-child) {
 .t-bolt-xxdark {
   --bolt-theme-background: 0, 0, 0;
   background-color: #000;
+}
+.t-bolt-light,
+.t-bolt-xlight,
+:root {
+  --bolt-theme--tertiary--background-color--default: rgba(141, 142, 153, 0.15);
+  --bolt-theme--tertiary--background-color--hover: rgba(141, 142, 153, 0.3);
+  --bolt-theme--tertiary--background-color--focus: rgba(141, 142, 153, 0.4);
+  --bolt-theme--tertiary--background-color--active: rgba(141, 142, 153, 0.5);
+  --bolt-theme--tertiary--text-color--default: rgba(21, 22, 25, 0.9);
+  --bolt-theme--tertiary--text-color--hover: #151619;
+  --bolt-theme--tertiary--text-color--active: var(
+    --bolt-theme--tertiary--text-color--hover
+  );
+  --bolt-theme--tertiary--text-color--focus: var(
+    --bolt-theme--tertiary--text-color--hover
+  );
+}
+.t-bolt-dark,
+.t-bolt-xdark,
+.t-bolt-xxdark {
+  --bolt-theme--tertiary--background-color--default: hsla(0, 0%, 100%, 0.2);
+  --bolt-theme--tertiary--background-color--hover: hsla(0, 0%, 100%, 0.3);
+  --bolt-theme--tertiary--background-color--focus: hsla(0, 0%, 100%, 0.35);
+  --bolt-theme--tertiary--background-color--active: hsla(0, 0%, 100%, 0.4);
+  --bolt-theme--tertiary--text-color--default: hsla(0, 0%, 100%, 0.9);
+  --bolt-theme--tertiary--text-color--hover: #fff;
+  --bolt-theme--tertiary--text-color--active: var(
+    --bolt-theme--tertiary--text-color--hover
+  );
+  --bolt-theme--tertiary--text-color--focus: var(
+    --bolt-theme--tertiary--text-color--hover
+  );
 }
 .u-bolt-border-radius-small {
   border-radius: 3px !important;

--- a/packages/build-tools/__tests__/multi-lang/__snapshots__/index.js.snap
+++ b/packages/build-tools/__tests__/multi-lang/__snapshots__/index.js.snap
@@ -196,12 +196,10 @@ bolt-button[type=\\"submit\\"] {
   transform: translate3d(0, 1px, 0);
 }
 .c-bolt-button--tertiary {
-  color: rgba(21, 22, 25, 0.9);
   color: var(
     --bolt-theme--tertiary--text-color--default,
     rgba(21, 22, 25, 0.9)
   );
-  background-color: rgba(141, 142, 153, 0.15);
   background-color: var(
     --bolt-theme--tertiary--background-color--default,
     rgba(141, 142, 153, 0.15)
@@ -215,9 +213,7 @@ bolt-button[type=\\"submit\\"] {
 }
 .c-bolt-button--tertiary.is-hover,
 .c-bolt-button--tertiary:hover {
-  color: #151619;
   color: var(--bolt-theme--tertiary--text-color--hover, #151619);
-  background-color: rgba(141, 142, 153, 0.3);
   background-color: var(
     --bolt-theme--tertiary--background-color--hover,
     rgba(141, 142, 153, 0.3)
@@ -227,9 +223,7 @@ bolt-button[type=\\"submit\\"] {
 .c-bolt-button--tertiary:active:focus,
 .c-bolt-button--tertiary:focus,
 .c-bolt-button--tertiary:focus:hover:not(:active) {
-  color: #151619;
   color: var(--bolt-theme--tertiary--text-color--focus, #151619);
-  background-color: rgba(141, 142, 153, 0.4);
   background-color: var(
     --bolt-theme--tertiary--background-color--focus,
     rgba(141, 142, 153, 0.4)
@@ -238,13 +232,21 @@ bolt-button[type=\\"submit\\"] {
 .c-bolt-button--tertiary.is-active,
 .c-bolt-button--tertiary:active,
 .c-bolt-button--tertiary:active:hover {
-  color: #151619;
   color: var(--bolt-theme--tertiary--text-color--active, #151619);
-  background-color: rgba(141, 142, 153, 0.5);
   background-color: var(
     --bolt-theme--tertiary--background-color--active,
     rgba(141, 142, 153, 0.5)
   );
+}
+.c-bolt-button--tertiary.is-hover:not([disabled]),
+.c-bolt-button--tertiary:hover:not([disabled]) {
+  transform: translateY(-2px);
+  box-shadow: 0 1px 8px 1px rgba(6, 10, 36, 0.18),
+    0 5px 10px 1px rgba(6, 10, 36, 0.15), 0 15px 30px 0 rgba(6, 10, 36, 0.16);
+}
+.c-bolt-button--tertiary.is-active:not([disabled]),
+.c-bolt-button--tertiary:active:not([disabled]) {
+  transform: translate3d(0, 1px, 0);
 }
 .c-bolt-button--text {
   opacity: 1;
@@ -18593,12 +18595,10 @@ bolt-button[type=\\"submit\\"] {
   transform: translate3d(0, 1px, 0);
 }
 .c-bolt-button--tertiary {
-  color: rgba(21, 22, 25, 0.9);
   color: var(
     --bolt-theme--tertiary--text-color--default,
     rgba(21, 22, 25, 0.9)
   );
-  background-color: rgba(141, 142, 153, 0.15);
   background-color: var(
     --bolt-theme--tertiary--background-color--default,
     rgba(141, 142, 153, 0.15)
@@ -18612,9 +18612,7 @@ bolt-button[type=\\"submit\\"] {
 }
 .c-bolt-button--tertiary.is-hover,
 .c-bolt-button--tertiary:hover {
-  color: #151619;
   color: var(--bolt-theme--tertiary--text-color--hover, #151619);
-  background-color: rgba(141, 142, 153, 0.3);
   background-color: var(
     --bolt-theme--tertiary--background-color--hover,
     rgba(141, 142, 153, 0.3)
@@ -18624,9 +18622,7 @@ bolt-button[type=\\"submit\\"] {
 .c-bolt-button--tertiary:active:focus,
 .c-bolt-button--tertiary:focus,
 .c-bolt-button--tertiary:focus:hover:not(:active) {
-  color: #151619;
   color: var(--bolt-theme--tertiary--text-color--focus, #151619);
-  background-color: rgba(141, 142, 153, 0.4);
   background-color: var(
     --bolt-theme--tertiary--background-color--focus,
     rgba(141, 142, 153, 0.4)
@@ -18635,13 +18631,21 @@ bolt-button[type=\\"submit\\"] {
 .c-bolt-button--tertiary.is-active,
 .c-bolt-button--tertiary:active,
 .c-bolt-button--tertiary:active:hover {
-  color: #151619;
   color: var(--bolt-theme--tertiary--text-color--active, #151619);
-  background-color: rgba(141, 142, 153, 0.5);
   background-color: var(
     --bolt-theme--tertiary--background-color--active,
     rgba(141, 142, 153, 0.5)
   );
+}
+.c-bolt-button--tertiary.is-hover:not([disabled]),
+.c-bolt-button--tertiary:hover:not([disabled]) {
+  transform: translateY(-2px);
+  box-shadow: 0 1px 8px 1px rgba(6, 10, 36, 0.18),
+    0 5px 10px 1px rgba(6, 10, 36, 0.15), 0 15px 30px 0 rgba(6, 10, 36, 0.16);
+}
+.c-bolt-button--tertiary.is-active:not([disabled]),
+.c-bolt-button--tertiary:active:not([disabled]) {
+  transform: translate3d(0, 1px, 0);
 }
 .c-bolt-button--text {
   opacity: 1;

--- a/packages/components/bolt-button/button.schema.js
+++ b/packages/components/bolt-button/button.schema.js
@@ -60,7 +60,7 @@ module.exports = {
       type: 'string',
       description: 'Style of the button determined by information hierarchy.',
       default: 'primary',
-      enum: ['primary', 'secondary', 'text'],
+      enum: ['primary', 'secondary', 'tertiary', 'text'],
     },
     width: {
       type: 'string',

--- a/packages/components/bolt-button/src/_button-settings-and-tools.scss
+++ b/packages/components/bolt-button/src/_button-settings-and-tools.scss
@@ -51,6 +51,7 @@ $bolt-button-translate--active: translate3d(0, 1px, 0);
   transform: translate3d(0, 0, 0);
   text-decoration: none;
   vertical-align: middle;
+  border-color: transparent;
   cursor: pointer;
   border-radius: bolt-button-border-radius('regular');
   border-width: $bolt-button-border-width;
@@ -90,27 +91,23 @@ $bolt-button-translate--active: translate3d(0, 1px, 0);
 // Button Colors / Types
 @mixin bolt-button-style--primary() {
   color: bolt-theme(text-on-primary);
-  border-color: bolt-theme(primary);
   background-color: bolt-theme(primary);
 
   &:hover,
   &.is-hover {
     color: bolt-theme(text-on-primary-lighten-15);
-    border-color: bolt-theme(primary-lighten-15);
     background-color: bolt-theme(primary-lighten-15);
   }
 
   &:focus:not([disabled]):not(.c-bolt-button--disabled):not(.c-bolt-button--inert),
   &.is-focus:not([disabled]):not(.c-bolt-button--disabled):not(.c-bolt-button--inert) {
     color: bolt-theme(text-on-primary-darken-15);
-    border-color: bolt-theme(primary-darken-15);
     background-color: bolt-theme(primary-darken-15);
   }
 
   &:active,
   &.is-active {
     color: bolt-theme(text-on-primary-darken-25);
-    border-color: bolt-theme(primary-darken-25);
     background-color: bolt-theme(primary-darken-25);
   }
 }
@@ -165,27 +162,23 @@ $bolt-button-translate--active: translate3d(0, 1px, 0);
 
 @mixin bolt-button-style--secondary() {
   color: bolt-theme(text-on-secondary);
-  border-color: bolt-theme(secondary);
   background-color: bolt-theme(secondary);
 
   &:hover,
   &.is-hover {
     color: bolt-theme(text-on-secondary-lighten-5);
-    border-color: bolt-theme(secondary-lighten-5);
     background-color: bolt-theme(secondary-lighten-5);
   }
 
   &:focus:not([disabled]):not(.c-bolt-button--disabled):not(.c-bolt-button--inert),
   &.is-focus:not([disabled]):not(.c-bolt-button--disabled):not(.c-bolt-button--inert) {
     color: bolt-theme(text-on-secondary-darken-3);
-    border-color: bolt-theme(secondary-darken-3);
     background-color: bolt-theme(secondary-darken-3);
   }
 
   &:active,
   &.is-active {
     color: bolt-theme(text-on-secondary-darken-10);
-    border-color: bolt-theme(secondary-darken-10);
     background-color: bolt-theme(secondary-darken-10);
   }
 }
@@ -196,7 +189,6 @@ $bolt-button-translate--active: translate3d(0, 1px, 0);
   opacity: bolt-opacity(100);
   color: bolt-theme(headline-link);
   text-decoration: none;
-  border-color: transparent;
 
   &,
   &[disabled],
@@ -258,18 +250,15 @@ $bolt-button-translate--active: translate3d(0, 1px, 0);
   &.c-bolt-button,
   &.c-bolt-button:visited {
     color: bolt-text-contrast($button-background-color-default);
-    border-color: $button-background-color-default;
     background-color: $button-background-color-default;
   }
   &:focus,
   &:hover {
     color: bolt-text-contrast($button-background-color-default);
-    border-color: $button-background-color-hover;
     background-color: $button-background-color-hover;
   }
   &:active {
     color: bolt-text-contrast($button-background-color-default);
-    border-color: $button-background-color-active;
     background-color: $button-background-color-active;
   }
 }

--- a/packages/components/bolt-button/src/_button-settings-and-tools.scss
+++ b/packages/components/bolt-button/src/_button-settings-and-tools.scss
@@ -30,13 +30,13 @@ $bolt-button-translate--active: translate3d(0, 1px, 0);
 }
 
 @mixin bolt-button-raised-effect {
-  &:hover,
-  &.is-hover {
+  &:hover:not([disabled]),
+  &.is-hover:not([disabled]) {
     @include bolt-shadow('level-20', true);
   }
 
-  &:active,
-  &.is-active {
+  &:active:not([disabled]),
+  &.is-active:not([disabled]) {
     transform: $bolt-button-translate--active;
   }
 }
@@ -224,37 +224,21 @@ $bolt-button-translate--active: translate3d(0, 1px, 0);
 
 @mixin bolt-button-style--disabled() {
   cursor: not-allowed;
+  color: bolt-theme(text-disabled);
+  transform: none;
+  opacity: 1;
 
-  &,
-  &:visited,
-  &:hover,
-  &.is-hover,
-  &:active,
-  &.is-active {
-    color: bolt-theme(text-disabled);
+  * {
+    pointer-events: none;
   }
 
-  &:not(.c-bolt-button--text),
-  &:not(.c-bolt-button--text):visited,
-  &:not(.c-bolt-button--text):hover,
-  &:not(.c-bolt-button--text).is-hover,
-  &:not(.c-bolt-button--text):active,
-  &:not(.c-bolt-button--text).is-active {
-    @include bolt-shadow('level-20');
-    opacity: bolt-opacity(100);
-    transform: none;
-    border-color: bolt-theme(disabled);
-    box-shadow: var(--bolt-button-box-shadow, #{bolt-shadow('level-20')});
+  &:not(.c-bolt-button--text){
     background-color: bolt-theme(disabled);
-    will-change: box-shadow;
   }
 
-  &:before,
-  &:hover:before,
-  &.is-hover:before,
-  &:active:before,
-  &.is-active:before {
+  &:before {
     display: none;
+    content: '';
   }
 }
 

--- a/packages/components/bolt-button/src/_button-settings-and-tools.scss
+++ b/packages/components/bolt-button/src/_button-settings-and-tools.scss
@@ -115,6 +115,54 @@ $bolt-button-translate--active: translate3d(0, 1px, 0);
   }
 }
 
+
+/**
+  1. @todo: how do we want to handle these global theming fallback values?
+  2. @todo: remove when IE 11 support dropped
+  **/
+@mixin bolt-button-style--tertiary() {
+  color: #{rgba(bolt-color(black), 0.9)}; /* [2] */
+  color: var(--bolt-theme--tertiary--text-color--default, #{rgba(bolt-color(black), 0.9)}); /* [1] */
+
+  background-color: #{rgba(bolt-color(gray), 0.15)}; /* [2] */
+  background-color: var(--bolt-theme--tertiary--background-color--default, #{rgba(bolt-color(gray), 0.15)}); /* [1] */
+
+  &,
+  &:before {
+    box-shadow: none;
+  }
+
+  &:hover,
+  &.is-hover {
+    color: bolt-color(black); /* [2] */
+    color: var(--bolt-theme--tertiary--text-color--hover, #{bolt-color(black)}); /* [1] */
+
+    background-color: #{rgba(bolt-color(gray), 0.3)}; /* [2] */
+    background-color: var(--bolt-theme--tertiary--background-color--hover, #{rgba(bolt-color(gray), 0.3)}); /* [1] */
+  }
+
+  &:focus:hover:not(:active),
+  &:active:focus,
+  &:focus,
+  &.is-focus {
+    color: bolt-color(black); /* [2] */
+    color: var(--bolt-theme--tertiary--text-color--focus, #{bolt-color(black)}); /* [1] */
+
+    background-color: #{rgba(bolt-color(gray), 0.4)}; /* [2] */
+    background-color: var(--bolt-theme--tertiary--background-color--focus, #{rgba(bolt-color(gray), 0.4)}); /* [1] */
+  }
+
+  &:active:hover,
+  &:active,
+  &.is-active {
+    color: bolt-color(black); /* [2] */
+    color: var(--bolt-theme--tertiary--text-color--active, #{bolt-color(black)}); /* [1] */
+
+    background-color: #{rgba(bolt-color(gray), 0.5)}; /* [2] */
+    background-color: var(--bolt-theme--tertiary--background-color--active, #{rgba(bolt-color(gray), 0.5)}); /* [1] */
+  }
+}
+
 @mixin bolt-button-style--secondary() {
   color: bolt-theme(text-on-secondary);
   border-color: bolt-theme(secondary);
@@ -262,5 +310,7 @@ $bolt-button-translate--active: translate3d(0, 1px, 0);
     @include bolt-button-style--text;
   } @else if ($style == 'disabled') {
     @include bolt-button-style--disabled;
+  } @else if ($style == 'tertiary') {
+    @include bolt-button-style--tertiary;
   }
 }

--- a/packages/components/bolt-button/src/_button-settings-and-tools.scss
+++ b/packages/components/bolt-button/src/_button-settings-and-tools.scss
@@ -51,11 +51,11 @@ $bolt-button-translate--active: translate3d(0, 1px, 0);
   transform: translate3d(0, 0, 0);
   text-decoration: none;
   vertical-align: middle;
-  border-color: transparent;
   cursor: pointer;
   border-radius: bolt-button-border-radius('regular');
   border-width: $bolt-button-border-width;
   border-style: $bolt-button-border-style;
+  border-color: transparent;
   @include bolt-shadow('level-20');
   box-shadow: var(--bolt-button-box-shadow, #{bolt-shadow('level-20')});
   outline: none;
@@ -215,10 +215,10 @@ $bolt-button-translate--active: translate3d(0, 1px, 0);
 }
 
 @mixin bolt-button-style--disabled() {
-  cursor: not-allowed;
-  color: bolt-theme(text-disabled);
-  transform: none;
   opacity: 1;
+  transform: none;
+  color: bolt-theme(text-disabled);
+  cursor: not-allowed;
 
   * {
     pointer-events: none;
@@ -229,8 +229,8 @@ $bolt-button-translate--active: translate3d(0, 1px, 0);
   }
 
   &:before {
-    display: none;
     content: '';
+    display: none;
   }
 }
 

--- a/packages/components/bolt-button/src/_button-settings-and-tools.scss
+++ b/packages/components/bolt-button/src/_button-settings-and-tools.scss
@@ -114,15 +114,11 @@ $bolt-button-translate--active: translate3d(0, 1px, 0);
 
 
 /**
-  1. @todo: how do we want to handle these global theming fallback values?
-  2. @todo: remove when IE 11 support dropped
+  @todo: how do we want to handle these global theming fallback values?
   **/
 @mixin bolt-button-style--tertiary() {
-  color: #{rgba(bolt-color(black), 0.9)}; /* [2] */
-  color: var(--bolt-theme--tertiary--text-color--default, #{rgba(bolt-color(black), 0.9)}); /* [1] */
-
-  background-color: #{rgba(bolt-color(gray), 0.15)}; /* [2] */
-  background-color: var(--bolt-theme--tertiary--background-color--default, #{rgba(bolt-color(gray), 0.15)}); /* [1] */
+  color: var(--bolt-theme--tertiary--text-color--default, #{rgba(bolt-color(black), 0.9)});
+  background-color: var(--bolt-theme--tertiary--background-color--default, #{rgba(bolt-color(gray), 0.15)});
 
   &,
   &:before {
@@ -131,32 +127,23 @@ $bolt-button-translate--active: translate3d(0, 1px, 0);
 
   &:hover,
   &.is-hover {
-    color: bolt-color(black); /* [2] */
-    color: var(--bolt-theme--tertiary--text-color--hover, #{bolt-color(black)}); /* [1] */
-
-    background-color: #{rgba(bolt-color(gray), 0.3)}; /* [2] */
-    background-color: var(--bolt-theme--tertiary--background-color--hover, #{rgba(bolt-color(gray), 0.3)}); /* [1] */
+    color: var(--bolt-theme--tertiary--text-color--hover, #{bolt-color(black)});
+    background-color: var(--bolt-theme--tertiary--background-color--hover, #{rgba(bolt-color(gray), 0.3)});
   }
 
   &:focus:hover:not(:active),
   &:active:focus,
   &:focus,
   &.is-focus {
-    color: bolt-color(black); /* [2] */
-    color: var(--bolt-theme--tertiary--text-color--focus, #{bolt-color(black)}); /* [1] */
-
-    background-color: #{rgba(bolt-color(gray), 0.4)}; /* [2] */
+    color: var(--bolt-theme--tertiary--text-color--focus, #{bolt-color(black)});
     background-color: var(--bolt-theme--tertiary--background-color--focus, #{rgba(bolt-color(gray), 0.4)}); /* [1] */
   }
 
   &:active:hover,
   &:active,
   &.is-active {
-    color: bolt-color(black); /* [2] */
-    color: var(--bolt-theme--tertiary--text-color--active, #{bolt-color(black)}); /* [1] */
-
-    background-color: #{rgba(bolt-color(gray), 0.5)}; /* [2] */
-    background-color: var(--bolt-theme--tertiary--background-color--active, #{rgba(bolt-color(gray), 0.5)}); /* [1] */
+    color: var(--bolt-theme--tertiary--text-color--active, #{bolt-color(black)});
+    background-color: var(--bolt-theme--tertiary--background-color--active, #{rgba(bolt-color(gray), 0.5)});
   }
 }
 

--- a/packages/components/bolt-button/src/button.scss
+++ b/packages/components/bolt-button/src/button.scss
@@ -43,6 +43,7 @@
 
 .c-bolt-button--tertiary {
   @include bolt-button-style(tertiary);
+  @include bolt-button-raised-effect;
   backdrop-filter: saturate(105%) blur(20px);
 }
 

--- a/packages/components/bolt-button/src/button.scss
+++ b/packages/components/bolt-button/src/button.scss
@@ -41,6 +41,11 @@
   @include bolt-button-raised-effect;
 }
 
+.c-bolt-button--tertiary {
+  @include bolt-button-style(tertiary);
+  backdrop-filter: saturate(105%) blur(20px);
+}
+
 .c-bolt-button--text {
   @include bolt-button-style(text);
 }

--- a/packages/global/styles/06-themes/_themes.all.scss
+++ b/packages/global/styles/06-themes/_themes.all.scss
@@ -48,6 +48,8 @@
 // system to auto-generate a ton of extra vars we don't need;
 //
 // Part of the broader initiative to move Bolt to CSS vars + simplify our CSS Architecture
+//
+// @todo: review this when working through the new CSS custom property / vars spec (ex. http://vjira2:8080/browse/BDS-2031)
 .t-bolt-light,
 .t-bolt-xlight,
 :root {

--- a/packages/global/styles/06-themes/_themes.all.scss
+++ b/packages/global/styles/06-themes/_themes.all.scss
@@ -43,3 +43,35 @@
   --bolt-theme-background: 0, 0, 0;
   background-color: black;
 }
+
+// manually spec out the tertiary background + text colors vs using the original Theming
+// system to auto-generate a ton of extra vars we don't need;
+//
+// Part of the broader initiative to move Bolt to CSS vars + simplify our CSS Architecture
+.t-bolt-light,
+.t-bolt-xlight,
+:root {
+  --bolt-theme--tertiary--background-color--default: #{rgba(bolt-color(gray), 0.15)};
+  --bolt-theme--tertiary--background-color--hover:   #{rgba(bolt-color(gray), 0.3)};
+  --bolt-theme--tertiary--background-color--focus:   #{rgba(bolt-color(gray), 0.4)};
+  --bolt-theme--tertiary--background-color--active:  #{rgba(bolt-color(gray), 0.5)};
+
+  --bolt-theme--tertiary--text-color--default: #{rgba(bolt-color(black), 0.9)};
+  --bolt-theme--tertiary--text-color--hover:   #{rgba(bolt-color(black), 1)};
+  --bolt-theme--tertiary--text-color--active:  var(--bolt-theme--tertiary--text-color--hover);
+  --bolt-theme--tertiary--text-color--focus:   var(--bolt-theme--tertiary--text-color--hover);
+}
+
+.t-bolt-dark,
+.t-bolt-xdark,
+.t-bolt-xxdark {
+  --bolt-theme--tertiary--background-color--default:   #{rgba(bolt-color(white), 0.2)};
+  --bolt-theme--tertiary--background-color--hover:     #{rgba(bolt-color(white), 0.3)};
+  --bolt-theme--tertiary--background-color--focus:     #{rgba(bolt-color(white), 0.35)};
+  --bolt-theme--tertiary--background-color--active:    #{rgba(bolt-color(white), 0.4)};
+
+  --bolt-theme--tertiary--text-color--default: #{rgba(bolt-color(white), 0.9)};
+  --bolt-theme--tertiary--text-color--hover:   #{rgba(bolt-color(white), 1)};
+  --bolt-theme--tertiary--text-color--active:  var(--bolt-theme--tertiary--text-color--hover);
+  --bolt-theme--tertiary--text-color--focus:   var(--bolt-theme--tertiary--text-color--hover);
+}


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/BDS-1465?filter=-1

## Summary
Adds a new semi-transparent "tertiary" variant of the Button, including psuedo states for hover, active, focus, disabled, etc + full theming support.

![CleanShot 2020-03-02 at 08 17 15](https://user-images.githubusercontent.com/1617209/75679838-61759b00-5c5e-11ea-9e30-2cf2e0767f0c.png)

## Details
- Manually specs out the `tertiary` theming system values to reduce the amount of cruft getting auto-generated --> likely a similar direction we're going to want to be going with other UI work moving forward
  - Note: since I'm _not_ using the `bolt-theme` Sass function here, I'm manually including basic IE 11 theming fallbacks styles (but can be easily removed in the near future)
- As a first for Bolt, tertiary Buttons now include basic theming support when _only_ the Button component's CSS / JS is compiled / loaded (unlike other Themed components which are visually broken if the `@bolt/global` styles aren't loaded).

<img width="1680" alt="CleanShot 2020-02-28 at 09 37 55@2x" src="https://user-images.githubusercontent.com/1617209/75561415-fa18da80-5a14-11ea-83eb-45a81824d36c.png">

### Button-related Cleanup
- Nixes some unused border-color CSS styles in Button since
  1. these effectively aren't visible since border color values are basically set to the background color 100% of the time and
  2. Can't be transparent (as I found out the hard way with Tertiary button) since they would otherwise be visible against the semi-transparent background

- Cleans up Button styles handling disabled states to be less complex + not require even more hacks in order to get Tertiary buttons styled correctly

## How to test
- Review code changes
- Confirm Button demos are visually and functionality working as expected
- Check out the new Tertiary styles (hover, active, etc -- on both light and dark themes) since I had very limited design comps to go off of for these!

