### PR TITLE
Update components to use `<ssr-keep>` instead of `<replace-with-children>` and `<replace-with-grandchildren>` for more stable SSR rendering

### DIFF
--- a/packages/components/bolt-button/src/button.twig
+++ b/packages/components/bolt-button/src/button.twig
@@ -121,7 +121,7 @@ Sort classes passed in via attributes into two groups:
 
 {% macro slottedIcon(icon, icon_position, slotName) %}
   {% if icon and icon_position == slotName %}
-    <replace-with-children class="c-bolt-button__icon c-bolt-button__icon-sizer">
+    <ssr-keep for="bolt-button" class="c-bolt-button__icon c-bolt-button__icon-sizer">
       {% set icon = icon | merge({
         attributes: {
           slot: slotName,
@@ -129,7 +129,7 @@ Sort classes passed in via attributes into two groups:
         }
       }) %}
       {% include "@bolt-components-icon/icon.twig" with icon only %}
-    </replace-with-children>
+    </ssr-keep>
   {% endif %}
 {% endmacro %}
 
@@ -162,7 +162,7 @@ Sort classes passed in via attributes into two groups:
     {% block slot_before %}
       {{ macros.slottedIcon(icon, icon_position, "before") }}
     {% endblock %}
-    <replace-with-children class="c-bolt-button__item">{{ text }}</replace-with-children>
+    <ssr-keep for="bolt-button" class="c-bolt-button__item">{{ text }}</ssr-keep>
     {% block slot_after %}
       {{ macros.slottedIcon(icon, icon_position, 'after') }}
     {% endblock %}

--- a/packages/components/bolt-card-replacement/src/card-replacement-actions/_card-replacement-action.twig
+++ b/packages/components/bolt-card-replacement/src/card-replacement-actions/_card-replacement-action.twig
@@ -1,5 +1,5 @@
 <bolt-card-replacement-action {% if external %} external {% endif %} {% if url %} url="{{url}}" {% endif %}>
-  <replace-with-children class="c-bolt-card_replacement__action">
+  <ssr-keep for="bolt-card-replacement-action" class="c-bolt-card_replacement__action">
     {% block action_item %}
       {% if text %}
         {% set button_props = {
@@ -21,5 +21,5 @@
         {% include "@bolt-components-button/button.twig" with button_props only %}
       {% endif %}
     {% endblock %}
-  </replace-with-children>
+  </ssr-keep>
 </bolt-card-replacement-action>

--- a/packages/components/bolt-card-replacement/src/card-replacement-actions/_card-replacement-actions.twig
+++ b/packages/components/bolt-card-replacement/src/card-replacement-actions/_card-replacement-actions.twig
@@ -1,9 +1,9 @@
 <bolt-card-replacement-actions>
-  <replace-with-children class="c-bolt-card_replacement__actions">
+  <ssr-keep for="bolt-card-replacement-actions" class="c-bolt-card_replacement__actions">
     {% block action_items %}
       {% for action in actions %}
         {% include "@bolt-components-card-replacement/_card-replacement-action.twig" with action %}
       {% endfor %}
     {% endblock %}
-  </replace-with-children>
+  </ssr-keep>
 </bolt-card-replacement-actions>

--- a/packages/components/bolt-card-replacement/src/card-replacement-body/_card-replacement-body.twig
+++ b/packages/components/bolt-card-replacement/src/card-replacement-body/_card-replacement-body.twig
@@ -8,7 +8,7 @@
 {% set attributes = create_attribute(body.attributes|default({})) %}
 
 <bolt-card-replacement-body {{ attributes }}>
-  <replace-with-children class="c-bolt-card_replacement__body">
+  <ssr-keep for="bolt-card-replacement-body" class="c-bolt-card_replacement__body">
     {% block body %}
       {% if card_replacement_body_content %}
         {{ card_replacement_body_content }}
@@ -35,5 +35,5 @@
         {% endif %}
       {% endif %}
     {% endblock %}
-  </replace-with-children>
+  </ssr-keep>
 </bolt-card-replacement-body>

--- a/packages/components/bolt-card-replacement/src/card-replacement-media/_card-replacement-media.twig
+++ b/packages/components/bolt-card-replacement/src/card-replacement-media/_card-replacement-media.twig
@@ -16,20 +16,20 @@
 {% else %}
   {% if card_replacement_image or block("media") %}
     <bolt-card-replacement-media {{ attributes }}>
-      <replace-with-children class="c-bolt-card_replacement__media">
+      <ssr-keep for="bolt-card-replacement-media" class="c-bolt-card_replacement__media">
         {% if card_replacement_image %}
           {% include "@bolt-components-image/image.twig" with card_replacement_image only %}
         {% elseif block("media") %}
           {{ block("media") }}
         {% endif %}
-      </replace-with-children>
+      </ssr-keep>
     </bolt-card-replacement-media>
   {% endif %}
   {% if card_replacement_video %}
     <bolt-card-replacement-media {{ attributes }}>
-      <replace-with-children class="c-bolt-card_replacement__media c-bolt-card_replacement__media--video">
+      <ssr-keep for="bolt-card-replacement-media" class="c-bolt-card_replacement__media c-bolt-card_replacement__media--video">
         {% include "@bolt-components-video/video.twig" with card_replacement_video only %}
-      </replace-with-children>
+      </ssr-keep>
     </bolt-card-replacement-media>
   {% endif %}
 {% endif %}

--- a/packages/components/bolt-card-replacement/src/card-replacement/card-replacement.twig
+++ b/packages/components/bolt-card-replacement/src/card-replacement/card-replacement.twig
@@ -58,13 +58,13 @@
     theme in theme_options ? "t-bolt-#{theme}" : "",
   ] %}
 
-  <replace-with-children {{ inner_attributes.addClass(classes) }}>
+  <ssr-keep for="bolt-card-replacement" {{ inner_attributes.addClass(classes) }}>
     {% if link and link_url %}
       <bolt-card-replacement-link {{ link_attributes }}>
         {% if link_url %}
           <a href="{{ link_url }}" class="{{ "#{base_class}__link" }}" {% if link_target %} target="{{ link_target }}" {% endif %}>
             {% if link_text %}
-              <replace-with-children class="u-bolt-visuallyhidden">{{ link_text }}</replace-with-children>
+              <ssr-keep for="bolt-card-replacement-link" class="u-bolt-visuallyhidden">{{ link_text }}</ssr-keep>
             {% endif %}
           </a>
         {% endif %}
@@ -119,5 +119,5 @@
       {% endblock %}
       {% if horizontal %}</div>{% endif %}
     {% endif %}
-  </replace-with-children>
+  </ssr-keep>
 </bolt-card-replacement>

--- a/packages/components/bolt-chip/src/chip.twig
+++ b/packages/components/bolt-chip/src/chip.twig
@@ -63,20 +63,18 @@
   {% if outer_classes %} class="{{ outer_classes|join(' ') }}" {% endif %}
   {{ this.props|without("text")|without("class") }}
 >
-  <replace-with-grandchildren>
-    <{{ tag }}
-      {% if url %}
-        href="{{ url }}"
-        {% if target %} target="{{ target }}" {% endif %}
-      {% endif %}
-      {{ inner_attributes.addClass(inner_classes) }}
-      is="shadow-root"
-    >
-      {{ macros.slotted_icon(icon, icon_position, "before") }}
-      <replace-with-children class="{{ "#{base_class}__text" }}">
-        {{ text }}
-      </replace-with-children>
-      {{ macros.slotted_icon(icon, icon_position, "after") }}
-    </{{ tag }}>
-  </replace-with-grandchildren>
+  <{{ tag }}
+    {% if url %}
+      href="{{ url }}"
+      {% if target %} target="{{ target }}" {% endif %}
+    {% endif %}
+    {{ inner_attributes.addClass(inner_classes) }}
+    is="shadow-root"
+  >
+    {{ macros.slotted_icon(icon, icon_position, "before") }}
+    <ssr-keep for="bolt-chip" class="{{ "#{base_class}__text" }}">
+      {{ text }}
+    </ssr-keep>
+    {{ macros.slotted_icon(icon, icon_position, "after") }}
+  </{{ tag }}>
 </bolt-chip>{% endspaceless %}

--- a/packages/components/bolt-figure/src/figure.twig
+++ b/packages/components/bolt-figure/src/figure.twig
@@ -36,10 +36,9 @@
   {% if outer_classes %} class="{{ outer_classes|join(' ') }}" {% endif %}
   {{ attributes|without('class') }}
 >
-  <replace-with-grandchildren>
     <figure {{ inner_attributes.addClass(inner_classes) }}>
       {% if media %}
-        <replace-with-children class="{{ "#{base_class}__media" }}">
+        <ssr-keep for="bolt-figure" class="{{ "#{base_class}__media" }}">
           <div slot="media">
             {% set content = media.content %}
 
@@ -61,15 +60,14 @@
               {% include "@bolt-components-table/table.twig" with table only %}
             {% endif %}
           </div>
-        </replace-with-children>
+        </ssr-keep>
       {% endif %}
       {% if caption %}
-        <replace-with-grandchildren>
           <figcaption class="{{ "#{base_class}__caption" }}">
-            {{ caption }}
+            <ssr-keep for="bolt-figure">
+              {{ caption }}
+            </ssr-keep>
           </figcaption>
-        </replace-with-grandchildren>
       {% endif %}
     </figure>
-  </replace-with-grandchildren>
 </bolt-figure>

--- a/packages/components/bolt-link/src/link.twig
+++ b/packages/components/bolt-link/src/link.twig
@@ -94,9 +94,9 @@ Sort classes passed in via attributes into two groups:
     {{ filtered_attributes|without('id') }}
   >
     {{ macros.slotted_icon(icon, icon_position, "before") }}
-    <replace-with-children class="{{ "#{base_class}__text" }}">
+    <ssr-keep for="bolt-link" class="{{ "#{base_class}__text" }}">
       {{- text | default(label) | default("Learn More") -}}
-    </replace-with-children>
+    </ssr-keep>
     {{ macros.slotted_icon(icon, icon_position, "after") }}
   </a>
 </bolt-link>{% endspaceless %}

--- a/packages/components/bolt-list/src/_list-item.twig
+++ b/packages/components/bolt-list/src/_list-item.twig
@@ -17,13 +17,13 @@
 <bolt-list-item
   {% if last %} last {% endif %}
 >
-  <replace-with-grandchildren>
-    <{{ tag }} {{ attributes.addClass(classes) }}>
+  <{{ tag }} {{ attributes.addClass(classes) }}>
+    <ssr-keep for="bolt-list-item">
       {% if item.content %}
         {{ item.content }}
       {% else %}
         {{ item }}
       {% endif %}
-    </{{ tag }}>
-  </replace-with-grandchildren>
+    </ssr-keep>
+  </{{ tag }}>
 </bolt-list-item>

--- a/packages/components/bolt-list/src/list.twig
+++ b/packages/components/bolt-list/src/list.twig
@@ -62,13 +62,13 @@
     nowrap ? "#{base_class}--nowrap",
   ] %}
 
-  <replace-with-grandchildren>
-    <{{ tag }} {{ inner_attributes.addClass(classes) }}>
-      {% for item in items %}
-        {% if item %}
-          {% include "@bolt-components-list/_list-item.twig" %}
-        {% endif %}
-      {% endfor %}
-    </{{ tag }}>
-  </replace-with-grandchildren>
+  <{{ tag }} {{ inner_attributes.addClass(classes) }}>
+    <ssr-keep for="bolt-list" style="display: contents;">
+        {% for item in items %}
+          {% if item %}
+            {% include "@bolt-components-list/_list-item.twig" %}
+          {% endif %}
+        {% endfor %}
+    </ssr-keep>
+  </{{ tag }}>
 </bolt-list>

--- a/packages/components/bolt-menu/src/menu.twig
+++ b/packages/components/bolt-menu/src/menu.twig
@@ -35,24 +35,26 @@
   {{ this.props|without("content")|without("title")|without("class") }}
   role="menu"
 >
-  <replace-with-children role="presentation" {% if inner_classes %} class="{{ inner_classes|join(' ') }}" {% endif %}>
+  <div role="presentation" {% if inner_classes %} class="{{ inner_classes|join(' ') }}" {% endif %}>
     {% if title %}
       {% set title_class = base_class ~ "__title" %}
       {% set title_classes = [
         title_class,
         this.data.spacing.value ? title_class ~ "--spacing-" ~ this.data.spacing.value,
       ] %}
-      <replace-with-children {% if title_classes %} class="{{ title_classes|join(' ') }}" {% endif %}>
+      <ssr-keep for="bolt-menu" {% if title_classes %} class="{{ title_classes|join(' ') }}" {% endif %}>
         <span slot="title">{{ title }}</span>
-      </replace-with-children>
+      </ssr-keep>
     {% endif %}
-    {% for item in items %}
-      {% if item %}
-        {% include "@bolt-components-menu/_menu-item.twig" with item|merge({
-          spacing: this.data.spacing.value,
-          last: loop.last,
-        }) only %}
-      {% endif %}
-    {% endfor %}
-  </replace-with-children>
+    <ssr-keep for="bolt-menu">
+      {% for item in items %}
+        {% if item %}
+          {% include "@bolt-components-menu/_menu-item.twig" with item|merge({
+            spacing: this.data.spacing.value,
+            last: loop.last,
+          }) only %}
+        {% endif %}
+      {% endfor %}
+    </ssr-keep>
+  </div>
 </bolt-menu>

--- a/packages/components/bolt-popover/src/popover.twig
+++ b/packages/components/bolt-popover/src/popover.twig
@@ -49,28 +49,32 @@
   {% endif %}
   uuid="{{ uuid }}"
   >
-  <replace-with-children
+  <div
     {% if inner_classes %} class="{{ inner_classes|join(' ') }}" {% endif %}
   >
     {% if trigger %}
-      <replace-with-grandchildren id="{{ trigger_id }}">
+      <div id="{{ trigger_id }}">
         <a href="#{{ content_id }}" class="{{ "#{base_class}__nojs-trigger" }}" tabindex="-1">
-          {{ trigger }}
+          <ssr-keep for="bolt-popover">
+            {{ trigger }}
+          </ssr-keep>
         </a>
-      </replace-with-grandchildren>
+      </div>
     {% endif %}
     {% if content %}
-      <span slot="content" id="{{ content_id }}">
-        <replace-with-grandchildren class="{{ "#{base_class}__content" }}">
-          <span class="{{ bubble_classes|join(' ') }}">
-            <a href="#{{ trigger_id }}" class="{{ "#{base_class}__nojs-close" }}">
-              <span aria-hidden="true">&times;</span>
-              <span class="u-bolt-visuallyhidden">Close popover</span>
-            </a>
-            {{ content }}
-          </span>
-        </replace-with-grandchildren>
-      </span>
+      <div id="{{ content_id }}" class="{{ "#{base_class}__content" }}">
+        <span class="{{ bubble_classes|join(' ') }}">
+          <ssr-keep for="bolt-popover">
+            <span slot="content">
+              <a href="#{{ trigger_id }}" class="{{ "#{base_class}__nojs-close" }}">
+                <span aria-hidden="true">&times;</span>
+                <span class="u-bolt-visuallyhidden">Close popover</span>
+              </a>
+              {{ content }}
+            </span>
+          </ssr-keep>
+        </span>
+      </div>
     {% endif %}
-  </replace-with-children>
+  </div>
 </bolt-popover>

--- a/packages/components/bolt-ratio/src/ratio.twig
+++ b/packages/components/bolt-ratio/src/ratio.twig
@@ -24,9 +24,9 @@
 {% endif %}
 
 <bolt-ratio {{ attributes }}>
-  <replace-with-children class="c-bolt-ratio" style="{{ inline_styles | join(" ") }}">
+  <ssr-keep for="bolt-ratio" class="c-bolt-ratio" style="{{ inline_styles | join(" ") }}">
     {% block ratio_content %}
       {{ children }}
     {% endblock %}
-  </replace-with-children>
+  </ssr-keep>
 </bolt-ratio>

--- a/packages/components/bolt-toc/src/_toc-item.twig
+++ b/packages/components/bolt-toc/src/_toc-item.twig
@@ -42,9 +42,9 @@
   {{ this.props|without("text")|without("class") }}
   role="presentation"
 >
-  <replace-with-grandchildren role="listitem">
-    <a {% if inner_classes %} class="{{ inner_classes|join(' ') }}" {% endif %} href="{{ url }}">
+   <div role="listitem">
+    <a {% if inner_classes %} class="{{ inner_classes|join(' ') }}" {% endif %} href="{{ url }}"><ssr-keep for="bolt-toc-item">
       {{ text }}
-    </a>
-  </replace-with-grandchildren>
+    </ssr-keep></a>
+  </div>
 </bolt-toc-item>

--- a/packages/components/bolt-tooltip/src/tooltip.twig
+++ b/packages/components/bolt-tooltip/src/tooltip.twig
@@ -68,11 +68,11 @@
   {% endif %}
   uuid="{{ uuid }}"
 >
-  <replace-with-children {% if inner_classes %} class="{{ inner_classes|join(' ') }}" {% endif %}>
+  <div {% if inner_classes %} class="{{ inner_classes|join(' ') }}" {% endif %}>
     {% if trigger %}
       {# Start adapter for old trigger data #}
       {% if trigger.type == "text" %}
-        <replace-with-children
+        <ssr-keep for="bolt-tooltip"
           role="button"
           tabindex="0"
           aria-describedby="{{ tooltip_uuid }}"
@@ -84,9 +84,9 @@
           {% if trigger.text %}
             {{ trigger.text }}
           {% endif %}
-        </replace-with-children>
+        </ssr-keep>
       {% elseif trigger.type == "button" %}
-        <replace-with-children
+        <ssr-keep for="bolt-tooltip"
           role="button"
           tabindex="0"
           aria-describedby="{{ tooltip_uuid }}"
@@ -101,31 +101,33 @@
             },
             style: "secondary",
           } only %}
-        </replace-with-children>
+        </ssr-keep>
       {# End adapter for old trigger data #}
 
       {# Start new trigger #}
       {% else %}
-        <replace-with-children
+        <ssr-keep for="bolt-tooltip"
           role="button"
           tabindex="0"
           aria-describedby="{{ tooltip_uuid }}"
           aria-controls="{{ tooltip_uuid }}"
         >
           {{ trigger }}
-        </replace-with-children>
+        </ssr-keep>
       {% endif %}
       {# End new trigger #}
     {% endif %}
 
     {% if content %}
-      <span slot="content">
-        <replace-with-grandchildren id="{{ tooltip_uuid }}" class="{{ "#{base_class}__content" }}" role="tooltip" aria-hidden="true">
-          <span class="{{ "#{base_class}__bubble" }}">
-            {{ content }}
-          </span>
-        </replace-with-grandchildren>
-      </span>
+      <div id="{{ tooltip_uuid }}" class="{{ "#{base_class}__content" }}" role="tooltip" aria-hidden="true">
+        <span class="{{ "#{base_class}__bubble" }}">
+          <ssr-keep for="bolt-tooltip">
+            <span slot="content">
+              {{ content }}
+            </span>
+          </ssr-keep>
+        </span>
+      </div>
     {% endif %}
-  </replace-with-children>
+  </div>
 </bolt-tooltip>


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/BDS-2107

## Summary
Updates several components currently using `<replace-with-children>` and `<replace-with-grandchildren>` to use `<ssr-keep>` to address SSR-related rendering issues when implementing the [new `lazy-queue` lazy loader](https://github.com/boltdesignsystem/bolt/pull/1821) pattern globally.

## Details
This work updates the Twig files in the following components (listed out below) to use our newer <ssr-keep> helper element for server-side rendering hydration + sync up the timing of tearing down / initially rendering lazily-loaded components.   

**Updated based on noticeable SSR hydration issues and/or delays:**
- Card (the new Card – "Card Replacement")
- Figure
- List / List Item
- Menu
- Popover
- Table of Contents (TOC Item specifically)
- Tooltip

While I can't recall running into visual rendering issues in the following, these components have also been updated proactively to be super careful when rolling out the broader Lazy Queue-related UI updates.
- Button
- Chip
- Link
- Ratio

Note: this PR has a hard dependency on adding `<ssr-keep>` support to `@bolt/element` in https://github.com/boltdesignsystem/bolt/pull/1832

## How to test
TBD 