### PR TITLE
hotfix: update Chip List JavaScript to handle when the `.c-bolt-chip-list__input` element doesn't exist

### DIFF
--- a/packages/components/bolt-chip-list/src/chip-list.js
+++ b/packages/components/bolt-chip-list/src/chip-list.js
@@ -44,8 +44,8 @@ class BoltChipList extends BoltElement {
   connectedCallback() {
     super.connectedCallback && super.connectedCallback();
 
-    // Preserve state if expanded before component loads
-    if (this.querySelector('.c-bolt-chip-list__input').checked) {
+    // Preserve state if expanded before component loads + input exists
+    if (this.querySelector('.c-bolt-chip-list__input')?.checked) {
       this.expanded = true;
     }
 

--- a/packages/components/bolt-chip-list/src/chip-list.twig
+++ b/packages/components/bolt-chip-list/src/chip-list.twig
@@ -99,7 +99,6 @@
           display: none;
         }
       </style>
-      </replace-with-children>
       <input type="checkbox" id="{{ inputId }}" class="c-bolt-chip-list__input c-bolt-chip-list--no-js" {% if expanded %} checked {% endif %}/>
     {% endif %}
 


### PR DESCRIPTION
## Jira
N/A

## Summary
Hotfix to the new `<bolt-chip-list>` truncate functionality released in `v2.22.0` that handles when the `.c-bolt-chip-list__input` element doesn't exist... throws a JS error otherwise when you hit the main Chip List docs section: https://v2-22-0.boltdesignsystem.com/pattern-lab/?p=viewall-components-chips-list

![image](https://user-images.githubusercontent.com/1617209/80017028-eb452600-84a1-11ea-8132-befadd19bc6b.png)

## How to test
1. Confirm that the new Chip List functionality still works as expected after this fix is applied
2. Confirm that the JS error that was getting thrown on the [Chip List docs page in `v2.22.0`](https://v2-22-0.boltdesignsystem.com/pattern-lab/?p=viewall-components-chips-list) no longer occurs.
