### PR TITLE
Fix: accordion open prop typo in web component demo

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/accordion/999-accordion-web-component.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/accordion/999-accordion-web-component.twig
@@ -50,7 +50,7 @@
     <bolt-text slot="trigger">Accordion item 1</bolt-text>
     <bolt-text>Lorem ipsum dolor sit, amet consectetur adipisicing elit.</bolt-text>
   </bolt-accordion-item>
-  <bolt-accordion-item auto-open>
+  <bolt-accordion-item open>
     <bolt-text slot="trigger">Accordion item 2</bolt-text>
     <bolt-text>This item is opened by default. Lorem ipsum dolor sit, amet consectetur adipisicing elit.</bolt-text>
   </bolt-accordion-item>
@@ -104,7 +104,7 @@
     Advanced Usage
   </bolt-text>
   <bolt-text>
-    Two advanced options are shown below. Automatically show an <bolt-code-snippet display="inline" lang="html">bolt-accordion-item</bolt-code-snippet> by adding the <bolt-code-snippet display="inline" lang="html">auto-open</bolt-code-snippet> prop.
+    Two advanced options are shown below. Automatically show an <bolt-code-snippet display="inline" lang="html">bolt-accordion-item</bolt-code-snippet> by adding the <bolt-code-snippet display="inline" lang="html">open</bolt-code-snippet> prop.
   </bolt-text>
   <div class="t-bolt-light u-bolt-margin-bottom-small u-bolt-padding-medium">
     {% grid "o-bolt-grid--flex o-bolt-grid--matrix o-bolt-grid--center" %}


### PR DESCRIPTION
## Jira

N/A

## Summary

Fixes a typo on the Accordion web component demo page.

## How to test

Run the branch locally and check the Accordion web component demo page, make sure the `open` prop is named `open` not `auto-open` on the accordion item. 
