### PR TITLE
fix: Remove join filters and related workarounds in replacement card

### DIFF
--- a/packages/components/bolt-card-replacement/src/card-replacement-body/_card-replacement-body.twig
+++ b/packages/components/bolt-card-replacement/src/card-replacement-body/_card-replacement-body.twig
@@ -11,8 +11,7 @@
   <replace-with-children class="c-bolt-card_replacement__body">
     {% block body %}
       {% if card_replacement_body_content %}
-        {# @todo: The replace function is a hack to get around the utf-8 bug. #}
-        {{ card_replacement_body_content | join | replace({"UTF-8": ""}) | raw }}
+        {{ card_replacement_body_content }}
       {% else %}
         {% set card_replacement_eyebrow = body.eyebrow %}
         {% set card_replacement_headline = body.headline %}

--- a/packages/components/bolt-card-replacement/src/card-replacement-media/_card-replacement-media.twig
+++ b/packages/components/bolt-card-replacement/src/card-replacement-media/_card-replacement-media.twig
@@ -12,8 +12,7 @@
 {% endif %}
 
 {% if card_replacement_media_content %}
-  {# @todo: The replace function is a hack to get around the utf-8 bug. #}
-  {{ card_replacement_media_content | join | replace({"UTF-8": ""}) }}
+  {{ card_replacement_media_content }}
 {% else %}
   {% if card_replacement_image or block("media") %}
     <bolt-card-replacement-media {{ attributes }}>

--- a/packages/components/bolt-card-replacement/src/card-replacement/card-replacement.twig
+++ b/packages/components/bolt-card-replacement/src/card-replacement/card-replacement.twig
@@ -84,8 +84,7 @@
     {% endif %}
 
     {% if content %}
-      {# @todo: The replace function is a hack to get around the utf-8 bug. #}
-      {{ content | join | replace({"UTF-8": ""}) }}
+      {{ content }}
     {% else %}
 
       {% if media or media_block %}


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-2059

## Summary

Adds support for render arrays to replacement card

## Details

This PR replaces `{{content | join}}` (and all the related workarounds, such as `{{ card_replacement_body_content | join | replace({"UTF-8": ""}) | raw }}`
) with a solution that supports render arrays, doesn't require any workarounds, and is consistent with our docs and all our other components.  It's also quite simple:

`{{ content }}`.

### FAQ
**Why was the `join` filter used to begin with?**
I think it was just a mistake.  There's no usage of `| join` in the original card.  There are some usages of the join filter [directly](https://github.com/boltdesignsystem/bolt/blob/master/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/05-pages/t1-landing-pages/module-landing/t1-module-landing-page.twig#L147) in [blueprints](https://github.com/boltdesignsystem/bolt/blob/master/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/05-pages/t1-landing-pages/certification-exam/certification-exam-page.twig#L156).  Maybe this was an attempt at a shortcut for that and we just forgot to take it out?

**Is this backwards breaking?**
Yes.  Oddly, there were no usages of replacement card in pattern lab that depended upon the join filter-- removing it didn't require any changes.  However, there are some places in the Academy site that do (I created a PR to address those-- once it's merged, there should be no side effects of this change downstream https://gitlab.com/pegadigital/pa/pegaacademy/-/merge_requests/80).

**Why is this not backwards compatible or in a major release then?**
It would be a pain to deprecate it instead (what do you call the new variable if not `content`?) and because replacement card is only actively in use on Academy.  I'm operating under the assumption that replacement card is still technically experimental.

**What's the utf-8 bug referenced in the comments?**
This happens when a Drupal [Markup](https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Render%21Markup.php/class/Markup/8.2.x) object is passed through the `join` filter.  If you imagine the markup object looking something like  {'Text string', 'UTF-8'} (the second parameter being the encoding), you can understand why.  Printing the markup object directly does not have this problem.

**Was this the problem @charginghawk was solving in [this PR](http://vstash:7990/projects/BOLT/repos/pega_bolt_theme/pull-requests/126/diff)?**
Apparently not.  That code was using the old card, which doesn't use join.  So something else was wrong there.

## How to test

- Confirm no regressions in replacement card or blueprints.