### PR TITLE
Add Basic Article Styling to Docs Site Articles

### DIFF
--- a/docs-site/src/components/hamburger-button/hamburger-button.twig
+++ b/docs-site/src/components/hamburger-button/hamburger-button.twig
@@ -4,7 +4,7 @@
       {% include "@bolt-components-button/button.twig" with {
         text: 'Open Menu',
         iconOnly: true,
-        url: "#menu",
+        url: "#nav",
         style: "primary",
         size: "medium",
         rounded: "rounded",

--- a/docs-site/src/components/hamburger-button/hamburger-button.twig
+++ b/docs-site/src/components/hamburger-button/hamburger-button.twig
@@ -4,7 +4,7 @@
       {% include "@bolt-components-button/button.twig" with {
         text: 'Open Menu',
         iconOnly: true,
-        url: "#nav",
+        url: "#menu",
         style: "primary",
         size: "medium",
         rounded: "rounded",

--- a/docs-site/src/docs-article.scss
+++ b/docs-site/src/docs-article.scss
@@ -1,0 +1,187 @@
+/* ------------------------------------ *\
+   Docs Site Article
+   Originally ported over from https://github.com/boltdesignsystem/bolt/pull/1438
+\* ------------------------------------ */
+
+@import '@bolt/core';
+
+$letter-spacing-tight: -0.025rem;
+$letter-spacing-loose: 0.05rem;
+$element-spacing: $bolt-spacing-leading - (($bolt-spacing-leading - 1) / 2) * 1rem;
+
+
+.c-bds-layout__main {
+  color: bolt-theme(text);
+
+  p,
+  blockquote,
+  figure,
+  // pre,
+  ul,
+  ol,
+  hr {
+    @include bolt-margin-top(0);
+    @include bolt-margin-right(0);
+    @include bolt-margin-left(0);
+
+    margin-bottom: $element-spacing;
+
+    &:last-child {
+      @include bolt-margin-bottom(0);
+    }
+  }
+
+  hr {
+    box-sizing: content-box;
+    opacity: 1;
+    height: 0;
+    overflow: visible;
+    margin-top: $element-spacing;
+    border: none;
+    border-bottom: 1px solid rgba(bolt-color(gray), 0.25);
+  }
+
+  p {
+    @include bolt-font-size(medium);
+  }
+
+  h1,
+  h2 {
+    & + ul,
+    & + ol {
+      margin-top: bolt-v-spacing(small) * -1;
+    }
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    color: bolt-theme(headline);
+  }
+
+  h1,
+  h2,
+  h3,
+  h4 {
+    letter-spacing: $letter-spacing-tight;
+  }
+
+  h1 {
+    @include bolt-font-size(xxxlarge);
+  }
+
+  h2 {
+    @include bolt-font-size(xxlarge);
+    @include bolt-font-weight(semibold);
+    @include bolt-margin-bottom(medium);
+  }
+
+  h3 {
+    @include bolt-font-size(xlarge);
+    @include bolt-font-weight(regular);
+    @include bolt-margin-bottom(small);
+  }
+
+  h4 {
+    @include bolt-font-size(large);
+    @include bolt-margin-bottom(xsmall);
+  }
+
+  h5 {
+    @include bolt-font-size(medium);
+    @include bolt-margin-bottom(xsmall);
+  }
+
+  h6 {
+    @include bolt-font-size(small);
+    @include bolt-font-weight(semibold);
+    @include bolt-margin-bottom(xsmall);
+
+    text-transform: uppercase;
+    letter-spacing: $letter-spacing-loose;
+  }
+
+  b,
+  strong {
+    @include bolt-font-weight(bold);
+  }
+
+  small,
+  figcaption {
+    @include bolt-font-size(xsmall);
+  }
+
+  sub,
+  sup {
+    position: relative;
+    line-height: 0;
+    vertical-align: baseline;
+    font-size: bolt-strip-unit(bolt-font-size(xsmall)) + em;
+  }
+
+  sub {
+    bottom: -0.25em;
+  }
+
+  sup {
+    top: -0.5em;
+  }
+
+  img {
+    border-style: none;
+  }
+
+  blockquote {
+    @include bolt-margin-right(0);
+    @include bolt-margin-left(0);
+    @include bolt-padding-left(small);
+    @include bolt-font-size(large);
+    @include bolt-font-weight(semibold);
+
+    border-left: 3px solid bolt-color(teal);
+
+    p {
+      font-size: inherit;
+
+      & + p {
+        margin-top: bolt-v-spacing(small) * -1;
+      }
+    }
+  }
+
+  blockquote footer,
+  figcaption {
+    opacity: 0.5;
+  }
+
+  figure {
+    @include bolt-padding(0);
+
+    img {
+      max-width: 100%;
+    }
+  }
+
+  ol,
+  ul {
+    @include bolt-padding-right(0);
+    @include bolt-padding-left(2.25em);
+
+    li {
+      @include bolt-margin-bottom(xsmall);
+
+      &:last-of-type {
+        @include bolt-margin-bottom(0);
+      }
+
+      ol,
+      ul {
+        @include bolt-margin-top(xsmall);
+        @include bolt-padding-left(1.25em);
+      }
+    }
+  }
+}

--- a/docs-site/src/index.scss
+++ b/docs-site/src/index.scss
@@ -1,4 +1,5 @@
 @import '@bolt/core';
+@import './docs-article.scss';
 @import './components/callout/callout.scss';
 @import './components/component-status/component-status.scss';
 @import './components/gearbox/gearbox.scss';

--- a/docs-site/src/pages/docs/999-css-custom-props-spec/00-index.md
+++ b/docs-site/src/pages/docs/999-css-custom-props-spec/00-index.md
@@ -8,43 +8,70 @@ hidden: false
   Recommendations + Notes:
 </bolt-text>
 
+- In general, Bolt has 3 tiers of CSS custom properties
+  1. **Global** (pure vars / values)
+  2. **Context-specific** (opinionated defaults shared across multiple things)
+  3. **Component-specific** (tokens for specific components like buttons, links, etc)
+
+### Implementation Details
+
 1. Switch to use Amazon's [Style Dictionary](https://github.com/amzn/style-dictionary) to auto-convert design tokens into the different formats required (including converting into Sass Maps...)
-   - These should most likely should be defined as JSON (Style Dictionary's default) OR preferably as `.js` files (my personal preference + also supported by Style Dictionary)
-2. We have 3 tiers of tokens
-   - **#1. Global tokens** (pure values)
-   - **#2. Context-specific** tokens (opinionated defaults shared across multiple things)
-   - **#3. Component-specific** tokens (tokens for specific components like buttons, links, etc)
-3. Our existing ITCSS `settings.global.scss` file needs to go away -- break some of these out into other settings / tokens appropriately
+   - These should most likely be defined as JSON (Style Dictionary's default) OR preferably as `.js` files (my personal preference + also supported by Style Dictionary)
+2. New Sass tooling + updates to existing Sass tooling required
+3. Our existing ITCSS `settings.global.scss` file goes away and gets broken out into other (new) settings / token files appropriately
   - Most of our other existing ITCSS settings files should map out quite nicely
-4. We should try to favor using _shorter_ variable names instead of trying to match the CSS property being used. (discussion needed)
+4. Global vars only use single dashes. Context and component-specific vars use double-dashes after the `--bolt-[THING]` prefix
 
-`--bolt-font-size-md` vs `--bolt-font-size-medium` <br>
-`--bolt-shadow-lg` vs `--bolt-box-shadow-large` <br>
-`--bolt--btn--bg-color` vs `--bolt--button--background-color` <br>
+### Considerations:
+- **The simpler, the better** (Limiting Verbosity)
+  - We should try to favor using _shorter_ variable names instead of trying to match the CSS property being used. (discussion needed)
+- **Web performance**
+  - Utility classes are the largest contributor to our large CSS file size. Auto-generated CSS custom prop values are probably the 2nd largest contributor to our large CSS file size...
+- **Best Docs Are No Docs**
+  - The simpler the naming convention, the easier it is to adopt and use (plus requires less docs to reference)
 
-5. `--default` suffix for UI with multiple states is optional?
-6. Global vars only use single dashes. Context and component-specific vars use double-dashes
+## Questions + Discussion Points:
+1. No more `rgba(var(--bolt-theme-primary), .5)` and instead favor `--bolt-theme-primary--transparent-50` or `--bolt-theme-primary--alpha-50` or something; basically transparency is part of our global tokens
+2. Retire `bolt-color(indigo, xlight)` and instead move to `bolt-color(indigo-500)`, `bolt-color(indigo-100)`, etc 
+   - alt. re-introduce (`light|lighter|lightest|dark|darker|darkest`)?
+   - Ex. `bolt-color(indigo, lightest)`
+3. Do we _REALLY_ need a `--default` suffix for UI that has multiple states?
+   - `--bolt-button--background-color` vs `--bolt-button--background-color--default`
+4. Do we _REALLY_ need to include `-color` suffix on everything?
+  - `--bolt-btn--background` === `--bolt-btn--background-color` acceptable shorthand?
+  - `--bolt-btn--text` === `--bolt-btn--text-color` acceptable shorthand?
+  - `--bolt-button--border` === `--bolt-btn--border-color` acceptable shorthand?
+5. Sass tooling
+6. When, where, why, and how do we handle CSS custom prop fallbacks
+3. How do utility classes tie into all of this?
 
 
 ```
-// Global
---bolt-color-indigo: ...
-
-// Context-specific
---bolt--theme--text-color: ...
---bolt--density--spacing--medium: ...
---bolt--density--spacing--medium-squished: ...
-
-// Component-specific
---bolt--button--color: ...
---bolt--button--text-color--default: ... // same as previous line?
-
---bolt--button--bg-color--hover: ...
---bolt--button--bg-color--active: ...
---bolt--button--bg-color--disabled: ...
+--bolt-font-size-md
+// vs
+--bolt-font-size-medium
 ```
 
-# references
+```
+--bolt-shadow-lg
+// vs
+--bolt-shadow-large
+```
+
+```
+--bolt-btn--bg
+--bolt-btn--bg-color
+--bolt-btn--background
+--bolt-btn--background-color
+
+--bolt-button--bg
+--bolt-button--bg-color
+--bolt-button--background
+--bolt-button--background-color
+```
+
+
+# References
 
 - https://www.duetds.com/tokens/
 - https://www.patternfly.org/v4/design-guidelines/styles/colors
@@ -72,185 +99,34 @@ hidden: false
 - not component or use-case specific
 - think of these as pure raw ingredients that can be used anywhere
 
-<details>
-  <summary>Global Token Examples</summary>
+```
+--bolt-color-indigo
+--bolt-spacing-large
+--bolt-opacity-50
+```
+
+
+### Mapping Global Tokens to ITCSS Settings
 
 <bolt-table first-col-fixed-width>
-<table>
-  <thead>
-    <tr>
-      <th scope="col">Type of Token</th>
-      <th scope="col">CSS Custom Property Name</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Border Radius</td>
-      <td>
 
-```
---bolt-border-radius-full
---bolt-border-radius-small
---bolt-border-radius-default
---bolt-border-radius-none
-```
-</td>
-    </tr>
-    <tr>
-      <td>Breakpoints</td>
-      <td>
+| Token           | CSS Custom Property Name |
+| ---             | ---                                                                     |
+| Border Radius   | `--bolt-border-radius-full`      <br> `--bolt-border-radius-small`      |
+| Breakpoints     | `--bolt-breakpoint-xxsmall`      <br> `--bolt-breakpoint-medium`        |
+| Colors          | `--bolt-color-indigo-xdark`      <br> `--bolt-color-red`                |
+| Font family     | `--bolt-font-family-heading`     <br> `--bolt-font-family-body`         |
+| Font size       | `--bolt-font-size-xsmall`        <br> `--bolt-font-size-medium`         |
+| Line height     | `--bolt-bolt-line-height-medium` <br> `--bolt-line-height-medium-tight` |
+| Font weight     | `--bolt-font-weight-light`       <br> `--bolt-font-weight-bold`         |
+| Transitions     | `--bolt-transition-fast`         <br> `--bolt-transition-slow`          |
+| Opacity         | `--bolt-opacity-20`              <br> `--bolt-opacity-50`               |
+| Spacing         | `--bolt-spacing-medium`          <br> `--bolt-vspacing-medium`          |
+| Shadows         | `--bolt-shadow-100`              <br> `--bolt-shadow-300`               |
 
-```
---bolt-breakpoint-xxsmall
---bolt-breakpoint-medium
-...
---bolt-breakpoint-xxlarge
-```
-</td>
-    </tr>
-    <tr>
-      <td>Colors</td>
-<td>
-
-```
---bolt-color-indigo-xdark
---bolt-color-indigo
---bolt-color-red
---bolt-color-blue-dark
-```
-<br>
-> Note: we might want to consider renaming our existing status colors at this level and redefine at a lower level
-</td>
-    </tr>
-    <tr>
-      <td>Font Family</td>
-<td>
-
-```
---bolt-font-family-heading
---bolt-font-family-body
---bolt-font-family-code
-```
-<br>
-> Note: nix font-family-bodySubset
-</td>
-    </tr>
-    <tr>
-      <td>Font Size</td>
-<td>
-
-```
---bolt-font-size-xsmall
---bolt-font-size-medium
---bolt-font-size-xxlarge
-```
-</td>
-    </tr>
-    <tr>
-      <td>Font Family</td>
-<td>
-
-```
---bolt-font-family-heading
---bolt-font-family-body
---bolt-font-family-code
-```
-<br>
-> Note: nix font-family-bodySubset
-</td>
-    </tr>
-    <tr>
-      <td>Line height</td>
-<td>
-
-```
---bolt-line-height-medium    // default for medium fonts
---bolt-line-height-medium-tight         // tighter line-height for medium-sized fonts
---bolt-line-height-medium-loose         //  looser line-height for large-sized fonts
-...
---bolt-line-height-large
-```
-</td>
-    </tr>
-    <tr>
-      <td>Font Weights</td>
-<td>
-
-```
---bolt-font-weight-light
---bolt-font-weight-regular
---bolt-font-weight-semibold
---bolt-font-weight-bold
---bolt-font-weight-extrabold
-```
-</td>
-</tr>
-
-<tr>
-<td>Transitions</td>
-<td>
-
-```
---bolt-transition-fast
---bolt-transition-slow
-```
-</td>
-    </tr>
-    <tr>
-      <td>Opacity</td>
-<td>
-
-```
---bolt-opacity-0
---bolt-opacity-20
---bolt-opacity-40
---bolt-opacity-50
---bolt-opacity-80
---bolt-opacity-100
-// ... etc
-```
-</td>
-    </tr>
-    <tr>
-      <td>Spacing</td>
-<td>
-
-```
-// horizontal spacing
---bolt-spacing-medium
---bolt-spacing-medium-squished
---bolt-spacing-medium-stretched
-...
-// v-spacing
---bolt-vspacing-medium
-```
-</td>
-</tr>
-<tr>
-  <td>Shadows</td>
-  <td>
-
-```
---bolt-shadow-100
---bolt-shadow-300
---bolt-shadow-500
---bolt-shadow-500
---bolt-shadow-900
-```
-  </td>
-</tr>
-</tbody>
-</table>
 </bolt-table>
 
-<!--
---bolt-color-warning
---bolt-color-warning-light
---bolt-color-succes
--->
-
-</details>
-
+> Note: we should consider renaming status colors to pure color names + move down to the context layer
 
 <hr>
 
@@ -264,9 +140,7 @@ hidden: false
 
 > NOTE: As a rule of thumb: if 2 or more bits of UI should stay magically in sync, it might make sense to define that shared rule here.
 
-<bolt-text font-size="large" font-weight="bold" class="u-bolt-margin-bottom-none">
-  Syntax
-</bolt-text>
+### Syntax
 
 <bolt-code-snippet lang="css">
 --bolt-[Context]--[SCOPE]--[PROP]--[MODIFIER]
@@ -294,10 +168,9 @@ hidden: false
 
 # Notes / Discussion Points
 
-- How do we handle surfaces / overlays over themes?
+- How do we handle surfaces / overlays in the context of themes (ex. Navbar dropdown within different themes)?
 
-<details>
-  <summary>Theming Examples</summary>
+### Theming Examples
 
 ```
 --bolt-theme--heading
@@ -327,12 +200,7 @@ hidden: false
 // --bolt-theme--shadow?
 ```
 
-</details>
-
-
-<details>
-
-  <summary>Density Examples</summary>
+### Density Examples
 
 ```
 --bolt-density--spacing--xlarge
@@ -341,31 +209,22 @@ hidden: false
 --bolt-density--line-height--medium
 ```
 
-</details>
-
-
-<details>
-  <summary>UI Examples?</summary>
-
-## By type of thing and/or element
+### UI Examples?
 
 ```
+// By type of thing and/or element
 --bolt-ui--text--...
 --bolt-ui--headings--...
 --bolt-ui--h1--...
 --bolt-ui--h6--...
-```
 
-### By component type
-
-```
+// By component type
 --bolt-ui--overlays--...
 --bolt-ui--dividers--...
 --bolt-ui--input--...
 ```
 
-</details>
-
+> NOTE: this UI-specific detail is one thing in still a little on the fence with... 
 
 <hr>
 
@@ -378,17 +237,19 @@ hidden: false
 - doesn't (and probably **shouldn't**) be required to map to a specific css property
 - the shorter (within reason), the better; when in doubt, prefer clarity over conciseness 
 
-
-<bolt-text font-size="large" font-weight="bold" class="u-bolt-margin-bottom-none">
-  Syntax
-</bolt-text>
+### Syntax
 
 ```
 --bolt-[COMPONENT-NAME]--[PURPOSE]--[STATE/MODIFIER]`
         ^- who            ^- what    ^- when / how
+
+--bolt-btn--bg-color--hover: ...
 ```
 
+### Examples
+
 ```css
+// ex. button vars
 --bolt-btn--bg-color: ...
 --bolt-btn--bg-color--hover: ...
 --bolt-btn--bg-color--active: ...
@@ -396,13 +257,14 @@ hidden: false
 --bolt-btn--border-width
 --bolt-btn--border-color
 
-
+// ex. icon vars
 --bolt-icon--color:
 --bolt-icon--bg-color:
 --bolt-icon--bg-opacity:
 --bolt-icon--size--medium:
 --bolt-icon--size--large:
 
+// ex. card vars
 --bolt-card--shadow
 --bolt-card--shadow--raised
 --bolt-card--spacing

--- a/docs-site/src/pages/docs/999-css-custom-props-spec/00-index.md
+++ b/docs-site/src/pages/docs/999-css-custom-props-spec/00-index.md
@@ -1,83 +1,257 @@
 ---
-title: Bolt CSS Custom Props Spec (Draft)
+title: CSS Custom Props Spec
 category: Architecture
 hidden: false
 ---
 
-<bolt-text font-size="large" font-weight="bold" class="u-bolt-margin-bottom-none">
-  Recommendations + Notes:
-</bolt-text>
+- [TLDR Spec](#tldr-spec)
+- [Do's and Don'ts](#dos-and-donts)
+- [Global Tokens](#global-tokens)
+  - [Syntax](#syntax)
+  - [Global Tokens Example](#global-tokens-example)
+  - [Mapping Global Tokens to ITCSS](#mapping-global-tokens-to-itcss)
+- [Context-specific Tokens (Themes, Density, UI Types)](#context-specific-tokens-themes-density-ui-types)
+  - [Syntax](#syntax-1)
+  - [Theming Examples](#theming-examples)
+  - [Density Examples (TBD)](#density-examples-tbd)
+- [Component-specific Tokens (Buttons, Cards, etc)](#component-specific-tokens-buttons-cards-etc)
+  - [Syntax](#syntax-2)
+  - [Component-specific Examples](#component-specific-examples)
+- [Things To Consider](#things-to-consider)
+- [Implementation Details](#implementation-details)
+- [Questions](#questions)
+- [References](#references)
 
-- In general, Bolt has 3 tiers of CSS custom properties
-  1. **Global** (pure vars / values)
-  2. **Context-specific** (opinionated defaults shared across multiple things)
+---
+
+
+## TLDR Spec
+
+- Bolt has 3 tiers of CSS custom properties
+  1. **Global** (pure design token values)
+  2. **Context-specific** (opinionated defaults that are shared -- like themes)
   3. **Component-specific** (tokens for specific components like buttons, links, etc)
 
-### Implementation Details
+```
+// global
+--bolt-color-yellow: ...
+--bolt-color-indigo-dark: ...
+--bolt-shadow-300
 
-1. Switch to use Amazon's [Style Dictionary](https://github.com/amzn/style-dictionary) to auto-convert design tokens into the different formats required (including converting into Sass Maps...)
-   - These should most likely be defined as JSON (Style Dictionary's default) OR preferably as `.js` files (my personal preference + also supported by Style Dictionary)
-2. New Sass tooling + updates to existing Sass tooling required
-3. Our existing ITCSS `settings.global.scss` file goes away and gets broken out into other (new) settings / token files appropriately
-     - Most of our other existing ITCSS settings files should map out quite nicely
-4. Global vars only use single dashes. Context and component-specific vars use double-dashes after the `--bolt-[THING]` prefix
+// contextual
+--bolt-theme-primary: ...
+--bolt-theme-secondary--active: ...
 
-### Considerations:
-- **Verbosity** (the simpler, the better)
-  - We should try to favor using _shorter_ variable names instead of trying to match the CSS property being used. (discussion needed)
-- **Web Performance**
-  - Utility classes are the largest contributor to our large CSS file size. Auto-generated CSS custom prop values are probably the 2nd largest contributor to our large CSS file size...
-- **Intuitive** (aka the best docs are no docs)
-  - The simpler the naming convention, the easier it is to adopt and use (plus requires less docs to reference)
+// component-specific
+--bolt-card-spacing
+--bolt-button-bg--disabled: ...
+```
+---
 
-## Questions + Discussion Points:
-1. No more `rgba(var(--bolt-theme-primary), .5)` and instead favor `--bolt-theme-primary--transparent-50` or `--bolt-theme-primary--alpha-50` or something; basically transparency is part of our global tokens
-2. Retire `bolt-color(indigo, xlight)` and instead move to `bolt-color(indigo-500)`, `bolt-color(indigo-100)`, etc 
-   - alt. re-introduce (`light|lighter|lightest|dark|darker|darkest`)?
-   - Ex. `bolt-color(indigo, lightest)`
-3. Do we _REALLY_ need a `--default` suffix for UI that has multiple states?
-   - `--bolt-button--background-color` vs `--bolt-button--background-color--default`
-4. Do we _REALLY_ need to include `-color` suffix on everything?
-  - `--bolt-button--background` === `--bolt-button--background-color` acceptable shorthand?
-  - `--bolt-button--text` === `--bolt-button--text-color` acceptable shorthand?
-  - `--bolt-button--border` === `--bolt-button--border-color` acceptable shorthand?
-5. Sass tooling
-6. When, where, why, and how do we handle CSS custom prop fallbacks
-7. How do utility classes tie into all of this?
-8. How concise can we make are CSS custom property names?
+## Do's and Don'ts
+
+<div class="o-bolt-grid o-bolt-grid--flex">
+  <div class="o-bolt-grid__cell u-bolt-width-6/12">
+    <h3 style="color: green;">Use single dashes for everything but modifiers</h3>
 
 ```
+--bolt-link-text--disabled
+--bolt-button--raised
+--bolt-theme-primary
+```
+</code>
+  </div>
+  <div class="o-bolt-grid__cell u-bolt-width-6/12">
+    <h3 style="color: red;">Only use double-dashes for modifiers</h3>
+
+```
+--bolt--link--text--disabled
+--bolt--button--raised
+--bolt-theme--primary
+```
+</code>
+  </div>
+</div>
+
+
+<div class="o-bolt-grid o-bolt-grid--flex">
+  <div class="o-bolt-grid__cell u-bolt-width-6/12">
+    <h3 style="color: green;">Do use the full component name</h3>
+
+```
+--bolt-button-bg
+--bolt-band-spacing
+```
+</code>
+  </div>
+  <div class="o-bolt-grid__cell u-bolt-width-6/12">
+    <h3 style="color: red;">Don't use component nicknames</h3>
+
+```
+--bolt-btn-bg
+--bolt-feature-band-spacing
+```
+</code>
+  </div>
+</div>
+
+
+
+<div class="o-bolt-grid o-bolt-grid--flex">
+  <div class="o-bolt-grid__cell u-bolt-width-6/12">
+    <h3 style="color: green;">Do use shorter variable names</h3>
+
+```
+--bolt-button-bg         
+--bolt-button-shadow
+```
+</code>
+  </div>
+  <div class="o-bolt-grid__cell u-bolt-width-6/12">
+    <h3 style="color: red;">Don't use verbose names</h3>
+
+```
+--bolt-button-background
+--bolt-button-box-shadow
+```
+</code>
+  </div>
+</div>
+
+
+<div class="o-bolt-grid o-bolt-grid--flex">
+  <div class="o-bolt-grid__cell u-bolt-width-6/12">
+    <h3 style="color: green;">Use shorter t-shirt sizes</h3>
+
+```
+--bolt-band-spacing-xl
+--bolt-card-spacing-md
 --bolt-font-size-md
-// vs
---bolt-font-size-medium
+--bolt-shadow-lg
 ```
+</code>
+  </div>
+  <div class="o-bolt-grid__cell u-bolt-width-6/12">
+    <h3 style="color: red;">Don't use longhand t-shirt sizes</h3>
 
 ```
---bolt-shadow-lg
-// vs
+--bolt-band-spacing-xlarge
+--bolt-card-spacing-medium
+--bolt-font-size-medium
 --bolt-shadow-large
 ```
+</code>
+  </div>
+</div>
+
+
+<div class="o-bolt-grid o-bolt-grid--flex">
+  <div class="o-bolt-grid__cell u-bolt-width-6/12">
+    <h3 style="color: green;">Use `-X00` suffix (`-100` to `-900`) for items in a series</h3>
 
 ```
---bolt-button--bg
---bolt-button--bg-color
---bolt-button--background
---bolt-button--background-color
+--bolt-shadow-100
+--bolt-shadow-500
 ```
+</code>
+  </div>
+  <div class="o-bolt-grid__cell u-bolt-width-6/12">
+    <h3 style="color: red;">Don't use the `-X00` suffix in colors</h3>
+
+```
+--bolt-color-indigo-100
+--bolt-color-yellow-700
+```
+</code>
+  </div>
+</div>
 
 
-# References
 
-- https://www.duetds.com/tokens/
-- https://www.patternfly.org/v4/design-guidelines/styles/colors
-- https://github.com/castastrophe/wc-theming-standards/wiki/Proposed-variables
-- https://github.com/material-components/material-components-web/blob/master/docs/theming.md
+<div class="o-bolt-grid o-bolt-grid--flex">
+  <div class="o-bolt-grid__cell u-bolt-width-6/12">
+    <h3 style="color: green;">Use `lighter`, `lightest`, `darker`, `darkest`, for colors</h3>
 
-<hr>
+```
+--bolt-color-indigo-lightest
+--bolt-color-indigo-lighter
+--bolt-color-indigo-light
+--bolt-color-indigo
+--bolt-color-indigo-dark
+--bolt-color-indigo-darker
+--bolt-color-indigo-darkest
+```
+</code>
+  </div>
+  <div class="o-bolt-grid__cell u-bolt-width-6/12">
+    <h3 style="color: red;">Don't use the old t-shirt size syntax for colors</h3>
 
-<bolt-text font-size="xxxlarge" tag="h2" font-weight="semibold">
-## 1. Global Tokens
-</bolt-text>
+```
+--bolt-color-indigo-xxlight ❌
+--bolt-color-indigo-xlight  ❌
+--bolt-color-indigo-light   ✅
+--bolt-color-indigo         ✅
+--bolt-color-indigo-dark    ✅
+--bolt-color-indigo-xdark   ❌
+--bolt-color-indigo-xxdark  ❌
+```
+</code>
+  </div>
+</div>
+
+
+<div class="o-bolt-grid o-bolt-grid--flex">
+  <div class="o-bolt-grid__cell u-bolt-width-6/12">
+    <h3 style="color: green;">Always omit `color` in `--bolt-theme` vars</h3>
+
+```
+--bolt-theme-bg
+--bolt-theme-primary
+```
+</code>
+  </div>
+  <div class="o-bolt-grid__cell u-bolt-width-6/12">
+    <h3 style="color: red;">Don't include `color` in theme vars</h3>
+
+```
+--bolt-theme-bg-color
+--bolt-theme-primary-color
+```
+</code>
+  </div>
+</div>
+
+<div class="o-bolt-grid o-bolt-grid--flex">
+  <div class="o-bolt-grid__cell u-bolt-width-6/12">
+    <h3 style="color: green;">Do use `color` in global vars</h3>
+
+```
+--bolt-color-indigo
+--bolt-color-orange
+--bolt-color-yellow-dark
+```
+</code>
+  </div>
+  <div class="o-bolt-grid__cell u-bolt-width-6/12">
+    <h3 style="color: red;">Don't omit `color` in global vars</h3>
+
+```
+--bolt-indigo
+--bolt-orange
+--bolt-yellow-dark
+```
+</code>
+  </div>
+</div>
+
+---
+
+
+## Global Tokens
+- TLDR: Basically ITCSS `settings.scss` layer as flat static CSS custom property values
+- no double-dashes in any of the names beyond the `--bolt-` at the start of the variable; only single dashes.
+- not component or use-case specific
+- think of these as pure raw ingredients that can be used anywhere
 
 ### Syntax
 
@@ -85,148 +259,117 @@ hidden: false
 --bolt-[NAME]-[VALUE]-[OPTIONAL VARIANT]
 ```
 
-<bolt-text font-size="xlarge" tag="h3" font-weight="light" class="u-bolt-margin-bottom-none">
-### Notes:
-</bolt-text>
-
-- TLDR: Basically ITCSS `settings.scss` layer as flat static CSS custom property values
-- no double-dashes in any of the names beyond the `--bolt-` at the start of the variable; only single dashes.
-- not component or use-case specific
-- think of these as pure raw ingredients that can be used anywhere
+### Global Tokens Example
 
 ```
 --bolt-color-indigo
---bolt-spacing-large
+--bolt-spacing-lg
 --bolt-opacity-50
 ```
 
 
-### Mapping Global Tokens to ITCSS Settings
+### Mapping Global Tokens to ITCSS
 
 <bolt-table first-col-fixed-width>
 
 | Token           | CSS Custom Property Name |
 | ---             | ---                                                                     |
-| Border Radius   | `--bolt-border-radius-full`      <br> `--bolt-border-radius-small`      |
-| Breakpoints     | `--bolt-breakpoint-xxsmall`      <br> `--bolt-breakpoint-medium`        |
+| Border Radius   | `--bolt-border-radius-full`      <br> `--bolt-border-radius-sm`      |
+| Breakpoints     | `--bolt-breakpoint-xxs`      <br> `--bolt-breakpoint-md`        |
 | Colors          | `--bolt-color-indigo-xdark`      <br> `--bolt-color-red`                |
 | Font family     | `--bolt-font-family-heading`     <br> `--bolt-font-family-body`         |
-| Font size       | `--bolt-font-size-xsmall`        <br> `--bolt-font-size-medium`         |
-| Line height     | `--bolt-bolt-line-height-medium` <br> `--bolt-line-height-medium-tight` |
+| Font size       | `--bolt-font-size-xsmall`        <br> `--bolt-font-size-md`         |
+| Line height     | `--bolt-bolt-line-height-md` <br> `--bolt-line-height-md-tight` |
 | Font weight     | `--bolt-font-weight-light`       <br> `--bolt-font-weight-bold`         |
 | Transitions     | `--bolt-transition-fast`         <br> `--bolt-transition-slow`          |
 | Opacity         | `--bolt-opacity-20`              <br> `--bolt-opacity-50`               |
-| Spacing         | `--bolt-spacing-medium`          <br> `--bolt-vspacing-medium`          |
+| Spacing         | `--bolt-spacing-md`          <br> `--bolt-vspacing-md`          |
 | Shadows         | `--bolt-shadow-100`              <br> `--bolt-shadow-300`               |
 
 </bolt-table>
 
 > Note: we should consider renaming status colors to pure color names + move down to the context layer
 
-<hr>
+---
 
-<bolt-text font-size="xxxlarge" tag="h2" font-weight="semibold">
-  #2. Context-specific Tokens (Themes, Density, UI Types)
-</bolt-text>
+## Context-specific Tokens (Themes, Density, UI Types)
 
 - Theming system definitions (previously living in `settings`)
 - New `density` layer
-- Generic component defaults also live here (some previously in `global.scss`)
+- Generic component defaults could also live here (previously in `settings.global.scss`)
 
 > NOTE: As a rule of thumb: if 2 or more bits of UI should stay magically in sync, it might make sense to define that shared rule here.
 
 ### Syntax
 
-<bolt-code-snippet lang="css">
---bolt-[Context]--[SCOPE]--[PROP]--[MODIFIER]
+```
+--bolt-[Context]-[SCOPE]-[PROP]--[MODIFIER]
 /**
   * Context will likely be one of 3 things: 
   * - `theme`
   * - `density`
   * - `ui` (maybe...)
   */
-    --bolt-theme--[SCOPE]--[PROP]--[MODIFIER]  //--> color palette
-  --bolt-density--[SCOPE]--[PROP]--[MODIFIER] //--> spacing density
-       --bolt-ui--[SCOPE]--[PROP]--[MODIFIER] // --> UI defaults
+    --bolt-theme-[SCOPE]-[PROP]--[MODIFIER]  //--> color palette
+  --bolt-density-[SCOPE]-[PROP]--[MODIFIER] //--> spacing density
+       --bolt-ui-[SCOPE]-[PROP]--[MODIFIER] // --> UI defaults
 /**
   * Note: because themes ONLY affect color, putting `color` 
   * in the name shouldn't be necessary
   **/
---bolt-theme--background
---bolt-theme--border
---bolt-theme--text
---bolt-theme--icon
---bolt-theme--primary--bg-color
---bolt-theme--primary--bg-color--disabled
-</bolt-code-snippet>
+--bolt-theme-background
+--bolt-theme-border
+--bolt-theme-text
+--bolt-theme-icon
+--bolt-theme-primary
+--bolt-theme-primary--disabled
+```
 
-
-# Notes / Discussion Points
-
-- How do we handle surfaces / overlays in the context of themes (ex. Navbar dropdown within different themes)?
 
 ### Theming Examples
 
 ```
---bolt-theme--heading
---bolt-theme--text
---bolt-theme--background-color
---bolt-theme--background-gradient
---bolt-theme--border
+--bolt-theme-heading
+--bolt-theme-text
+--bolt-theme-background-color
+--bolt-theme-background-gradient
+--bolt-theme-border
 
---bolt-theme--primary--background-color
---bolt-theme--primary--background-color--hover
+--bolt-theme-primary-background-color
+--bolt-theme-primary-background-color--hover
 
---bolt-theme--primary--shadow
---bolt-theme--primary--shadow--raised
+--bolt-theme-primary-shadow
+--bolt-theme-primary-shadow--raised
 
---bolt-theme--secondary--text
---bolt-theme--secondary--text--disabled
---bolt-theme--tertiary--border-color
+--bolt-theme-secondary-text
+--bolt-theme-secondary-text--disabled
+--bolt-theme-tertiary-border-color
 
---bolt-theme--text-on-background
---bolt-theme--heading-on-background
---bolt-theme--text-on-primary
---bolt-theme--text-on-secondary
---bolt-theme--text-on-tertiary
+--bolt-theme-text-on-background
+--bolt-theme-heading-on-background
+--bolt-theme-text-on-primary
+--bolt-theme-text-on-secondary
+--bolt-theme-text-on-tertiary
 
-// --bolt-theme--surface?
-// --bolt-theme--overlay?
-// --bolt-theme--shadow?
+// --bolt-theme-surface?
+// --bolt-theme-overlay?
+// --bolt-theme-shadow?
 ```
 
-### Density Examples
+### Density Examples (TBD)
 
 ```
---bolt-density--spacing--xlarge
---bolt-density--vspacing--medium
---bolt-density--font-size--medium
---bolt-density--line-height--medium
-```
-
-### UI Examples?
-
-```
-// By type of thing and/or element
---bolt-ui--text--...
---bolt-ui--headings--...
---bolt-ui--h1--...
---bolt-ui--h6--...
-
-// By component type
---bolt-ui--overlays--...
---bolt-ui--dividers--...
---bolt-ui--input--...
+--bolt-density-spacing-xl
+--bolt-density-vspacing-md
+--bolt-density-font-size-md
+--bolt-density-line-height-md
 ```
 
 > NOTE: this UI-specific detail is one thing in still a little on the fence with... 
 
-<hr>
+---
 
-<bolt-text font-size="xxxlarge" tag="h2" font-weight="semibold">
-## 3. Component-specific Tokens (Buttons, Cards, etc)
-</bolt-text>
-
+## Component-specific Tokens (Buttons, Cards, etc)
 
 - doesn't have to be 1:1 to the component name
 - doesn't (and probably **shouldn't**) be required to map to a specific css property
@@ -235,37 +378,70 @@ hidden: false
 ### Syntax
 
 ```
---bolt-[COMPONENT-NAME]--[PURPOSE]--[STATE/MODIFIER]`
+--bolt-[COMPONENT-NAME]-[PURPOSE]--[STATE/MODIFIER]`
         ^- who            ^- what    ^- when / how
 
---bolt-button--bg-color--hover: ...
+--bolt-button-bg--hover: ...
 ```
 
-### Examples
+### Component-specific Examples
 
 ```css
 // ex. button vars
---bolt-button--bg-color: ...
---bolt-button--bg-color--hover: ...
---bolt-button--bg-color--active: ...
---bolt-button--bg-color--disabled: ..
---bolt-button--border-width
---bolt-button--border-color
+--bolt-button-bg: ...
+--bolt-button-bg--hover: ...
+--bolt-button-bg--active: ...
+--bolt-button-bg--disabled: ..
+--bolt-button-border-width
+--bolt-button-border-color
 
 // ex. icon vars
---bolt-icon--color:
---bolt-icon--bg-color:
---bolt-icon--bg-opacity:
---bolt-icon--size--medium:
---bolt-icon--size--large:
+--bolt-icon-color:
+--bolt-icon-bg:
+--bolt-icon-bg-opacity:
+--bolt-icon-size-md:
+--bolt-icon-size-lg:
 
 // ex. card vars
---bolt-card--shadow
---bolt-card--shadow--raised
---bolt-card--spacing
---bolt-card--spacing--large
---bolt-card--radius
---bolt-card--radius--large
---bolt-card--bg-color
+--bolt-card-shadow
+--bolt-card-shadow--raised
+--bolt-card-spacing
+--bolt-card-spacing--lg
+--bolt-card-radius
+--bolt-card-radius--lg
+--bolt-card-bg-color
 
 ```
+
+
+---
+
+## Things To Consider
+- **Verbosity** (the simpler, the better)
+  - We should try to favor using _shorter_ variable names instead of trying to match the CSS property being used. (discussion needed)
+- **Web Performance**
+  - Utility classes are the largest contributor to our large CSS file size. Auto-generated CSS custom prop values are probably the 2nd largest contributor to our large CSS file size...
+- **Intuitive** (aka the best docs are no docs)
+  - The simpler the naming convention, the easier it is to adopt and use (plus requires less docs to reference)
+
+## Implementation Details
+
+1. Switch to use Amazon's [Style Dictionary](https://github.com/amzn/style-dictionary) to auto-convert design tokens into the different formats required (including converting into Sass Maps...)
+   - These should most likely be defined as JSON (Style Dictionary's default) OR preferably as `.js` files (my personal preference + also supported by Style Dictionary)
+2. New Sass tooling + updates to existing Sass tooling required
+3. Our existing ITCSS `settings.global.scss` file goes away and gets broken out into other (new) settings / token files appropriately
+     - Most of our other existing ITCSS settings files should map out quite nicely
+4. ~Global vars only use single dashes. Context and component-specific vars use double-dashes after the `--bolt-[THING]` prefix~ Only use single dashes for custom prop names unless it's for a modifier at the end (ex. `--active`, `--raised`, or `--disabled`)
+
+---
+
+## Questions
+1. How do we handle surfaces / overlays in the context of themes (ex. Navbar dropdown within different themes)?
+2. When do we / don't include a default CSS custom property value?
+
+## References
+
+- https://www.duetds.com/tokens/
+- https://www.patternfly.org/v4/design-guidelines/styles/colors
+- https://github.com/castastrophe/wc-theming-standards/wiki/Proposed-variables
+- https://github.com/material-components/material-components-web/blob/master/docs/theming.md

--- a/docs-site/src/pages/docs/999-css-custom-props-spec/00-index.md
+++ b/docs-site/src/pages/docs/999-css-custom-props-spec/00-index.md
@@ -19,15 +19,15 @@ hidden: false
    - These should most likely be defined as JSON (Style Dictionary's default) OR preferably as `.js` files (my personal preference + also supported by Style Dictionary)
 2. New Sass tooling + updates to existing Sass tooling required
 3. Our existing ITCSS `settings.global.scss` file goes away and gets broken out into other (new) settings / token files appropriately
-  - Most of our other existing ITCSS settings files should map out quite nicely
+     - Most of our other existing ITCSS settings files should map out quite nicely
 4. Global vars only use single dashes. Context and component-specific vars use double-dashes after the `--bolt-[THING]` prefix
 
 ### Considerations:
-- **The simpler, the better** (Limiting Verbosity)
+- **Verbosity** (the simpler, the better)
   - We should try to favor using _shorter_ variable names instead of trying to match the CSS property being used. (discussion needed)
-- **Web performance**
+- **Web Performance**
   - Utility classes are the largest contributor to our large CSS file size. Auto-generated CSS custom prop values are probably the 2nd largest contributor to our large CSS file size...
-- **Best Docs Are No Docs**
+- **Intuitive** (aka the best docs are no docs)
   - The simpler the naming convention, the easier it is to adopt and use (plus requires less docs to reference)
 
 ## Questions + Discussion Points:
@@ -38,13 +38,13 @@ hidden: false
 3. Do we _REALLY_ need a `--default` suffix for UI that has multiple states?
    - `--bolt-button--background-color` vs `--bolt-button--background-color--default`
 4. Do we _REALLY_ need to include `-color` suffix on everything?
-  - `--bolt-btn--background` === `--bolt-btn--background-color` acceptable shorthand?
-  - `--bolt-btn--text` === `--bolt-btn--text-color` acceptable shorthand?
-  - `--bolt-button--border` === `--bolt-btn--border-color` acceptable shorthand?
+  - `--bolt-button--background` === `--bolt-button--background-color` acceptable shorthand?
+  - `--bolt-button--text` === `--bolt-button--text-color` acceptable shorthand?
+  - `--bolt-button--border` === `--bolt-button--border-color` acceptable shorthand?
 5. Sass tooling
 6. When, where, why, and how do we handle CSS custom prop fallbacks
-3. How do utility classes tie into all of this?
-
+7. How do utility classes tie into all of this?
+8. How concise can we make are CSS custom property names?
 
 ```
 --bolt-font-size-md
@@ -59,11 +59,6 @@ hidden: false
 ```
 
 ```
---bolt-btn--bg
---bolt-btn--bg-color
---bolt-btn--background
---bolt-btn--background-color
-
 --bolt-button--bg
 --bolt-button--bg-color
 --bolt-button--background
@@ -81,17 +76,17 @@ hidden: false
 <hr>
 
 <bolt-text font-size="xxxlarge" tag="h2" font-weight="semibold">
-  #1. Global Tokens
+## 1. Global Tokens
 </bolt-text>
 
-<bolt-text font-size="large" font-weight="bold" class="u-bolt-margin-bottom-none">
-  Syntax
-</bolt-text>
+### Syntax
 
-<bolt-code-snippet lang="html">--bolt-[NAME]-[VALUE]-[OPTIONAL VARIANT]</bolt-code-snippet>
+```
+--bolt-[NAME]-[VALUE]-[OPTIONAL VARIANT]
+```
 
 <bolt-text font-size="xlarge" tag="h3" font-weight="light" class="u-bolt-margin-bottom-none">
-  Notes:
+### Notes:
 </bolt-text>
 
 - TLDR: Basically ITCSS `settings.scss` layer as flat static CSS custom property values
@@ -229,7 +224,7 @@ hidden: false
 <hr>
 
 <bolt-text font-size="xxxlarge" tag="h2" font-weight="semibold">
-  #3. Component-specific Tokens (Buttons, Cards, etc)
+## 3. Component-specific Tokens (Buttons, Cards, etc)
 </bolt-text>
 
 
@@ -243,19 +238,19 @@ hidden: false
 --bolt-[COMPONENT-NAME]--[PURPOSE]--[STATE/MODIFIER]`
         ^- who            ^- what    ^- when / how
 
---bolt-btn--bg-color--hover: ...
+--bolt-button--bg-color--hover: ...
 ```
 
 ### Examples
 
 ```css
 // ex. button vars
---bolt-btn--bg-color: ...
---bolt-btn--bg-color--hover: ...
---bolt-btn--bg-color--active: ...
---bolt-btn--bg-color--disabled: ..
---bolt-btn--border-width
---bolt-btn--border-color
+--bolt-button--bg-color: ...
+--bolt-button--bg-color--hover: ...
+--bolt-button--bg-color--active: ...
+--bolt-button--bg-color--disabled: ..
+--bolt-button--border-width
+--bolt-button--border-color
 
 // ex. icon vars
 --bolt-icon--color:

--- a/docs-site/src/pages/docs/999-css-custom-props-spec/00-index.md
+++ b/docs-site/src/pages/docs/999-css-custom-props-spec/00-index.md
@@ -12,7 +12,7 @@ hidden: false
    - Most likely should be defined as JSON (Style Dictionary's default) OR as `.js` files (my personal preference)
 2. We have 3 tiers of tokens
    - **#1. Global tokens** (pure values)
-   - **#2. Category-specific** tokens (opinionated defaults shared across multiple things)
+   - **#2. Context-specific** tokens (opinionated defaults shared across multiple things)
    - **#3. Component-specific** tokens (tokens just for buttons, just for links, etc)
 3. Our existing ITCSS `settings.global.scss` file needs to go away -- break some of these out into other settings / tokens appropriately
 4. Most other existing ITCSS settings files map out fairly nicely 
@@ -207,6 +207,7 @@ hidden: false
 <bolt-code-snippet lang="css" class="u-bolt-negative-margin-bottom-medium u-bolt-block">--bolt-shadow-100
 --bolt-shadow-300
 --bolt-shadow-500
+--bolt-shadow-500
 --bolt-shadow-900
 </bolt-code-snippet>
       </td>
@@ -227,61 +228,71 @@ hidden: false
 
 
 
+<hr>
 
-## Opacity
+<bolt-text font-size="xxxlarge" tag="h2" font-weight="semibold">
+  #2. Context-specific Tokens (Themes, Density, UI Types)
+</bolt-text>
 
-
-## Shadows
-
-
-
-
+> As a rule of thumb: if 2 or more bits of UI should stay magically in sync, it might make sense to define that shared rule here.
 
 
-# Tier 2: Prop Values Affected By Context
+<bolt-text font-size="large" font-weight="bold" class="u-bolt-margin-bottom-none">
+  Syntax
+</bolt-text>
 
-Theme
-Density
-UI
-
-Rule of thumb: if 2 or more pieces of UI need to stay magically in sync, you probably want a definition here.
-
-
+<bolt-code-snippet lang="css">
 --bolt-[Context]--[SCOPE]--[PROP]--[MODIFIER]
-    --bolt-theme--[SCOPE]--[PROP]--[MODIFIER]  --> color palette
-  --bolt-density--[SCOPE]--[PROP]--[MODIFIER] --> spacing density
-       --bolt-ui--[SCOPE]--[PROP]--[MODIFIER] --> UI defaults
-
-
-
-Themes ONLY affect color so putting color in the name isn't necessary
+/**
+  * Context will likely be one of 3 things: 
+  * - `theme`
+  * - `density`
+  * - `ui` (maybe...)
+  */
+    --bolt-theme--[SCOPE]--[PROP]--[MODIFIER]  //--> color palette
+  --bolt-density--[SCOPE]--[PROP]--[MODIFIER] //--> spacing density
+       --bolt-ui--[SCOPE]--[PROP]--[MODIFIER] // --> UI defaults
+/**
+  * Note: because themes ONLY affect color, putting `color` 
+  * in the name shouldn't be necessary
+  **/
 --bolt-theme--background
 --bolt-theme--border
 --bolt-theme--text
 --bolt-theme--icon
 --bolt-theme--primary--bg-color
 --bolt-theme--primary--bg-color--disabled
+</bolt-code-snippet>
 
 
 
-
-// by hierchy
+<bolt-text font-size="large" font-weight="bold" class="u-bolt-margin-bottom-none">
+  By Hierarchy
+</bolt-text>
+<bolt-code-snippet lang="css">
 --bolt-...--primary--...
 --bolt-...--secondary--...
 --bolt-...--tertiary--...
+<bolt-code-snippet>
 
-// by type of thing and/or element
+<bolt-text font-size="large" font-weight="bold" class="u-bolt-margin-bottom-none">
+  By type of thing and/or element
+</bolt-text>
+<bolt-code-snippet lang="css">
 --bolt-...--text--...
 --bolt-...--headings--...
 --bolt-...--h1--...
 --bolt-...--h6--...
+<bolt-code-snippet>
 
+<bolt-text font-size="large" font-weight="bold" class="u-bolt-margin-bottom-none">
+  By component type
+</bolt-text>
+<bolt-code-snippet lang="css">
 --bolt-...--overlays--...
 --bolt-...--dividers--...
-
 --bolt-...--input--...
-
-
+<bolt-code-snippet>
 
 
 

--- a/docs-site/src/pages/docs/999-css-custom-props-spec/00-index.md
+++ b/docs-site/src/pages/docs/999-css-custom-props-spec/00-index.md
@@ -1,0 +1,700 @@
+---
+title: Bolt CSS Custom Props Spec (Draft)
+category: Architecture
+hidden: false
+---
+
+<bolt-text font-size="large" font-weight="bold" class="u-bolt-margin-bottom-none">
+  Notes / Discussion Points
+</bolt-text>
+
+1. Switch to use Amazon's [Style Dictionary](https://github.com/amzn/style-dictionary) to auto-convert design tokens into the different formats required (including converting into Sass Maps...)
+   - Most likely should be defined as JSON (Style Dictionary's default) OR as `.js` files (my personal preference)
+2. We have 3 tiers of tokens
+   - **#1. Global tokens** (pure values)
+   - **#2. Category-specific** tokens (opinionated defaults shared across multiple things)
+   - **#3. Component-specific** tokens (tokens just for buttons, just for links, etc)
+3. Our existing ITCSS `settings.global.scss` file needs to go away -- break some of these out into other settings / tokens appropriately
+4. Most other existing ITCSS settings files map out fairly nicely 
+5. We should really try to favor using shorter variable names instead of trying to match the CSS property being used.
+
+```
+// example of "shorthand" font sizes
+--bolt-font-size-md
+--bolt-font-size-lg
+--bolt-font-size-xxl
+
+// vs. 
+
+--bolt-font-size-medium
+--bolt-font-size-large
+--bolt-font-size-xxlarge
+```
+
+
+# references
+- https://www.duetds.com/tokens/
+- https://www.patternfly.org/v4/design-guidelines/styles/colors
+- https://github.com/castastrophe/wc-theming-standards/wiki/Proposed-variables
+- https://github.com/material-components/material-components-web/blob/master/docs/theming.md
+
+<hr>
+
+<bolt-text font-size="xxxlarge" tag="h2" font-weight="semibold">
+  #1. Global Tokens
+</bolt-text>
+
+<bolt-text font-size="large" font-weight="bold" class="u-bolt-margin-bottom-none">
+  Syntax
+</bolt-text>
+
+<bolt-code-snippet lang="html">--bolt-[NAME]-[VALUE]-[OPTIONAL VARIANT]</bolt-code-snippet>
+
+<bolt-text font-size="xlarge" tag="h3" font-weight="light" class="u-bolt-margin-bottom-none">
+  Notes:
+</bolt-text>
+
+- no double-dashes in any of the names beyond the `--bolt-` at the start of the variable
+- not component or use-case specific
+- think of these as pure raw ingredients that can be used anywhere 
+
+
+
+<bolt-table first-col-fixed-width>
+<table>
+  <thead>
+    <tr>
+      <th scope="col">Type of Token</th>
+      <th scope="col">CSS Custom Property Name</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Border Radius</td>
+      <td>
+<bolt-code-snippet lang="css" class="u-bolt-negative-margin-bottom-medium u-bolt-block">--bolt-border-radius-full
+--bolt-border-radius-small
+--bolt-border-radius-default
+--bolt-border-radius-none
+</bolt-code-snippet>
+      </td>
+    </tr>
+    <tr>
+      <td>Breakpoints</td>
+      <td>
+<bolt-code-snippet lang="css" class="u-bolt-negative-margin-bottom-medium u-bolt-block">--bolt-breakpoint-xxsmall
+--bolt-breakpoint-medium
+...
+--bolt-breakpoint-xxlarge
+</bolt-code-snippet>
+      </td>
+    </tr>
+    <tr>
+      <td>Colors</td>
+      <td>
+<bolt-code-snippet lang="css" class="u-bolt-negative-margin-bottom-medium u-bolt-block">--bolt-color-indigo-xdark
+--bolt-color-indigo
+--bolt-color-red
+--bolt-color-blue-dark
+</bolt-code-snippet>
+
+<br>
+> Note: we might want to consider renaming our existing status colors at this level and redefine at a lower level
+      </td>
+    </tr>
+    <tr>
+      <td>Font Family</td>
+      <td>
+<bolt-code-snippet lang="css" class="u-bolt-negative-margin-bottom-medium u-bolt-block">--bolt-font-family-heading
+--bolt-font-family-body
+--bolt-font-family-code
+</bolt-code-snippet>
+<br>
+> Note: nix font-family-bodySubset
+      </td>
+    </tr>
+    <tr>
+      <td>Font Size</td>
+      <td>
+<bolt-code-snippet lang="css" class="u-bolt-negative-margin-bottom-medium u-bolt-block">--bolt-font-size-xsmall
+--bolt-font-size-medium
+--bolt-font-size-xxlarge
+</bolt-code-snippet>
+      </td>
+    </tr>
+    <tr>
+      <td>Font Family</td>
+      <td>
+<bolt-code-snippet lang="css" class="u-bolt-negative-margin-bottom-medium u-bolt-block">--bolt-font-family-heading
+--bolt-font-family-body
+--bolt-font-family-code
+</bolt-code-snippet>
+<br>
+> Note: nix font-family-bodySubset
+      </td>
+    </tr>
+    <tr>
+      <td>Line height</td>
+      <td>
+<bolt-code-snippet lang="css" class="u-bolt-negative-margin-bottom-medium u-bolt-block">--bolt-line-height-medium    // default for medium fonts
+--bolt-line-height-medium-tight         // tighter line-height for medium-sized fonts
+--bolt-line-height-medium-loose         //  looser line-height for large-sized fonts
+...
+--bolt-line-height-large
+...
+</bolt-code-snippet>
+      </td>
+    </tr>
+    <tr>
+      <td>Font Weights</td>
+      <td>
+<bolt-code-snippet lang="css" class="u-bolt-negative-margin-bottom-medium u-bolt-block">--bolt-font-weight-light
+--bolt-font-weight-regular
+--bolt-font-weight-semibold
+--bolt-font-weight-bold
+--bolt-font-weight-extrabold
+</bolt-code-snippet>
+      </td>
+    </tr>
+    <tr>
+      <td>Font Weights</td>
+      <td>
+<bolt-code-snippet lang="css" class="u-bolt-negative-margin-bottom-medium u-bolt-block">--bolt-font-weight-light
+--bolt-font-weight-regular
+--bolt-font-weight-semibold
+--bolt-font-weight-bold
+--bolt-font-weight-extrabold
+</bolt-code-snippet>
+      </td>
+    </tr>
+    <tr>
+      <td>Transitions</td>
+      <td>
+<bolt-code-snippet lang="css" class="u-bolt-negative-margin-bottom-medium u-bolt-block">--bolt-transition-fast
+--bolt-transition-slow
+</bolt-code-snippet>
+      </td>
+    </tr>
+    <tr>
+      <td>Opacity</td>
+      <td>
+<bolt-code-snippet lang="css" class="u-bolt-negative-margin-bottom-medium u-bolt-block">--bolt-opacity-0
+--bolt-opacity-20
+--bolt-opacity-40
+--bolt-opacity-50
+--bolt-opacity-80
+--bolt-opacity-100
+// ... etc
+</bolt-code-snippet>
+      </td>
+    </tr>
+    <tr>
+      <td>Spacing</td>
+      <td>
+<bolt-code-snippet lang="css" class="u-bolt-negative-margin-bottom-medium u-bolt-block">// horizontal spacing
+--bolt-spacing-medium
+--bolt-spacing-medium-squished
+--bolt-spacing-medium-stretched
+...
+// v-spacing
+--bolt-vspacing-medium
+</bolt-code-snippet>
+      </td>
+    </tr>
+    <tr>
+      <td>Shadows</td>
+      <td>
+<bolt-code-snippet lang="css" class="u-bolt-negative-margin-bottom-medium u-bolt-block">--bolt-shadow-100
+--bolt-shadow-300
+--bolt-shadow-500
+--bolt-shadow-900
+</bolt-code-snippet>
+      </td>
+    </tr>
+  </tbody>
+</table>
+</bolt-table>
+
+
+<!--
+--bolt-color-warning
+--bolt-color-warning-light
+--bolt-color-succes
+-->
+
+
+
+
+
+
+
+## Opacity
+
+
+## Shadows
+
+
+
+
+
+
+# Tier 2: Prop Values Affected By Context
+
+Theme
+Density
+UI
+
+Rule of thumb: if 2 or more pieces of UI need to stay magically in sync, you probably want a definition here.
+
+
+--bolt-[Context]--[SCOPE]--[PROP]--[MODIFIER]
+    --bolt-theme--[SCOPE]--[PROP]--[MODIFIER]  --> color palette
+  --bolt-density--[SCOPE]--[PROP]--[MODIFIER] --> spacing density
+       --bolt-ui--[SCOPE]--[PROP]--[MODIFIER] --> UI defaults
+
+
+
+Themes ONLY affect color so putting color in the name isn't necessary
+--bolt-theme--background
+--bolt-theme--border
+--bolt-theme--text
+--bolt-theme--icon
+--bolt-theme--primary--bg-color
+--bolt-theme--primary--bg-color--disabled
+
+
+
+
+// by hierchy
+--bolt-...--primary--...
+--bolt-...--secondary--...
+--bolt-...--tertiary--...
+
+// by type of thing and/or element
+--bolt-...--text--...
+--bolt-...--headings--...
+--bolt-...--h1--...
+--bolt-...--h6--...
+
+--bolt-...--overlays--...
+--bolt-...--dividers--...
+
+--bolt-...--input--...
+
+
+
+
+
+--bolt-ui--primary--bg-color
+--bolt-ui--primary--bg-color--hover
+--bolt-ui--primary--bg-color--active
+--bolt-ui--secondary--bg-color
+--bolt-ui--tertiary--bg-color
+--bolt-ui--input--border-color--disabled
+
+
+--bolt-ui--input--border-color--disabled
+
+--bolt-ui--divider--border-color
+
+
+--bolt-ui--dropdown--bg-color
+
+
+- Status colors
+- Interactive UI with Hierchy (Primary, Secondary, Tertiary)
+- Themed UI
+
+Basically if you want all of X type of UI to use Y styles, this is where those definitions live.
+
+
+
+Themes are still color only:
+
+--bolt-theme--dark--background
+--bolt-theme--light--background
+--bolt-theme--orange--background
+--bolt-theme--purple--background
+
+--bolt-theme--teal--background-gradient
+--bolt-theme--teal--background-gradient
+
+--bolt-theme--teal--text-on-background
+--bolt-theme--teal--text-on-background
+--bolt-theme--teal--heading-on-background
+
+--bolt-theme--teal--primary-on-background
+
+--bolt-theme--teal--primary
+--bolt-theme--teal--text-on-primary
+
+
+
+
+
+--bolt-theme--background
+--bolt-theme--background-gradient
+--bolt-theme--text-on-background
+--bolt-theme--heading-on-background
+
+
+--bolt-theme--primary-ui--bg-color
+--bolt-theme--primary-ui--bg-color--hover
+--bolt-theme--primary-ui--bg-color--disabled
+--bolt-theme--primary-ui--text-color--disabled
+
+
+
+
+--bolt-theme--primary--background
+--bolt-theme--primary--background--hover
+--bolt-theme--primary--background--hover
+
+--bolt-theme--secondary
+--bolt-theme--tertiary
+--bolt-theme--primary
+
+
+--bolt-theme--primary-on-background
+--bolt-theme--secondary-on-background
+
+--bolt-theme--background
+
+
+States:
+info
+error
+warning
+success
+
+
+--bolt-ui--container--bg-color--indigo-dark
+--bolt-ui--container--bg-color--teal
+
+--bolt-theme--teal--background
+--bolt-theme--teal--text-on-background
+--bolt-theme--teal--heading-on-background
+--bolt-theme--teal--primary-on-background
+--bolt-theme--teal--secondary-on-background
+
+--bolt-theme--text-on--teal
+--bolt-theme-teal
+
+
+--bolt-ui--container--bg-color--indigo-dark
+
+
+
+--bolt-ui--primary--bg-color:
+--bolt-ui--primary--bg-color--active
+--bolt-ui--primary--bg-color--disabled
+
+--bolt-ui--secondary--bg-color:
+--bolt-ui--secondary--bg-color--hover
+--bolt-ui--secondary--bg-color--focus
+--bolt-ui--secondary--bg-color--active
+--bolt-ui--secondary--bg-color--disabled
+
+
+
+--bolt-ui--success
+
+
+--bolt-ui--success--text-color:
+--bolt-ui--success--bg-color:
+
+
+--bolt-ui--primary-interactive--border-width:
+--bolt-ui--primary-interactive--border-color:
+--bolt-ui--primary-interactive--bg-color:
+
+--bolt-ui--primary-interactive--bg-color--disabled
+--bolt-ui--primary-interactive--text-color--disabled
+
+
+
+
+
+
+--bolt-opacity-30
+--bolt-opacity-50
+--bolt-opacity-85
+--bolt-opacity-100
+
+
+
+# Types of CSS Custom Properties
+
+## Tier 1: Global DS Definitions
+
+```css
+--bolt-global--color--indigo
+--bolt-global--color--indigo-base
+
+--bolt-global--color--indigo-dark
+--bolt-global--color--indigo-dark--transparent-100
+
+
+
+--bolt-global--spacing--xsmall
+--bolt-global--spacing--medium-squished
+--bolt-global--spacing--medium-stretched
+--bolt-global--spacing--medium
+
+
+// always transparent = --[OPACITY] (> 99 and < 1000)
+--bolt-global--opacity--500
+```
+
+
+## Tier 2: Design Tokens (which use Global Definitions)
+
+
+```css
+--bolt-global--divider--background
+
+
+
+
+
+--bolt-global--font-family--sans
+
+
+
+
+--bolt-ui--primary
+--bolt-ui--primary--background-color
+--bolt-ui--primary--background-color--disabled
+
+--bolt-ui--secondary
+--bolt-ui--secondary--text-color
+--bolt-ui--secondary--shadow
+
+
+--bolt-ui--tertiary--background-color
+--bolt-ui--tertiary--text-color
+--bolt-ui--tertiary--text-color--active
+
+
+--bolt-ui--surface
+
+
+--bolt-ui--input--padding--medium
+--bolt-ui--input--padding--small
+
+--bolt-ui--h1
+--bolt-ui--h5
+--bolt-ui--title
+--bolt-ui--subtitle
+--bolt-ui--eyebrow--text-color
+--bolt-ui--eyebrow--font-size
+--bolt-ui--divider
+--bolt-ui--divider--subtle
+
+
+
+
+--bolt-tokens--input--border-color
+--bolt-tokens--input--border-color--disabled
+
+--bolt-tokens--primary-ui--background:        --bolt-color--indigo-default--500
+--bolt-tokens--primary-ui--text--active:        bolt-color(indigo, default, 0.5);
+
+
+--bolt-tokens--text-on-primary:        bolt-color(indigo, dark, 0.5);
+--bolt-tokens--primary-ui--background: bolt-color(indigo, dark, 0.5);
+
+
+--bolt-tokens--warning:
+--bolt-tokens--text-on-warning:
+
+
+--bolt-tokens--text-h1--font-size:
+--bolt-tokens--text-h6--line-height:
+
+
+--bolt-tokens--border-color--default
+--bolt-tokens--border-color--focus
+--bolt-tokens--border-color--active
+```
+
+
+## Tier 3: Design Tokens (which use Global Definitions)
+
+// component-specific vars:
+  - doesn't have to be 1:1 to the component name
+  - doesn't (and probably shouldn't) have to map to a specific css property
+  - the shorter, the better
+  - use `--bolt-[COMPONENT-NAME]--[PURPOSE]--[OPTIONAL-STATE]` format
+
+```css
+--bolt-btn--bg-color
+--bolt-btn--bg-color--hover
+--bolt-btn--bg-color--active
+--bolt-btn--bg-color--disabled
+
+
+--bolt-btn--font-size
+--bolt-btn--text-color--focus
+
+
+--bolt-btn--text-color
+--bolt-btn--shadow-color
+
+
+--bolt-btn--border-width
+--bolt-btn--icon-color
+
+
+
+
+
+--bolt--color--indigo-light
+--bolt--color--indigo
+--bolt--color--indigo-dark
+--bolt--color--indigo-xdark
+
+
+--bolt-global--color--indigo-100
+
+
+--bolt-global--spacing--xlarge
+
+
+
+--bolt-global--background-color--teal
+--bolt-global--background-color--light
+--bolt-global--background-color--dark
+
+
+
+--bolt-input--border-color
+--bolt-input--border-color--focus
+--bolt-input--background-color--error
+background-color--input
+
+
+--bolt-theme--primary-bg
+--botl-theme--primary-bg--hover
+
+
+bolt-theme--background
+bolt-theme--interactive--primary
+
+
+bolt-theme--shadow--primary
+
+
+//
+--bolt-theme--background
+--bolt-theme--primary
+--bolt-theme--primary--hover
+
+
+--bolt-theme--border
+--bolt-theme--border-dark
+--bolt-theme--border-light
+
+--bolt-theme--text-on-primary
+--bolt-theme--text-on-background
+
+--bolt-global--spacing-
+
+
+--botl-theme--text-on-primary-bg
+
+--botl-theme--primary-text--hover
+
+--botl-theme--dark-text--hover
+
+
+--bolt--color--indigo--transparent-900
+--bolt--color--indigo--transparent-500
+--bolt--color--indigo--transparent-100
+
+
+
+--bolt--color--orange
+--bolt--color--black
+--bolt--color--white
+
+
+--bolt--color--warning
+
+
+
+--bolt--color--primary--default
+--bolt--color--primary--hover
+--bolt--color--primary--hover
+
+
+
+// values
+--bolt-color-success-default
+--bolt-color-success-hover
+--bolt-color-success-active
+
+
+--bolt-color-success-transparent-100
+
+
+
+
+
+--bolt--colors--indigo-xdark
+--bolt--spacing--large
+--bolt--spacing--large-squished
+
+
+
+
+// tokens
+
+--bolt-global--primary-bg--hover
+--bolt-global--primary-bg--hover
+
+
+--bolt-global--link--color--hover
+--bolt-global--link--color--hover
+
+
+--bolt-global--link--color--hover
+
+
+//
+--button--bg:
+
+
+--bolt--
+
+
+
+--bolt--color--indigo
+--bolt--color--indigo-dark
+--bolt--color--indigo-light
+
+
+--bolt--spacing--xxs
+--bolt--spacing--xs
+--bolt--spacing--sm
+--bolt--spacing--md
+--bolt--spacing--lg
+--bolt--spacing--xl
+--bolt--spacing--xxl
+
+--bolt--shadow--50
+
+
+--bolt--font-size--md
+--bolt--font-size--lg
+
+--bolt--font-family--serif
+
+
+--bolt--opacity--60
+
+
+
+
+
+```

--- a/docs-site/src/pages/docs/999-css-custom-props-spec/00-index.md
+++ b/docs-site/src/pages/docs/999-css-custom-props-spec/00-index.md
@@ -5,34 +5,47 @@ hidden: false
 ---
 
 <bolt-text font-size="large" font-weight="bold" class="u-bolt-margin-bottom-none">
-  Notes / Discussion Points
+  Recommendations + Notes:
 </bolt-text>
 
 1. Switch to use Amazon's [Style Dictionary](https://github.com/amzn/style-dictionary) to auto-convert design tokens into the different formats required (including converting into Sass Maps...)
-   - Most likely should be defined as JSON (Style Dictionary's default) OR as `.js` files (my personal preference)
+   - These should most likely should be defined as JSON (Style Dictionary's default) OR preferably as `.js` files (my personal preference + also supported by Style Dictionary)
 2. We have 3 tiers of tokens
    - **#1. Global tokens** (pure values)
    - **#2. Context-specific** tokens (opinionated defaults shared across multiple things)
-   - **#3. Component-specific** tokens (tokens just for buttons, just for links, etc)
+   - **#3. Component-specific** tokens (tokens for specific components like buttons, links, etc)
 3. Our existing ITCSS `settings.global.scss` file needs to go away -- break some of these out into other settings / tokens appropriately
-4. Most other existing ITCSS settings files map out fairly nicely 
-5. We should really try to favor using shorter variable names instead of trying to match the CSS property being used.
+  - Most of our other existing ITCSS settings files should map out quite nicely
+4. We should try to favor using _shorter_ variable names instead of trying to match the CSS property being used. (discussion needed)
+
+`--bolt-font-size-md` vs `--bolt-font-size-medium` <br>
+`--bolt-shadow-lg` vs `--bolt-box-shadow-large` <br>
+`--bolt--btn--bg-color` vs `--bolt--button--background-color` <br>
+
+5. `--default` suffix for UI with multiple states is optional?
+6. Global vars only use single dashes. Context and component-specific vars use double-dashes
+
 
 ```
-// example of "shorthand" font sizes
---bolt-font-size-md
---bolt-font-size-lg
---bolt-font-size-xxl
+// Global
+--bolt-color-indigo: ...
 
-// vs. 
+// Context-specific
+--bolt--theme--text-color: ...
+--bolt--density--spacing--medium: ...
+--bolt--density--spacing--medium-squished: ...
 
---bolt-font-size-medium
---bolt-font-size-large
---bolt-font-size-xxlarge
+// Component-specific
+--bolt--button--color: ...
+--bolt--button--text-color--default: ... // same as previous line?
+
+--bolt--button--bg-color--hover: ...
+--bolt--button--bg-color--active: ...
+--bolt--button--bg-color--disabled: ...
 ```
-
 
 # references
+
 - https://www.duetds.com/tokens/
 - https://www.patternfly.org/v4/design-guidelines/styles/colors
 - https://github.com/castastrophe/wc-theming-standards/wiki/Proposed-variables
@@ -54,11 +67,13 @@ hidden: false
   Notes:
 </bolt-text>
 
-- no double-dashes in any of the names beyond the `--bolt-` at the start of the variable
+- TLDR: Basically ITCSS `settings.scss` layer as flat static CSS custom property values
+- no double-dashes in any of the names beyond the `--bolt-` at the start of the variable; only single dashes.
 - not component or use-case specific
-- think of these as pure raw ingredients that can be used anywhere 
+- think of these as pure raw ingredients that can be used anywhere
 
-
+<details>
+  <summary>Global Token Examples</summary>
 
 <bolt-table first-col-fixed-width>
 <table>
@@ -72,150 +87,161 @@ hidden: false
     <tr>
       <td>Border Radius</td>
       <td>
-<bolt-code-snippet lang="css" class="u-bolt-negative-margin-bottom-medium u-bolt-block">--bolt-border-radius-full
+
+```
+--bolt-border-radius-full
 --bolt-border-radius-small
 --bolt-border-radius-default
 --bolt-border-radius-none
-</bolt-code-snippet>
-      </td>
+```
+</td>
     </tr>
     <tr>
       <td>Breakpoints</td>
       <td>
-<bolt-code-snippet lang="css" class="u-bolt-negative-margin-bottom-medium u-bolt-block">--bolt-breakpoint-xxsmall
+
+```
+--bolt-breakpoint-xxsmall
 --bolt-breakpoint-medium
 ...
 --bolt-breakpoint-xxlarge
-</bolt-code-snippet>
-      </td>
+```
+</td>
     </tr>
     <tr>
       <td>Colors</td>
-      <td>
-<bolt-code-snippet lang="css" class="u-bolt-negative-margin-bottom-medium u-bolt-block">--bolt-color-indigo-xdark
+<td>
+
+```
+--bolt-color-indigo-xdark
 --bolt-color-indigo
 --bolt-color-red
 --bolt-color-blue-dark
-</bolt-code-snippet>
-
+```
 <br>
 > Note: we might want to consider renaming our existing status colors at this level and redefine at a lower level
-      </td>
+</td>
     </tr>
     <tr>
       <td>Font Family</td>
-      <td>
-<bolt-code-snippet lang="css" class="u-bolt-negative-margin-bottom-medium u-bolt-block">--bolt-font-family-heading
+<td>
+
+```
+--bolt-font-family-heading
 --bolt-font-family-body
 --bolt-font-family-code
-</bolt-code-snippet>
+```
 <br>
 > Note: nix font-family-bodySubset
-      </td>
+</td>
     </tr>
     <tr>
       <td>Font Size</td>
-      <td>
-<bolt-code-snippet lang="css" class="u-bolt-negative-margin-bottom-medium u-bolt-block">--bolt-font-size-xsmall
+<td>
+
+```
+--bolt-font-size-xsmall
 --bolt-font-size-medium
 --bolt-font-size-xxlarge
-</bolt-code-snippet>
-      </td>
+```
+</td>
     </tr>
     <tr>
       <td>Font Family</td>
-      <td>
-<bolt-code-snippet lang="css" class="u-bolt-negative-margin-bottom-medium u-bolt-block">--bolt-font-family-heading
+<td>
+
+```
+--bolt-font-family-heading
 --bolt-font-family-body
 --bolt-font-family-code
-</bolt-code-snippet>
+```
 <br>
 > Note: nix font-family-bodySubset
-      </td>
+</td>
     </tr>
     <tr>
       <td>Line height</td>
-      <td>
-<bolt-code-snippet lang="css" class="u-bolt-negative-margin-bottom-medium u-bolt-block">--bolt-line-height-medium    // default for medium fonts
+<td>
+
+```
+--bolt-line-height-medium    // default for medium fonts
 --bolt-line-height-medium-tight         // tighter line-height for medium-sized fonts
 --bolt-line-height-medium-loose         //  looser line-height for large-sized fonts
 ...
 --bolt-line-height-large
-...
-</bolt-code-snippet>
-      </td>
+```
+</td>
     </tr>
     <tr>
       <td>Font Weights</td>
-      <td>
-<bolt-code-snippet lang="css" class="u-bolt-negative-margin-bottom-medium u-bolt-block">--bolt-font-weight-light
+<td>
+
+```
+--bolt-font-weight-light
 --bolt-font-weight-regular
 --bolt-font-weight-semibold
 --bolt-font-weight-bold
 --bolt-font-weight-extrabold
-</bolt-code-snippet>
-      </td>
-    </tr>
-    <tr>
-      <td>Font Weights</td>
-      <td>
-<bolt-code-snippet lang="css" class="u-bolt-negative-margin-bottom-medium u-bolt-block">--bolt-font-weight-light
---bolt-font-weight-regular
---bolt-font-weight-semibold
---bolt-font-weight-bold
---bolt-font-weight-extrabold
-</bolt-code-snippet>
-      </td>
-    </tr>
-    <tr>
-      <td>Transitions</td>
-      <td>
-<bolt-code-snippet lang="css" class="u-bolt-negative-margin-bottom-medium u-bolt-block">--bolt-transition-fast
+```
+</td>
+</tr>
+
+<tr>
+<td>Transitions</td>
+<td>
+
+```
+--bolt-transition-fast
 --bolt-transition-slow
-</bolt-code-snippet>
-      </td>
+```
+</td>
     </tr>
     <tr>
       <td>Opacity</td>
-      <td>
-<bolt-code-snippet lang="css" class="u-bolt-negative-margin-bottom-medium u-bolt-block">--bolt-opacity-0
+<td>
+
+```
+--bolt-opacity-0
 --bolt-opacity-20
 --bolt-opacity-40
 --bolt-opacity-50
 --bolt-opacity-80
 --bolt-opacity-100
 // ... etc
-</bolt-code-snippet>
-      </td>
+```
+</td>
     </tr>
     <tr>
       <td>Spacing</td>
-      <td>
-<bolt-code-snippet lang="css" class="u-bolt-negative-margin-bottom-medium u-bolt-block">// horizontal spacing
+<td>
+
+```
+// horizontal spacing
 --bolt-spacing-medium
 --bolt-spacing-medium-squished
 --bolt-spacing-medium-stretched
 ...
 // v-spacing
 --bolt-vspacing-medium
-</bolt-code-snippet>
-      </td>
-    </tr>
-    <tr>
-      <td>Shadows</td>
-      <td>
-<bolt-code-snippet lang="css" class="u-bolt-negative-margin-bottom-medium u-bolt-block">--bolt-shadow-100
+```
+</td>
+</tr>
+<tr>
+  <td>Shadows</td>
+  <td>
+
+```
+--bolt-shadow-100
 --bolt-shadow-300
 --bolt-shadow-500
 --bolt-shadow-500
 --bolt-shadow-900
-</bolt-code-snippet>
-      </td>
-    </tr>
-  </tbody>
+```
+  </td>
+</tr>
+</tbody>
 </table>
 </bolt-table>
-
 
 <!--
 --bolt-color-warning
@@ -223,9 +249,7 @@ hidden: false
 --bolt-color-succes
 -->
 
-
-
-
+</details>
 
 
 <hr>
@@ -234,8 +258,11 @@ hidden: false
   #2. Context-specific Tokens (Themes, Density, UI Types)
 </bolt-text>
 
-> As a rule of thumb: if 2 or more bits of UI should stay magically in sync, it might make sense to define that shared rule here.
+- Theming system definitions (previously living in `settings`)
+- New `density` layer
+- Generic component defaults also live here (some previously in `global.scss`)
 
+> NOTE: As a rule of thumb: if 2 or more bits of UI should stay magically in sync, it might make sense to define that shared rule here.
 
 <bolt-text font-size="large" font-weight="bold" class="u-bolt-margin-bottom-none">
   Syntax
@@ -265,447 +292,123 @@ hidden: false
 </bolt-code-snippet>
 
 
+# Notes / Discussion Points
 
-<bolt-text font-size="large" font-weight="bold" class="u-bolt-margin-bottom-none">
-  By Hierarchy
-</bolt-text>
-<bolt-code-snippet lang="css">
---bolt-...--primary--...
---bolt-...--secondary--...
---bolt-...--tertiary--...
-<bolt-code-snippet>
+- How do we handle surfaces / overlays over themes?
 
-<bolt-text font-size="large" font-weight="bold" class="u-bolt-margin-bottom-none">
-  By type of thing and/or element
-</bolt-text>
-<bolt-code-snippet lang="css">
---bolt-...--text--...
---bolt-...--headings--...
---bolt-...--h1--...
---bolt-...--h6--...
-<bolt-code-snippet>
+<details>
+  <summary>Theming Examples</summary>
 
-<bolt-text font-size="large" font-weight="bold" class="u-bolt-margin-bottom-none">
-  By component type
-</bolt-text>
-<bolt-code-snippet lang="css">
---bolt-...--overlays--...
---bolt-...--dividers--...
---bolt-...--input--...
-<bolt-code-snippet>
-
-
-
---bolt-ui--primary--bg-color
---bolt-ui--primary--bg-color--hover
---bolt-ui--primary--bg-color--active
---bolt-ui--secondary--bg-color
---bolt-ui--tertiary--bg-color
---bolt-ui--input--border-color--disabled
-
-
---bolt-ui--input--border-color--disabled
-
---bolt-ui--divider--border-color
-
-
---bolt-ui--dropdown--bg-color
-
-
-- Status colors
-- Interactive UI with Hierchy (Primary, Secondary, Tertiary)
-- Themed UI
-
-Basically if you want all of X type of UI to use Y styles, this is where those definitions live.
-
-
-
-Themes are still color only:
-
---bolt-theme--dark--background
---bolt-theme--light--background
---bolt-theme--orange--background
---bolt-theme--purple--background
-
---bolt-theme--teal--background-gradient
---bolt-theme--teal--background-gradient
-
---bolt-theme--teal--text-on-background
---bolt-theme--teal--text-on-background
---bolt-theme--teal--heading-on-background
-
---bolt-theme--teal--primary-on-background
-
---bolt-theme--teal--primary
---bolt-theme--teal--text-on-primary
-
-
-
-
-
---bolt-theme--background
+```
+--bolt-theme--heading
+--bolt-theme--text
+--bolt-theme--background-color
 --bolt-theme--background-gradient
+--bolt-theme--border
+
+--bolt-theme--primary--background-color
+--bolt-theme--primary--background-color--hover
+
+--bolt-theme--primary--shadow
+--bolt-theme--primary--shadow--raised
+
+--bolt-theme--secondary--text
+--bolt-theme--secondary--text--disabled
+--bolt-theme--tertiary--border-color
+
 --bolt-theme--text-on-background
 --bolt-theme--heading-on-background
-
-
---bolt-theme--primary-ui--bg-color
---bolt-theme--primary-ui--bg-color--hover
---bolt-theme--primary-ui--bg-color--disabled
---bolt-theme--primary-ui--text-color--disabled
-
-
-
-
---bolt-theme--primary--background
---bolt-theme--primary--background--hover
---bolt-theme--primary--background--hover
-
---bolt-theme--secondary
---bolt-theme--tertiary
---bolt-theme--primary
-
-
---bolt-theme--primary-on-background
---bolt-theme--secondary-on-background
-
---bolt-theme--background
-
-
-States:
-info
-error
-warning
-success
-
-
---bolt-ui--container--bg-color--indigo-dark
---bolt-ui--container--bg-color--teal
-
---bolt-theme--teal--background
---bolt-theme--teal--text-on-background
---bolt-theme--teal--heading-on-background
---bolt-theme--teal--primary-on-background
---bolt-theme--teal--secondary-on-background
-
---bolt-theme--text-on--teal
---bolt-theme-teal
-
-
---bolt-ui--container--bg-color--indigo-dark
-
-
-
---bolt-ui--primary--bg-color:
---bolt-ui--primary--bg-color--active
---bolt-ui--primary--bg-color--disabled
-
---bolt-ui--secondary--bg-color:
---bolt-ui--secondary--bg-color--hover
---bolt-ui--secondary--bg-color--focus
---bolt-ui--secondary--bg-color--active
---bolt-ui--secondary--bg-color--disabled
-
-
-
---bolt-ui--success
-
-
---bolt-ui--success--text-color:
---bolt-ui--success--bg-color:
-
-
---bolt-ui--primary-interactive--border-width:
---bolt-ui--primary-interactive--border-color:
---bolt-ui--primary-interactive--bg-color:
-
---bolt-ui--primary-interactive--bg-color--disabled
---bolt-ui--primary-interactive--text-color--disabled
-
-
-
-
-
-
---bolt-opacity-30
---bolt-opacity-50
---bolt-opacity-85
---bolt-opacity-100
-
-
-
-# Types of CSS Custom Properties
-
-## Tier 1: Global DS Definitions
-
-```css
---bolt-global--color--indigo
---bolt-global--color--indigo-base
-
---bolt-global--color--indigo-dark
---bolt-global--color--indigo-dark--transparent-100
-
-
-
---bolt-global--spacing--xsmall
---bolt-global--spacing--medium-squished
---bolt-global--spacing--medium-stretched
---bolt-global--spacing--medium
-
-
-// always transparent = --[OPACITY] (> 99 and < 1000)
---bolt-global--opacity--500
-```
-
-
-## Tier 2: Design Tokens (which use Global Definitions)
-
-
-```css
---bolt-global--divider--background
-
-
-
-
-
---bolt-global--font-family--sans
-
-
-
-
---bolt-ui--primary
---bolt-ui--primary--background-color
---bolt-ui--primary--background-color--disabled
-
---bolt-ui--secondary
---bolt-ui--secondary--text-color
---bolt-ui--secondary--shadow
-
-
---bolt-ui--tertiary--background-color
---bolt-ui--tertiary--text-color
---bolt-ui--tertiary--text-color--active
-
-
---bolt-ui--surface
-
-
---bolt-ui--input--padding--medium
---bolt-ui--input--padding--small
-
---bolt-ui--h1
---bolt-ui--h5
---bolt-ui--title
---bolt-ui--subtitle
---bolt-ui--eyebrow--text-color
---bolt-ui--eyebrow--font-size
---bolt-ui--divider
---bolt-ui--divider--subtle
-
-
-
-
---bolt-tokens--input--border-color
---bolt-tokens--input--border-color--disabled
-
---bolt-tokens--primary-ui--background:        --bolt-color--indigo-default--500
---bolt-tokens--primary-ui--text--active:        bolt-color(indigo, default, 0.5);
-
-
---bolt-tokens--text-on-primary:        bolt-color(indigo, dark, 0.5);
---bolt-tokens--primary-ui--background: bolt-color(indigo, dark, 0.5);
-
-
---bolt-tokens--warning:
---bolt-tokens--text-on-warning:
-
-
---bolt-tokens--text-h1--font-size:
---bolt-tokens--text-h6--line-height:
-
-
---bolt-tokens--border-color--default
---bolt-tokens--border-color--focus
---bolt-tokens--border-color--active
-```
-
-
-## Tier 3: Design Tokens (which use Global Definitions)
-
-// component-specific vars:
-  - doesn't have to be 1:1 to the component name
-  - doesn't (and probably shouldn't) have to map to a specific css property
-  - the shorter, the better
-  - use `--bolt-[COMPONENT-NAME]--[PURPOSE]--[OPTIONAL-STATE]` format
-
-```css
---bolt-btn--bg-color
---bolt-btn--bg-color--hover
---bolt-btn--bg-color--active
---bolt-btn--bg-color--disabled
-
-
---bolt-btn--font-size
---bolt-btn--text-color--focus
-
-
---bolt-btn--text-color
---bolt-btn--shadow-color
-
-
---bolt-btn--border-width
---bolt-btn--icon-color
-
-
-
-
-
---bolt--color--indigo-light
---bolt--color--indigo
---bolt--color--indigo-dark
---bolt--color--indigo-xdark
-
-
---bolt-global--color--indigo-100
-
-
---bolt-global--spacing--xlarge
-
-
-
---bolt-global--background-color--teal
---bolt-global--background-color--light
---bolt-global--background-color--dark
-
-
-
---bolt-input--border-color
---bolt-input--border-color--focus
---bolt-input--background-color--error
-background-color--input
-
-
---bolt-theme--primary-bg
---botl-theme--primary-bg--hover
-
-
-bolt-theme--background
-bolt-theme--interactive--primary
-
-
-bolt-theme--shadow--primary
-
-
-//
---bolt-theme--background
---bolt-theme--primary
---bolt-theme--primary--hover
-
-
---bolt-theme--border
---bolt-theme--border-dark
---bolt-theme--border-light
-
 --bolt-theme--text-on-primary
---bolt-theme--text-on-background
+--bolt-theme--text-on-secondary
+--bolt-theme--text-on-tertiary
 
---bolt-global--spacing-
+// --bolt-theme--surface?
+// --bolt-theme--overlay?
+// --bolt-theme--shadow?
+```
 
-
---botl-theme--text-on-primary-bg
-
---botl-theme--primary-text--hover
-
---botl-theme--dark-text--hover
-
-
---bolt--color--indigo--transparent-900
---bolt--color--indigo--transparent-500
---bolt--color--indigo--transparent-100
+</details>
 
 
+<details>
 
---bolt--color--orange
---bolt--color--black
---bolt--color--white
+  <summary>Density Examples</summary>
 
+```
+--bolt-density--spacing--xlarge
+--bolt-density--vspacing--medium
+--bolt-density--font-size--medium
+--bolt-density--line-height--medium
+```
 
---bolt--color--warning
-
-
-
---bolt--color--primary--default
---bolt--color--primary--hover
---bolt--color--primary--hover
-
+</details>
 
 
-// values
---bolt-color-success-default
---bolt-color-success-hover
---bolt-color-success-active
+<details>
+  <summary>UI Examples?</summary>
+
+## By type of thing and/or element
+
+```
+--bolt-ui--text--...
+--bolt-ui--headings--...
+--bolt-ui--h1--...
+--bolt-ui--h6--...
+```
+
+### By component type
+
+```
+--bolt-ui--overlays--...
+--bolt-ui--dividers--...
+--bolt-ui--input--...
+```
+
+</details>
 
 
---bolt-color-success-transparent-100
+<hr>
+
+<bolt-text font-size="xxxlarge" tag="h2" font-weight="semibold">
+  #3. Component-specific Tokens (Buttons, Cards, etc)
+</bolt-text>
 
 
+- doesn't have to be 1:1 to the component name
+- doesn't (and probably **shouldn't**) be required to map to a specific css property
+- the shorter (within reason), the better; when in doubt, prefer clarity over conciseness 
 
 
+<bolt-text font-size="large" font-weight="bold" class="u-bolt-margin-bottom-none">
+  Syntax
+</bolt-text>
 
---bolt--colors--indigo-xdark
---bolt--spacing--large
---bolt--spacing--large-squished
+```
+--bolt-[COMPONENT-NAME]--[PURPOSE]--[STATE/MODIFIER]`
+        ^- who            ^- what    ^- when / how
+```
 
-
-
-
-// tokens
-
---bolt-global--primary-bg--hover
---bolt-global--primary-bg--hover
-
-
---bolt-global--link--color--hover
---bolt-global--link--color--hover
-
-
---bolt-global--link--color--hover
+```css
+--bolt-btn--bg-color: ...
+--bolt-btn--bg-color--hover: ...
+--bolt-btn--bg-color--active: ...
+--bolt-btn--bg-color--disabled: ..
+--bolt-btn--border-width
+--bolt-btn--border-color
 
 
-//
---button--bg:
+--bolt-icon--color:
+--bolt-icon--bg-color:
+--bolt-icon--bg-opacity:
+--bolt-icon--size--medium:
+--bolt-icon--size--large:
 
-
---bolt--
-
-
-
---bolt--color--indigo
---bolt--color--indigo-dark
---bolt--color--indigo-light
-
-
---bolt--spacing--xxs
---bolt--spacing--xs
---bolt--spacing--sm
---bolt--spacing--md
---bolt--spacing--lg
---bolt--spacing--xl
---bolt--spacing--xxl
-
---bolt--shadow--50
-
-
---bolt--font-size--md
---bolt--font-size--lg
-
---bolt--font-family--serif
-
-
---bolt--opacity--60
-
-
-
-
+--bolt-card--shadow
+--bolt-card--shadow--raised
+--bolt-card--spacing
+--bolt-card--spacing--large
+--bolt-card--radius
+--bolt-card--radius--large
+--bolt-card--bg-color
 
 ```

--- a/docs-site/src/templates/_page-header.twig
+++ b/docs-site/src/templates/_page-header.twig
@@ -46,8 +46,7 @@
   attributes: {
     class: [
       "c-bolt-site__header",
-      "c-bds-layout__header",
-      "js-bolt-smooth-scroll-offset"
+      "c-bds-layout__header"
     ]
   },
   content: navbar

--- a/docs-site/src/templates/_page-header.twig
+++ b/docs-site/src/templates/_page-header.twig
@@ -46,7 +46,8 @@
   attributes: {
     class: [
       "c-bolt-site__header",
-      "c-bds-layout__header"
+      "c-bds-layout__header",
+      "js-bolt-smooth-scroll-offset"
     ]
   },
   content: navbar

--- a/docs-site/src/templates/default.twig
+++ b/docs-site/src/templates/default.twig
@@ -16,7 +16,7 @@
   {% include "@bolt-site/_page-header.twig" %}
 
    {% if hasSidebar %}
-    <aside class="c-bds-layout__sidebar" id="menu">
+    <aside class="c-bds-layout__sidebar" id="nav">
       {% if nestedPages %}
         {% include '@bolt-site/off-canvas-nav.twig' with {
           nestedPages: nestedPages,

--- a/docs-site/src/templates/default.twig
+++ b/docs-site/src/templates/default.twig
@@ -54,7 +54,7 @@
           {% include "@bolt-components-headline/headline.twig" with {
             text: page.meta.title,
             size: "xxxlarge",
-            tag: "h2",
+            tag: "h1",
             longTitle: true,
           } only %}
 

--- a/docs-site/src/templates/default.twig
+++ b/docs-site/src/templates/default.twig
@@ -54,7 +54,7 @@
           {% include "@bolt-components-headline/headline.twig" with {
             text: page.meta.title,
             size: "xxxlarge",
-            tag: "h1",
+            tag: "h2",
             longTitle: true,
           } only %}
 

--- a/docs-site/src/templates/default.twig
+++ b/docs-site/src/templates/default.twig
@@ -16,7 +16,7 @@
   {% include "@bolt-site/_page-header.twig" %}
 
    {% if hasSidebar %}
-    <aside class="c-bds-layout__sidebar" id="nav">
+    <aside class="c-bds-layout__sidebar" id="menu">
       {% if nestedPages %}
         {% include '@bolt-site/off-canvas-nav.twig' with {
           nestedPages: nestedPages,


### PR DESCRIPTION
## Jira
N/A

## Summary
This is a very, very long overdue update that adds basic docs site article styles. Uses most of the styles from https://github.com/boltdesignsystem/bolt/pull/1438 (albeit, with a few tweaks) to significantly improve the default HTML element styles that show up on the boltdesignsystem.com docs site. 

Also makes sure that TOC links added to the docs site will smooth scroll to the correct location.

## Details
Note: this PR branches off of the spec work from https://github.com/boltdesignsystem/bolt/pull/1774 to use this real-world example as a before vs after comparison.

## How to test
Check out the updated docs site styles (before vs after links pending). Nothing being shipped changes with this so this (docs site-only updates) should be a quick and easy win for everybody.