### PR TITLE
Fix: change breadcrumb popover demo to reflect valid usage

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/breadcrumb/10-breadcrumb-use-case-popover.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/breadcrumb/10-breadcrumb-use-case-popover.twig
@@ -17,16 +17,24 @@
     url: "#!",
   } only %}
 {% endset %}
-{% set trigger %}
-  {% include "@bolt-components-link/link.twig" with {
-    text: "Current Page with Popover",
-    url: "#!",
-    attributes: {
-      "aria-current": "page",
-    },
+
+{% set trigger_content %}
+  {% include "@bolt-components-headline/text.twig" with {
+    text: "Current Page",
+    weight: "bold",
+    size: "small",
+    icon: {
+      name: "chevron-down",
+      position: "after",
+    }
   } only %}
 {% endset %}
-{% set content %}
+{% set trigger %}
+  {% include "@bolt-components-trigger/trigger.twig" with {
+    content: trigger_content,
+  } only %}
+{% endset %}
+{% set menu_content %}
   {% include "@bolt-components-menu/menu.twig" with {
     title: "Choose one of these",
     items: [
@@ -51,8 +59,11 @@
 {% set popover %}
   {% include "@bolt-components-popover/popover.twig" with {
     trigger: trigger,
-    content: content,
+    content: menu_content,
     spacing: "none",
+    attributes: {
+      "aria-current": "page",
+    },
   } only %}
 {% endset %}
 


### PR DESCRIPTION
## Jira

N/A

## Summary

Fixes incorrect usage in breadcrumb popover demo page.

## Details

Changes `bolt-link` to `bolt-trigger` as the popover trigger. Currently there's a [bug](http://vjira2:8080/browse/BDS-2057) with using `bolt-link` as the trigger. This hides the bug for now.

## How to test

Run the branch locally and check this page (http://localhost:3000/pattern-lab/?p=components-breadcrumb-use-case-popover). Make sure the popover works as expected.
