### PR TITLE
fix: Rework logic for grid ordering in hero component

### DIFF
--- a/packages/components/bolt-hero/hero.twig
+++ b/packages/components/bolt-hero/hero.twig
@@ -17,9 +17,16 @@
 {% set _imagePaddingTop = imageValign == "top" ? "none" : "large" %}
 {% set _imagePaddingBottom = this.data["image_valign"] == "bottom" ? "none" : "large" %}
 
-{% set _isImageFirstOnMobile = (imageValign != 'bottom') or (imageValign == 'top') %}
+{# Image order on desktop is always determined by the reverseOrder prop; order on mobile is always set automatically #}
 {% set _isImageFirstOnDesktop = reverseOrder == true %}
-{% set _isImageLastOnMobile = (imageValign != 'top') or (imageValign == 'bottom') %}
+{% set _isImageFirstOnMobile = imageValign != 'bottom' %}
+
+{#
+  Image and content will be printed in the order they should appear on mobile.  For desktop, leave it the same unless:
+    - An image is present, in which case check to see if mobile and desktop ordering should be different
+    - No image is present, in which case simply honor the reverseOrder prop.
+#}
+{% set _reverseGrid = image ? (_isImageFirstOnDesktop != _isImageFirstOnMobile) : reverseOrder %}
 
 {% if image %}
   {% set renderedImage %}
@@ -32,7 +39,7 @@
         u-bolt-width-6/12@{{ _largeBreakpoint }}
         u-bolt-padding-{{_isImageFirstOnDesktop ? 'right' : 'left'}}-large@{{_largeBreakpoint}}
         {{ _isImageFirstOnMobile and imageValign != 'top' ? 'u-bolt-padding-top-large' : '' }}
-        {{ _isImageLastOnMobile and imageValign != 'bottom' and not _isImageFirstOnMobile ? 'u-bolt-padding-bottom-large' : '' }}
+        {{ _isImageFirstOnMobile == false and imageValign != 'bottom' ? 'u-bolt-padding-bottom-large' : '' }}
         u-bolt-padding-top-{{_imagePaddingTop}}@{{_mediumBreakpoint}}
         u-bolt-padding-bottom-{{_imagePaddingBottom}}@{{_mediumBreakpoint}}
       ">
@@ -54,11 +61,17 @@
   {% endset %}
 {% endif %}
 
+{#
+  Image and content are printed in the order they should appear on mobile.  For desktop, leave it the same unless:
+    - An image is present, in which case check to see if mobile and desktop ordering should be different.
+    - No image is present, in which case simply honor the reverseOrder prop.
+#}
+{% set _reverseGrid = image ? (_isImageFirstOnDesktop != _isImageFirstOnMobile) : reverseOrder %}
 
 {% set content %}
-  {% grid "o-bolt-grid--flex o-bolt-grid--middle o-bolt-grid--medium #{(reverseOrder == false and imageValign != 'bottom') or (reverseOrder == true and not image) ? 'o-bolt-grid--rev' : '' }" %}
+  {% grid "o-bolt-grid--flex o-bolt-grid--middle o-bolt-grid--medium #{_reverseGrid ? 'o-bolt-grid--rev' : '' }" %}
 
-    {% if _isImageFirstOnMobile and image %}
+    {% if image and _isImageFirstOnMobile %}
       {{ renderedImage }}
     {% endif %}
 
@@ -72,7 +85,7 @@
       {{ content }}
     {% endcell %}
 
-    {% if _isImageLastOnMobile and image and not _isImageFirstOnMobile %}
+    {% if image and _isImageFirstOnMobile == false %}
       {{ renderedImage }}
     {% endif %}
 

--- a/packages/components/bolt-hero/hero.twig
+++ b/packages/components/bolt-hero/hero.twig
@@ -21,13 +21,6 @@
 {% set _isImageFirstOnDesktop = reverseOrder == true %}
 {% set _isImageFirstOnMobile = imageValign != 'bottom' %}
 
-{#
-  Image and content will be printed in the order they should appear on mobile.  For desktop, leave it the same unless:
-    - An image is present, in which case check to see if mobile and desktop ordering should be different
-    - No image is present, in which case simply honor the reverseOrder prop.
-#}
-{% set _reverseGrid = image ? (_isImageFirstOnDesktop != _isImageFirstOnMobile) : reverseOrder %}
-
 {% if image %}
   {% set renderedImage %}
     <div


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-2079

## Summary

Fixes a bug where hero `reverseOrder` prop does not work when `imageValign` is `bottom`

## Details

I set out only to fix the original bug.  However, I found the existing twig logic for `hero` to be pretty difficult to read, in part because there were a number of logic errors.  For example:

```
{% set _isImageFirstOnMobile = (imageValign != 'bottom') or (imageValign == 'top') %}
{% set _isImageLastOnMobile = (imageValign != 'top') or (imageValign == 'bottom') %}
```

First, both of these statements are logically identical if you remove the second conditions (if something is "not bottom", you don't need to also check for whether it could be "top").
```
{% set _isImageFirstOnMobile = (imageValign != 'bottom') %}
{% set _isImageLastOnMobile = (imageValign != 'top') %}
```

Digging in further, what happens if the value of `imageValign` is `middle`?  Well, both of the above statements evaluate to `true`, so you end up with image on mobile being both first _and_ last. 🙃 

So I ended up re-working a lot of the logic here.  Hopefully it's equivalent to what was there before without the additional bugs.

## How to test

### Reproduce the bug
- Check out any other branch
- Edit docs-site/src/pages/pattern-lab/_patterns/02-components/hero/20-hero--reverse-order.twig
Change `imageValign` to `bottom`
View the pattern at /pattern-lab/?p=components-hero--reverse-order
Note that the image is on the right (expected on the left).

### Confirm the fix
- Check out the branch in this PR
- Confirm that the steps above give the expected results
- Confirm that all other scenarios give expected results