### PR TITLE
Hotfix: tiny CSS update to List component -- workaround to wrapping related issue in Safari

### DIFF
--- a/packages/components/bolt-list/src/list.scss
+++ b/packages/components/bolt-list/src/list.scss
@@ -80,7 +80,9 @@
     // The inline here is talking about the items inside, the List component itself is still a block level element that would fill up the space of any container.
     &.c-bolt-list--display-inline,
     &.c-bolt-list--display-flex {
-      width: calc(100% + #{bolt-spacing($spacing-value-name)}); // Width must be defined in order for the list to dislay correctly in Firefox.
+      // Width must be defined in order for the list to display correctly in Firefox.
+      // Extra 1px added as workaround to Safari wrapping issue in BDS-2087
+      width: calc(100% + #{bolt-spacing($spacing-value-name)} + 1px);
     }
 
     @each $breakpoint in $bolt-breakpoints {
@@ -89,7 +91,9 @@
       // The inline here is talking about the items inside, the List component itself is still a block level element that would fill up the space of any container.
       &.c-bolt-list--display-inline\@#{$breakpoint-name} {
         @include bolt-mq($breakpoint-name) {
-          width: calc(100% + #{bolt-spacing($spacing-value-name)}); // Width must be defined in order for the list to dislay correctly in Firefox.
+          // Width must be defined in order for the list to display correctly in Firefox.
+          // Extra 1px added as workaround to Safari wrapping issue in BDS-2087
+          width: calc(100% + #{bolt-spacing($spacing-value-name)} + 1px);
         }
       }
     }


### PR DESCRIPTION
## Jira
- http://vjira2:8080/browse/BDS-2087

## Summary
Adds a tiny `1px` addition to the two `calc(width: 100% + X)` rules in the List component as a workaround to address quirky wrapping behavior.

**Safari - Before**
![safari--before](https://user-images.githubusercontent.com/1617209/78138141-76c41d80-73f4-11ea-8c9a-8fbce14dae2e.gif)

**Safari - After**
![safari--after](https://user-images.githubusercontent.com/1617209/78138125-7035a600-73f4-11ea-9237-d74b68d3db1a.gif)

## Details
Technically adding `0.4px` seems to work (making me suspect that this could be related to a Webkit sub-pixel rounding issue / quirk) -- in either case, this change should basically be unnoticable, other than addressing the main layout wrapping issue in Safari.

## How to test
- Review the List component demos (specifically the inline / flex demos) to confirm there aren't any unintentional side-effects from this change
- Review the updated Completed Training page (especially in Safari) to confirm the wrapping issue is addressed when compared to the [Completed Training Page](https://v2-20-2.boltdesignsystem.com/pattern-lab/patterns/03-blueprints-05-pages-completed-training-completed-training/03-blueprints-05-pages-completed-training-completed-training.html) from the v2.20.2 release.