### PR TITLE
Fix / update Popover to better support color theming

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/popover/25-popover-theme-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/popover/25-popover-theme-variations.twig
@@ -1,0 +1,33 @@
+{# Setting variables for demo purposes #}
+{% set schema = bolt.data.components["@bolt-components-popover"].schema %}
+{% set link %}
+  {% include "@bolt-components-link/link.twig" with {
+    text: "call to action",
+    url: "https://pega.com",
+  } only %}
+{% endset %}
+{% set content %}
+  This is the content of the popover with a {{ link }}.
+{% endset %}
+
+<bolt-text headline>Content theme</bolt-text>
+<bolt-text>Adjust the Bolt color theme of the content by using the <bolt-code-snippet display="inline" lang="html">theme</bolt-code-snippet> prop.</bolt-text>
+<bolt-list display="inline" spacing="medium">
+  {% for theme in schema.properties.theme.enum %}
+    <bolt-list-item>
+      {% set trigger %}
+        {% include "@bolt-components-button/button.twig" with {
+          text: "theme: " ~ theme,
+          size: "small",
+        } only %}
+      {% endset %}
+      {# Start component specific code #}
+      {% include "@bolt-components-popover/popover.twig" with {
+        trigger: trigger,
+        content: content,
+        theme: theme,
+      } only %}
+      {# End component specific code #}
+    </bolt-list-item>
+  {% endfor %}
+</bolt-list>

--- a/packages/components/bolt-popover/__tests__/__snapshots__/popover.js.snap
+++ b/packages/components/bolt-popover/__tests__/__snapshots__/popover.js.snap
@@ -17,7 +17,7 @@ exports[`<bolt-popover> Component UUID of the popover 1`] = `
           id="js-bolt-popover-custom-unique-id"
     >
       <replace-with-grandchildren class="c-bolt-popover__content">
-        <span class="c-bolt-popover__bubble">
+        <span class="c-bolt-popover__bubble ">
           <a href="#js-bolt-popover-trigger-custom-unique-id"
              class="c-bolt-popover__nojs-close"
           >
@@ -57,7 +57,7 @@ exports[`<bolt-popover> Component basic usage 1`] = `
           id="js-bolt-popover-12345"
     >
       <replace-with-grandchildren class="c-bolt-popover__content">
-        <span class="c-bolt-popover__bubble">
+        <span class="c-bolt-popover__bubble ">
           <a href="#js-bolt-popover-trigger-12345"
              class="c-bolt-popover__nojs-close"
           >
@@ -99,7 +99,7 @@ exports[`<bolt-popover> Component content placement: auto 1`] = `
           id="js-bolt-popover-12345"
     >
       <replace-with-grandchildren class="c-bolt-popover__content">
-        <span class="c-bolt-popover__bubble">
+        <span class="c-bolt-popover__bubble ">
           <a href="#js-bolt-popover-trigger-12345"
              class="c-bolt-popover__nojs-close"
           >
@@ -141,7 +141,7 @@ exports[`<bolt-popover> Component content placement: bottom 1`] = `
           id="js-bolt-popover-12345"
     >
       <replace-with-grandchildren class="c-bolt-popover__content">
-        <span class="c-bolt-popover__bubble">
+        <span class="c-bolt-popover__bubble ">
           <a href="#js-bolt-popover-trigger-12345"
              class="c-bolt-popover__nojs-close"
           >
@@ -183,7 +183,7 @@ exports[`<bolt-popover> Component content placement: bottom-end 1`] = `
           id="js-bolt-popover-12345"
     >
       <replace-with-grandchildren class="c-bolt-popover__content">
-        <span class="c-bolt-popover__bubble">
+        <span class="c-bolt-popover__bubble ">
           <a href="#js-bolt-popover-trigger-12345"
              class="c-bolt-popover__nojs-close"
           >
@@ -225,7 +225,7 @@ exports[`<bolt-popover> Component content placement: bottom-start 1`] = `
           id="js-bolt-popover-12345"
     >
       <replace-with-grandchildren class="c-bolt-popover__content">
-        <span class="c-bolt-popover__bubble">
+        <span class="c-bolt-popover__bubble ">
           <a href="#js-bolt-popover-trigger-12345"
              class="c-bolt-popover__nojs-close"
           >
@@ -267,7 +267,7 @@ exports[`<bolt-popover> Component content placement: left 1`] = `
           id="js-bolt-popover-12345"
     >
       <replace-with-grandchildren class="c-bolt-popover__content">
-        <span class="c-bolt-popover__bubble">
+        <span class="c-bolt-popover__bubble ">
           <a href="#js-bolt-popover-trigger-12345"
              class="c-bolt-popover__nojs-close"
           >
@@ -309,7 +309,7 @@ exports[`<bolt-popover> Component content placement: left-end 1`] = `
           id="js-bolt-popover-12345"
     >
       <replace-with-grandchildren class="c-bolt-popover__content">
-        <span class="c-bolt-popover__bubble">
+        <span class="c-bolt-popover__bubble ">
           <a href="#js-bolt-popover-trigger-12345"
              class="c-bolt-popover__nojs-close"
           >
@@ -351,7 +351,7 @@ exports[`<bolt-popover> Component content placement: left-start 1`] = `
           id="js-bolt-popover-12345"
     >
       <replace-with-grandchildren class="c-bolt-popover__content">
-        <span class="c-bolt-popover__bubble">
+        <span class="c-bolt-popover__bubble ">
           <a href="#js-bolt-popover-trigger-12345"
              class="c-bolt-popover__nojs-close"
           >
@@ -393,7 +393,7 @@ exports[`<bolt-popover> Component content placement: right 1`] = `
           id="js-bolt-popover-12345"
     >
       <replace-with-grandchildren class="c-bolt-popover__content">
-        <span class="c-bolt-popover__bubble">
+        <span class="c-bolt-popover__bubble ">
           <a href="#js-bolt-popover-trigger-12345"
              class="c-bolt-popover__nojs-close"
           >
@@ -435,7 +435,7 @@ exports[`<bolt-popover> Component content placement: right-end 1`] = `
           id="js-bolt-popover-12345"
     >
       <replace-with-grandchildren class="c-bolt-popover__content">
-        <span class="c-bolt-popover__bubble">
+        <span class="c-bolt-popover__bubble ">
           <a href="#js-bolt-popover-trigger-12345"
              class="c-bolt-popover__nojs-close"
           >
@@ -477,7 +477,7 @@ exports[`<bolt-popover> Component content placement: right-start 1`] = `
           id="js-bolt-popover-12345"
     >
       <replace-with-grandchildren class="c-bolt-popover__content">
-        <span class="c-bolt-popover__bubble">
+        <span class="c-bolt-popover__bubble ">
           <a href="#js-bolt-popover-trigger-12345"
              class="c-bolt-popover__nojs-close"
           >
@@ -519,7 +519,7 @@ exports[`<bolt-popover> Component content placement: top 1`] = `
           id="js-bolt-popover-12345"
     >
       <replace-with-grandchildren class="c-bolt-popover__content">
-        <span class="c-bolt-popover__bubble">
+        <span class="c-bolt-popover__bubble ">
           <a href="#js-bolt-popover-trigger-12345"
              class="c-bolt-popover__nojs-close"
           >
@@ -561,7 +561,7 @@ exports[`<bolt-popover> Component content placement: top-end 1`] = `
           id="js-bolt-popover-12345"
     >
       <replace-with-grandchildren class="c-bolt-popover__content">
-        <span class="c-bolt-popover__bubble">
+        <span class="c-bolt-popover__bubble ">
           <a href="#js-bolt-popover-trigger-12345"
              class="c-bolt-popover__nojs-close"
           >
@@ -603,7 +603,7 @@ exports[`<bolt-popover> Component content placement: top-start 1`] = `
           id="js-bolt-popover-12345"
     >
       <replace-with-grandchildren class="c-bolt-popover__content">
-        <span class="c-bolt-popover__bubble">
+        <span class="c-bolt-popover__bubble ">
           <a href="#js-bolt-popover-trigger-12345"
              class="c-bolt-popover__nojs-close"
           >
@@ -645,7 +645,7 @@ exports[`<bolt-popover> Component content spacing: medium 1`] = `
           id="js-bolt-popover-12345"
     >
       <replace-with-grandchildren class="c-bolt-popover__content">
-        <span class="c-bolt-popover__bubble">
+        <span class="c-bolt-popover__bubble ">
           <a href="#js-bolt-popover-trigger-12345"
              class="c-bolt-popover__nojs-close"
           >
@@ -687,7 +687,7 @@ exports[`<bolt-popover> Component content spacing: none 1`] = `
           id="js-bolt-popover-12345"
     >
       <replace-with-grandchildren class="c-bolt-popover__content">
-        <span class="c-bolt-popover__bubble">
+        <span class="c-bolt-popover__bubble ">
           <a href="#js-bolt-popover-trigger-12345"
              class="c-bolt-popover__nojs-close"
           >
@@ -729,7 +729,7 @@ exports[`<bolt-popover> Component content spacing: small 1`] = `
           id="js-bolt-popover-12345"
     >
       <replace-with-grandchildren class="c-bolt-popover__content">
-        <span class="c-bolt-popover__bubble">
+        <span class="c-bolt-popover__bubble ">
           <a href="#js-bolt-popover-trigger-12345"
              class="c-bolt-popover__nojs-close"
           >
@@ -771,7 +771,217 @@ exports[`<bolt-popover> Component content spacing: xsmall 1`] = `
           id="js-bolt-popover-12345"
     >
       <replace-with-grandchildren class="c-bolt-popover__content">
-        <span class="c-bolt-popover__bubble">
+        <span class="c-bolt-popover__bubble ">
+          <a href="#js-bolt-popover-trigger-12345"
+             class="c-bolt-popover__nojs-close"
+          >
+            <span aria-hidden="true">
+              &times;
+            </span>
+            <span class="u-bolt-visuallyhidden">
+              Close popover
+            </span>
+          </a>
+          This is the content of the popover with a
+          <bolt-link url="https://pega.com">
+            call to action
+          </bolt-link>
+          .
+        </span>
+      </replace-with-grandchildren>
+    </span>
+  </replace-with-children>
+</bolt-popover>
+`;
+
+exports[`<bolt-popover> Component content theme: dark 1`] = `
+<bolt-popover theme="dark"
+              uuid="12345"
+>
+  <replace-with-children class="c-bolt-popover c-bolt-popover--bottom c-bolt-popover--text-wrap c-bolt-popover--spacing-small">
+    <replace-with-grandchildren id="js-bolt-popover-trigger-12345">
+      <a href="#js-bolt-popover-12345"
+         class="c-bolt-popover__nojs-trigger"
+         tabindex="-1"
+      >
+        <bolt-button>
+          This triggers a popover
+        </bolt-button>
+      </a>
+    </replace-with-grandchildren>
+    <span slot="content"
+          id="js-bolt-popover-12345"
+    >
+      <replace-with-grandchildren class="c-bolt-popover__content">
+        <span class="c-bolt-popover__bubble t-bolt-dark">
+          <a href="#js-bolt-popover-trigger-12345"
+             class="c-bolt-popover__nojs-close"
+          >
+            <span aria-hidden="true">
+              &times;
+            </span>
+            <span class="u-bolt-visuallyhidden">
+              Close popover
+            </span>
+          </a>
+          This is the content of the popover with a
+          <bolt-link url="https://pega.com">
+            call to action
+          </bolt-link>
+          .
+        </span>
+      </replace-with-grandchildren>
+    </span>
+  </replace-with-children>
+</bolt-popover>
+`;
+
+exports[`<bolt-popover> Component content theme: light 1`] = `
+<bolt-popover theme="light"
+              uuid="12345"
+>
+  <replace-with-children class="c-bolt-popover c-bolt-popover--bottom c-bolt-popover--text-wrap c-bolt-popover--spacing-small">
+    <replace-with-grandchildren id="js-bolt-popover-trigger-12345">
+      <a href="#js-bolt-popover-12345"
+         class="c-bolt-popover__nojs-trigger"
+         tabindex="-1"
+      >
+        <bolt-button>
+          This triggers a popover
+        </bolt-button>
+      </a>
+    </replace-with-grandchildren>
+    <span slot="content"
+          id="js-bolt-popover-12345"
+    >
+      <replace-with-grandchildren class="c-bolt-popover__content">
+        <span class="c-bolt-popover__bubble t-bolt-light">
+          <a href="#js-bolt-popover-trigger-12345"
+             class="c-bolt-popover__nojs-close"
+          >
+            <span aria-hidden="true">
+              &times;
+            </span>
+            <span class="u-bolt-visuallyhidden">
+              Close popover
+            </span>
+          </a>
+          This is the content of the popover with a
+          <bolt-link url="https://pega.com">
+            call to action
+          </bolt-link>
+          .
+        </span>
+      </replace-with-grandchildren>
+    </span>
+  </replace-with-children>
+</bolt-popover>
+`;
+
+exports[`<bolt-popover> Component content theme: none 1`] = `
+<bolt-popover theme="none"
+              uuid="12345"
+>
+  <replace-with-children class="c-bolt-popover c-bolt-popover--bottom c-bolt-popover--text-wrap c-bolt-popover--spacing-small">
+    <replace-with-grandchildren id="js-bolt-popover-trigger-12345">
+      <a href="#js-bolt-popover-12345"
+         class="c-bolt-popover__nojs-trigger"
+         tabindex="-1"
+      >
+        <bolt-button>
+          This triggers a popover
+        </bolt-button>
+      </a>
+    </replace-with-grandchildren>
+    <span slot="content"
+          id="js-bolt-popover-12345"
+    >
+      <replace-with-grandchildren class="c-bolt-popover__content">
+        <span class="c-bolt-popover__bubble ">
+          <a href="#js-bolt-popover-trigger-12345"
+             class="c-bolt-popover__nojs-close"
+          >
+            <span aria-hidden="true">
+              &times;
+            </span>
+            <span class="u-bolt-visuallyhidden">
+              Close popover
+            </span>
+          </a>
+          This is the content of the popover with a
+          <bolt-link url="https://pega.com">
+            call to action
+          </bolt-link>
+          .
+        </span>
+      </replace-with-grandchildren>
+    </span>
+  </replace-with-children>
+</bolt-popover>
+`;
+
+exports[`<bolt-popover> Component content theme: xdark 1`] = `
+<bolt-popover theme="xdark"
+              uuid="12345"
+>
+  <replace-with-children class="c-bolt-popover c-bolt-popover--bottom c-bolt-popover--text-wrap c-bolt-popover--spacing-small">
+    <replace-with-grandchildren id="js-bolt-popover-trigger-12345">
+      <a href="#js-bolt-popover-12345"
+         class="c-bolt-popover__nojs-trigger"
+         tabindex="-1"
+      >
+        <bolt-button>
+          This triggers a popover
+        </bolt-button>
+      </a>
+    </replace-with-grandchildren>
+    <span slot="content"
+          id="js-bolt-popover-12345"
+    >
+      <replace-with-grandchildren class="c-bolt-popover__content">
+        <span class="c-bolt-popover__bubble t-bolt-xdark">
+          <a href="#js-bolt-popover-trigger-12345"
+             class="c-bolt-popover__nojs-close"
+          >
+            <span aria-hidden="true">
+              &times;
+            </span>
+            <span class="u-bolt-visuallyhidden">
+              Close popover
+            </span>
+          </a>
+          This is the content of the popover with a
+          <bolt-link url="https://pega.com">
+            call to action
+          </bolt-link>
+          .
+        </span>
+      </replace-with-grandchildren>
+    </span>
+  </replace-with-children>
+</bolt-popover>
+`;
+
+exports[`<bolt-popover> Component content theme: xlight 1`] = `
+<bolt-popover theme="xlight"
+              uuid="12345"
+>
+  <replace-with-children class="c-bolt-popover c-bolt-popover--bottom c-bolt-popover--text-wrap c-bolt-popover--spacing-small">
+    <replace-with-grandchildren id="js-bolt-popover-trigger-12345">
+      <a href="#js-bolt-popover-12345"
+         class="c-bolt-popover__nojs-trigger"
+         tabindex="-1"
+      >
+        <bolt-button>
+          This triggers a popover
+        </bolt-button>
+      </a>
+    </replace-with-grandchildren>
+    <span slot="content"
+          id="js-bolt-popover-12345"
+    >
+      <replace-with-grandchildren class="c-bolt-popover__content">
+        <span class="c-bolt-popover__bubble t-bolt-xlight">
           <a href="#js-bolt-popover-trigger-12345"
              class="c-bolt-popover__nojs-close"
           >

--- a/packages/components/bolt-popover/__tests__/popover.js
+++ b/packages/components/bolt-popover/__tests__/popover.js
@@ -6,7 +6,7 @@ import {
   html,
 } from '../../../testing/testing-helpers';
 import schema from '../popover.schema';
-const { placement, spacing, uuid } = schema.properties;
+const { placement, spacing, theme, uuid } = schema.properties;
 const timeout = 120000;
 
 describe('<bolt-popover> Component', () => {
@@ -46,6 +46,19 @@ describe('<bolt-popover> Component', () => {
         content:
           'This is the content of the popover with a <bolt-link url="https://pega.com">call to action</bolt-link>.',
         spacing: spacingChoice,
+      });
+      expect(results.ok).toBe(true);
+      expect(results.html).toMatchSnapshot();
+    });
+  });
+
+  theme.enum.forEach(async themeChoice => {
+    test(`content theme: ${themeChoice}`, async () => {
+      const results = await render('@bolt-components-popover/popover.twig', {
+        trigger: '<bolt-button>This triggers a popover</bolt-button>',
+        content:
+          'This is the content of the popover with a <bolt-link url="https://pega.com">call to action</bolt-link>.',
+        theme: themeChoice,
       });
       expect(results.ok).toBe(true);
       expect(results.html).toMatchSnapshot();

--- a/packages/components/bolt-popover/popover.schema.js
+++ b/packages/components/bolt-popover/popover.schema.js
@@ -50,6 +50,12 @@ module.exports = {
       enum: ['none', 'xsmall', 'small', 'medium'],
       default: 'small',
     },
+    theme: {
+      type: 'string',
+      description:
+        'Applies a Bolt color theme to the bubble that contains the main Popover content.',
+      enum: ['none', 'xlight', 'light', 'dark', 'xdark'],
+    },
     boundary: {
       type: 'string',
       description:

--- a/packages/components/bolt-popover/popover.schema.js
+++ b/packages/components/bolt-popover/popover.schema.js
@@ -55,6 +55,7 @@ module.exports = {
       description:
         'Applies a Bolt color theme to the bubble that contains the main Popover content.',
       enum: ['none', 'xlight', 'light', 'dark', 'xdark'],
+      default: 'none',
     },
     boundary: {
       type: 'string',

--- a/packages/components/bolt-popover/src/popover.js
+++ b/packages/components/bolt-popover/src/popover.js
@@ -26,6 +26,9 @@ class BoltPopover extends BoltElement {
         type: Boolean,
         reflect: true,
       },
+      theme: {
+        type: String,
+      },
       hasPopup: Boolean,
       hasFocusableContent: Boolean,
       boundary: String,
@@ -215,6 +218,10 @@ class BoltPopover extends BoltElement {
       [`c-bolt-popover--text-wrap`]: this.textContentLength > 31,
     });
 
+    const bubbleClasses = cx('c-bolt-popover__bubble', {
+      [`t-bolt-${this.theme}`]: this.theme && this.theme !== 'none',
+    });
+
     return html`
       <span class="${classes}">
         ${this.slotMap.get('default') &&
@@ -239,7 +246,7 @@ class BoltPopover extends BoltElement {
               class="${cx(`c-bolt-popover__content`)}"
               aria-hidden="${!this.open}"
             >
-              <span class="${cx(`c-bolt-popover__bubble`)}">
+              <span class="${bubbleClasses}">
                 ${this.slotify('content')}
               </span>
             </span>

--- a/packages/components/bolt-popover/src/popover.scss
+++ b/packages/components/bolt-popover/src/popover.scss
@@ -2,6 +2,7 @@
    Popover
 \* ------------------------------------ */
 @import '@bolt/core-v3.x';
+@import '@bolt/global/styles/06-themes/_themes.all.scss';
 
 // Dev Notes
 // 1. Any instance of bolt-popover:not([ready]) in this file is used to create NoJS fallback styles.

--- a/packages/components/bolt-popover/src/popover.twig
+++ b/packages/components/bolt-popover/src/popover.twig
@@ -19,7 +19,7 @@
 ] %}
 {% set bubble_classes = [
   base_class ~ "__bubble",
-  this.data.theme.value != "none" ? "t-bolt-" ~ this.data.theme.value,
+  this.data.theme.value != "none" ? "t-bolt-#{this.data.theme.value}" : "",
 ] %}
 
 {#

--- a/packages/components/bolt-popover/src/popover.twig
+++ b/packages/components/bolt-popover/src/popover.twig
@@ -58,7 +58,7 @@
     {% if content %}
       <span slot="content" id="{{ content_id }}">
         <replace-with-grandchildren class="{{ "#{base_class}__content" }}">
-          <span class="{{ "#{base_class}__bubble" }} {{ theme != 'none' ? 't-bolt-' ~ theme : '' }}">
+          <span class="{{ "#{base_class}__bubble" }}{{ theme and theme != 'none' ? ' t-bolt-' ~ theme : '' }}">
             <a href="#{{ trigger_id }}" class="{{ "#{base_class}__nojs-close" }}">
               <span aria-hidden="true">&times;</span>
               <span class="u-bolt-visuallyhidden">Close popover</span>

--- a/packages/components/bolt-popover/src/popover.twig
+++ b/packages/components/bolt-popover/src/popover.twig
@@ -58,7 +58,7 @@
     {% if content %}
       <span slot="content" id="{{ content_id }}">
         <replace-with-grandchildren class="{{ "#{base_class}__content" }}">
-          <span class="{{ "#{base_class}__bubble" }}">
+          <span class="{{ "#{base_class}__bubble" }} {{ theme != 'none' ? 't-bolt-' ~ theme : '' }}">
             <a href="#{{ trigger_id }}" class="{{ "#{base_class}__nojs-close" }}">
               <span aria-hidden="true">&times;</span>
               <span class="u-bolt-visuallyhidden">Close popover</span>

--- a/packages/components/bolt-popover/src/popover.twig
+++ b/packages/components/bolt-popover/src/popover.twig
@@ -17,6 +17,10 @@
   base_class ~ "--text-wrap",
   this.data.spacing.value != "none" ? base_class ~ "--spacing-" ~ this.data.spacing.value : "",
 ] %}
+{% set bubble_classes = [
+  base_class ~ "__bubble",
+  this.data.theme.value != "none" ? "t-bolt-" ~ this.data.theme.value,
+] %}
 
 {#
   Sort classes passed in via attributes into two groups:
@@ -58,7 +62,7 @@
     {% if content %}
       <span slot="content" id="{{ content_id }}">
         <replace-with-grandchildren class="{{ "#{base_class}__content" }}">
-          <span class="{{ "#{base_class}__bubble" }}{{ theme and theme != 'none' ? ' t-bolt-' ~ theme : '' }}">
+          <span class="{{ bubble_classes|join(' ') }}">
             <a href="#{{ trigger_id }}" class="{{ "#{base_class}__nojs-close" }}">
               <span aria-hidden="true">&times;</span>
               <span class="u-bolt-visuallyhidden">Close popover</span>


### PR DESCRIPTION
## Jira
N/A (related to http://vjira2:8080/browse/BDS-1465)

## Summary
Adds a new `theme` prop to Popover so theming classes are added to the correct inner container -- particularly important when wiring up the new Tertiary button styles in https://github.com/boltdesignsystem/bolt/pull/1764.

## Details
Note: without this update, themed Popovers using the new Tertiary button have broken styles (colored container that doesn't match up with the button) 

![image](https://user-images.githubusercontent.com/1617209/75680369-756dcc80-5c5f-11ea-8d44-050fbf17eac7.png)

## How to test
- Test that the new `theme` prop works / is styled correctly for Popover 