### PR TITLE
feat: replace `xxsmall` with `xsmall` in Blueprints

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/training/_completed-training-item.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/02-molecules/training/_completed-training-item.twig
@@ -103,7 +103,7 @@
                 } only %}
                 {% include "@bolt-components-headline/text.twig" with {
                   text: "Archived",
-                  size: "xxsmall",
+                  size: "xsmall",
                   attributes: {
                     class: [
                       "u-bolt-margin-top-xxsmall",

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/modals/_test-completed-modal.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/03-organisms/modals/_test-completed-modal.twig
@@ -66,7 +66,7 @@
         }),
         macros.include("@bolt-components-headline/text.twig", {
           text: "<strong>NOTE:</strong> Please allow 24-48 hours for the badge to appear on your Achievements page.",
-          size: "xxsmall",
+          size: "xsmall",
           style: "italic",
           align: "center",
           attributes: {

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/05-pages/t1-landing-pages/certification-exam/certification-exam-page.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/05-pages/t1-landing-pages/certification-exam/certification-exam-page.twig
@@ -119,7 +119,7 @@
                   "Take an exam at a test center, or",
                   "Take an exam via Online Proctored delivery" ~ macros.include("@bolt-components-headline/text.twig", {
                     text: "(e.g., in a quiet, uninterrupted room in your home or office, proctored via webcam).",
-                    size: "xxsmall",
+                    size: "xsmall",
                     style: "italic",
                     align: "left",
                   }),


### PR DESCRIPTION
## Jira

n/a

## Summary

Replace `xxsmall` text with `xsmall` in Blueprints.

## Details

`xsmall` is small enough and `xxsmall` may be deprecated in the future. Replace now proactively so that these values aren't copied into the Academy project.

## How to test

- [Certification Exam](http://localhost:3000/pattern-lab/patterns/03-blueprints-05-pages-t1-landing-pages-certification-exam-certification-exam-page/03-blueprints-05-pages-t1-landing-pages-certification-exam-certification-exam-page.html): "e.g., in a quiet, uninterrupted room..."
- [Completed Training](http://localhost:3000/pattern-lab/patterns/03-blueprints-05-pages-completed-training-completed-training/03-blueprints-05-pages-completed-training-completed-training.html): "Archived"
