### PR TITLE
Add `<ssr-keep>` support to `@bolt/element`

### DIFF
--- a/packages/base-element/src/BoltElement.js
+++ b/packages/base-element/src/BoltElement.js
@@ -13,11 +13,49 @@ import {
 @conditionalShadowDom()
 @jsonSchemaProps()
 class BoltElement extends Slotify {
+  connectedCallback() {
+    super.connectedCallback && super.connectedCallback();
+
+    // Check if any `<ssr-keep>` elements have registered themselves here. If so, kick off the one-time hydration prep task.
+    if (this.ssrKeep && !this.ssrPrepped) {
+      this.ssrHydrationPrep();
+    }
+  }
+
+  /**
+   * Replace server-side rendered HTML with only the markup needed to hydrate web component, as marked by `<ssr-keep>` elements.
+   */
+  ssrHydrationPrep() {
+    this.nodesToKeep = [];
+
+    this.ssrKeep.forEach((item) => {
+      while (item.firstChild) {
+        this.nodesToKeep.push(item.firstChild); // track the nodes that will be preserved
+        this.appendChild(item.firstChild);
+      }
+    });
+
+    // Remove all children not in the "keep" array
+    Array.from(this.children)
+      .filter((item) => !this.nodesToKeep.includes(item))
+      .forEach((node) => {
+        node.parentElement.removeChild(node);
+      });
+
+    this.ssrPrepped = true;
+  }
+
   // patch to https://github.com/Polymer/lit-element/blob/master/src/lit-element.ts#L208
   // as a temp workaround to constructible stylesheets not working when
   // rendering inside + outside an iframe. Filing a bug with lit-element shortly!
   update(changedProperties) {
     super.update(changedProperties);
+
+    // double-check if any `<ssr-keep>` elements have registered anything after connectedCallback fired.
+    // this extra check addresses a bug encountered where components like accordions connect BEFORE <ssr-keep> fires
+    if (this.ssrKeep && !this.ssrPrepped) {
+      this.ssrHydrationPrep();
+    }
 
     // When native Shadow DOM is used but adoptedStyles are not supported
     // (or can't be used -- ex. attached to more than one document), insert


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/BDS-2106

## Summary
Ports over the existing `<ssr-keep>`-related hydration logic from `@bolt/core-v3.x` into `@bolt/element`.

## Details
This update was required after running into timing / race condition-related rendering issues once most (all) UI in Bolt started to get loaded and rendered asynchronously.

## How to test
Review code (gut check). Anything else?

All the work actually using this in BoltElement-based components has been split into it's own separate PR so you might need to reference https://github.com/boltdesignsystem/bolt/pull/1839 if you want to see this in action...