### PR TITLE
Add 'rel' attribute support to button component

### DIFF
--- a/packages/components/bolt-button/src/button.twig
+++ b/packages/components/bolt-button/src/button.twig
@@ -58,6 +58,9 @@
     {% if url %}
       {% set inner_attributes = inner_attributes.setAttribute("href", url) %}
     {% endif %}
+    {% if attributes.rel %}
+      {% set inner_attributes = inner_attributes.setAttribute("rel", attributes.rel) %}
+    {% endif %}
   {% endif %}
   {% if attributes.target %}
     {% set inner_attributes = inner_attributes.setAttribute("target", attributes.target) %}


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/WWWD-4631

## Summary

For SEO reason links rendered by button.twig template need `rel` attribute added.

## How to test

```
{% include "@bolt-components-button/button.twig" with {
...
  attributes: {
    'rel': 'canonical'
  }
...
} only %}
```