### PR TITLE
Update Github Deployment Status logic so deployment env names are tied to a specific branch 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,17 +79,19 @@ jobs:
       install:
         - yarn run setup
         - npx lerna run postbootstrap
+        - export GIT_SHA=$(./scripts/get-git-sha.js)
+        - echo $GIT_SHA
         # - yarn global add @lhci/cli@0.3.x
       script:
         # - cd example-integrations/drupal-lab
         # - yarn run generate # generate static version of Drupal Lab in the integration folder
         # - cd ../../
         - yarn run build
-        - travis_retry yarn gds -a create -e ${TRAVIS_BRANCH}--${TRAVIS_COMMIT}--commit-preview -r ${TRAVIS_BRANCH}
-        - travis_retry yarn gds -a in_progress -e ${TRAVIS_BRANCH}--${TRAVIS_COMMIT}--commit-preview -r ${TRAVIS_BRANCH}
+        - travis_retry yarn gds -a create -e ${TRAVIS_BRANCH}--${GIT_SHA}--commit-preview -r ${TRAVIS_BRANCH}
+        - travis_retry yarn gds -a in_progress -e ${TRAVIS_BRANCH}--${GIT_SHA}--commit-preview -r ${TRAVIS_BRANCH}
         - yarn run deploy
         - export NOW_URL=$(./scripts/get-latest-deploy.js)
-        - travis_retry yarn gds -a success -e ${TRAVIS_BRANCH}--${TRAVIS_COMMIT}--commit-preview -r ${TRAVIS_BRANCH} -l ${NOW_URL}
+        - travis_retry yarn gds -a success -e ${TRAVIS_BRANCH}--${GIT_SHA}--commit-preview -r ${TRAVIS_BRANCH} -l ${NOW_URL}
         - travis_retry yarn run test:e2e:quick-local
         # - lhci autorun --collect.numberOfRuns=3 --collect.url=$NOW_URL --collect.url=$NOW_URL/pattern-lab/patterns/04-pages-10-d8-product-pages-product-t2/04-pages-10-d8-product-pages-product-t2.html --collect.url=$NOW_URL/pattern-lab/patterns/06-experiments-micro-journeys-90-micro-journeys/06-experiments-micro-journeys-90-micro-journeys.html
       after_success:
@@ -99,10 +101,10 @@ jobs:
         - export NOW_BRANCH_URL=$(./scripts/get-branch-alias.js)
         - travis_retry yarn gds -a success -e ${TRAVIS_BRANCH}--branch-preview -r ${TRAVIS_BRANCH} -l ${NOW_BRANCH_URL}
       after_failure:
-        - travis_retry yarn gds -a failure -e ${TRAVIS_BRANCH}--${TRAVIS_COMMIT}--commit-preview -r ${TRAVIS_BRANCH}
+        - travis_retry yarn gds -a failure -e ${TRAVIS_BRANCH}--${GIT_SHA}--commit-preview -r ${TRAVIS_BRANCH}
         - travis_retry yarn gds -a failure -e ${TRAVIS_BRANCH}--branch-preview -r ${TRAVIS_BRANCH}
       after_script:
-        - travis_retry yarn gds -a fail_if_unsuccessful -e ${TRAVIS_BRANCH}--${TRAVIS_COMMIT}--commit-preview -r ${TRAVIS_BRANCH}
+        - travis_retry yarn gds -a fail_if_unsuccessful -e ${TRAVIS_BRANCH}--${GIT_SHA}--commit-preview -r ${TRAVIS_BRANCH}
         - travis_retry yarn gds -a fail_if_unsuccessful -e ${TRAVIS_BRANCH}--branch-preview -r ${TRAVIS_BRANCH}
 
     # full build + Nightwatch tests for non-feature branches + tagged releases
@@ -111,21 +113,22 @@ jobs:
       if: (tag =~ ^v) OR (branch =~ /(master|release|bug|fix)/)
       install:
         - yarn run setup
+        - export GIT_SHA=$(./scripts/get-git-sha.js)
       before_script:
         - find . -name '.incache' -exec rm -rf {} +
       script:
         # - cd example-integrations/drupal-lab
         # - yarn run generate # generate static version of Drupal Lab in the integration folder
         # - cd ../../
-        - travis_retry yarn gds -a create -e ${TRAVIS_BRANCH}--${TRAVIS_COMMIT}--commit-preview -r ${TRAVIS_BRANCH}
+        - travis_retry yarn gds -a create -e ${TRAVIS_BRANCH}--${GIT_SHA}--commit-preview -r ${TRAVIS_BRANCH}
         - yarn run build
-        - travis_retry yarn gds -a in_progress -e ${TRAVIS_BRANCH}--${TRAVIS_COMMIT}--commit-preview -r ${TRAVIS_BRANCH}
+        - travis_retry yarn gds -a in_progress -e ${TRAVIS_BRANCH}--${GIT_SHA}--commit-preview -r ${TRAVIS_BRANCH}
         - yarn run deploy
       after_success:
         - export NOW_URL=$(./scripts/get-latest-deploy.js)
-        - travis_retry yarn gds -a success -e ${TRAVIS_BRANCH}--${TRAVIS_COMMIT}--commit-preview -r ${TRAVIS_BRANCH} -l ${NOW_URL}
+        - travis_retry yarn gds -a success -e ${TRAVIS_BRANCH}--${GIT_SHA}--commit-preview -r ${TRAVIS_BRANCH} -l ${NOW_URL}
       after_script:
-        - travis_retry yarn gds -a fail_if_unsuccessful -e ${TRAVIS_BRANCH}--${TRAVIS_COMMIT}--commit-preview -r ${TRAVIS_BRANCH}
+        - travis_retry yarn gds -a fail_if_unsuccessful -e ${TRAVIS_BRANCH}--${GIT_SHA}--commit-preview -r ${TRAVIS_BRANCH}
 
     - stage: Post-deploy
       name: 'Nightwatch End-to-End (Full)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,25 +85,25 @@ jobs:
         # - yarn run generate # generate static version of Drupal Lab in the integration folder
         # - cd ../../
         - yarn run build
-        - travis_retry yarn gds -a create -e commit-preview -r ${TRAVIS_BRANCH}
-        - travis_retry yarn gds -a in_progress -e commit-preview -r ${TRAVIS_BRANCH}
+        - travis_retry yarn gds -a create -e ${TRAVIS_BRANCH}--${TRAVIS_COMMIT}--commit-preview -r ${TRAVIS_BRANCH}
+        - travis_retry yarn gds -a in_progress -e ${TRAVIS_BRANCH}--${TRAVIS_COMMIT}--commit-preview -r ${TRAVIS_BRANCH}
         - yarn run deploy
         - export NOW_URL=$(./scripts/get-latest-deploy.js)
-        - travis_retry yarn gds -a success -e commit-preview -r ${TRAVIS_BRANCH} -l ${NOW_URL}
+        - travis_retry yarn gds -a success -e ${TRAVIS_BRANCH}--${TRAVIS_COMMIT}--commit-preview -r ${TRAVIS_BRANCH} -l ${NOW_URL}
         - travis_retry yarn run test:e2e:quick-local
         # - lhci autorun --collect.numberOfRuns=3 --collect.url=$NOW_URL --collect.url=$NOW_URL/pattern-lab/patterns/04-pages-10-d8-product-pages-product-t2/04-pages-10-d8-product-pages-product-t2.html --collect.url=$NOW_URL/pattern-lab/patterns/06-experiments-micro-journeys-90-micro-journeys/06-experiments-micro-journeys-90-micro-journeys.html
       after_success:
-        - travis_retry yarn gds -a create -e branch-preview -r ${TRAVIS_BRANCH}
-        - travis_retry yarn gds -a in_progress -e branch-preview -r ${TRAVIS_BRANCH}
+        - travis_retry yarn gds -a create -e ${TRAVIS_BRANCH}--branch-preview -r ${TRAVIS_BRANCH}
+        - travis_retry yarn gds -a in_progress -e ${TRAVIS_BRANCH}--branch-preview -r ${TRAVIS_BRANCH}
         - ./scripts/deploy-branch-alias.js
         - export NOW_BRANCH_URL=$(./scripts/get-branch-alias.js)
-        - travis_retry yarn gds -a success -e branch-preview -r ${TRAVIS_BRANCH} -l ${NOW_BRANCH_URL}
+        - travis_retry yarn gds -a success -e ${TRAVIS_BRANCH}--branch-preview -r ${TRAVIS_BRANCH} -l ${NOW_BRANCH_URL}
       after_failure:
-        - travis_retry yarn gds -a failure -e commit-preview -r ${TRAVIS_BRANCH}
-        - travis_retry yarn gds -a failure -e branch-preview -r ${TRAVIS_BRANCH}
+        - travis_retry yarn gds -a failure -e ${TRAVIS_BRANCH}--${TRAVIS_COMMIT}--commit-preview -r ${TRAVIS_BRANCH}
+        - travis_retry yarn gds -a failure -e ${TRAVIS_BRANCH}--branch-preview -r ${TRAVIS_BRANCH}
       after_script:
-        - travis_retry yarn gds -a fail_if_unsuccessful -e commit-preview -r ${TRAVIS_BRANCH}
-        - travis_retry yarn gds -a fail_if_unsuccessful -e branch-preview -r ${TRAVIS_BRANCH}
+        - travis_retry yarn gds -a fail_if_unsuccessful -e ${TRAVIS_BRANCH}--${TRAVIS_COMMIT}--commit-preview -r ${TRAVIS_BRANCH}
+        - travis_retry yarn gds -a fail_if_unsuccessful -e ${TRAVIS_BRANCH}--branch-preview -r ${TRAVIS_BRANCH}
 
     # full build + Nightwatch tests for non-feature branches + tagged releases
     - stage: Pre-deploy
@@ -117,15 +117,15 @@ jobs:
         # - cd example-integrations/drupal-lab
         # - yarn run generate # generate static version of Drupal Lab in the integration folder
         # - cd ../../
-        - travis_retry yarn gds -a create -e commit-preview -r ${TRAVIS_BRANCH}
+        - travis_retry yarn gds -a create -e ${TRAVIS_BRANCH}--${TRAVIS_COMMIT}--commit-preview -r ${TRAVIS_BRANCH}
         - yarn run build
-        - travis_retry yarn gds -a in_progress -e commit-preview -r ${TRAVIS_BRANCH}
+        - travis_retry yarn gds -a in_progress -e ${TRAVIS_BRANCH}--${TRAVIS_COMMIT}--commit-preview -r ${TRAVIS_BRANCH}
         - yarn run deploy
       after_success:
         - export NOW_URL=$(./scripts/get-latest-deploy.js)
-        - travis_retry yarn gds -a success -e commit-preview -r ${TRAVIS_BRANCH} -l ${NOW_URL}
+        - travis_retry yarn gds -a success -e ${TRAVIS_BRANCH}--${TRAVIS_COMMIT}--commit-preview -r ${TRAVIS_BRANCH} -l ${NOW_URL}
       after_script:
-        - travis_retry yarn gds -a fail_if_unsuccessful -e commit-preview -r ${TRAVIS_BRANCH}
+        - travis_retry yarn gds -a fail_if_unsuccessful -e ${TRAVIS_BRANCH}--${TRAVIS_COMMIT}--commit-preview -r ${TRAVIS_BRANCH}
 
     - stage: Post-deploy
       name: 'Nightwatch End-to-End (Full)'
@@ -136,17 +136,17 @@ jobs:
       # before_script: ./scripts/check-run-in-progress.js 'Nightwatch'
       script:
         - export NOW_URL=$(./scripts/get-latest-deploy.js)
-        - travis_retry yarn gds -a create -e branch-preview -r ${TRAVIS_BRANCH}
-        - travis_retry yarn gds -a in_progress -e branch-preview -r ${TRAVIS_BRANCH}
+        - travis_retry yarn gds -a create -e ${TRAVIS_BRANCH}--branch-preview -r ${TRAVIS_BRANCH}
+        - travis_retry yarn gds -a in_progress -e ${TRAVIS_BRANCH}--branch-preview -r ${TRAVIS_BRANCH}
         - travis_retry yarn run test:e2e:full
       after_success:
         - ./scripts/deploy-branch-alias.js
         - export NOW_BRANCH_URL=$(./scripts/get-branch-alias.js)
-        - travis_retry yarn gds -a success -e branch-preview -r ${TRAVIS_BRANCH} -l ${NOW_BRANCH_URL}
+        - travis_retry yarn gds -a success -e ${TRAVIS_BRANCH}--branch-preview -r ${TRAVIS_BRANCH} -l ${NOW_BRANCH_URL}
         - ./scripts/deploy-tagged-release.js
         # - ./packages/testing/testing-nightwatch/nightwatch-report-results.js
       after_script:
-        - travis_retry yarn gds -a fail_if_unsuccessful -e branch-preview -r ${TRAVIS_BRANCH}
+        - travis_retry yarn gds -a fail_if_unsuccessful -e ${TRAVIS_BRANCH}--branch-preview -r ${TRAVIS_BRANCH}
 
     - stage: Auto-release
       name: 'Canary Release'

--- a/scripts/get-git-sha.js
+++ b/scripts/get-git-sha.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+const { gitSha } = require('./utils');
+process.stdout.write(gitSha);


### PR DESCRIPTION
## Jira
N/A

## Summary
Updates the Travis CI logic handling deployment URL integration with more that most recent deployments don't accidently wipe older deployments (especially on different branches).