### PR TITLE
Create new "Numbered Headline" blueprint

### DIFF
--- a/.boltrc.js
+++ b/.boltrc.js
@@ -78,6 +78,7 @@ module.exports = {
       '@bolt/components-animate',
       '@bolt/micro-journeys',
       '@bolt/analytics-autolink',
+      '@bolt/blueprints',
     ],
   },
   images: {

--- a/__tests__/monorepo-deps.test.js
+++ b/__tests__/monorepo-deps.test.js
@@ -69,7 +69,12 @@ describe('Bolt Components declare dependencies in package.json if used in Twig f
             [join(boltPkg.location, '**/*.twig')],
             {
               gitignore: true,
-              ignore: ['**/__tests__/**', '**/node_modules/**', '**/vendor/**'],
+              ignore: [
+                '**/__tests__/**',
+                '**/__demos__/**',
+                '**/node_modules/**',
+                '**/vendor/**',
+              ],
             },
           );
 

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/numbered-headline/__demos__/10-numbered-headline-blueprint.md
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/numbered-headline/__demos__/10-numbered-headline-blueprint.md
@@ -1,0 +1,3 @@
+---
+title: Numbered Headline
+---

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/numbered-headline/__demos__/10-numbered-headline-blueprint.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/numbered-headline/__demos__/10-numbered-headline-blueprint.twig
@@ -95,7 +95,7 @@
 
   {% include "@bolt-components-headline/text.twig" with {
     tag: "p",
-    text: "It might also be worth pointing out: the size of the numbered bullet is currently a fixed however could be easily updated to have proportionally-sized bullets."
+    text: "It might also be worth pointing out: the size of the numbered bullet is currently fixed however could be easily updated to have proportionally-sized bullets."
   } only %}
 
   {% for size in headlineSchema.properties.size.enum %}

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/numbered-headline/__demos__/10-numbered-headline-blueprint.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/numbered-headline/__demos__/10-numbered-headline-blueprint.twig
@@ -1,0 +1,109 @@
+
+{% set schema = bolt.data.components["@bolt-blueprints-numbered-headline"].schema %}
+{% set headlineSchema = bolt.data.components["@bolt-components-headline"].schema %}
+
+{% set usage %}
+{% verbatim %}
+{% include "@bolt-blueprints/numbered-headline.twig" with {
+  tag: "h2",
+  size: "xxlarge",
+  text: "Numbered Headline",
+  numberText: 1,
+  numberColor: "indigo"
+} only %}
+{% endverbatim %}
+{% endset %}
+
+<div class="o-bolt-wrapper">
+  {% include "@bolt-components-headline/headline.twig" with {
+    size: "xxxlarge",
+    tag: "h1",
+    text: "Numbered Headline",
+  } only %}
+
+  {% include "@bolt-components-headline/subheadline.twig" with {
+    size: "xxlarge",
+    tag: "h2",
+    text: schema.description,
+  } only %}
+
+  {# start usage #}
+  {% include "@bolt-components-headline/headline.twig" with {
+    size: "xxlarge",
+    tag: "h2",
+    text: "Usage",
+  } only %}
+
+  {% include "@bolt-blueprints/numbered-headline.twig" with {
+    tag: "h2",
+    size: "xxlarge",
+    text: "Numbered Headline",
+    numberText: 1,
+    numberColor: "indigo"
+  } only %}
+
+  {% include "@bolt-components-code-snippet/code-snippet.twig" with {
+    lang: "twig",
+    content: usage
+  } only %}
+  {# end usage #}
+
+  {# start schema #}
+  {% if schema and schema.properties %}
+    {% include "@bolt/headline.twig" with {
+      size: "xxlarge",
+      tag: "h2",
+      text: "Schema",
+      icon: "none",
+    } only %}
+    {% include '@utils/schema-docs.twig' with { schema: schema } only %}
+  {% endif %}
+
+  <aside class="c-bds-callout c-bds-callout--notice u-bolt-margin-top-medium u-bolt-margin-bottom-large">
+    <p>Check out the <a href="{{ link["viewall-components-headline"]}}">Headline component docs</a> to reference the additional props supported by the Numbered Headline variant.
+    </p>
+  </aside>
+  {# end schema #}
+
+  <p>
+    By setting the Numbered Headline's <code>numberColor</code> prop to <code>indigo</code>, <code>purple</code>, <code>teal</code>, or <code>orange</code>, you can choose the background color of the Numbered Headline's Number Bullet. NOTE: if you don't specify a <code>numberColor</code>, the bullet doesn't show up by default.
+  </p>
+
+  {% include "@bolt-components-headline/headline.twig" with {
+    tag: "h2",
+    size: "xlarge",
+    text: "Color options",
+  } only %}
+
+  {% for color in schema.properties.numberColor.enum %}
+    <h3>numberColor: <code>{{ color ? color : "undefined" }}</code></h3>
+    {% include "@bolt-blueprints/numbered-headline.twig" with {
+      size: "xxlarge",
+      text: "Numbered Headline w/ #{color} bullet",
+      numberText: loop.index,
+      numberColor: color
+    } only %}
+  {% endfor %}
+
+  <hr>
+
+  {% include "@bolt-components-headline/headline.twig" with {
+    tag: "h2",
+    size: "xlarge",
+    text: "Bullet size",
+  } only %}
+
+  {% include "@bolt-components-headline/text.twig" with {
+    tag: "p",
+    text: "It might also be worth pointing out: the size of the numbered bullet is currently a fixed however could be easily updated to have proportionally-sized bullets."
+  } only %}
+
+  {% for size in headlineSchema.properties.size.enum %}
+    {% include "@bolt-blueprints/numbered-headline.twig" with {
+      size: size,
+      text: "Numbered Headline that's #{size} in size",
+      numberText: loop.index,
+      numberColor: "indigo"
+    } only %}
+  {% endfor %}
+</div>

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/numbered-headline/numbered-headline.schema.js
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/numbered-headline/numbered-headline.schema.js
@@ -1,0 +1,18 @@
+module.exports = {
+  $schema: 'http://json-schema.org/draft-04/schema#',
+  title: 'Numbered Headline',
+  description:
+    'A variation of the Headline component that can display a numbered bullet. Included by default in the @bolt/blueprints package.',
+  type: 'object',
+  properties: {
+    numberText: {
+      description: "The text to display in the Numbered Headline's bullet",
+      type: 'string',
+    },
+    numberColor: {
+      description: "The background color of the Numbered Headline's bullet",
+      type: 'string',
+      enum: ['teal', 'indigo', 'orange', 'purple'],
+    },
+  },
+};

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/numbered-headline/package.json
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/numbered-headline/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@bolt/blueprints-numbered-headline",
+  "version": "0.0.0",
+  "description": "A Headline component variation that displays a numbered bullet.",
+  "keywords": [
+    "bolt design system",
+    "bolt",
+    "design system",
+    "atomic design",
+    "patterns",
+    "component composition"
+  ],
+  "style": "src/numbered-headline.scss",
+  "schema": "numbered-headline.schema.js",
+  "license": "MIT",
+  "dependencies": {
+    "@bolt/components-headline": "^2.19.0",
+    "@bolt/core-v3.x": "^2.19.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "maintainers": [
+    {
+      "name": "Salem Ghoweri",
+      "email": "me@salemghoweri.com",
+      "web": "https://github.com/sghoweri"
+    },
+    {
+      "name": "Mike Mai",
+      "email": "boss@mikemai.net",
+      "web": "http://mikemai.net/"
+    },
+    {
+      "name": "Dan Morse",
+      "web": "https://github.com/danielamorse"
+    }
+  ]
+}

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/numbered-headline/src/_numbered-headline-bullet.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/numbered-headline/src/_numbered-headline-bullet.twig
@@ -1,0 +1,5 @@
+{% if number %}
+  <div class="c-bolt-numbered-headline__bullet c-bolt-numbered-headline__bullet--{{color}}">
+    <div class="c-bolt-numbered-headline__bullet-text">{{ number }}</span>
+  </div>
+{% endif %}

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/numbered-headline/src/numbered-headline.md
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/numbered-headline/src/numbered-headline.md
@@ -1,0 +1,4 @@
+---
+hidden: true
+---
+Note: this file is required so Pattern Lab doesn't show the numbered-headline.twig file in the PL menu.

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/numbered-headline/src/numbered-headline.scss
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/numbered-headline/src/numbered-headline.scss
@@ -1,0 +1,38 @@
+@import '@bolt/core-v3.x';
+
+/**
+  * 1. keep the bullet size consistent regardless of the font-size of the headline it's used within
+  *    note: update to ~1.2em to make the bullet size proportional to the headline font-size
+  */
+.c-bolt-numbered-headline__bullet {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: bolt-spacing(medium); /* 1 */
+  height: bolt-spacing(medium); /* 1 */
+  border-radius: bolt-border-radius(full);
+
+  &-text {
+    @include bolt-font-size(xsmall);
+  }
+
+  &--orange {
+    color: bolt-color(white);
+    background-color: bolt-color(orange);
+  }
+
+  &--indigo {
+    color: bolt-color(white);
+    background-color: bolt-color(indigo, light);
+  }
+
+  &--purple {
+    color: bolt-color(white);
+    background-color: #751b84;
+  }
+
+  &--teal {
+    color: bolt-color(white);
+    background-color: bolt-color(teal);
+  }
+}

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/numbered-headline/src/numbered-headline.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/numbered-headline/src/numbered-headline.twig
@@ -1,0 +1,24 @@
+{% import "@bolt-blueprints/macros.twig" as macros %}
+
+{% set schema = bolt.data.components["@bolt-blueprints-numbered-headline"].schema %}
+
+{% set numberColor = numberColor in schema.properties.numberColor.enum ? numberColor : null %}
+
+{% if numberText and numberColor != null %}
+  {% include "@bolt-components-headline/headline.twig" with {
+    text: macros.include("@bolt/flag.twig", {
+      valign: "middle",
+      figure: {
+        content: numberText ? macros.include("@bolt-blueprints/_numbered-headline-bullet.twig", {
+          number: numberText,
+          color: numberColor,
+        }) : null
+      },
+      content: text | default(""),
+    }),
+  } %}
+{% else %}
+  {% include "@bolt-components-headline/headline.twig" with {
+    text: text | default(""),
+  } %}
+{% endif %}

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/05-pages/t2-inner-pages/challenge-details/t2-challenge-detail-page.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/05-pages/t2-inner-pages/challenge-details/t2-challenge-detail-page.twig
@@ -3,10 +3,12 @@
 {% block page_content %}
   {% import "@bolt-blueprints/macros.twig" as macros %}
 
-  {% include "@bolt-components-headline/headline.twig" with {
+  {% include "@bolt-blueprints/numbered-headline.twig" with {
     tag: "h2",
     size: "xxlarge",
     text: "Scenario",
+    numberText: 1,
+    numberColor: "orange"
   } only %}
 
   {% include "@bolt-components-headline/text.twig" with {

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/index.scss
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/index.scss
@@ -1,5 +1,7 @@
 @import '@bolt/core-v3.x';
 
+@import './02-molecules/numbered-headline/src/numbered-headline.scss';
+
 .c-bolt-featured-hero {
   position: relative;
 

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/package.json
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/package.json
@@ -16,6 +16,7 @@
   "license": "MIT",
   "style": "index.scss",
   "dependencies": {
+    "@bolt/blueprints-numbered-headline": "0.0.0",
     "@bolt/components-background": "^2.19.0",
     "@bolt/components-band": "^2.19.0",
     "@bolt/components-breadcrumb": "^2.19.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "workspaces": {
     "packages": [
       "docs-site/src/pages/pattern-lab/_patterns/03-blueprints",
+      "docs-site/src/pages/pattern-lab/_patterns/03-blueprints/**/*",
       "docs-site",
       "docs-site/src/components/banner",
       "docs-site/src/components/theme-switcher",


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/BDS-2063

## Summary
Adds a new Numbered Headline variation under Blueprints + basic docs / demo support.

![screencapture-localhost-3000-pattern-lab-patterns-03-blueprints-02-molecules-numbered-headline-demos-10-numbered-headline-blueprint-03-blueprints-02-molecules-numbered-headline-demos-10-numbered-headline-blueprint-html-2020-03-11-12_33_29](https://user-images.githubusercontent.com/1617209/76441423-bf5c5e00-6395-11ea-8e8c-944b8601ef8e.png)


## Details
Since this isn't a full blown component, I had to get a little creative on how to get at least _something_ to show up in the Pattern Lab menu + get some basic schema support in place.

Thoughts? Suggestions?

## How to test
- Review PL docs and demos