### PR TITLE
IE11 deprecation testing updates

### DIFF
--- a/docs-site/__tests__/pattern-lab.e2e.js
+++ b/docs-site/__tests__/pattern-lab.e2e.js
@@ -23,13 +23,6 @@ module.exports = {
   //     .assert.elementPresent('.js-c-typeahead__input')
   //     .click('.js-c-typeahead__input'); // click on the PL search input
 
-  //   // type "Components-Card" in the input field. Adjust command based on browser support
-  //   if (browser.sendKeys) {
-  //     browser.sendKeys('.js-c-typeahead__input', 'Components-Card');
-  //   } else {
-  //     browser.keys('Components-Card');
-  //   }
-
   // browser.saveScreenshot(
   //   `screenshots/pattern-lab/pattern-lab-search-input--${browser.capabilities
   //     .browserName || 'chrome'}.png`,

--- a/packages/components/bolt-typeahead/__tests__/typeahead.e2e.js
+++ b/packages/components/bolt-typeahead/__tests__/typeahead.e2e.js
@@ -17,7 +17,8 @@ module.exports = {
       .assert.elementPresent(
         '.js-typeahead-hook--dynamically-fetch-data .c-bolt-button',
       )
-      .click('.js-c-typeahead__input'); // click on the PL search input
+      .click('.js-c-typeahead__input')
+      .keys('AI');
 
     browser.saveScreenshot(
       `screenshots/pattern-lab/typeahead--${browser.capabilities.browserName ||

--- a/packages/components/bolt-typeahead/__tests__/typeahead.e2e.js
+++ b/packages/components/bolt-typeahead/__tests__/typeahead.e2e.js
@@ -19,12 +19,6 @@ module.exports = {
       )
       .click('.js-c-typeahead__input'); // click on the PL search input
 
-    if (browser.sendKeys) {
-      browser.sendKeys('.js-c-typeahead__input', 'AI');
-    } else {
-      browser.keys('AI');
-    }
-
     browser.saveScreenshot(
       `screenshots/pattern-lab/typeahead--${browser.capabilities.browserName ||
         'chrome'}.png`,


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-2033

## Summary

Remove uses of `browser.sendKeys()` from our tests, only needed if we're supporting IE11.

## How to test

- Review changes
- Tests are passing