### PR TITLE
Fix: add proper attributes to bolt-ol and bolt-ul for accessibility

### DIFF
--- a/packages/components/bolt-li/src/li.js
+++ b/packages/components/bolt-li/src/li.js
@@ -54,7 +54,7 @@ class BoltListItem extends withLitHtml {
 
     return html`
       ${this.addStyles([styles])}
-      <li class="${classes}">${this.slot('default')}</li>
+      <div class="${classes}" role="listitem">${this.slot('default')}</div>
     `;
   }
 }

--- a/packages/components/bolt-li/src/li.scss
+++ b/packages/components/bolt-li/src/li.scss
@@ -13,11 +13,11 @@ bolt-li {
 }
 
 .c-bolt-li {
+  @include bolt-padding(0);
   box-sizing: border-box;
   position: relative;
   margin-bottom: bolt-spacing(xxsmall);
   margin-left: $bolt-li-spacing;
-  @include bolt-padding(0);
 
   &--last-item {
     margin-bottom: 0;
@@ -73,8 +73,8 @@ bolt-li {
   }
 }
 
-ol,
-bolt-ol {
+bolt-ol,
+.c-bolt-ol {
   > bolt-li {
     position: relative;
 
@@ -107,11 +107,4 @@ bolt-ol {
   line-height: $bolt-ol-bullet-size;
   border-radius: $bolt-ol-bullet-size;
   background-color: $bolt-ol-bullet-bg-color;
-}
-
-// [Mai] This is an IE specific fix to center the number inside the circle. IE calculates line-height differently.
-@include bolt-ie11-only {
-  .c-bolt-li--ol-item:before {
-    line-height: $bolt-line-height--medium;
-  }
 }

--- a/packages/components/bolt-li/src/li.twig
+++ b/packages/components/bolt-li/src/li.twig
@@ -9,22 +9,22 @@
 
 {% if nested %}
   {% if index == 1 %}
-    <bolt-li {{ attributes }}>
-      <replace-with-grandchildren>
-        <li class="{{ classes|join(" ") }}">
+    <bolt-li {{ attributes }} role="presentation">
+      <replace-with-grandchildren role="presentation">
+        <div class="{{ classes|join(" ") }}" role="listitem">
   {% endif %}
   {{ children }}
   {% if length == index %}
-        </li>
+        </div>
       </replace-with-grandchildren>
     </bolt-li>
   {% endif %}
 {% else %}
-  <bolt-li {{ attributes }}>
-    <replace-with-grandchildren>
-      <li class="{{ classes|join(" ") }}">
+  <bolt-li {{ attributes }} role="presentation">
+    <replace-with-grandchildren role="presentation">
+      <div class="{{ classes|join(" ") }}" role="listitem">
         {{ children }}
-      </li>
+      </div>
     </replace-with-grandchildren>
   </bolt-li>
 {% endif %}

--- a/packages/components/bolt-ol/__tests__/__snapshots__/ol.js.snap
+++ b/packages/components/bolt-ol/__tests__/__snapshots__/ol.js.snap
@@ -5,39 +5,48 @@ exports[`<bolt-ol> Component basic usage with attributes 1`] = `
          onclick="location.href=&#039;https://pega.com&#039;"
 >
   <replace-with-grandchildren>
-    <ol data-attr="some attribute"
-        onclick="location.href=&#039;https://pega.com&#039;"
-        class="c-bolt-ol"
+    <div data-attr="some attribute"
+         onclick="location.href=&#039;https://pega.com&#039;"
+         class="c-bolt-ol"
+         role="list"
     >
-      <bolt-li>
-        <replace-with-grandchildren>
-          <li class="c-bolt-li c-bolt-li--ol-item ">
+      <bolt-li role="presentation">
+        <replace-with-grandchildren role="presentation">
+          <div class="c-bolt-li c-bolt-li--ol-item "
+               role="listitem"
+          >
             Do not include any data or information in your posts that are confidential!
-          </li>
+          </div>
         </replace-with-grandchildren>
       </bolt-li>
-      <bolt-li>
-        <replace-with-grandchildren>
-          <li class="c-bolt-li c-bolt-li--ol-item ">
+      <bolt-li role="presentation">
+        <replace-with-grandchildren role="presentation">
+          <div class="c-bolt-li c-bolt-li--ol-item "
+               role="listitem"
+          >
             Apply basic practices for collaborative work.
-          </li>
+          </div>
         </replace-with-grandchildren>
       </bolt-li>
-      <bolt-li>
-        <replace-with-grandchildren>
-          <li class="c-bolt-li c-bolt-li--ol-item ">
+      <bolt-li role="presentation">
+        <replace-with-grandchildren role="presentation">
+          <div class="c-bolt-li c-bolt-li--ol-item "
+               role="listitem"
+          >
             Be honest, respectful, trustworthy and helpful.
-          </li>
+          </div>
         </replace-with-grandchildren>
       </bolt-li>
-      <bolt-li>
-        <replace-with-grandchildren>
-          <li class="c-bolt-li c-bolt-li--ol-item c-bolt-li--last-item">
+      <bolt-li role="presentation">
+        <replace-with-grandchildren role="presentation">
+          <div class="c-bolt-li c-bolt-li--ol-item c-bolt-li--last-item"
+               role="listitem"
+          >
             Answer questions authoritatively and concisely. Avoid cluttering discussions with noise.
-          </li>
+          </div>
         </replace-with-grandchildren>
       </bolt-li>
-    </ol>
+    </div>
   </replace-with-grandchildren>
 </bolt-ol>
 `;
@@ -45,77 +54,99 @@ exports[`<bolt-ol> Component basic usage with attributes 1`] = `
 exports[`<bolt-ol> Component with nested <bolt-ol> list compiles 1`] = `
 <bolt-ol>
   <replace-with-grandchildren>
-    <ol class="c-bolt-ol">
-      <bolt-li>
-        <replace-with-grandchildren>
-          <li class="c-bolt-li c-bolt-li--ol-item ">
+    <div class="c-bolt-ol"
+         role="list"
+    >
+      <bolt-li role="presentation">
+        <replace-with-grandchildren role="presentation">
+          <div class="c-bolt-li c-bolt-li--ol-item "
+               role="listitem"
+          >
             Do not include any data or information in your posts that are confidential!
-          </li>
+          </div>
         </replace-with-grandchildren>
       </bolt-li>
-      <bolt-li>
-        <replace-with-grandchildren>
-          <li class="c-bolt-li c-bolt-li--ol-item ">
+      <bolt-li role="presentation">
+        <replace-with-grandchildren role="presentation">
+          <div class="c-bolt-li c-bolt-li--ol-item "
+               role="listitem"
+          >
             Apply basic practices for collaborative work.
-          </li>
+          </div>
         </replace-with-grandchildren>
       </bolt-li>
-      <bolt-li>
-        <replace-with-grandchildren>
-          <li class="c-bolt-li c-bolt-li--ol-item ">
+      <bolt-li role="presentation">
+        <replace-with-grandchildren role="presentation">
+          <div class="c-bolt-li c-bolt-li--ol-item "
+               role="listitem"
+          >
             Be honest, respectful, trustworthy and helpful.
-          </li>
+          </div>
         </replace-with-grandchildren>
       </bolt-li>
-      <bolt-li>
-        <replace-with-grandchildren>
-          <li class="c-bolt-li c-bolt-li--ol-item ">
+      <bolt-li role="presentation">
+        <replace-with-grandchildren role="presentation">
+          <div class="c-bolt-li c-bolt-li--ol-item "
+               role="listitem"
+          >
             Answer questions authoritatively and concisely. Avoid cluttering discussions with noise.
-          </li>
+          </div>
         </replace-with-grandchildren>
       </bolt-li>
-      <bolt-li>
-        <replace-with-grandchildren>
-          <li class="c-bolt-li c-bolt-li--ol-item ">
+      <bolt-li role="presentation">
+        <replace-with-grandchildren role="presentation">
+          <div class="c-bolt-li c-bolt-li--ol-item "
+               role="listitem"
+          >
             Answer questions authoritatively and concisely.
             <bolt-ol>
               <replace-with-grandchildren>
-                <ol class="c-bolt-ol">
-                  <bolt-li>
-                    <replace-with-grandchildren>
-                      <li class="c-bolt-li c-bolt-li--ol-item ">
+                <div class="c-bolt-ol"
+                     role="list"
+                >
+                  <bolt-li role="presentation">
+                    <replace-with-grandchildren role="presentation">
+                      <div class="c-bolt-li c-bolt-li--ol-item "
+                           role="listitem"
+                      >
                         Item 1
-                      </li>
+                      </div>
                     </replace-with-grandchildren>
                   </bolt-li>
-                  <bolt-li>
-                    <replace-with-grandchildren>
-                      <li class="c-bolt-li c-bolt-li--ol-item ">
+                  <bolt-li role="presentation">
+                    <replace-with-grandchildren role="presentation">
+                      <div class="c-bolt-li c-bolt-li--ol-item "
+                           role="listitem"
+                      >
                         Item 2
-                      </li>
+                      </div>
                     </replace-with-grandchildren>
                   </bolt-li>
-                  <bolt-li>
-                    <replace-with-grandchildren>
-                      <li class="c-bolt-li c-bolt-li--ol-item ">
+                  <bolt-li role="presentation">
+                    <replace-with-grandchildren role="presentation">
+                      <div class="c-bolt-li c-bolt-li--ol-item "
+                           role="listitem"
+                      >
                         Item 3
-                      </li>
+                      </div>
                     </replace-with-grandchildren>
                   </bolt-li>
-                  <bolt-li>
-                    <replace-with-grandchildren>
-                      <li class="c-bolt-li c-bolt-li--ol-item c-bolt-li--last-item">
+                  <bolt-li role="presentation">
+                    <replace-with-grandchildren role="presentation">
+                      <div class="c-bolt-li c-bolt-li--ol-item c-bolt-li--last-item"
+                           role="listitem"
+                      >
                         Item 4
-                      </li>
+                      </div>
                     </replace-with-grandchildren>
                   </bolt-li>
-                </ol>
+                </div>
               </replace-with-grandchildren>
             </bolt-ol>
-          </li>
+          </div>
         </replace-with-grandchildren>
       </bolt-li>
-    </ol>
+    </div>
   </replace-with-grandchildren>
 </bolt-ol>
 `;
@@ -123,77 +154,99 @@ exports[`<bolt-ol> Component with nested <bolt-ol> list compiles 1`] = `
 exports[`<bolt-ol> Component with nested <bolt-ul> list compiles 1`] = `
 <bolt-ol>
   <replace-with-grandchildren>
-    <ol class="c-bolt-ol">
-      <bolt-li>
-        <replace-with-grandchildren>
-          <li class="c-bolt-li c-bolt-li--ol-item ">
+    <div class="c-bolt-ol"
+         role="list"
+    >
+      <bolt-li role="presentation">
+        <replace-with-grandchildren role="presentation">
+          <div class="c-bolt-li c-bolt-li--ol-item "
+               role="listitem"
+          >
             Do not include any data or information in your posts that are confidential!
-          </li>
+          </div>
         </replace-with-grandchildren>
       </bolt-li>
-      <bolt-li>
-        <replace-with-grandchildren>
-          <li class="c-bolt-li c-bolt-li--ol-item ">
+      <bolt-li role="presentation">
+        <replace-with-grandchildren role="presentation">
+          <div class="c-bolt-li c-bolt-li--ol-item "
+               role="listitem"
+          >
             Apply basic practices for collaborative work.
-          </li>
+          </div>
         </replace-with-grandchildren>
       </bolt-li>
-      <bolt-li>
-        <replace-with-grandchildren>
-          <li class="c-bolt-li c-bolt-li--ol-item ">
+      <bolt-li role="presentation">
+        <replace-with-grandchildren role="presentation">
+          <div class="c-bolt-li c-bolt-li--ol-item "
+               role="listitem"
+          >
             Be honest, respectful, trustworthy and helpful.
-          </li>
+          </div>
         </replace-with-grandchildren>
       </bolt-li>
-      <bolt-li>
-        <replace-with-grandchildren>
-          <li class="c-bolt-li c-bolt-li--ol-item ">
+      <bolt-li role="presentation">
+        <replace-with-grandchildren role="presentation">
+          <div class="c-bolt-li c-bolt-li--ol-item "
+               role="listitem"
+          >
             Answer questions authoritatively and concisely. Avoid cluttering discussions with noise.
-          </li>
+          </div>
         </replace-with-grandchildren>
       </bolt-li>
-      <bolt-li>
-        <replace-with-grandchildren>
-          <li class="c-bolt-li c-bolt-li--ol-item ">
+      <bolt-li role="presentation">
+        <replace-with-grandchildren role="presentation">
+          <div class="c-bolt-li c-bolt-li--ol-item "
+               role="listitem"
+          >
             Answer questions authoritatively and concisely.
             <bolt-ul>
               <replace-with-grandchildren>
-                <ul class="c-bolt-ul">
-                  <bolt-li>
-                    <replace-with-grandchildren>
-                      <li class="c-bolt-li c-bolt-li--ul-item ">
+                <div class="c-bolt-ul"
+                     role="list"
+                >
+                  <bolt-li role="presentation">
+                    <replace-with-grandchildren role="presentation">
+                      <div class="c-bolt-li c-bolt-li--ul-item "
+                           role="listitem"
+                      >
                         Item 1
-                      </li>
+                      </div>
                     </replace-with-grandchildren>
                   </bolt-li>
-                  <bolt-li>
-                    <replace-with-grandchildren>
-                      <li class="c-bolt-li c-bolt-li--ul-item ">
+                  <bolt-li role="presentation">
+                    <replace-with-grandchildren role="presentation">
+                      <div class="c-bolt-li c-bolt-li--ul-item "
+                           role="listitem"
+                      >
                         Item 2
-                      </li>
+                      </div>
                     </replace-with-grandchildren>
                   </bolt-li>
-                  <bolt-li>
-                    <replace-with-grandchildren>
-                      <li class="c-bolt-li c-bolt-li--ul-item ">
+                  <bolt-li role="presentation">
+                    <replace-with-grandchildren role="presentation">
+                      <div class="c-bolt-li c-bolt-li--ul-item "
+                           role="listitem"
+                      >
                         Item 3
-                      </li>
+                      </div>
                     </replace-with-grandchildren>
                   </bolt-li>
-                  <bolt-li>
-                    <replace-with-grandchildren>
-                      <li class="c-bolt-li c-bolt-li--ul-item c-bolt-li--last-item">
+                  <bolt-li role="presentation">
+                    <replace-with-grandchildren role="presentation">
+                      <div class="c-bolt-li c-bolt-li--ul-item c-bolt-li--last-item"
+                           role="listitem"
+                      >
                         Item 4
-                      </li>
+                      </div>
                     </replace-with-grandchildren>
                   </bolt-li>
-                </ul>
+                </div>
               </replace-with-grandchildren>
             </bolt-ul>
-          </li>
+          </div>
         </replace-with-grandchildren>
       </bolt-li>
-    </ol>
+    </div>
   </replace-with-grandchildren>
 </bolt-ol>
 `;

--- a/packages/components/bolt-ol/src/ol.js
+++ b/packages/components/bolt-ol/src/ol.js
@@ -65,9 +65,9 @@ class BoltOrderedList extends withLitHtml {
 
     return html`
       ${this.addStyles([styles])}
-      <ol class="${classes}">
+      <div class="${classes}" role="list">
         ${this.slot('default')}
-      </ol>
+      </div>
     `;
   }
 }

--- a/packages/components/bolt-ol/src/ol.twig
+++ b/packages/components/bolt-ol/src/ol.twig
@@ -15,7 +15,7 @@
 
 <bolt-ol {{ attributes | without("class") }}>
   <replace-with-grandchildren>
-    <ol {{ attributes.addClass(classes) }}>
+    <div {{ attributes.addClass(classes) }} role="list">
       {% for item in items %}
         {% if item is iterable %}
           {% for i in item %}
@@ -41,6 +41,6 @@
           {% include "@bolt-components-li/li.twig" with list_item only %}
         {% endif %}
       {% endfor %}
-    </ol>
+    </div>
   </replace-with-grandchildren>
 </bolt-ol>

--- a/packages/components/bolt-ul/__tests__/__snapshots__/ul.js.snap
+++ b/packages/components/bolt-ul/__tests__/__snapshots__/ul.js.snap
@@ -5,39 +5,48 @@ exports[`<bolt-ul> Component basic usage with attributes 1`] = `
          onclick="location.href=&#039;https://pega.com&#039;"
 >
   <replace-with-grandchildren>
-    <ul data-attr="some attribute"
-        onclick="location.href=&#039;https://pega.com&#039;"
-        class="c-bolt-ul"
+    <div data-attr="some attribute"
+         onclick="location.href=&#039;https://pega.com&#039;"
+         class="c-bolt-ul"
+         role="list"
     >
-      <bolt-li>
-        <replace-with-grandchildren>
-          <li class="c-bolt-li c-bolt-li--ul-item ">
+      <bolt-li role="presentation">
+        <replace-with-grandchildren role="presentation">
+          <div class="c-bolt-li c-bolt-li--ul-item "
+               role="listitem"
+          >
             Do not include any data or information in your posts that are confidential!
-          </li>
+          </div>
         </replace-with-grandchildren>
       </bolt-li>
-      <bolt-li>
-        <replace-with-grandchildren>
-          <li class="c-bolt-li c-bolt-li--ul-item ">
+      <bolt-li role="presentation">
+        <replace-with-grandchildren role="presentation">
+          <div class="c-bolt-li c-bolt-li--ul-item "
+               role="listitem"
+          >
             Apply basic practices for collaborative work.
-          </li>
+          </div>
         </replace-with-grandchildren>
       </bolt-li>
-      <bolt-li>
-        <replace-with-grandchildren>
-          <li class="c-bolt-li c-bolt-li--ul-item ">
+      <bolt-li role="presentation">
+        <replace-with-grandchildren role="presentation">
+          <div class="c-bolt-li c-bolt-li--ul-item "
+               role="listitem"
+          >
             Be honest, respectful, trustworthy and helpful.
-          </li>
+          </div>
         </replace-with-grandchildren>
       </bolt-li>
-      <bolt-li>
-        <replace-with-grandchildren>
-          <li class="c-bolt-li c-bolt-li--ul-item c-bolt-li--last-item">
+      <bolt-li role="presentation">
+        <replace-with-grandchildren role="presentation">
+          <div class="c-bolt-li c-bolt-li--ul-item c-bolt-li--last-item"
+               role="listitem"
+          >
             Answer questions authoritatively and concisely. Avoid cluttering discussions with noise.
-          </li>
+          </div>
         </replace-with-grandchildren>
       </bolt-li>
-    </ul>
+    </div>
   </replace-with-grandchildren>
 </bolt-ul>
 `;
@@ -45,77 +54,99 @@ exports[`<bolt-ul> Component basic usage with attributes 1`] = `
 exports[`<bolt-ul> Component with nested <bolt-ol> list compiles 1`] = `
 <bolt-ul>
   <replace-with-grandchildren>
-    <ul class="c-bolt-ul">
-      <bolt-li>
-        <replace-with-grandchildren>
-          <li class="c-bolt-li c-bolt-li--ul-item ">
+    <div class="c-bolt-ul"
+         role="list"
+    >
+      <bolt-li role="presentation">
+        <replace-with-grandchildren role="presentation">
+          <div class="c-bolt-li c-bolt-li--ul-item "
+               role="listitem"
+          >
             Do not include any data or information in your posts that are confidential!
-          </li>
+          </div>
         </replace-with-grandchildren>
       </bolt-li>
-      <bolt-li>
-        <replace-with-grandchildren>
-          <li class="c-bolt-li c-bolt-li--ul-item ">
+      <bolt-li role="presentation">
+        <replace-with-grandchildren role="presentation">
+          <div class="c-bolt-li c-bolt-li--ul-item "
+               role="listitem"
+          >
             Apply basic practices for collaborative work.
-          </li>
+          </div>
         </replace-with-grandchildren>
       </bolt-li>
-      <bolt-li>
-        <replace-with-grandchildren>
-          <li class="c-bolt-li c-bolt-li--ul-item ">
+      <bolt-li role="presentation">
+        <replace-with-grandchildren role="presentation">
+          <div class="c-bolt-li c-bolt-li--ul-item "
+               role="listitem"
+          >
             Be honest, respectful, trustworthy and helpful.
-          </li>
+          </div>
         </replace-with-grandchildren>
       </bolt-li>
-      <bolt-li>
-        <replace-with-grandchildren>
-          <li class="c-bolt-li c-bolt-li--ul-item ">
+      <bolt-li role="presentation">
+        <replace-with-grandchildren role="presentation">
+          <div class="c-bolt-li c-bolt-li--ul-item "
+               role="listitem"
+          >
             Answer questions authoritatively and concisely. Avoid cluttering discussions with noise.
-          </li>
+          </div>
         </replace-with-grandchildren>
       </bolt-li>
-      <bolt-li>
-        <replace-with-grandchildren>
-          <li class="c-bolt-li c-bolt-li--ul-item ">
+      <bolt-li role="presentation">
+        <replace-with-grandchildren role="presentation">
+          <div class="c-bolt-li c-bolt-li--ul-item "
+               role="listitem"
+          >
             Answer questions authoritatively and concisely.
             <bolt-ol>
               <replace-with-grandchildren>
-                <ol class="c-bolt-ol">
-                  <bolt-li>
-                    <replace-with-grandchildren>
-                      <li class="c-bolt-li c-bolt-li--ol-item ">
+                <div class="c-bolt-ol"
+                     role="list"
+                >
+                  <bolt-li role="presentation">
+                    <replace-with-grandchildren role="presentation">
+                      <div class="c-bolt-li c-bolt-li--ol-item "
+                           role="listitem"
+                      >
                         Item 1
-                      </li>
+                      </div>
                     </replace-with-grandchildren>
                   </bolt-li>
-                  <bolt-li>
-                    <replace-with-grandchildren>
-                      <li class="c-bolt-li c-bolt-li--ol-item ">
+                  <bolt-li role="presentation">
+                    <replace-with-grandchildren role="presentation">
+                      <div class="c-bolt-li c-bolt-li--ol-item "
+                           role="listitem"
+                      >
                         Item 2
-                      </li>
+                      </div>
                     </replace-with-grandchildren>
                   </bolt-li>
-                  <bolt-li>
-                    <replace-with-grandchildren>
-                      <li class="c-bolt-li c-bolt-li--ol-item ">
+                  <bolt-li role="presentation">
+                    <replace-with-grandchildren role="presentation">
+                      <div class="c-bolt-li c-bolt-li--ol-item "
+                           role="listitem"
+                      >
                         Item 3
-                      </li>
+                      </div>
                     </replace-with-grandchildren>
                   </bolt-li>
-                  <bolt-li>
-                    <replace-with-grandchildren>
-                      <li class="c-bolt-li c-bolt-li--ol-item c-bolt-li--last-item">
+                  <bolt-li role="presentation">
+                    <replace-with-grandchildren role="presentation">
+                      <div class="c-bolt-li c-bolt-li--ol-item c-bolt-li--last-item"
+                           role="listitem"
+                      >
                         Item 4
-                      </li>
+                      </div>
                     </replace-with-grandchildren>
                   </bolt-li>
-                </ol>
+                </div>
               </replace-with-grandchildren>
             </bolt-ol>
-          </li>
+          </div>
         </replace-with-grandchildren>
       </bolt-li>
-    </ul>
+    </div>
   </replace-with-grandchildren>
 </bolt-ul>
 `;
@@ -123,77 +154,99 @@ exports[`<bolt-ul> Component with nested <bolt-ol> list compiles 1`] = `
 exports[`<bolt-ul> Component with nested <bolt-ul> list compiles 1`] = `
 <bolt-ul>
   <replace-with-grandchildren>
-    <ul class="c-bolt-ul">
-      <bolt-li>
-        <replace-with-grandchildren>
-          <li class="c-bolt-li c-bolt-li--ul-item ">
+    <div class="c-bolt-ul"
+         role="list"
+    >
+      <bolt-li role="presentation">
+        <replace-with-grandchildren role="presentation">
+          <div class="c-bolt-li c-bolt-li--ul-item "
+               role="listitem"
+          >
             Do not include any data or information in your posts that are confidential!
-          </li>
+          </div>
         </replace-with-grandchildren>
       </bolt-li>
-      <bolt-li>
-        <replace-with-grandchildren>
-          <li class="c-bolt-li c-bolt-li--ul-item ">
+      <bolt-li role="presentation">
+        <replace-with-grandchildren role="presentation">
+          <div class="c-bolt-li c-bolt-li--ul-item "
+               role="listitem"
+          >
             Apply basic practices for collaborative work.
-          </li>
+          </div>
         </replace-with-grandchildren>
       </bolt-li>
-      <bolt-li>
-        <replace-with-grandchildren>
-          <li class="c-bolt-li c-bolt-li--ul-item ">
+      <bolt-li role="presentation">
+        <replace-with-grandchildren role="presentation">
+          <div class="c-bolt-li c-bolt-li--ul-item "
+               role="listitem"
+          >
             Be honest, respectful, trustworthy and helpful.
-          </li>
+          </div>
         </replace-with-grandchildren>
       </bolt-li>
-      <bolt-li>
-        <replace-with-grandchildren>
-          <li class="c-bolt-li c-bolt-li--ul-item ">
+      <bolt-li role="presentation">
+        <replace-with-grandchildren role="presentation">
+          <div class="c-bolt-li c-bolt-li--ul-item "
+               role="listitem"
+          >
             Answer questions authoritatively and concisely. Avoid cluttering discussions with noise.
-          </li>
+          </div>
         </replace-with-grandchildren>
       </bolt-li>
-      <bolt-li>
-        <replace-with-grandchildren>
-          <li class="c-bolt-li c-bolt-li--ul-item ">
+      <bolt-li role="presentation">
+        <replace-with-grandchildren role="presentation">
+          <div class="c-bolt-li c-bolt-li--ul-item "
+               role="listitem"
+          >
             Answer questions authoritatively and concisely.
             <bolt-ul>
               <replace-with-grandchildren>
-                <ul class="c-bolt-ul">
-                  <bolt-li>
-                    <replace-with-grandchildren>
-                      <li class="c-bolt-li c-bolt-li--ul-item ">
+                <div class="c-bolt-ul"
+                     role="list"
+                >
+                  <bolt-li role="presentation">
+                    <replace-with-grandchildren role="presentation">
+                      <div class="c-bolt-li c-bolt-li--ul-item "
+                           role="listitem"
+                      >
                         Item 1
-                      </li>
+                      </div>
                     </replace-with-grandchildren>
                   </bolt-li>
-                  <bolt-li>
-                    <replace-with-grandchildren>
-                      <li class="c-bolt-li c-bolt-li--ul-item ">
+                  <bolt-li role="presentation">
+                    <replace-with-grandchildren role="presentation">
+                      <div class="c-bolt-li c-bolt-li--ul-item "
+                           role="listitem"
+                      >
                         Item 2
-                      </li>
+                      </div>
                     </replace-with-grandchildren>
                   </bolt-li>
-                  <bolt-li>
-                    <replace-with-grandchildren>
-                      <li class="c-bolt-li c-bolt-li--ul-item ">
+                  <bolt-li role="presentation">
+                    <replace-with-grandchildren role="presentation">
+                      <div class="c-bolt-li c-bolt-li--ul-item "
+                           role="listitem"
+                      >
                         Item 3
-                      </li>
+                      </div>
                     </replace-with-grandchildren>
                   </bolt-li>
-                  <bolt-li>
-                    <replace-with-grandchildren>
-                      <li class="c-bolt-li c-bolt-li--ul-item c-bolt-li--last-item">
+                  <bolt-li role="presentation">
+                    <replace-with-grandchildren role="presentation">
+                      <div class="c-bolt-li c-bolt-li--ul-item c-bolt-li--last-item"
+                           role="listitem"
+                      >
                         Item 4
-                      </li>
+                      </div>
                     </replace-with-grandchildren>
                   </bolt-li>
-                </ul>
+                </div>
               </replace-with-grandchildren>
             </bolt-ul>
-          </li>
+          </div>
         </replace-with-grandchildren>
       </bolt-li>
-    </ul>
+    </div>
   </replace-with-grandchildren>
 </bolt-ul>
 `;

--- a/packages/components/bolt-ul/src/ul.js
+++ b/packages/components/bolt-ul/src/ul.js
@@ -62,9 +62,9 @@ class BoltUnorderedList extends withLitHtml {
 
     return html`
       ${this.addStyles([styles])}
-      <ul class="${classes}">
+      <div class="${classes}" role="list">
         ${this.slot('default')}
-      </ul>
+      </div>
     `;
   }
 }

--- a/packages/components/bolt-ul/src/ul.twig
+++ b/packages/components/bolt-ul/src/ul.twig
@@ -15,7 +15,7 @@
 
 <bolt-ul {{ attributes | without("class") }}>
   <replace-with-grandchildren>
-    <ul {{ attributes.addClass(classes) }}>
+    <div {{ attributes.addClass(classes) }} role="list">
       {% for item in items %}
         {% if item is iterable %}
           {% for i in item %}
@@ -41,6 +41,6 @@
           {% include "@bolt-components-li/li.twig" with list_item only %}
         {% endif %}
       {% endfor %}
-    </ul>
+    </div>
   </replace-with-grandchildren>
 </bolt-ul>


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-2042

## Summary

Fixes an issue where `bolt-ol` and `bolt-ul` are not being read as a list by screen readers.

## Details

1. `role="list"` is added to the `.c-bolt-ol` and `.c-bolt-ul` elements
2. `role="listitem"` is added to the `.c-bolt-li` element
3. `role="presentation"` is added to any layers in between `.c-bolt-ol` and `.c-bolt-li`
4. `role="presentation"` is added to any layers in between `.c-bolt-ul` and `.c-bolt-li`

## How to test

Pull down the branch locally and perform the following.

### Check tests

- [ ] 1. Given I have pulled down the branch locally
- [ ] 2. And I am in the root folder
- [ ] 3. When I run the commands `npx jest packages/components/bolt-ol/__tests__/ol.js` and `npx jest packages/components/bolt-ul/__tests__/ul.js`
- [ ] 4. Then I should see all tests indicated as "Pass"

### Check voiceOver announcements

- [ ] 1. Given I am looking at the `bolt-ol` or `bolt-ul`'s docs (preferably the Nested Items page)
- [ ] 2. Then I turn on Apple voiceOver by pressing `cmd` + `f5`
- [ ] 3. And I press `ctrl` + `opt` + `a` to read all content on the page
- [ ] 4. Then I should hear voiceOver announce "List of [number] items..."
