### PR TITLE
Add deprecation notices and migration docs

### DIFF
--- a/docs-site/src/pages/docs/50-guides/60-migrating-to-3.x.md
+++ b/docs-site/src/pages/docs/50-guides/60-migrating-to-3.x.md
@@ -1,0 +1,35 @@
+---
+title: Migrating to Bolt 3.x
+---
+
+## Loading styles and scripts
+
+If you are migrating to Bolt `v3.x` from `v2.x` you may need to update how you load Bolt styles and scripts. We recommend the following document structure:
+
+```
+<html>
+  <head>
+    <link rel="stylesheet" href="./build/bolt-global.css" media="all">
+    <script type="module" src="./build/bolt-global.js" async></script>
+  </head>
+  <body>
+    <bolt-text>Hello World!</bolt-text>
+  </body>
+</html>
+```
+
+Previously, we recommended including the `<script>` tag just before the closing `<body>` tag. With the introduction of the `async` attribute on the `<script>` tag we can now efficiently load JS in the `<head>`. That is where we recommend including the `<script>` tag for `v3.x`.
+
+Be sure to include `type="module"` on the `<script>` tag as well. It is required for `async` to work. See the [V8 docs](https://v8.dev/features/modules#browser) for more on using JS modules in the browser.
+
+That's it. We no longer support IE11, so there's no need to include any other fallback `<script>` tags for legacy browsers and no need to inline critical CSS and JS in the `<head>` as we did in the past.
+
+## Configuring .boltrc.js
+
+The following packages are no longer required now that we've dropped IE11 support. Please remove them from `.boltrc`:
+
+- `postcss-themify`
+- `components-critical-css`
+- `components-critical-css-vars`
+- `components-critical-fonts`
+- `critical-path-polyfills`

--- a/packages/build-tools/plugins/postcss-themify/README.md
+++ b/packages/build-tools/plugins/postcss-themify/README.md
@@ -1,3 +1,5 @@
+> Note: This package will be removed in Bolt `v3.0` when we drop IE11 support, use CSS custom properties instead. See [Migrating to Bolt v3.x](http://boltdesignsystem.com/docs/guides/migrating-to-3.x.html) docs for more info.
+
 ![themify](https://i.imgur.com/JZyjWm6.png)
 
 [![Build Status](https://travis-ci.org/datorama/themify.svg?branch=master)](https://travis-ci.org/datorama/themify)

--- a/packages/components/bolt-critical-css-vars/README.md
+++ b/packages/components/bolt-critical-css-vars/README.md
@@ -1,3 +1,5 @@
-Async loads fallback CSS that's automatically generated for browsers that don't natively support CSS Variables. 
+> Note: This package will be removed in Bolt `v3.0` when we drop IE11 support, modern browsers support async CSS loading natively. See [migrating to Bolt `v3.x`](http://boltdesignsystem.com/docs/guides/migrating-to-3.x.html) docs for more info.
+
+Async loads fallback CSS that's automatically generated for browsers that don't natively support CSS Variables.
 
 Also adds support for the Filamentgroup's invaluable [loadCSS])(https://www.npmjs.com/package/fg-loadcss) library to allow CSS to be conditionally loaded.

--- a/packages/components/bolt-critical-css/README.md
+++ b/packages/components/bolt-critical-css/README.md
@@ -1,1 +1,3 @@
+> Note: This package will be removed in Bolt `v3.0` when we drop IE11 support, modern browsers support async CSS loading natively. See [migrating to Bolt `v3.x`](http://boltdesignsystem.com/docs/guides/migrating-to-3.x.html) docs for more info.
+
 Adds automatic `<link rel="preload">` async CSS Loading support for browsers that don't natively support it (via the Filamentgroup's invaluable [loadCSS])(https://www.npmjs.com/package/fg-loadcss) library).

--- a/packages/components/bolt-critical-fonts/README.md
+++ b/packages/components/bolt-critical-fonts/README.md
@@ -1,0 +1,1 @@
+> Note: This package will be removed in Bolt `v3.0` when we drop IE11 support and rely less on JS for font-loading. See [migrating to Bolt `v3.x`](http://boltdesignsystem.com/docs/guides/migrating-to-3.x.html) docs for more info.

--- a/packages/components/bolt-critical-path-polyfills/README.md
+++ b/packages/components/bolt-critical-path-polyfills/README.md
@@ -1,3 +1,5 @@
+> Note: This package will be removed in Bolt `v3.0` when we drop IE11 support. See [migrating to Bolt `v3.x`](http://boltdesignsystem.com/docs/guides/migrating-to-3.x.html) docs for more info.
+
 # Critical Path Polyfills
 A small batch of cross-browser polyfills (element.closest and element.matches) meant to be inlined and run at the the browser's [critical rendering path](https://developers.google.com/web/fundamentals/performance/critical-rendering-path/).
 


### PR DESCRIPTION
## Jira

- http://vjira2:8080/browse/BDS-2091 (deprecate packages)
- http://vjira2:8080/browse/BDS-2071 (migration docs)

## Summary

Deprecate packages that will be removed in `v3.x` and add docs for migrating to `v3.x`.

## Details

- Deprecates the following packages in the NPM registry:
    - `postcss-themify`
    - `components-critical-css`
    - `components-critical-css-vars`
    - `components-critical-fonts`
    - `critical-path-polyfills`
- Add note to each package's `README.md` linking to migration docs
- Add initial migration docs (subject to change as we get closer to v3.0)

## How to test
1. View the following on NPM and verify they are deprecated:
    - https://www.npmjs.com/package/@bolt/postcss-themify
    - https://www.npmjs.com/package/@bolt/components-critical-css
    - https://www.npmjs.com/package/@bolt/components-critical-css-vars
    - https://www.npmjs.com/package/@bolt/components-critical-fonts
    - https://www.npmjs.com/package/@bolt/critical-path-polyfills

2. Review the code changes and the [migration docs page](https://feature-add-deprecation-notice.boltdesignsystem.com/docs/guides/migrating-to-3.x.html).
