### PR TITLE
Card + Popover related UI updates; new strategy for handling rendering issues relating to overflow

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/card-replacement/06-card-horizontal-image-only-without-url.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/card-replacement/06-card-horizontal-image-only-without-url.twig
@@ -1,0 +1,13 @@
+{% import "@bolt-blueprints/macros.twig" as macros %}
+
+{% embed "@bolt-components-card-replacement/card-replacement.twig" with {
+  horizontal: true,
+  theme: "xlight",
+  rounded: true,
+} %}
+  {% block media %}
+    {% include "@bolt-components-image/image.twig" with {
+      src: "/images/placeholders/landscape-16x9-mountains.jpg",
+    } only %}
+  {% endblock %}
+{% endembed %}

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/card-replacement/06-card-horizontal-image-with-url.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/card-replacement/06-card-horizontal-image-with-url.twig
@@ -1,0 +1,14 @@
+{% import "@bolt-blueprints/macros.twig" as macros %}
+
+{% embed "@bolt-components-card-replacement/card-replacement.twig" with {
+  horizontal: true,
+  theme: "xlight",
+  url: "#!",
+  rounded: true,
+} %}
+  {% block media %}
+    {% include "@bolt-components-image/image.twig" with {
+      src: "/images/placeholders/landscape-16x9-mountains.jpg",
+    } only %}
+  {% endblock %}
+{% endembed %}

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/card-replacement/06-card-horizontal-with-popover.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/card-replacement/06-card-horizontal-with-popover.twig
@@ -1,0 +1,174 @@
+{% import "@bolt-blueprints/macros.twig" as macros %}
+
+{% embed "@bolt-components-card-replacement/card-replacement.twig" with {
+  horizontal: true,
+  theme: "xlight",
+  link_url: cardUrl,
+  cardUrl: "#!",
+  cardSubtitle: "Mission",
+  cardTitle: bolt.faker.sentence(3),
+  cardMetaItems: [
+    macros.include("@bolt-components-headline/text.twig", {
+      size: "small",
+      weight: "bold",
+      text: "#{bolt.faker.numberBetween(2,10)} Modules",
+    }, false),
+    macros.include("@bolt-components-headline/text.twig", {
+      size: "small",
+      weight: "bold",
+      text: "1 Challenge",
+    }, false),
+    macros.include("@bolt-components-headline/text.twig", {
+      size: "small",
+      weight: "bold",
+      text: "25% complete",
+      attributes: {
+        class: ["u-bolt-color-orange"]
+      }
+    }, false)
+  ],
+  cardGradient: "purple",
+  cardIcon: "brand-rocket",
+  cardDescription: bolt.faker.paragraph(2),
+  removeButton: true,
+  cardStatusItems: [
+    macros.include("@bolt-components-headline/eyebrow.twig", {
+      text: "Last activity: 3 days ago",
+      align: "center",
+      attributes: {
+        class: ["u-bolt-padding-small"]
+      }
+    }, false)
+  ]
+} %}
+  {% block media %}
+    {% include "@bolt-components-image/image.twig" with {
+      src: "/images/placeholders/landscape-16x9-mountains.jpg",
+      cover: true,
+    } only %}
+  {% endblock %}
+
+  {% block body %}
+    <div class="c-bolt-card_replacement__overflow-menu c-bolt-card_replacement__overflow-menu--top c-bolt-card_replacement__overflow-menu--right">
+      {% include "@bolt-components-popover/popover.twig" with {
+        trigger: macros.include("@bolt-components-button/button.twig", {
+          text: "Share",
+          size: "small",
+          style: "tertiary",
+          iconOnly: true,
+          icon: {
+            name: "share",
+          }
+        }),
+        content: macros.include("@bolt-components-menu/menu.twig", {
+          items: [
+            {
+              content: macros.include("@bolt-components-headline/text.twig", {
+                text: "Facebook",
+                size: "medium",
+                icon: {
+                  name: "facebook-solid",
+                  position: "before"
+                }
+              }, false),
+              url: "#!"
+            },
+            {
+              content: macros.include("@bolt-components-headline/text.twig", {
+                text: "Twitter",
+                size: "medium",
+                icon: {
+                  name: "twitter",
+                  position: "before"
+                }
+              }, false),
+              url: "#!"
+            },
+            {
+              content: macros.include("@bolt-components-headline/text.twig", {
+                text: "LinkedIn",
+                size: "medium",
+                icon: {
+                  name: "linkedin",
+                  position: "before"
+                }
+              }, false),
+              url: "#!"
+            },
+            {
+              content: macros.include("@bolt-components-headline/text.twig", {
+                text: "Email",
+                size: "medium",
+                icon: {
+                  name: "email",
+                  position: "before"
+                }
+              }, false),
+              url: "#!"
+            },
+            {
+              content: macros.include("@bolt-components-headline/text.twig", {
+                text: "Link",
+                size: "medium",
+                icon: {
+                  name: "asset-link",
+                  position: "before"
+                }
+              }, false),
+              url: "#!"
+            },
+          ]
+        }),
+        placement: "bottom-end",
+        spacing: "none",
+        theme: "xlight",
+      } only %}
+    </div>
+
+    <div class="u-bolt-overflow-hidden">
+      {% grid "o-bolt-grid--flex o-bolt-grid--matrix o-bolt-grid--border" %}
+        {% cell "u-bolt-width-12/12 u-bolt-width-6/12@small" %}
+          {% if cardSubtitle %}
+            {% include "@bolt-components-headline/eyebrow.twig" with {
+              text: cardSubtitle,
+            } only %}
+          {% endif %}
+
+          {% if cardTitle %}
+            {% include "@bolt-components-headline/headline.twig" with {
+              text: cardTitle,
+              size: "xlarge",
+              attributes: {
+                class: "u-bolt-margin-bottom-small",
+              }
+            } only %}
+          {% endif %}
+          {% if cardMetaItems %}
+            {% include "@bolt-components-list/list.twig" with {
+              display: "inline",
+              separator: "solid",
+              tag: "ul",
+              items: cardMetaItems
+            } %}
+          {% endif %}
+        {% endcell %}
+
+        {% if cardDescription %}
+          {% cell "u-bolt-width-12/12 u-bolt-width-6/12@small" %}
+            {% include "@bolt-components-headline/text.twig" with {
+              text: cardDescription,
+              size: "small",
+              attributes: {
+                class: [
+                  "u-bolt-padding-top-xsmall@small",
+                  "u-bolt-padding-bottom-xsmall@small",
+                ]
+              }
+            } only %}
+          {% endcell %}
+        {% endif %}
+      {% endgrid %}
+    </div>
+  {% endblock %}
+
+{% endembed %}

--- a/packages/base-element/src/Slotify.js
+++ b/packages/base-element/src/Slotify.js
@@ -45,12 +45,13 @@ export class Slotify extends LitElement {
     super.update(changedProperties);
   }
 
-  slotify(slot = 'default', defaultContent) {
+  slotify(slot = 'default', tryToUseRealSlots = true, defaultContent) {
     const slotContent = this.slotMap.get(slot);
 
     // render actualy slots if Shadow DOM supported + getting used
     // @todo: what's a better way to allow customizing the checks to perform?
     if (
+      tryToUseRealSlots === true &&
       this.shadowRoot &&
       (this.useShadow === undefined || this.useShadow === true) &&
       (this.noShadow === undefined || this.useShadow === false) &&

--- a/packages/components/bolt-card-replacement/__tests__/__snapshots__/card-replacement.js.snap
+++ b/packages/components/bolt-card-replacement/__tests__/__snapshots__/card-replacement.js.snap
@@ -110,6 +110,7 @@ exports[`<bolt-card-replacement> Component clickable card-replacement 1`] = `
                        theme="none"
                        height="full"
                        url="https://pega.com"
+                       can-raise
 >
   <replace-with-children class="c-bolt-card-replacement">
     <bolt-card-replacement-link>

--- a/packages/components/bolt-card-replacement/src/_card-replacement-settings-and-tools.scss
+++ b/packages/components/bolt-card-replacement/src/_card-replacement-settings-and-tools.scss
@@ -24,37 +24,6 @@ $bolt-card-replacement-z-index-inner-link: 2;
 }
 
 @mixin bolt-card-replacement-content-conditions {
-  // [Mai] Only the card-replacement body should not have hidden overflow and border radius because its background is transparent. This also catches any kind of free-form content being passed, making sure they don't poke outside the card-replacement (which has rounded corners and box shadows). The reason the card-replacement itself shouldn't have hidden overflow is because the card-replacement body can contain some kind of tooltip bubble or dropdown ui, they can poke out of the card-replacement naturally.
-  > * {
-    &:first-child {
-      border-radius: $bolt-card-replacement-border-radius
-        $bolt-card-replacement-border-radius 0 0;
-    }
-
-    &:last-child {
-      border-radius: 0 0 $bolt-card-replacement-border-radius
-        $bolt-card-replacement-border-radius;
-    }
-
-    &:only-child {
-      border-radius: $bolt-card-replacement-border-radius;
-    }
-  }
-
-  > bolt-card-replacement-link + * {
-    border-radius: $bolt-card-replacement-border-radius
-      $bolt-card-replacement-border-radius 0 0;
-
-    &:last-child {
-      border-radius: $bolt-card-replacement-border-radius;
-    }
-  }
-
-  > bolt-card-replacement-body,
-  > bolt-card-replacement-link,
-  > replace-with-children {
-    overflow: visible;
-  }
 
   > bolt-card-replacement-actions {
     &:last-child {

--- a/packages/components/bolt-card-replacement/src/card-replacement-actions/_card-replacement-actions.scss
+++ b/packages/components/bolt-card-replacement/src/card-replacement-actions/_card-replacement-actions.scss
@@ -7,7 +7,6 @@
 
 bolt-card-replacement-actions {
   @include bolt-card-replacement-border-reset;
-  overflow: hidden;
   margin-top: auto;
 }
 

--- a/packages/components/bolt-card-replacement/src/card-replacement-link/_card-replacement-link.scss
+++ b/packages/components/bolt-card-replacement/src/card-replacement-link/_card-replacement-link.scss
@@ -15,7 +15,10 @@
   bottom: 0;
   left: 0;
   z-index: $bolt-card-replacement-z-index-outer-link;
+  overflow: hidden;
   cursor: pointer;
+  outline-offset: -3px;
+  border-radius: var(--bolt-card-border-radius);
 }
 
 button.c-bolt-card_replacement__link {

--- a/packages/components/bolt-card-replacement/src/card-replacement-media/_card-replacement-media.scss
+++ b/packages/components/bolt-card-replacement/src/card-replacement-media/_card-replacement-media.scss
@@ -10,8 +10,6 @@
     flex-shrink: 1;
     min-width: 80px;
     max-width: 300px;
-    overflow: auto;
-    border-radius: 4px 0 0 4px;
   }
 }
 
@@ -21,11 +19,14 @@ bolt-card-replacement-media {
   position: relative;
 
   [horizontal] & {
+    flex-grow: 1;
     flex-shrink: 1;
     min-width: 80px;
     max-width: 300px;
-    overflow: auto;
-    border-radius: 4px 0 0 4px;
+
+    &:last-child {
+      max-width: 100%;
+    }
   }
 }
 

--- a/packages/components/bolt-card-replacement/src/card-replacement/card-replacement.js
+++ b/packages/components/bolt-card-replacement/src/card-replacement/card-replacement.js
@@ -17,12 +17,6 @@ class BoltCardReplacement extends withContext(BoltElement) {
   //   return [card-replacementContext];
   // }
 
-  static get providedContexts() {
-    return {
-      horizontal: { value: this.horizontal },
-    };
-  }
-
   static get styles() {
     return [unsafeCSS(cardReplacementStyles)];
   }
@@ -36,7 +30,10 @@ class BoltCardReplacement extends withContext(BoltElement) {
       theme: String, // xdark | dark | light | xlight
       tag: String, // div | figure | article
       height: String, // full | auto
-      raised: Boolean,
+      raised: {
+        type: Boolean,
+        reflect: true,
+      },
       url: String,
       urlText: String,
       rounded: {
@@ -47,16 +44,24 @@ class BoltCardReplacement extends withContext(BoltElement) {
   }
 
   render() {
-    const isRaised =
+    const canBeRaised =
       (this.raised && this.raised === true) ||
       (this.url && this.url.length > 0) ||
-      this.querySelector('bolt-card-replacement-link');
+      this.querySelector('bolt-card-replacement-link')
+        ? true
+        : false;
+
+    if (canBeRaised) {
+      this.setAttribute('can-raise', '');
+    } else {
+      this.removeAttribute('can-raise');
+    }
 
     // validate the original prop data passed along -- returns back the validated data w/ added default values
     // const { theme, tag } = this.validateProps(this.props);
 
     const classes = cx('c-bolt-card-replacement', {
-      [`c-bolt-card-replacement--raised`]: isRaised,
+      [`c-bolt-card-replacement--raised`]: canBeRaised,
       [`c-bolt-card-replacement--horizontal`]: this.horizontal,
       [`c-bolt-card-replacement--rounded`]: this.rounded,
       [`t-bolt-${this.theme}`]: this.theme && this.theme !== 'none',
@@ -66,6 +71,7 @@ class BoltCardReplacement extends withContext(BoltElement) {
 
     const cardReplacementLink =
       this.url !== undefined &&
+      this.url !== null &&
       !this.querySelector('bolt-card-replacement-link')
         ? html`
             <bolt-card-replacement-link

--- a/packages/components/bolt-card-replacement/src/card-replacement/card-replacement.scss
+++ b/packages/components/bolt-card-replacement/src/card-replacement/card-replacement.scss
@@ -10,11 +10,12 @@
 @include bolt-custom-element('bolt-card-replacement', block, medium);
 
 bolt-card-replacement {
+  --bolt-card-border-radius: #{$bolt-card-replacement-border-radius};
+
   @include bolt-card-replacement-content-conditions;
   @include bolt-card-replacement-border-reset;
-
   position: relative;
-  border-radius: $bolt-card-replacement-border-radius;
+  border-radius: var(--bolt-card-border-radius);
   border-width: $bolt-card-replacement-border-width;
 
   &[height='full'] {
@@ -24,12 +25,34 @@ bolt-card-replacement {
   }
 
   &[rounded] {
-    @include bolt-border-radius(large);
+    --bolt-card-border-radius: #{bolt-border-radius(large)};
   }
 
-  &[horizontal] > *:first-child {
-    border-radius: $bolt-card-replacement-border-radius 0 0
-      $bolt-card-replacement-border-radius;
+  &:before,
+  &:after {
+    content: '';
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    pointer-events: none;
+    border-radius: inherit;
+    transition: opacity $bolt-transition;
+  }
+
+  &:before {
+    @include bolt-shadow('level-20', false, $bolt-card-replacement-shadow-color);
+  }
+
+  &:after {
+    opacity: 0;
+
+    @include bolt-shadow(
+      'level-30',
+      false,
+      $bolt-card-replacement-shadow-color
+    );
   }
 }
 
@@ -38,15 +61,15 @@ bolt-card-replacement {
   @include bolt-card-replacement-content-conditions;
   @include bolt-margin(0);
   @include bolt-padding(0);
-  @include bolt-shadow('level-20', false, $bolt-card-replacement-shadow-color);
-
   display: flex;
   flex-direction: column;
   flex-grow: 1;
   position: relative;
   width: 100%; // Fix for IE 11 when height is set to full
   height: 100%;
-  border-radius: $bolt-card-replacement-border-radius;
+  overflow: hidden;
+  border-radius: var(--bolt-card-border-radius);
+  border-width: $bolt-card-replacement-border-width;
 
   // Non-themed card-replacement color settings.
   // Note: when a card-replacement is themed, the `t-bolt-` class will define the color and background-color, these settings won't be loaded.
@@ -69,51 +92,34 @@ bolt-card-replacement {
   }
 }
 
-.c-bolt-card-replacement--rounded {
-  @include bolt-border-radius(large);
-}
 
 .c-bolt-card-replacement--horizontal {
   display: flex;
   flex-direction: row;
 }
 
-.c-bolt-card-replacement--raised {
-  transition: transform $bolt-transition;
-
-  &:before {
-    @include bolt-shadow(
-      'level-30',
-      false,
-      $bolt-card-replacement-shadow-color
-    );
-    content: '';
-    opacity: 0;
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    border-radius: $bolt-card-replacement-border-radius;
-    transition: opacity $bolt-transition;
-  }
+bolt-card-replacement[can-raise] {
+  transition: transform 0.1s ease;
 
   &:hover,
   &:focus-within {
     transform: translate3d(0, -1px, 0);
 
-    &:before {
-      opacity: 1;
+    &:after {
+      opacity: 1
     }
   }
 
-  &:active {
-    transform: translate3d(0, 0, 0);
+  &:active:hover {
+    transform: translate3d(0, 1px, 0);
+
+    &:after {
+      opacity: 0.5;
+    }
   }
 }
 
 // Old card-replacement footer
-
 .c-bolt-card_replacement__footer {
   @include bolt-card-replacement-border-reset;
 
@@ -125,11 +131,11 @@ bolt-card-replacement {
   position: absolute;
 
   &--top {
-    top: 0;
+    top: 0.5rem;
   }
 
   &--right {
-    right: 0;
+    right: 0.5rem;
   }
 }
 

--- a/packages/components/bolt-card-replacement/src/card-replacement/card-replacement.twig
+++ b/packages/components/bolt-card-replacement/src/card-replacement/card-replacement.twig
@@ -47,7 +47,11 @@
 {# card-replacement component's custom element wrapper #}
 <bolt-card-replacement
   {% if rounded %} rounded {% endif %}
-  {% if tag %} tag="{{ tag }}" {% endif %} {% if theme %} theme="{{ theme }}" {% endif %} {% if height %} height="{{ height }}" {% endif %} {% if link_url %} url="{{ link_url }}" {% endif %} {% if horizontal %} horizontal {% endif %} {{ attributes }}>
+  {% if tag %} tag="{{ tag }}" {% endif %}
+  {% if theme %} theme="{{ theme }}" {% endif %}
+  {% if height %} height="{{ height }}" {% endif %}
+  {% if link_url or url %} url="{{ link_url | default(url) }}" can-raise {% endif %}
+  {% if horizontal %} horizontal {% endif %} {{ attributes }}>
   {# This sets none values to not render anything. #}
   {% set theme = theme == "none" ? false : theme %}
 
@@ -100,7 +104,7 @@
         {% endif %}
       {% endif %}
 
-      {% if horizontal %}<div class="c-bolt-card-replacement__horizontal-wrapper">{% endif %}
+      {% if horizontal and (body or actions) %}<div class="c-bolt-card-replacement__horizontal-wrapper">{% endif %}
       {% if body or body_block %}
         {% if body_block %}
           {% embed "@bolt-components-card-replacement/_card-replacement-body.twig" %}
@@ -118,7 +122,7 @@
           {% include "@bolt-components-card-replacement/_card-replacement-actions.twig" %}
         {% endif %}
       {% endblock %}
-      {% if horizontal %}</div>{% endif %}
+      {% if horizontal and (body or actions) %}</div>{% endif %}
     {% endif %}
   </replace-with-children>
 </bolt-card-replacement>

--- a/packages/components/bolt-popover/package.json
+++ b/packages/components/bolt-popover/package.json
@@ -22,7 +22,7 @@
     "@bolt/components-link": "^2.19.0",
     "@bolt/components-trigger": "^2.19.0",
     "@bolt/core-v3.x": "^2.19.0",
-    "@popperjs/core": "^2.0.0",
+    "@popperjs/core": "^2.1.1",
     "mousetrap": "^1.6.5"
   },
   "publishConfig": {

--- a/packages/components/bolt-popover/src/popover.scss
+++ b/packages/components/bolt-popover/src/popover.scss
@@ -70,6 +70,7 @@ $bolt-popover-transition: $bolt-transition-timing
   z-index: bolt-z-index(popover);
   transition: opacity $bolt-popover-transition;
 
+  &[aria-hidden="false"],
   .c-bolt-popover.is-expanded &,
   bolt-popover:not([ready]) [slot='content']:target & {
     visibility: visible;
@@ -134,6 +135,7 @@ $bolt-popover-transition: $bolt-transition-timing
   display: block;
   transform: scale3d(1, 1, 1) translate3d(0, 0, 0);
   overflow: hidden;
+  margin: 0;
   color: bolt-theme(text);
   text-align: left;
   text-align: start;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2550,6 +2550,11 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.0.0.tgz#a832f8da4c9547cb7afae92845bfb73563ba6b66"
   integrity sha512-bN4670c4wr7RAOWTaf+h5KpC8al3h5fZSXqffakZrxZA01aKulM3rwIsU7qutrnYWw/nC1W06buOms/Rh+ZEDA==
 
+"@popperjs/core@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.1.1.tgz#12c572ab88ef7345b43f21883fca26631c223085"
+  integrity sha512-sLqWxCzC5/QHLhziXSCAksBxHfOnQlhPRVgPK0egEw+ktWvG75T2k+aYWVjVh9+WKeT3tlG3ZNbZQvZLmfuOIw==
+
 "@prerenderer/prerenderer@^0.7.2":
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/@prerenderer/prerenderer/-/prerenderer-0.7.2.tgz#b26a806bcdb3b313d527b313bdd72a57434b45fd"


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/BDS-2041

> Superseded by #1817, but Popover work done here may be useful in the future.

## Summary
Card + related UI refactoring (Popover) to the root problem(s) of overflowing / clipping content within Cards + the need to have `overflow: hidden` usage not break other nested UI like Popover.

![image](https://user-images.githubusercontent.com/1617209/76860671-cbcb3580-6831-11ea-9d5b-cc0ed20dfb90.png)
> Prior to this update, this wouldn't have been possible if the Card set `overflow: hidden`

![image](https://user-images.githubusercontent.com/1617209/76860192-f9fc4580-6830-11ea-84ce-dc1d4f76acc3.png)
> After this update, `overflow: hidden` won't cause any problems 

**TLDR**
- Card has simpler styles that better handle long running issues dealing with `overflow: hidden`, bug fixes, and new supporting demos
- Popover now renders slotted content externally as a permanent strategy to how we handle clipping / cropping issues with `overflow: hidden`

## Details

### Card Updates

1. Adds new Card demos to check for properly clipped images (both being the first / last child, plus having a Card Link as a sibling)
2. Also adds a Card demo to test that Popover renders and is positioned correctly
3. Removes / simplifies Card styles no longer required with simplified overflow approach
4. Simplifies how Card's border-radius styles are applied
5. Fixes image-only Horizontal Cards to properly fill the space available
6. Fixes the Card's `url` related JS logic so raised cards (ex. with custom links) are more consistent
7. Makes sure that the Card's border styles move with the rest of the card when hovering / clicking down
8. Adjusts how the Card's shadows are applied so they aren't chopped over by setting `overflow: hidden` on the root parent container.
9. Fixes another separate Card issue where the card's internal wrapper for horizontal content was getting added by the Twig template even if a Card doesn't contain any body or action content.

### Popover Updates

10. Updates Popperjs to the latest version.
11. Updates the Popperjs web component to render content to an external container on the page to work around the problems encountered when rendering to containers that have overflow set. This now matches similar rendering strategies found in other libraries!

### Core Updates
12. Updates Slotify to add a new optional param to allow rendering slotted content _without_ using native `<slots>` -- used in the Popover updates that allow Popover to continue to use Shadow DOM while rendering the slotted content to an external container for more predictable positioning

<hr>

## Open Questions
1. Should we be using this same technique with Tooltip as well?
2. I know this seems to work fine with 3D transformed UI (ex. Carousel) but did we want to double check this with Modal as well?
3. Should we be nuking the externally rendered Popover content once the component is closed / gets disconnected from the page?
4. Should this [new optional Slotify prop](https://github.com/boltdesignsystem/bolt/pull/1786/files#diff-9314574ce6412c13f9a56d5735da16d9R48) be the 2nd or 3rd param? I opted for 2nd but could also see this being the 3rd prop as well...

## How to test
- Review the Card component demos to confirm previous issues with content not being clipped / issues related to overflow hidden are addressed. In particular, check out the new horizontal Card demo with Popover which previously would have been broken.
- Review Popover (especially in Academy's dashboard prototypes -- ex. within Toolbar and Carousel) to confirm consistent rendering and placement.