### PR TITLE
fix: Allow card url attributes to be empty

### DIFF
--- a/packages/components/bolt-card-replacement/src/card-replacement/card-replacement.twig
+++ b/packages/components/bolt-card-replacement/src/card-replacement/card-replacement.twig
@@ -23,7 +23,7 @@
   {% set link_url = link.url %}
   {% set link_text = link.text %}
   {% set link_target = link.target %}
-  {% set link_attributes = create_attribute(link.attributes) %}
+  {% set link_attributes = create_attribute(link.attributes|default({})) %}
 {% endif %}
 
 {% if block("background") %}


### PR DESCRIPTION
## Jira

N/A

## Summary

Allows card url attributes to be empty

## Details

null arguments to the `create_attributes()` twig function result in PHP errors in Drupal.  Based on existing Bolt conventions, you should provide an empty default argument unless you know the argument will not be null.