### PR TITLE
Micro Journey intersection observer-related fix to prevent "restarts" when scrolling away

### DIFF
--- a/packages/experimental/micro-journeys/src/interactive-pathways.js
+++ b/packages/experimental/micro-journeys/src/interactive-pathways.js
@@ -76,10 +76,10 @@ class BoltInteractivePathways extends withLitContext {
   }
 
   connectedCallback() {
-    super.connectedCallback();
+    super.connectedCallback && super.connectedCallback();
 
-    if (window.IntersectionObserver) {
-      const observer = new IntersectionObserver(
+    if (window.IntersectionObserver && !this._hasBeenInViewport) {
+      this.observer = new IntersectionObserver(
         entries => {
           entries.forEach(entry => {
             if (entry.isIntersecting) {
@@ -97,8 +97,8 @@ class BoltInteractivePathways extends withLitContext {
         },
       );
 
-      observer.observe(this);
-    } else {
+      this.observer.observe(this);
+    } else if (!window.IntersectionObserver && !this._hasBeenInViewport) {
       // If IntersectionObserver is not available (i.e. IE11) the alternative is debounced scroll event listeners that would add even more JS burden; it's not worth it - showing first step right away instead
       this._hasBeenInViewport = true;
       if (this._isReady) {
@@ -108,6 +108,15 @@ class BoltInteractivePathways extends withLitContext {
   }
 
   beginItAll() {
+    // if this micro journey's been triggered programmatically but hasn't been marked as "visible in the viewport", register it now
+    if (!this._hasBeenInViewport){
+      this._hasBeenInViewport = true;
+    }
+
+    // clean up any intersection observers (if present)
+    if (this.observer && this.observer.unobserve) {
+      this.observer.unobserve(this);
+    }
     this.showPathway(0);
   }
 


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/WWWD-4726

## Summary
Updates the Micro Journey JS logic in the Interactive Pathways subcomponent to only have the `beginItAll` (aka init() function) method fire _once_ so the animation sequence won't be unintentionally restarted. 

## Details
This small patch also cleans up any existing observers present which also helps to ensure that animations (or previous interactions the user has taken) aren't unintentionally restarted.

## How to test
This JS update is 1:1 with what was already tested and approved downstream ([see this comment for reference](http://vjira2:8080/browse/WWWD-4726?focusedCommentId=79974&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-79974)) but in general with these updates any panels that have already been opened (or scrolled away from before scrolling back) won't unexpectedly restart.