### PR TITLE
Fix List wrapping bug

### DIFF
--- a/packages/components/bolt-list/src/list.scss
+++ b/packages/components/bolt-list/src/list.scss
@@ -19,6 +19,7 @@
 //
 // 1. Reset typography so it doesn't inherit from a higher level container.
 // 2. Reset text-align so it doesn't conflict with the align prop which handles the horizontal alignment of inline items in a list, not the text-align within.
+// 3. Width must be defined in order for the list to dislay correctly in Firefox.
 .c-bolt-list {
   @include bolt-margin(0);
   @include bolt-padding(0);
@@ -79,12 +80,13 @@
     margin-left: bolt-spacing(#{$spacing-value-name}) * -1;
   }
 
+  // CSS hack targeting any Firefox version: https://css-tricks.com/snippets/css/css-hacks-targeting-firefox/
   @-moz-document url-prefix('') {
     .c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--inset {
       // The inline here is talking about the items inside, the List component itself is still a block level element that would fill up the space of any container.
       &.c-bolt-list--display-inline,
       &.c-bolt-list--display-flex {
-        width: 100%; // Width must be defined in order for the list to dislay correctly in Firefox.
+        width: 100%; // [3]
       }
 
       @each $breakpoint in $bolt-breakpoints {
@@ -92,7 +94,7 @@
 
         &.c-bolt-list--display-inline\@#{$breakpoint-name} {
           @include bolt-mq($breakpoint-name) {
-            width: 100%; // Width must be defined in order for the list to dislay correctly in Firefox.
+            width: 100%; // [3]
           }
         }
       }
@@ -101,9 +103,7 @@
       // The inline here is talking about the items inside, the List component itself is still a block level element that would fill up the space of any container.
       &.c-bolt-list--display-inline,
       &.c-bolt-list--display-flex {
-        width: calc(
-          100% + #{bolt-spacing($spacing-value-name)}
-        ); // Width must be defined in order for the list to dislay correctly in Firefox.
+        width: calc(100% + #{bolt-spacing($spacing-value-name)}); // [3]
       }
 
       @each $breakpoint in $bolt-breakpoints {
@@ -111,9 +111,7 @@
 
         &.c-bolt-list--display-inline\@#{$breakpoint-name} {
           @include bolt-mq($breakpoint-name) {
-            width: calc(
-              100% + #{bolt-spacing($spacing-value-name)}
-            ); // Width must be defined in order for the list to dislay correctly in Firefox.
+            width: calc(100% + #{bolt-spacing($spacing-value-name)}); // [3]
           }
         }
       }

--- a/packages/components/bolt-list/src/list.scss
+++ b/packages/components/bolt-list/src/list.scss
@@ -80,7 +80,8 @@
     // The inline here is talking about the items inside, the List component itself is still a block level element that would fill up the space of any container.
     &.c-bolt-list--display-inline,
     &.c-bolt-list--display-flex {
-      width: calc(100% + #{bolt-spacing($spacing-value-name)}); // Width must be defined in order for the list to dislay correctly in Firefox.
+      // @todo: testing without FF hack
+      // width: calc(100% + #{bolt-spacing($spacing-value-name)}); // Width must be defined in order for the list to dislay correctly in Firefox.
     }
 
     @each $breakpoint in $bolt-breakpoints {
@@ -89,7 +90,8 @@
       // The inline here is talking about the items inside, the List component itself is still a block level element that would fill up the space of any container.
       &.c-bolt-list--display-inline\@#{$breakpoint-name} {
         @include bolt-mq($breakpoint-name) {
-          width: calc(100% + #{bolt-spacing($spacing-value-name)}); // Width must be defined in order for the list to dislay correctly in Firefox.
+          // @todo: testing without FF hack
+          // width: calc(100% + #{bolt-spacing($spacing-value-name)}); // Width must be defined in order for the list to dislay correctly in Firefox.
         }
       }
     }

--- a/packages/components/bolt-list/src/list.scss
+++ b/packages/components/bolt-list/src/list.scss
@@ -47,10 +47,12 @@
   flex-flow: row wrap;
 }
 
-@include bolt-repeat-rule((
-  '.c-bolt-list--display-flex bolt-list-item',
-  '.c-bolt-list--display-flex ::slotted(bolt-list-item)'
-)) {
+@include bolt-repeat-rule(
+  (
+    '.c-bolt-list--display-flex bolt-list-item',
+    '.c-bolt-list--display-flex ::slotted(bolt-list-item)'
+  )
+) {
   flex: 1;
 }
 
@@ -67,7 +69,6 @@
     }
   }
 }
-
 
 // Spacing Prop
 @each $spacing-value in $bolt-spacing-values {
@@ -133,11 +134,9 @@ $bolt-list-alignments: start, center, end, justify;
     &.c-bolt-list--display-inline {
       @if $alignment != center and $alignment != justify {
         justify-content: flex-#{$alignment};
-      }
-      @else if $alignment == justify {
+      } @else if $alignment == justify {
         justify-content: space-between;
-      }
-      @else {
+      } @else {
         justify-content: #{$alignment};
       }
     }
@@ -149,11 +148,9 @@ $bolt-list-alignments: start, center, end, justify;
         @include bolt-mq($breakpoint-name) {
           @if $alignment != center and $alignment != justify {
             justify-content: flex-#{$alignment};
-          }
-          @else if $alignment == justify {
+          } @else if $alignment == justify {
             justify-content: space-between;
-          }
-          @else {
+          } @else {
             justify-content: #{$alignment};
           }
         }
@@ -171,8 +168,7 @@ $bolt-list-valignments: start, center, end;
     &.c-bolt-list--display-flex {
       @if $alignment != center {
         align-items: flex-#{$alignment};
-      }
-      @else {
+      } @else {
         align-items: #{$alignment};
       }
     }
@@ -184,8 +180,7 @@ $bolt-list-valignments: start, center, end;
         @include bolt-mq($breakpoint-name) {
           @if $alignment != center {
             align-items: flex-#{$alignment};
-          }
-          @else {
+          } @else {
             align-items: #{$alignment};
           }
         }
@@ -210,5 +205,4 @@ $bolt-list-valignments: start, center, end;
       }
     }
   }
-
 }

--- a/packages/components/bolt-list/src/list.scss
+++ b/packages/components/bolt-list/src/list.scss
@@ -79,7 +79,7 @@
     margin-left: bolt-spacing(#{$spacing-value-name}) * -1;
   }
 
-  @-moz-document url-prefix() {
+  @-moz-document url-prefix('') {
     .c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--inset {
       // The inline here is talking about the items inside, the List component itself is still a block level element that would fill up the space of any container.
       &.c-bolt-list--display-inline,

--- a/packages/components/bolt-list/src/list.scss
+++ b/packages/components/bolt-list/src/list.scss
@@ -76,22 +76,44 @@
   .c-bolt-list--spacing-#{$spacing-value-name}:not(.c-bolt-list--inset) {
     margin-bottom: bolt-v-spacing(#{$spacing-value-name}) * -1;
     margin-left: bolt-spacing(#{$spacing-value-name}) * -1;
+  }
 
-    // The inline here is talking about the items inside, the List component itself is still a block level element that would fill up the space of any container.
-    &.c-bolt-list--display-inline,
-    &.c-bolt-list--display-flex {
-      // @todo: testing without FF hack
-      // width: calc(100% + #{bolt-spacing($spacing-value-name)}); // Width must be defined in order for the list to dislay correctly in Firefox.
-    }
-
-    @each $breakpoint in $bolt-breakpoints {
-      $breakpoint-name: nth($breakpoint, 1);
-
+  @-moz-document url-prefix() {
+    .c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--inset {
       // The inline here is talking about the items inside, the List component itself is still a block level element that would fill up the space of any container.
-      &.c-bolt-list--display-inline\@#{$breakpoint-name} {
-        @include bolt-mq($breakpoint-name) {
-          // @todo: testing without FF hack
-          // width: calc(100% + #{bolt-spacing($spacing-value-name)}); // Width must be defined in order for the list to dislay correctly in Firefox.
+      &.c-bolt-list--display-inline,
+      &.c-bolt-list--display-flex {
+        width: 100%; // Width must be defined in order for the list to dislay correctly in Firefox.
+      }
+
+      @each $breakpoint in $bolt-breakpoints {
+        $breakpoint-name: nth($breakpoint, 1);
+
+        &.c-bolt-list--display-inline\@#{$breakpoint-name} {
+          @include bolt-mq($breakpoint-name) {
+            width: 100%; // Width must be defined in order for the list to dislay correctly in Firefox.
+          }
+        }
+      }
+    }
+    .c-bolt-list--spacing-#{$spacing-value-name}:not(.c-bolt-list--inset) {
+      // The inline here is talking about the items inside, the List component itself is still a block level element that would fill up the space of any container.
+      &.c-bolt-list--display-inline,
+      &.c-bolt-list--display-flex {
+        width: calc(
+          100% + #{bolt-spacing($spacing-value-name)}
+        ); // Width must be defined in order for the list to dislay correctly in Firefox.
+      }
+
+      @each $breakpoint in $bolt-breakpoints {
+        $breakpoint-name: nth($breakpoint, 1);
+
+        &.c-bolt-list--display-inline\@#{$breakpoint-name} {
+          @include bolt-mq($breakpoint-name) {
+            width: calc(
+              100% + #{bolt-spacing($spacing-value-name)}
+            ); // Width must be defined in order for the list to dislay correctly in Firefox.
+          }
         }
       }
     }


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-2087

## Summary

Fixes Safari sub-pixel rendering bug.

## Details

Setting a width on List was required to fix a FF-only bug, but it turns out it causes a different bug in Safari. To fix Safari, simply scope the `width` rule to FF-only.

Supercedes #1805.

## How to test
Review the following pages in Chrome, Safari, FF, and Edge. Verify they work as expected:
- [Completed Training template](https://fix-list-wrapping-bug.boltdesignsystem.com/pattern-lab/patterns/03-blueprints-05-pages-completed-training-completed-training/03-blueprints-05-pages-completed-training-completed-training.html)
- [List demos](https://fix-list-wrapping-bug.boltdesignsystem.com/pattern-lab/patterns/02-components-list/index.html)