### PR TITLE
Fix/stack component shadow root

### DIFF
--- a/packages/components/bolt-stack/__tests__/__snapshots__/stack.js.snap
+++ b/packages/components/bolt-stack/__tests__/__snapshots__/stack.js.snap
@@ -2,129 +2,99 @@
 
 exports[`<bolt-stack> component basic usage 1`] = `
 <bolt-stack>
-  <div class="c-bolt-stack"
-       is="shadow-root"
-  >
+  <replace-with-children class="c-bolt-stack c-bolt-example--spacing-medium">
     This is one stack. A stack spans the full width of its parent container.
-  </div>
+  </replace-with-children>
 </bolt-stack>
 <bolt-stack>
-  <div class="c-bolt-stack"
-       is="shadow-root"
-  >
+  <replace-with-children class="c-bolt-stack c-bolt-example--spacing-medium">
     This is another stack.
-  </div>
+  </replace-with-children>
 </bolt-stack>
 `;
 
 exports[`<bolt-stack> component outer CSS class via Drupal Attributes 1`] = `
 <bolt-stack class="u-bolt-color-teal">
-  <div class="c-bolt-stack"
-       is="shadow-root"
-  >
+  <replace-with-children class="c-bolt-stack c-bolt-example--spacing-medium">
     This is a stack
-  </div>
+  </replace-with-children>
 </bolt-stack>
 `;
 
 exports[`<bolt-stack> component stack spacing: large 1`] = `
 <bolt-stack>
-  <div class="c-bolt-stack"
-       is="shadow-root"
-  >
+  <replace-with-children class="c-bolt-stack c-bolt-example--spacing-medium">
     This is one stack. A stack spans the full width of its parent container.
-  </div>
+  </replace-with-children>
 </bolt-stack>
 <bolt-stack>
-  <div class="c-bolt-stack"
-       is="shadow-root"
-  >
+  <replace-with-children class="c-bolt-stack c-bolt-example--spacing-medium">
     This is another stack.
-  </div>
+  </replace-with-children>
 </bolt-stack>
 `;
 
 exports[`<bolt-stack> component stack spacing: medium 1`] = `
 <bolt-stack>
-  <div class="c-bolt-stack"
-       is="shadow-root"
-  >
+  <replace-with-children class="c-bolt-stack c-bolt-example--spacing-medium">
     This is one stack. A stack spans the full width of its parent container.
-  </div>
+  </replace-with-children>
 </bolt-stack>
 <bolt-stack>
-  <div class="c-bolt-stack"
-       is="shadow-root"
-  >
+  <replace-with-children class="c-bolt-stack c-bolt-example--spacing-medium">
     This is another stack.
-  </div>
+  </replace-with-children>
 </bolt-stack>
 `;
 
 exports[`<bolt-stack> component stack spacing: none 1`] = `
 <bolt-stack>
-  <div class="c-bolt-stack"
-       is="shadow-root"
-  >
+  <replace-with-children class="c-bolt-stack c-bolt-example--spacing-medium">
     This is one stack. A stack spans the full width of its parent container.
-  </div>
+  </replace-with-children>
 </bolt-stack>
 <bolt-stack>
-  <div class="c-bolt-stack"
-       is="shadow-root"
-  >
+  <replace-with-children class="c-bolt-stack c-bolt-example--spacing-medium">
     This is another stack.
-  </div>
+  </replace-with-children>
 </bolt-stack>
 `;
 
 exports[`<bolt-stack> component stack spacing: small 1`] = `
 <bolt-stack>
-  <div class="c-bolt-stack"
-       is="shadow-root"
-  >
+  <replace-with-children class="c-bolt-stack c-bolt-example--spacing-medium">
     This is one stack. A stack spans the full width of its parent container.
-  </div>
+  </replace-with-children>
 </bolt-stack>
 <bolt-stack>
-  <div class="c-bolt-stack"
-       is="shadow-root"
-  >
+  <replace-with-children class="c-bolt-stack c-bolt-example--spacing-medium">
     This is another stack.
-  </div>
+  </replace-with-children>
 </bolt-stack>
 `;
 
 exports[`<bolt-stack> component stack spacing: xlarge 1`] = `
 <bolt-stack>
-  <div class="c-bolt-stack"
-       is="shadow-root"
-  >
+  <replace-with-children class="c-bolt-stack c-bolt-example--spacing-medium">
     This is one stack. A stack spans the full width of its parent container.
-  </div>
+  </replace-with-children>
 </bolt-stack>
 <bolt-stack>
-  <div class="c-bolt-stack"
-       is="shadow-root"
-  >
+  <replace-with-children class="c-bolt-stack c-bolt-example--spacing-medium">
     This is another stack.
-  </div>
+  </replace-with-children>
 </bolt-stack>
 `;
 
 exports[`<bolt-stack> component stack spacing: xsmall 1`] = `
 <bolt-stack>
-  <div class="c-bolt-stack"
-       is="shadow-root"
-  >
+  <replace-with-children class="c-bolt-stack c-bolt-example--spacing-medium">
     This is one stack. A stack spans the full width of its parent container.
-  </div>
+  </replace-with-children>
 </bolt-stack>
 <bolt-stack>
-  <div class="c-bolt-stack"
-       is="shadow-root"
-  >
+  <replace-with-children class="c-bolt-stack c-bolt-example--spacing-medium">
     This is another stack.
-  </div>
+  </replace-with-children>
 </bolt-stack>
 `;

--- a/packages/components/bolt-stack/src/stack.js
+++ b/packages/components/bolt-stack/src/stack.js
@@ -29,7 +29,7 @@ class BoltStack extends withLitHtml {
 
     return html`
       ${this.addStyles([styles])}
-      <div class="${classes}" is="shadow-root">
+      <div class="${classes}">
         ${this.slot('default')}
       </div>
     `;

--- a/packages/components/bolt-stack/src/stack.twig
+++ b/packages/components/bolt-stack/src/stack.twig
@@ -5,14 +5,27 @@
 {% endif %}
 
 {# Variables #}
-{% set base_class = "c-bolt-stack" %}
 {% set this = init(schema) %}
 {% set inner_attributes = create_attribute({}) %}
 
-{% set outer_classes = [] %}
+{% set classes = [
+  "c-bolt-stack",
+  this.data.spacing.value ? "c-bolt-example--spacing-" ~ this.data.spacing.value : "",
+  this.data.borderless.value ? "c-bolt-example--borderless" : "",
+] %}
 
-{% for class in attributes["class"] %}
-  {% if class starts with "c-bolt-" == false %}
+{#
+  Sort classes passed in via attributes into two groups:
+  1. Those that should be applied to the inner tag (namely, "is-" and "has-" classes)
+  2. Those that should be applied to the outer custom element (everything else EXCEPT c-bolt-* classes, which should never be passed in via attributes)
+#}
+{% set outer_classes = [] %}
+{% set inner_classes = classes %}
+
+{% for class in this.props.class %}
+  {% if class starts with "is-" or class starts with "has-" %}
+    {% set inner_classes = inner_classes|merge([class]) %}
+  {% elseif class starts with "c-bolt-" == false %}
     {% set outer_classes = outer_classes|merge([class]) %}
   {% endif %}
 {% endfor %}
@@ -21,7 +34,7 @@
   {% if outer_classes %} class="{{ outer_classes|join(' ') }}" {% endif %}
   {{ this.props|without("content")|without("class") }}
 >
-  <div {{ inner_attributes.addClass(base_class) }} is="shadow-root">
+  <replace-with-children {{ inner_attributes.addClass(inner_classes) }}>
     {{ content }}
-  </div>
+  </replace-with-children>
 </bolt-stack>


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-2066

## Summary

Remove `is=shadow-root` from Stack component. It causes an error when placed inside a Carousel (on Academy).

## Details

We've seen this before on the Teaser component. When a parent component queries the DOM and finds the `is=shadow-root` attribute on an inner component (instead of on itself), it mistakes that inner component as its own and consequently a bunch of necessary markup gets removed.

This PR replaces `is=shadow-root` with `replace-with-children`, which wasn't available when this component was created.

Also, I brought the Twig file up to date with our current conventions.

## How to test

- Review code
- Checkout feature branch
  - Verify Stacked demo works as expected
  - Temporarily replace the Stack Spacing Variations demo with the following code and verify it works as expected (i.e. a carousel loads with the placeholder component in each slide):
```
{% set schema = bolt.data.components["@bolt-components-stack"].schema %}

{% for spacing in schema.properties.spacing.enum %}
  <div class="u-bolt-margin-bottom-large">
    <h3>Multiple stacks with {{ spacing }} spacing</h3>
    {% set placeholder %}
      {% include "@bolt-components-placeholder/placeholder.twig" with {
        size: "xsmall",
        text: "This stack has " ~ spacing ~ " spacing."
      } only %}
    {% endset %}
    {% set stack %}
      {% include "@bolt-components-stack/stack.twig" with {
        content: placeholder,
        spacing: spacing
      } only %}
    {% endset %}
    {% include "@bolt-components-carousel/carousel.twig" with {
      slides: [
        stack,
        stack,
        stack,
      ]
    } only %}
  </div>
{% endfor %}
```