### PR TITLE
Fix/broken video in tabs

### DIFF
--- a/packages/components/bolt-tabs/__tests__/tabs.e2e.js
+++ b/packages/components/bolt-tabs/__tests__/tabs.e2e.js
@@ -73,12 +73,8 @@ module.exports = {
       .assert.elementPresent(video)
       .assert.not.visible(video)
       .execute(function(data) {
-        document
-          .querySelector('bolt-tabs')
-          .renderRoot.querySelector(
-            '.c-bolt-tabs__nav > .c-bolt-tabs__label:nth-child(4)',
-          )
-          .click();
+        // Opens video tab
+        document.querySelector('bolt-tabs').setAttribute('selected-tab', 4);
       })
       .assert.visible(video)
       .click(videoPlayer)

--- a/packages/components/bolt-tabs/__tests__/tabs.e2e.js
+++ b/packages/components/bolt-tabs/__tests__/tabs.e2e.js
@@ -56,4 +56,52 @@ module.exports = {
       )
       .end();
   },
+
+  'Tabs: loads video content in inactive tab': function(browser) {
+    const { testingUrl } = browser.globals;
+    console.log(`global browser url: ${testingUrl}`);
+    currentBrowser = '--' + browser.currentEnv || 'chrome';
+    let testName = 'tabs-adaptive-menu';
+    const video = 'bolt-video';
+    const videoPlayer = 'bolt-video video-js'; // click on video element not button itself
+
+    browser
+      .url(
+        `${testingUrl}/pattern-lab/patterns/02-components-tabs-30-tabs-content/02-components-tabs-30-tabs-content.html`,
+      )
+      .waitForElementVisible('bolt-tabs', 1000)
+      .assert.elementPresent(video)
+      .assert.not.visible(video)
+      .execute(function(data) {
+        document
+          .querySelector('bolt-tabs')
+          .renderRoot.querySelector(
+            '.c-bolt-tabs__nav > .c-bolt-tabs__label:nth-child(4)',
+          )
+          .click();
+      })
+      .assert.visible(video)
+      .click(videoPlayer)
+      .pause(4000)
+      .assert.cssClassPresent(videoPlayer, ['vjs-has-started', 'vjs-playing'])
+      .click(videoPlayer)
+      .pause(1000)
+      .assert.cssClassPresent(videoPlayer, ['vjs-paused'])
+      .execute(
+        function(data) {
+          return document.querySelector('bolt-video').player.currentTime();
+        },
+        [],
+        function(result) {
+          browser.assert.ok(
+            result.value > 1,
+            `<bolt-video> starts playing when <bolt-button> is clicked -- verified since the current video's play time is ${result.value} seconds`,
+          );
+        },
+      )
+      .saveScreenshot(
+        `screenshots/bolt-tabs/${testName}--${currentBrowser}.png`,
+      )
+      .end();
+  },
 };

--- a/packages/components/bolt-tabs/__tests__/tabs.e2e.js
+++ b/packages/components/bolt-tabs/__tests__/tabs.e2e.js
@@ -71,12 +71,23 @@ module.exports = {
       )
       .waitForElementVisible('bolt-tabs', 1000)
       .assert.elementPresent(video)
-      .assert.not.visible(video)
+      .execute(
+        function(data) {
+          // Get initial selected tab
+          return document.querySelector('bolt-tabs').selectedTab;
+        },
+        [],
+        function(result) {
+          browser.assert.ok(
+            result.value === 1,
+            `On load the first tab is open and Video is hidden`,
+          );
+        },
+      )
       .execute(function(data) {
         // Opens video tab
         document.querySelector('bolt-tabs').setAttribute('selected-tab', 4);
       })
-      .assert.visible(video)
       .click(videoPlayer)
       .pause(4000)
       .assert.cssClassPresent(videoPlayer, ['vjs-has-started', 'vjs-playing'])

--- a/packages/components/bolt-video/src/video.standalone.js
+++ b/packages/components/bolt-video/src/video.standalone.js
@@ -599,25 +599,8 @@ class BoltVideo extends withPreact {
       }
 
       this.hasInitialized = true;
-
-      if (this.offsetHeight) {
-        // Set flag so that video will not be re-initialized unnecessarily on update()
-        this.removeAttribute('will-update', '');
-      } else {
-        // If not visible, add attribute so that it can be found by other components and updated manually.
-        this.setAttribute('will-update', '');
-      }
     } catch (error) {
       console.log(error);
-    }
-  }
-
-  update() {
-    // Brightcove doesn't have a simple "reset/update" method that I could find, so we must dispose and reinit
-    if (this.player) {
-      this.player.dispose();
-      this.hasInitialized = false;
-      this.triggerUpdate();
     }
   }
 

--- a/packages/testing/testing-nightwatch/nightwatch.js
+++ b/packages/testing/testing-nightwatch/nightwatch.js
@@ -85,7 +85,7 @@ module.exports = {
       desiredCapabilities: {
         browserName: 'chrome',
         platform: 'macOS 10.14',
-        version: '76',
+        version: '80',
         javascriptEnabled: true,
         acceptSslCerts: true,
         chromeOptions: {

--- a/packages/testing/testing-nightwatch/package.json
+++ b/packages/testing/testing-nightwatch/package.json
@@ -18,7 +18,7 @@
   "main": "nightwatch.js",
   "dependencies": {
     "@zeit/fetch-retry": "^4.0.1",
-    "chromedriver": "^78.0.1",
+    "chromedriver": "^80.0.1",
     "ci-utils": "^0.6.0",
     "geckodriver": "^1.16.2",
     "globby": "^10.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2859,6 +2859,11 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@testim/chrome-version@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@testim/chrome-version/-/chrome-version-1.0.7.tgz#0cd915785ec4190f08a3a6acc9b61fc38fb5f1a9"
+  integrity sha512-8UT/J+xqCYfn3fKtOznAibsHpiuDshCb0fwgWxRazTT19Igp9ovoXMPhXyLD6m3CKQGTMHgqoxaFfMWaL40Rnw==
+
 "@theme-tools/core@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@theme-tools/core/-/core-1.0.0.tgz#7ed9915cb4d0f3591404346612ce3adfc2d9923e"
@@ -4122,6 +4127,13 @@ axios@^0.18.0:
   dependencies:
     follow-redirects "1.5.10"
     is-buffer "^2.0.2"
+
+axios@^0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+  dependencies:
+    follow-redirects "1.5.10"
 
 babel-eslint@^10.0.3:
   version "10.0.3"
@@ -5496,17 +5508,6 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@^78.0.1:
-  version "78.0.1"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-78.0.1.tgz#2db3425a2cba6fcaf1a41d9538b16c3d06fa74a8"
-  integrity sha512-eOsyFk4xb9EECs1VMrDbxO713qN+Bu1XUE8K9AuePc3839TPdAegg72kpXSzkeNqRNZiHbnJUItIVCLFkDqceA==
-  dependencies:
-    del "^4.1.1"
-    extract-zip "^1.6.7"
-    mkdirp "^0.5.1"
-    request "^2.88.0"
-    tcp-port-used "^1.0.1"
-
 chromedriver@^79.0.0:
   version "79.0.0"
   resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-79.0.0.tgz#1660ac29924dfcd847911025593d6b6746aeea35"
@@ -5516,6 +5517,18 @@ chromedriver@^79.0.0:
     extract-zip "^1.6.7"
     mkdirp "^0.5.1"
     request "^2.88.0"
+    tcp-port-used "^1.0.1"
+
+chromedriver@^80.0.1:
+  version "80.0.1"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-80.0.1.tgz#35c1642e2d864b9e8262f291003e455b0e422917"
+  integrity sha512-VfRtZUpBUIjeypS+xM40+VD9g4Drv7L2VibG/4+0zX3mMx4KayN6gfKETycPfO6JwQXTLSxEr58fRcrsa8r5xQ==
+  dependencies:
+    "@testim/chrome-version" "^1.0.7"
+    axios "^0.19.2"
+    del "^5.1.0"
+    extract-zip "^1.6.7"
+    mkdirp "^1.0.3"
     tcp-port-used "^1.0.1"
 
 ci-info@^1.5.0, ci-info@^1.6.0:


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-2058

## Summary

Fixes broken videos in inactive Tabs.

## Details

It looks like changes to Preact caused this regression, and there was no test in place to cover this exact use case. There is now a test to prevent future regressions.

In Bolt v2.13 we upgraded Preact, which changed the way components (like Video) re-render. Something about the new way of re-rendering doesn't fully destroy and re-create the element like it used to. That's good in some ways but bad for Brightcove which expects a clean slate when it initializes or the player may not properly load.

Our old fix re-initialized the video player when a hidden video became visible. While debugging, I found that I can remove the old fix entirely and the video loads fine, even when it is initially hidden. This tells me that support for loading hidden videos has improved on the Brightcove side because that was the whole reason for the original fix.

So, I removed the old fix and added the missing test.

Also, I updated the version of Chrome used by our Nightwatch tests to match the current version we all run locally for consistency between the two environments.

## How to test

- Verify tests are passing
- View [Tabs Content](https://fix-broken-video-in-tabs.boltdesignsystem.com/pattern-lab/?p=components-tabs-content) and [Accordion Content](https://fix-broken-video-in-tabs.boltdesignsystem.com/pattern-lab/?p=components-accordion-content-variations) pages and verify video loads properly when you open that panel.
  - Note: same underlying issue affects Accordion as Tabs.
