### PR TITLE
Add JSON Schema Support to BoltElement (LitElement) component base Class 

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/button/15-button-style-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/button/15-button-style-variations.twig
@@ -9,7 +9,7 @@
 <p><mark>Note: interactive states only appear when the user interacts with the button, they are not styles that are available for use.</mark></p>
 
 <h3>Regular States</h3>
-{% for style in schema.properties.style.enum %}
+{% for style in schema.properties.color.enum %}
   {% set button %}
     {% include "@bolt-components-button/button.twig" with {
       text: style|capitalize ~ " button",
@@ -34,7 +34,7 @@
 {% endfor %}
 
 <h3>Interactive States</h3>
-{% for style in schema.properties.style.enum %}
+{% for style in schema.properties.color.enum %}
   {% set button_hover %}
     {% include "@bolt-components-button/button.twig" with {
       text: style|capitalize ~ " button (hover)",

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/button/20-button-theme-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/button/20-button-theme-variations.twig
@@ -6,7 +6,7 @@
   <div class="u-bolt-margin-bottom-medium">
     {% embed "@utils/theme-demo.twig" %}
       {% block demo_content %}
-        {% for style in schema.properties.style.enum %}
+        {% for style in schema.properties.color.enum %}
           {% include "@bolt-components-button/button.twig" with {
             text: style|capitalize ~ " button",
             style: style

--- a/packages/base-element/package.json
+++ b/packages/base-element/package.json
@@ -7,7 +7,9 @@
   "dependencies": {
     "@bolt/core-v3.x": "^2.20.0",
     "@bolt/polyfills": "^2.19.0",
-    "lit-element": "2.2.1"
+    "camel-case": "^4.1.1",
+    "lit-element": "2.2.1",
+    "param-case": "^3.0.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/base-element/src/BoltElement.js
+++ b/packages/base-element/src/BoltElement.js
@@ -5,11 +5,13 @@ import {
   renderAndRenderedEvents,
   lazyStyles,
   conditionalShadowDom,
+  jsonSchemaProps,
 } from './lib/decorators';
 
 @renderAndRenderedEvents()
 @lazyStyles()
 @conditionalShadowDom()
+@jsonSchemaProps()
 class BoltElement extends Slotify {
   // patch to https://github.com/Polymer/lit-element/blob/master/src/lit-element.ts#L208
   // as a temp workaround to constructible stylesheets not working when

--- a/packages/base-element/src/lib/decorators.js
+++ b/packages/base-element/src/lib/decorators.js
@@ -333,6 +333,7 @@ const jsonSchemaPropsDecorator = clazz => {
       for (const key in this.schema.properties) {
         let property = this.schema.properties[key];
 
+        // skip any schema properties marked as being deprecated
         if (
           !property.title ||
           (!property.title.includes('deprecated') &&
@@ -346,6 +347,8 @@ const jsonSchemaPropsDecorator = clazz => {
 
           let propType;
 
+          // map the JSON schema property type to LitElement property types
+          // see https://lit-element.polymer-project.org/guide/properties#declare for more info
           switch (property.type) {
             case 'boolean':
               propType = Boolean;
@@ -366,7 +369,7 @@ const jsonSchemaPropsDecorator = clazz => {
               propType = String;
               break;
 
-            // @todo: re-evaluate this approach for handling `any` + multi-types
+            // @todo: re-evaluate this switch default for handling `any` + multi-types
             default:
               propType = Object;
               break;
@@ -402,7 +405,7 @@ const standardJsonSchemaPropsDecorator = descriptor => {
 };
 
 /**
- * Class decorator factory that adds `render` and `rendered` custom events to the LitElement-based web component
+ * Class decorator factory that adds JSON schema support to the LitElement-based web component
  * Automatically uses the appropriate decorator syntax based on what's supported / how the code is being compiled.
  */
 export const jsonSchemaProps = () => classOrDescriptor =>

--- a/packages/components/bolt-button/button.schema.js
+++ b/packages/components/bolt-button/button.schema.js
@@ -57,6 +57,10 @@ module.exports = {
       enum: ['xsmall', 'small', 'medium', 'large', 'xlarge'],
     },
     style: {
+      title: 'DEPRECATED',
+      description: 'Use the color parameter instead.',
+    },
+    color: {
       type: 'string',
       description: 'Style of the button determined by information hierarchy.',
       default: 'primary',

--- a/packages/components/bolt-button/src/button.js
+++ b/packages/components/bolt-button/src/button.js
@@ -10,7 +10,7 @@ import {
 import classNames from 'classnames/bind';
 
 import buttonStyles from './button.scss';
-// import schema from '../button.schema.js'; @todo: temporarily removed while we switch to `lit-element`, soon to be re-added
+import schema from '../button.schema.js';
 
 let cx = classNames.bind(buttonStyles);
 
@@ -21,29 +21,19 @@ class BoltButton extends BoltActionElement {
     return [unsafeCSS(buttonStyles)];
   }
 
-  // static useShadow = false; example of manually disabling Shadow DOM w/ BoltElement
+  static schema = schema;
 
   static get properties() {
     return {
-      ...BoltActionElement.properties, // Provides: disabled, onClick, onClickTarget, target, url
-      color: { type: String },
-      text: { type: String },
-      size: { type: String },
-      rounded: { type: Boolean }, // DEPRECATED.  Use border-radius instead of rounded.
-      borderRadius: {
+      ...this.props,
+      onClick: {
         type: String,
-        attribute: 'border-radius',
+        attribute: 'on-click',
       },
-      iconOnly: {
-        type: Boolean,
-        attribute: 'icon-only',
+      onClickTarget: {
+        type: String,
+        attribute: 'on-click-target',
       },
-      width: { type: String },
-      align: { type: String },
-      transform: { type: String },
-      type: { type: String },
-      tabindex: { type: Number },
-      inert: { type: Boolean }, // will eventually go hand in hand with https://github.com/WICG/inert#notes-on-the-polyfill
     };
   }
 

--- a/packages/components/bolt-button/src/button.twig
+++ b/packages/components/bolt-button/src/button.twig
@@ -13,6 +13,11 @@
   {% set align = itemAlignment %}
 {% endif %}
 
+{# DEPRECATED.  Use the prooperty `align` instead of `itemAlignment`. #}
+{% if style %}
+  {% set color = style %}
+{% endif %}
+
 {# DEPRECATED.  Use the values `start` and `end` insted of `left` and `right`. #}
 {% if align == "left" %}
  {% set align = "start" %}
@@ -32,7 +37,7 @@
 
 {# Set up checks to validate that the component's prop values are allowed, based on the component's schema #}
 {% set size_options = schema.properties.size.enum %}
-{% set style_options = schema.properties.style.enum %}
+{% set color_options = schema.properties.color.enum %}
 {% set width_options = schema.properties.width.enum %}
 {% set border_radius_options = schema.properties.border_radius.enum %}
 {% set align_options = schema.properties.align.enum %}
@@ -43,7 +48,7 @@
 
 {# Check that the component's current prop values are valid. if not, default to the schema default #}
 {% set size = size in size_options ? size : schema.properties.size.default %}
-{% set style = style in style_options ? style : schema.properties.style.default %}
+{% set color = color in color_options ? color : schema.properties.color.default %}
 {% set width = width in width_options ? width : schema.properties.width.default %}
 {% set border_radius = border_radius in border_radius_options ? border_radius : schema.properties.border_radius.default %}
 {% set align = align in align_options ? align : schema.properties.align.default %}
@@ -76,7 +81,7 @@
   base_class,
   disabled ? "#{base_class}--disabled" : "",
   size ? "#{base_class}--#{size}" : "",
-  style ? "#{base_class}--#{style}" : "",
+  color ? "#{base_class}--#{color}" : "",
   width != "auto" ? "#{base_class}--#{width}" : "",
   border_radius ? "#{base_class}--border-radius-#{border_radius}" : "",
   align ? "#{base_class}--#{align}" : "",
@@ -138,7 +143,7 @@ Sort classes passed in via attributes into two groups:
 {# Set up the custom element's prop values based on the params passed into the Twig template - used to hydrate the component's initial state and appearance once the Button Component's JavaScript kicks in #}
 <bolt-button
   {% if size %} size="{{ size }}" {% endif %}
-  {% if style %} color="{{ style }}" {% endif %}
+  {% if color %} color="{{ color }}" {% endif %}
   {% if width %} width="{{ width }}" {% endif %}
   {% if border_radius %} border-radius="{{ border_radius }}" {% endif %}
   {% if align %} align="{{ align }}" {% endif %}

--- a/packages/components/bolt-button/src/button.twig
+++ b/packages/components/bolt-button/src/button.twig
@@ -13,7 +13,8 @@
   {% set align = itemAlignment %}
 {% endif %}
 
-{# DEPRECATED.  Use the prooperty `align` instead of `itemAlignment`. #}
+{# DEPRECATED.  Use the `color` instead of `style` property in Twig. 
+  Note: this prop name is ultimately switching to `variant` with the next SEMVER release #}
 {% if style %}
   {% set color = style %}
 {% endif %}

--- a/packages/components/bolt-link/src/link.js
+++ b/packages/components/bolt-link/src/link.js
@@ -21,25 +21,20 @@ class BoltLink extends BoltActionElement {
     return [unsafeCSS(linkStyles)];
   }
 
+  static schema = schema;
+
   static get properties() {
     return {
-      ...BoltActionElement.properties,
-      display: String,
-      valign: String,
-      isHeadline: {
-        type: Boolean,
-        attribute: 'is-headline',
+      ...this.props,
+      onClick: {
+        type: String,
+        attribute: 'on-click',
+      },
+      onClickTarget: {
+        type: String,
+        attribute: 'on-click-target',
       },
     };
-  }
-
-  // https://github.com/WebReflection/document-register-element#upgrading-the-constructor-context
-  constructor(self) {
-    self = super(self);
-    self.schema = schema;
-    self.display = schema.properties.display.default;
-    self.valign = schema.properties.valign.default;
-    return self;
   }
 
   render() {

--- a/packages/experimental/editor/src/setup-bolt.js
+++ b/packages/experimental/editor/src/setup-bolt.js
@@ -361,7 +361,7 @@ export function setupBolt(editor) {
 
   // schema has it as `style` but web component uses it as `color` since `style` is a reserved HTML attribute; see http://vjira2:8080/browse/BDS-721 & http://vjira2:8080/browse/BDS-1104
   const colorTrait = convertSchemaPropToTrait({
-    prop: buttonSchema.properties.style,
+    prop: buttonSchema.properties.color,
     name: 'color',
   });
   colorTrait.label = 'Color';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5091,6 +5091,14 @@ camel-case@3.0.x, camel-case@^3.0.0:
     no-case "^2.2.0"
     upper-case "^1.1.1"
 
+camel-case@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-4.1.1.tgz#1fc41c854f00e2f7d0139dfeba1542d6896fe547"
+  integrity sha512-7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==
+  dependencies:
+    pascal-case "^3.1.1"
+    tslib "^1.10.0"
+
 camelcase-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7"
@@ -7839,6 +7847,14 @@ dot-case@^2.1.0:
   integrity sha1-NNzzf1Co6TwrO8qLt/uRVcfaO+4=
   dependencies:
     no-case "^2.2.0"
+
+dot-case@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/dot-case/-/dot-case-3.0.3.tgz#21d3b52efaaba2ea5fda875bb1aa8124521cf4aa"
+  integrity sha512-7hwEmg6RiSQfm/GwPL4AAWXKy3YNNZA3oFv2Pdiey0mwkRCPZ9x6SZbkLcn8Ma5PYeVokzoD4Twv2n7LKp5WeA==
+  dependencies:
+    no-case "^3.0.3"
+    tslib "^1.10.0"
 
 dot-prop@^3.0.0:
   version "3.0.0"
@@ -14550,6 +14566,13 @@ lower-case@^1.1.0, lower-case@^1.1.1, lower-case@^1.1.2:
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
   integrity sha1-miyr0bno4K6ZOkv31YdcOcQujqw=
 
+lower-case@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.1.tgz#39eeb36e396115cc05e29422eaea9e692c9408c7"
+  integrity sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==
+  dependencies:
+    tslib "^1.10.0"
+
 lowercase-keys@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
@@ -15629,6 +15652,14 @@ no-case@^2.2.0, no-case@^2.3.2:
   integrity sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==
   dependencies:
     lower-case "^1.1.1"
+
+no-case@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.3.tgz#c21b434c1ffe48b39087e86cfb4d2582e9df18f8"
+  integrity sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==
+  dependencies:
+    lower-case "^2.0.1"
+    tslib "^1.10.0"
 
 no-emit-webpack-plugin@^2.0.1:
   version "2.0.1"
@@ -17072,6 +17103,14 @@ param-case@2.1.x, param-case@^2.1.0, param-case@^2.1.1:
   dependencies:
     no-case "^2.2.0"
 
+param-case@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/param-case/-/param-case-3.0.3.tgz#4be41f8399eff621c56eebb829a5e451d9801238"
+  integrity sha512-VWBVyimc1+QrzappRs7waeN2YmoZFCGXWASRYX1/rGHtXqEcrGEIDm+jqIwFa2fRXNgQEwrxaYuIrX0WcAguTA==
+  dependencies:
+    dot-case "^3.0.3"
+    tslib "^1.10.0"
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -17245,6 +17284,14 @@ pascal-case@^2.0.0:
   dependencies:
     camel-case "^3.0.0"
     upper-case-first "^1.1.0"
+
+pascal-case@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-3.1.1.tgz#5ac1975133ed619281e88920973d2cd1f279de5f"
+  integrity sha512-XIeHKqIrsquVTQL2crjq3NfJUxmdLasn3TYOU0VBM+UX2a6ztAWBlJQBePLGY7VHW8+2dRadeIPK5+KImwTxQA==
+  dependencies:
+    no-case "^3.0.3"
+    tslib "^1.10.0"
 
 pascalcase@^0.1.1:
   version "0.1.1"
@@ -22692,6 +22739,11 @@ tslib@1.10.0, tslib@^1.9.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
+tslib@^1.10.0:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
+  integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
## Jira
- http://vjira2:8080/browse/BDS-1104
- http://vjira2:8080/browse/BDS-1266

## Summary
Adds proper JSON Schema support to our custom LitElement-based BoltElement base class + minimally updates the Link and Button components to demonstrate usage.

## How To Use
```
class MyComponent extends BoltElement {
  static schema = schema; // --> 1. add imported schema data to a static `schema` property

  static get properties() {	  
    return {
      ...this.props, // --> 2. then add the auto-generated `this.props` property data to your component
     
      // 3. optionally add any extra props not included in the component schema 
      onClickTarget: {
        type: String,
        attribute: 'on-click-target',
      },
      ...
  }
}
```

## Details
While this PR doesn't cover adding schema validation to LitElement, it _does_ tackle most of the related upfront work. Specifically this PR covers:

1. Adds a new decorator to `@bolt/element` which uses static schema data set on a component to:
    - Auto-generate most of the component property data (ie. map schema data to LitElement properties)
    - Automatically add default component prop values based on the JSON schema
2. Updates the Button and Link components to demonstrate actually using this new functionality
    - Note: we're also doing the long-overdue `style` to `color` prop swap for Button which is needed in order for this 1:1 mapping to work... the actual `variants` prop rename should come separately so this PR doesn't introduce any breaking changes.

## How to test
- Review code changes -- especially the decorator updates to LitElement
- Smoke test Link and Button to confirm everything continues to work as expected given CI tests are all passing