### PR TITLE
Add "locked" Badge to Blueprints

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/01-atoms/_badge.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/01-atoms/_badge.twig
@@ -1,17 +1,28 @@
-{% grid "o-bolt-grid--flex o-bolt-grid--matrix o-bolt-grid--center" %}
+{% grid "o-bolt-grid--flex o-bolt-grid--center" %}
   {% cell "u-bolt-flex-shrink" %}
-    {% include "@bolt-components-icon/icon.twig" with {
-      name: "launchpad",
-      background: "circle",
-      size: "xlarge"
-    } only %}
-  {% endcell %}
-  {% cell "u-bolt-width-1/1" %}
-    {% include "@bolt-components-headline/text.twig" with {
-      size: "small",
-      weight: "semibold",
-      align: "center",
-      text: "Achievement Badge Awarded",
-    } only %}
+    <div class="c-bolt-badge">
+      {% include "@bolt-components-image/image.twig" with {
+        src: "/images/mission-test-badge-example.svg",
+        max_width: "200px",
+        attributes: {
+          class: [
+            locked ? "u-bolt-opacity-20" : "",
+          ]
+        }
+      } only %}
+      {% if locked %}
+        {% include "@bolt-components-icon/icon.twig" with {
+          name: "lock",
+          background: "circle",
+          color: "orange",
+          size: "large",
+          attributes: {
+            class: [
+              "c-bolt-badge__lock"
+            ]
+          }
+        } only %}
+      {% endif %}
+    </div>
   {% endcell %}
 {% endgrid %}

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/05-pages/t1-landing-pages/mission-landing/t1-mission-landing.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/05-pages/t1-landing-pages/mission-landing/t1-mission-landing.twig
@@ -98,6 +98,8 @@
       cardIcon: "brand-atom",
       cardDescription: bolt.faker.paragraph(3),
     },
-    macros.include("@bolt-blueprints/_badge.twig"),
+    macros.include("@bolt-blueprints/_badge.twig", {
+      locked: hideCompleted
+    }),
   ]
 } %}

--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/index.scss
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/index.scss
@@ -11,7 +11,11 @@
     z-index: 1;
     width: 100vw;
     height: 100%;
-    background-image: radial-gradient( 100% 109% at bottom 10% right 0%, #FF9B00 36%, rgba(0, 0, 0, 0) 67% );
+    background-image: radial-gradient(
+      100% 109% at bottom 10% right 0%,
+      #ff9b00 36%,
+      rgba(0, 0, 0, 0) 67%
+    );
     mix-blend-mode: multiply;
     background-position: bottom right;
     background-repeat: no-repeat;
@@ -22,7 +26,6 @@
 .c-bolt-featured-hero__image {
   filter: hue-rotate(345deg) contrast(1.3);
 }
-
 
 .c-bolt-horizontal-divider {
   display: flex;
@@ -48,7 +51,6 @@
   @include bolt-font-size(small);
 }
 
-
 // WIP Rating Component
 .c-bolt-rating {
   display: flex;
@@ -64,7 +66,7 @@
   display: inline-flex;
   color: bolt-color(gray);
   @include bolt-font-size(xsmall);
-  @include bolt-font-weight(600)
+  @include bolt-font-weight(600);
 
   & + * {
     @include bolt-margin-left(xsmall);
@@ -113,7 +115,6 @@
   background-color: bolt-color(gray, light);
   transition: all 0.01s linear;
 
-
   &:before,
   &:after {
     content: '';
@@ -155,27 +156,27 @@
   background-color: bolt-color(gray);
 
   &--0\/10 {
-    background-color: #D61219;
+    background-color: #d61219;
   }
 
   &--1\/10 {
-    background-color: #CE3900;
+    background-color: #ce3900;
   }
 
   &--2\/10 {
-    background-color: #C35000;
+    background-color: #c35000;
   }
 
   &--3\/10 {
-    background-color: #B66200;
+    background-color: #b66200;
   }
 
   &--4\/10 {
-    background-color: #A77100;
+    background-color: #a77100;
   }
 
   &--5\/10 {
-    background-color: #977E00;
+    background-color: #977e00;
   }
 
   &--6\/10 {
@@ -187,15 +188,15 @@
   }
 
   &--8\/10 {
-    background-color: #609B12;
+    background-color: #609b12;
   }
 
   &--9\/10 {
-    background-color: #47A334;
+    background-color: #47a334;
   }
 
   &--10\/10 {
-    background-color: #20AA50;
+    background-color: #20aa50;
   }
 }
 
@@ -214,4 +215,15 @@
 
 .c-bolt-rating__input--no-rating:focus ~ .c-bolt-rating__no-rating-outline {
   opacity: 1;
+}
+
+.c-bolt-badge {
+  position: relative;
+
+  &__lock {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
 }


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-2114

## Summary

Add "locked" Badge template to Blueprints.

## Details

> Opened instead of #1847 which had unexplained failing tests.

Add "locked" option to Badge template that fades out the badge and displays a lock over it.

Added a new utility class, `u-bolt-absolute-center`, to help set this up. Also removed some unnecessary grid and utility classes from the Badge template.

## How to test

- Review files changed
- Do you approve of the [new utility class](https://github.com/boltdesignsystem/bolt/pull/1847/files#diff-1c64ddc1abae139b0b22adc69eb8fbb2)?
- See "locked" badge demo on feature branch: `/pattern-lab/patterns/03-blueprints-05-pages-t1-landing-pages-mission-landing-t1-mission-landing/03-blueprints-05-pages-t1-landing-pages-mission-landing-t1-mission-landing.html`