### PR TITLE
Fix/toc scroll position fixes

### DIFF
--- a/packages/components/bolt-toc/src/_toc-item.js
+++ b/packages/components/bolt-toc/src/_toc-item.js
@@ -89,9 +89,11 @@ class BoltTocItem extends withContext(BoltElement) {
         let scrollOpts = scrollOptions;
 
         const scrollOffset = this.scrollOffset || 0;
-        const scrollOffsetElemHeight = this.scrollOffsetSelector
-          ? document.querySelector(this.scrollOffsetSelector).clientHeight
-          : 0;
+        const scrollOffsetElemHeight =
+          this.scrollOffsetSelector &&
+          document.querySelector(this.scrollOffsetSelector)
+            ? document.querySelector(this.scrollOffsetSelector).clientHeight
+            : 0;
 
         scrollOpts.offset = scrollOffset + scrollOffsetElemHeight;
 

--- a/packages/components/bolt-toc/src/_toc-item.js
+++ b/packages/components/bolt-toc/src/_toc-item.js
@@ -97,6 +97,11 @@ class BoltTocItem extends withContext(BoltElement) {
 
         scrollOpts.offset = scrollOffset + scrollOffsetElemHeight;
 
+        // Delete the default `header` value: https://github.com/cferdinandi/smooth-scroll#fixed-headers
+        // It works with fixed but not sticky elements. For consistency, handle scroll position entirely through `offset`.
+        // @todo We need a solution for multiple stacked fixed/sticky elements. Also see `onPositionChange()` in toc.js.
+        delete scrollOpts.header;
+
         smoothScroll.animateScroll(this.target, this.shadowLink, scrollOpts);
       }
     } catch (err) {

--- a/packages/components/bolt-toc/src/toc.js
+++ b/packages/components/bolt-toc/src/toc.js
@@ -147,7 +147,7 @@ class BoltToc extends withContext(BoltElement) {
     const marker = document.createElement('div');
     marker.setAttribute(
       'style',
-      `position: fixed; bottom: ${this.boundaryBottom}; top: ${this.boundaryTop}; width: 100%; border: 1px solid red; opacity: 0.5`,
+      `position: fixed; bottom: ${this.boundaryBottom}; top: ${this.boundaryTop}; width: 100%; border: 1px solid red; opacity: 0.5; pointer-events: none;`,
     );
     document.body.appendChild(marker);
     BoltToc.debuggerAdded = true;

--- a/packages/components/bolt-toc/src/toc.js
+++ b/packages/components/bolt-toc/src/toc.js
@@ -173,11 +173,16 @@ class BoltToc extends withContext(BoltElement) {
     };
   }
 
+  // Smooth scroll events triggered by clicking menu items
   logScrollEvent(event) {
     if (event.type === 'scrollStart') {
       this.scrolling = true;
     } else if (event.type === 'scrollStop' || event.type === 'scrollCancel') {
-      this.scrolling = false;
+      // Wait before unsetting the scrolling flag as waypoint events may fire
+      // at same time as `scrollStop` event, avoids race condition
+      setTimeout(() => {
+        this.scrolling = false;
+      }, 100);
     }
   }
 


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-2080

## Summary

Fix scroll position on when you click on a menu item.

## Details

Supersedes #1800

On Academy, TOC is not scrolling to the correct position. This is because the global header includes the class '.js-bolt-smooth-scroll-offset' which is the default smoothScroll [`header` prop](https://github.com/cferdinandi/smooth-scroll#fixed-headers). This means smoothScroll does both its own internal offset for this element, plus our own offset on top of that. So, it scrolls about twice as far as it should.

For consistency across sites, and because smoothScroll only works with fixed not sticky elements, I'm removing that default header value from the smoothScroll config (in TOC only), and handling all the offset ourselves.

In addition, I fixed the following:
- Providing a `scrollOffsetSelector` that returns no results throws an error and smoothScroll is never called.
- After smoothScroll, Waypoint event fires and triggers active menu item to be updated. Can cause unexpected results when scrolling to end of page and second to last section is set to active.

## How to test

- Reproduce the bug by going to [current demo page](https://boltdesignsystem.com/pattern-lab/patterns/02-components-toc-30-toc-use-case-sticky-and-scroll-offset/02-components-toc-30-toc-use-case-sticky-and-scroll-offset.html) and in the inspector add the class `js-bolt-smooth-scroll-offset` to the `bolt-sticky` element. Click on a menu item and see that it scrolls too far.
- Repeat the same on [feature branch demo page](https://fix-toc-js-fixes.boltdesignsystem.com/pattern-lab/patterns/02-components-toc-30-toc-use-case-sticky-and-scroll-offset/02-components-toc-30-toc-use-case-sticky-and-scroll-offset.html) and verify fixed.