### PR TITLE
Re-enable branch and commit-specific now.sh deploy preview URLs on Github

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,9 +93,14 @@ jobs:
         - travis_retry yarn run test:e2e:quick-local
         # - lhci autorun --collect.numberOfRuns=3 --collect.url=$NOW_URL --collect.url=$NOW_URL/pattern-lab/patterns/04-pages-10-d8-product-pages-product-t2/04-pages-10-d8-product-pages-product-t2.html --collect.url=$NOW_URL/pattern-lab/patterns/06-experiments-micro-journeys-90-micro-journeys/06-experiments-micro-journeys-90-micro-journeys.html
       after_success:
+        - npx github-deploy-status --token ${GITHUB_TOKEN} --action create -e staging --ref ${TRAVIS_BRANCH} --user boltdesignsystem --repo bolt
+        - npx github-deploy-status --token ${GITHUB_TOKEN} --action in_progress -e staging --ref ${TRAVIS_BRANCH} --user boltdesignsystem --repo bolt
         - ./scripts/deploy-branch-alias.js
+        - export NOW_BRANCH_URL=$(./scripts/get-branch-alias.js)
+        - npx github-deploy-status --token ${GITHUB_TOKEN} --action success -e staging --ref feature/update-mission-modal --user boltdesignsystem --repo bolt -l ${NOW_BRANCH_URL}
       after_failure:
         - npx github-deploy-status --token ${GITHUB_TOKEN} --action failure -e dev --ref ${TRAVIS_BRANCH} --user boltdesignsystem --repo bolt
+        - npx github-deploy-status --token ${GITHUB_TOKEN} --action failure -e staging --ref ${TRAVIS_BRANCH} --user boltdesignsystem --repo bolt
 
     # full build + Nightwatch tests for non-feature branches + tagged releases
     - stage: Pre-deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,23 +84,23 @@ jobs:
         # - cd example-integrations/drupal-lab
         # - yarn run generate # generate static version of Drupal Lab in the integration folder
         # - cd ../../
-        - npx github-deploy-status --token ${GITHUB_TOKEN} --action create -e dev --ref ${TRAVIS_BRANCH} --user boltdesignsystem --repo bolt
+        - npx github-deploy-status --token ${GITHUB_TOKEN} --action create -e commit-specific preview --ref ${TRAVIS_BRANCH} --user boltdesignsystem --repo bolt
         - yarn run build
-        - npx github-deploy-status --token ${GITHUB_TOKEN} --action in_progress -e dev --ref ${TRAVIS_BRANCH} --user boltdesignsystem --repo bolt
+        - npx github-deploy-status --token ${GITHUB_TOKEN} --action in_progress -e commit-specific preview --ref ${TRAVIS_BRANCH} --user boltdesignsystem --repo bolt
         - yarn run deploy
         - export NOW_URL=$(./scripts/get-latest-deploy.js)
-        - npx github-deploy-status --token ${GITHUB_TOKEN} --action success -e dev --ref feature/update-mission-modal --user boltdesignsystem --repo bolt -l ${NOW_URL}
+        - npx github-deploy-status --token ${GITHUB_TOKEN} --action success -e commit-specific preview --ref feature/update-mission-modal --user boltdesignsystem --repo bolt -l ${NOW_URL}
         - travis_retry yarn run test:e2e:quick-local
         # - lhci autorun --collect.numberOfRuns=3 --collect.url=$NOW_URL --collect.url=$NOW_URL/pattern-lab/patterns/04-pages-10-d8-product-pages-product-t2/04-pages-10-d8-product-pages-product-t2.html --collect.url=$NOW_URL/pattern-lab/patterns/06-experiments-micro-journeys-90-micro-journeys/06-experiments-micro-journeys-90-micro-journeys.html
       after_success:
-        - npx github-deploy-status --token ${GITHUB_TOKEN} --action create -e staging --ref ${TRAVIS_BRANCH} --user boltdesignsystem --repo bolt
-        - npx github-deploy-status --token ${GITHUB_TOKEN} --action in_progress -e staging --ref ${TRAVIS_BRANCH} --user boltdesignsystem --repo bolt
+        - npx github-deploy-status --token ${GITHUB_TOKEN} --action create -e branch-specific preview --ref ${TRAVIS_BRANCH} --user boltdesignsystem --repo bolt
+        - npx github-deploy-status --token ${GITHUB_TOKEN} --action in_progress -e branch-specific preview --ref ${TRAVIS_BRANCH} --user boltdesignsystem --repo bolt
         - ./scripts/deploy-branch-alias.js
         - export NOW_BRANCH_URL=$(./scripts/get-branch-alias.js)
-        - npx github-deploy-status --token ${GITHUB_TOKEN} --action success -e staging --ref feature/update-mission-modal --user boltdesignsystem --repo bolt -l ${NOW_BRANCH_URL}
+        - npx github-deploy-status --token ${GITHUB_TOKEN} --action success -e branch-specific preview --ref feature/update-mission-modal --user boltdesignsystem --repo bolt -l ${NOW_BRANCH_URL}
       after_failure:
-        - npx github-deploy-status --token ${GITHUB_TOKEN} --action failure -e dev --ref ${TRAVIS_BRANCH} --user boltdesignsystem --repo bolt
-        - npx github-deploy-status --token ${GITHUB_TOKEN} --action failure -e staging --ref ${TRAVIS_BRANCH} --user boltdesignsystem --repo bolt
+        - npx github-deploy-status --token ${GITHUB_TOKEN} --action failure -e commit-specific preview --ref ${TRAVIS_BRANCH} --user boltdesignsystem --repo bolt
+        - npx github-deploy-status --token ${GITHUB_TOKEN} --action failure -e branch-specific preview --ref ${TRAVIS_BRANCH} --user boltdesignsystem --repo bolt
 
     # full build + Nightwatch tests for non-feature branches + tagged releases
     - stage: Pre-deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,23 +84,23 @@ jobs:
         # - cd example-integrations/drupal-lab
         # - yarn run generate # generate static version of Drupal Lab in the integration folder
         # - cd ../../
-        - npx github-deploy-status --token ${GITHUB_TOKEN} --action create -e commit-specific preview --ref ${TRAVIS_BRANCH} --user boltdesignsystem --repo bolt
+        - npx github-deploy-status --token ${GITHUB_TOKEN} -a create -e commit-preview -r ${TRAVIS_BRANCH} -u boltdesignsystem -p bolt
         - yarn run build
-        - npx github-deploy-status --token ${GITHUB_TOKEN} --action in_progress -e commit-specific preview --ref ${TRAVIS_BRANCH} --user boltdesignsystem --repo bolt
+        - npx github-deploy-status --token ${GITHUB_TOKEN} -a in_progress -e commit-preview -r ${TRAVIS_BRANCH} -u boltdesignsystem -p bolt
         - yarn run deploy
         - export NOW_URL=$(./scripts/get-latest-deploy.js)
-        - npx github-deploy-status --token ${GITHUB_TOKEN} --action success -e commit-specific preview --ref feature/update-mission-modal --user boltdesignsystem --repo bolt -l ${NOW_URL}
+        - npx github-deploy-status --token ${GITHUB_TOKEN} -a success -e commit-preview -r ${TRAVIS_BRANCH} -u boltdesignsystem -p bolt -l ${NOW_URL}
         - travis_retry yarn run test:e2e:quick-local
         # - lhci autorun --collect.numberOfRuns=3 --collect.url=$NOW_URL --collect.url=$NOW_URL/pattern-lab/patterns/04-pages-10-d8-product-pages-product-t2/04-pages-10-d8-product-pages-product-t2.html --collect.url=$NOW_URL/pattern-lab/patterns/06-experiments-micro-journeys-90-micro-journeys/06-experiments-micro-journeys-90-micro-journeys.html
       after_success:
-        - npx github-deploy-status --token ${GITHUB_TOKEN} --action create -e branch-specific preview --ref ${TRAVIS_BRANCH} --user boltdesignsystem --repo bolt
-        - npx github-deploy-status --token ${GITHUB_TOKEN} --action in_progress -e branch-specific preview --ref ${TRAVIS_BRANCH} --user boltdesignsystem --repo bolt
+        - npx github-deploy-status --token ${GITHUB_TOKEN} -a create -e branch-preview -r ${TRAVIS_BRANCH} -u boltdesignsystem -p bolt
+        - npx github-deploy-status --token ${GITHUB_TOKEN} -a in_progress -e branch-preview -r ${TRAVIS_BRANCH} -u boltdesignsystem -p bolt
         - ./scripts/deploy-branch-alias.js
         - export NOW_BRANCH_URL=$(./scripts/get-branch-alias.js)
-        - npx github-deploy-status --token ${GITHUB_TOKEN} --action success -e branch-specific preview --ref feature/update-mission-modal --user boltdesignsystem --repo bolt -l ${NOW_BRANCH_URL}
+        - npx github-deploy-status --token ${GITHUB_TOKEN} -a success -e branch-preview -r ${TRAVIS_BRANCH} -u boltdesignsystem -p bolt -l ${NOW_BRANCH_URL}
       after_failure:
-        - npx github-deploy-status --token ${GITHUB_TOKEN} --action failure -e commit-specific preview --ref ${TRAVIS_BRANCH} --user boltdesignsystem --repo bolt
-        - npx github-deploy-status --token ${GITHUB_TOKEN} --action failure -e branch-specific preview --ref ${TRAVIS_BRANCH} --user boltdesignsystem --repo bolt
+        - npx github-deploy-status --token ${GITHUB_TOKEN} -a failure -e commit-preview -r ${TRAVIS_BRANCH} -u boltdesignsystem -p bolt
+        - npx github-deploy-status --token ${GITHUB_TOKEN} -a failure -e branch-preview -r ${TRAVIS_BRANCH} -u boltdesignsystem -p bolt
 
     # full build + Nightwatch tests for non-feature branches + tagged releases
     - stage: Pre-deploy
@@ -114,8 +114,13 @@ jobs:
         # - cd example-integrations/drupal-lab
         # - yarn run generate # generate static version of Drupal Lab in the integration folder
         # - cd ../../
+        - npx github-deploy-status --token ${GITHUB_TOKEN} -a create -e commit-preview -r ${TRAVIS_BRANCH} -u boltdesignsystem -p bolt
         - yarn run build
+        - npx github-deploy-status --token ${GITHUB_TOKEN} -a in_progress -e commit-preview -r ${TRAVIS_BRANCH} -u boltdesignsystem -p bolt
         - yarn run deploy
+      after_success:
+        - export NOW_URL=$(./scripts/get-latest-deploy.js)
+        - npx github-deploy-status --token ${GITHUB_TOKEN} -a success -e commit-preview -r ${TRAVIS_BRANCH} -u boltdesignsystem -p bolt -l ${NOW_URL}
 
     - stage: Post-deploy
       name: 'Nightwatch End-to-End (Full)'
@@ -126,9 +131,13 @@ jobs:
       # before_script: ./scripts/check-run-in-progress.js 'Nightwatch'
       script:
         - export NOW_URL=$(./scripts/get-latest-deploy.js)
+        - npx github-deploy-status --token ${GITHUB_TOKEN} -a create -e branch-preview -r ${TRAVIS_BRANCH} -u boltdesignsystem -p bolt
+        - npx github-deploy-status --token ${GITHUB_TOKEN} -a in_progress -e branch-preview -r ${TRAVIS_BRANCH} -u boltdesignsystem -p bolt
         - travis_retry yarn run test:e2e:full
       after_success:
         - ./scripts/deploy-branch-alias.js
+        - export NOW_BRANCH_URL=$(./scripts/get-branch-alias.js)
+        - npx github-deploy-status --token ${GITHUB_TOKEN} -a success -e branch-preview -r ${TRAVIS_BRANCH} -u boltdesignsystem -p bolt -l ${NOW_BRANCH_URL}
         - ./scripts/deploy-tagged-release.js
         # - ./packages/testing/testing-nightwatch/nightwatch-report-results.js
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,10 @@ cache:
     - cache
 
 before_cache:
-- mkdir -p node_modules
-- mkdir -p docs-site/cache
-- mkdir -p cache
-- mkdir -p www
+  - mkdir -p node_modules
+  - mkdir -p docs-site/cache
+  - mkdir -p cache
+  - mkdir -p www
 
 before_install:
   - openssl aes-256-cbc -K $encrypted_4537e53f71e7_key -iv $encrypted_4537e53f71e7_iv -in scripts/bolt-design-system-bot.private-key.pem.enc -out scripts/bolt-design-system-bot.private-key.pem -d
@@ -84,13 +84,18 @@ jobs:
         # - cd example-integrations/drupal-lab
         # - yarn run generate # generate static version of Drupal Lab in the integration folder
         # - cd ../../
+        - npx github-deploy-status --token ${GITHUB_TOKEN} --action create -e dev --ref ${TRAVIS_BRANCH} --user boltdesignsystem --repo bolt
         - yarn run build
+        - npx github-deploy-status --token ${GITHUB_TOKEN} --action in_progress -e dev --ref ${TRAVIS_BRANCH} --user boltdesignsystem --repo bolt
         - yarn run deploy
         - export NOW_URL=$(./scripts/get-latest-deploy.js)
+        - npx github-deploy-status --token ${GITHUB_TOKEN} --action success -e dev --ref feature/update-mission-modal --user boltdesignsystem --repo bolt -l ${NOW_URL}
         - travis_retry yarn run test:e2e:quick-local
         # - lhci autorun --collect.numberOfRuns=3 --collect.url=$NOW_URL --collect.url=$NOW_URL/pattern-lab/patterns/04-pages-10-d8-product-pages-product-t2/04-pages-10-d8-product-pages-product-t2.html --collect.url=$NOW_URL/pattern-lab/patterns/06-experiments-micro-journeys-90-micro-journeys/06-experiments-micro-journeys-90-micro-journeys.html
       after_success:
         - ./scripts/deploy-branch-alias.js
+      after_failure:
+        - npx github-deploy-status --token ${GITHUB_TOKEN} --action failure -e dev --ref ${TRAVIS_BRANCH} --user boltdesignsystem --repo bolt
 
     # full build + Nightwatch tests for non-feature branches + tagged releases
     - stage: Pre-deploy

--- a/scripts/get-branch-alias.js
+++ b/scripts/get-branch-alias.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+const { branchName } = require('./utils/branch-name');
+const { normalizeUrlAlias } = require('./utils/normalize-url-alias');
+
+const alias = normalizeUrlAlias(branchName).trim();
+process.stdout.write(alias);


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/BDS-2037 (Related But Doesn't 100% Resolve) 

## Summary
Re-enables the our ability to easily find the commit-specific and branch-specific deployment URLs in Github -- a core piece of functionality that we unfortunately lost recently (when we added a temp workaround to the check run bad credentials error on Travis). 

## Details
This PR adds inline "View Deployment" buttons next to specific commits that are pushed up in addition to providing a super helpful box at the bottom of the PR screen with the latest branch and commit-specific URLs:

![image](https://user-images.githubusercontent.com/1617209/78701495-23127200-78d5-11ea-864b-121af3236a9c.png)

NOTE: I renamed the labels for these `branch-preview` and `commit-preview` deployments mid-way through the work on this, hence why this PR has 4 links but [this bugfix test PR](https://github.com/boltdesignsystem/bolt/pull/1816) only has the two expected links.

## How to test
Does it work? No Travis CI errors? Then ship it! 🚀 

There's zero code in this PR that gets published to NPM so there's very little risk merging this in ASAP so everyone can start to take advantage of this.