### PR TITLE
Link as popover trigger

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/link/28-link-with-button-element.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/link/28-link-with-button-element.twig
@@ -1,0 +1,6 @@
+<h3>Link with Button element</h3>
+<p>When you want the appearance of Link but the on-click behavior is handled separately (by Tooltip for example), omit the <code>url</code> property and the Link component will internally render a <code>&lt;button&gt;</code>.</p>
+
+{% include "@bolt-components-link/link.twig" with {
+  text: "Link with button element"
+} only %}

--- a/packages/build-tools/__tests__/multi-lang/__snapshots__/index.js.snap
+++ b/packages/build-tools/__tests__/multi-lang/__snapshots__/index.js.snap
@@ -18372,6 +18372,9 @@ bolt-link {
 .c-bolt-link:focus:active {
   opacity: 0.6;
 }
+button.c-bolt-link {
+  font-size: inherit;
+}
 .c-bolt-link--display-flex {
   display: inline-flex;
 }
@@ -36728,6 +36731,9 @@ bolt-link {
 .c-bolt-link:active,
 .c-bolt-link:focus:active {
   opacity: 0.6;
+}
+button.c-bolt-link {
+  font-size: inherit;
 }
 .c-bolt-link--display-flex {
   display: inline-flex;

--- a/packages/components/bolt-link/__tests__/__snapshots__/link.js.snap
+++ b/packages/components/bolt-link/__tests__/__snapshots__/link.js.snap
@@ -6,8 +6,8 @@ exports[`link Default <bolt-link> w/o Shadow DOM renders 1`] = `
              no-shadow
   >
     <a href="http://pega.com"
-       class="c-bolt-link c-bolt-link--display-inline c-bolt-link--valign-center"
        target="_self"
+       class="c-bolt-link c-bolt-link--display-inline c-bolt-link--valign-center"
     >
       <slot name="before">
       </slot>
@@ -30,6 +30,7 @@ exports[`link Default <bolt-link> w/o Shadow DOM renders 3`] = `
     style=""
     url="http://pega.com"
   >
+    <!---->
     <!---->
   </bolt-link>
   <a
@@ -64,15 +65,14 @@ exports[`link Default <bolt-link> w/o Shadow DOM renders 3`] = `
     <!---->
   </a>
   <!---->
+  <!---->
 </div>
 `;
 
 exports[`link Default <bolt-link> w/o Shadow DOM renders and without url prop 1`] = `
 <div>
   <bolt-link no-shadow>
-    <a class="c-bolt-link c-bolt-link--display-inline c-bolt-link--valign-center"
-       target="_self"
-    >
+    <button class="c-bolt-link c-bolt-link--display-inline c-bolt-link--valign-center">
       <slot name="before">
       </slot>
       <span class="c-bolt-link__text">
@@ -80,7 +80,7 @@ exports[`link Default <bolt-link> w/o Shadow DOM renders and without url prop 1`
       </span>
       <slot name="after">
       </slot>
-    </a>
+    </button>
   </bolt-link>
 </div>
 `;
@@ -94,11 +94,11 @@ exports[`link Default <bolt-link> w/o Shadow DOM renders and without url prop 3`
     style=""
   >
     <!---->
+    <!---->
   </bolt-link>
-  <a
+  <button
     class="c-bolt-link c-bolt-link--display-inline c-bolt-link--valign-center"
     style=""
-    target="_self"
   >
     <!---->
     <!---->
@@ -124,15 +124,16 @@ exports[`link Default <bolt-link> w/o Shadow DOM renders and without url prop 3`
     />
     <!---->
     <!---->
-  </a>
+  </button>
+  <!---->
   <!---->
 </div>
 `;
 
 exports[`link Default <bolt-link> with Shadow DOM renders 1`] = `
 <a href="http://pega.com"
-   class="c-bolt-link c-bolt-link--display-inline c-bolt-link--valign-center"
    target="_self"
+   class="c-bolt-link c-bolt-link--display-inline c-bolt-link--valign-center"
 >
   <slot name="before">
   </slot>
@@ -152,9 +153,7 @@ exports[`link Default <bolt-link> with Shadow DOM renders 2`] = `
 `;
 
 exports[`link Default <bolt-link> with Shadow DOM renders and without url prop 1`] = `
-<a class="c-bolt-link c-bolt-link--display-inline c-bolt-link--valign-center"
-   target="_self"
->
+<button class="c-bolt-link c-bolt-link--display-inline c-bolt-link--valign-center">
   <slot name="before">
   </slot>
   <span class="c-bolt-link__text">
@@ -163,7 +162,7 @@ exports[`link Default <bolt-link> with Shadow DOM renders and without url prop 1
   </span>
   <slot name="after">
   </slot>
-</a>
+</button>
 `;
 
 exports[`link Default <bolt-link> with Shadow DOM renders and without url prop 2`] = `
@@ -200,9 +199,11 @@ exports[`link Default <bolt-link> with Shadow DOM renders with no extra whitespa
 exports[`link Link with an onClick attributes renders properly 1`] = `
 <bolt-link display="inline"
            valign="center"
+           url="https://pega.com"
            on-click="on-click-test"
 >
-  <a is="shadow-root"
+  <a href="https://pega.com"
+     is="shadow-root"
      class="c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center"
      on-click="on-click-test"
   >
@@ -218,9 +219,11 @@ exports[`link Link with an onClick attributes renders properly 1`] = `
 exports[`link Link with an onClick param renders properly 1`] = `
 <bolt-link display="inline"
            valign="center"
+           url="https://pega.com"
            on-click="on-click-test"
 >
-  <a is="shadow-root"
+  <a href="https://pega.com"
+     is="shadow-root"
      class="c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center"
   >
     <ssr-keep for="bolt-link"
@@ -235,8 +238,10 @@ exports[`link Link with an onClick param renders properly 1`] = `
 exports[`link Link with c-bolt- class is thrown out 1`] = `
 <bolt-link display="inline"
            valign="center"
+           url="https://pega.com"
 >
-  <a is="shadow-root"
+  <a href="https://pega.com"
+     is="shadow-root"
      class="c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center"
   >
     <ssr-keep for="bolt-link"
@@ -251,8 +256,10 @@ exports[`link Link with c-bolt- class is thrown out 1`] = `
 exports[`link Link with inner classes via Drupal Attributes 1`] = `
 <bolt-link display="inline"
            valign="center"
+           url="https://pega.com"
 >
-  <a is="shadow-root"
+  <a href="https://pega.com"
+     is="shadow-root"
      class="c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center is-active"
   >
     <ssr-keep for="bolt-link"
@@ -267,9 +274,11 @@ exports[`link Link with inner classes via Drupal Attributes 1`] = `
 exports[`link Link with outer JS-class via Drupal Attributes 1`] = `
 <bolt-link display="inline"
            valign="center"
+           url="https://pega.com"
            class="js-click-me"
 >
-  <a is="shadow-root"
+  <a href="https://pega.com"
+     is="shadow-root"
      class="c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center"
   >
     <ssr-keep for="bolt-link"
@@ -284,9 +293,11 @@ exports[`link Link with outer JS-class via Drupal Attributes 1`] = `
 exports[`link Link with outer classes via Drupal Attributes 1`] = `
 <bolt-link display="inline"
            valign="center"
+           url="https://pega.com"
            class="u-bolt-padding-medium"
 >
-  <a is="shadow-root"
+  <a href="https://pega.com"
+     is="shadow-root"
      class="c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center"
   >
     <ssr-keep for="bolt-link"
@@ -301,8 +312,10 @@ exports[`link Link with outer classes via Drupal Attributes 1`] = `
 exports[`link basic link 1`] = `
 <bolt-link display="inline"
            valign="center"
+           url="https://pega.com"
 >
-  <a is="shadow-root"
+  <a href="https://pega.com"
+     is="shadow-root"
      class="c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center"
   >
     <ssr-keep for="bolt-link"
@@ -317,8 +330,10 @@ exports[`link basic link 1`] = `
 exports[`link link display: block 1`] = `
 <bolt-link display="block"
            valign="center"
+           url="https://pega.com"
 >
-  <a is="shadow-root"
+  <a href="https://pega.com"
+     is="shadow-root"
      class="c-bolt-link  c-bolt-link--display-block c-bolt-link--valign-center"
   >
     <ssr-keep for="bolt-link"
@@ -333,8 +348,10 @@ exports[`link link display: block 1`] = `
 exports[`link link display: flex 1`] = `
 <bolt-link display="flex"
            valign="center"
+           url="https://pega.com"
 >
-  <a is="shadow-root"
+  <a href="https://pega.com"
+     is="shadow-root"
      class="c-bolt-link  c-bolt-link--display-flex c-bolt-link--valign-center"
   >
     <ssr-keep for="bolt-link"
@@ -349,8 +366,10 @@ exports[`link link display: flex 1`] = `
 exports[`link link display: inline 1`] = `
 <bolt-link display="inline"
            valign="center"
+           url="https://pega.com"
 >
-  <a is="shadow-root"
+  <a href="https://pega.com"
+     is="shadow-root"
      class="c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center"
   >
     <ssr-keep for="bolt-link"
@@ -365,8 +384,10 @@ exports[`link link display: inline 1`] = `
 exports[`link link valign: center 1`] = `
 <bolt-link display="inline"
            valign="center"
+           url="https://pega.com"
 >
-  <a is="shadow-root"
+  <a href="https://pega.com"
+     is="shadow-root"
      class="c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center"
   >
     <ssr-keep for="bolt-link"
@@ -381,8 +402,10 @@ exports[`link link valign: center 1`] = `
 exports[`link link valign: start 1`] = `
 <bolt-link display="inline"
            valign="start"
+           url="https://pega.com"
 >
-  <a is="shadow-root"
+  <a href="https://pega.com"
+     is="shadow-root"
      class="c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-start"
   >
     <ssr-keep for="bolt-link"

--- a/packages/components/bolt-link/__tests__/link.js
+++ b/packages/components/bolt-link/__tests__/link.js
@@ -34,6 +34,7 @@ describe('link', () => {
   test('basic link', async () => {
     const results = await render('@bolt-components-link/link.twig', {
       text: 'Hello World',
+      url: 'https://pega.com',
     });
     expect(results.ok).toBe(true);
     expect(results.html).toMatchSnapshot();
@@ -43,6 +44,7 @@ describe('link', () => {
     test(`link display: ${option}`, async () => {
       const results = await render('@bolt-components-link/link.twig', {
         text: 'Hello World',
+        url: 'https://pega.com',
         display: option,
       });
       expect(results.ok).toBe(true);
@@ -54,6 +56,7 @@ describe('link', () => {
     test(`link valign: ${option}`, async () => {
       const results = await render('@bolt-components-link/link.twig', {
         text: 'Hello World',
+        url: 'https://pega.com',
         valign: option,
       });
       expect(results.ok).toBe(true);
@@ -64,6 +67,7 @@ describe('link', () => {
   test('Link with outer classes via Drupal Attributes', async () => {
     const results = await render('@bolt-components-link/link.twig', {
       text: 'Link with outer classes',
+      url: 'https://pega.com',
       attributes: {
         class: ['u-bolt-padding-medium'],
       },
@@ -75,6 +79,7 @@ describe('link', () => {
   test('Link with inner classes via Drupal Attributes', async () => {
     const results = await render('@bolt-components-link/link.twig', {
       text: 'Link with inner classes',
+      url: 'https://pega.com',
       attributes: {
         class: ['is-active'],
       },
@@ -86,6 +91,7 @@ describe('link', () => {
   test('Link with outer JS-class via Drupal Attributes', async () => {
     const results = await render('@bolt-components-link/link.twig', {
       text: 'Link with outer JS-prefixed class',
+      url: 'https://pega.com',
       attributes: {
         class: ['js-click-me'],
       },
@@ -97,6 +103,7 @@ describe('link', () => {
   test('Link with c-bolt- class is thrown out', async () => {
     const results = await render('@bolt-components-link/link.twig', {
       text: 'Link with outer JS-prefixed class',
+      url: 'https://pega.com',
       attributes: {
         class: ['c-bolt-link--secondary'],
       },
@@ -108,6 +115,7 @@ describe('link', () => {
   test('Link with an onClick param renders properly', async () => {
     const results = await render('@bolt-components-link/link.twig', {
       text: 'Link with onClick via param',
+      url: 'https://pega.com',
       onClick: 'on-click-test',
     });
     expect(results.ok).toBe(true);
@@ -117,6 +125,7 @@ describe('link', () => {
   test('Link with an onClick attributes renders properly', async () => {
     const results = await render('@bolt-components-link/link.twig', {
       text: 'Link w/ onClick via attributes',
+      url: 'https://pega.com',
       attributes: {
         'on-click': 'on-click-test',
       },

--- a/packages/components/bolt-link/src/link.js
+++ b/packages/components/bolt-link/src/link.js
@@ -50,10 +50,16 @@ class BoltLink extends BoltActionElement {
       [`c-bolt-link--headline`]: this.isHeadline,
     });
 
+    const allAttributes = {
+      ...this.rootElementAttributes,
+      ...(this.url && { href: this.url }),
+      ...(this.target && { target: this.target }),
+      class: classes,
+    };
+
     // 1. Remove line breaks before and after lit-html template tags, causes unwanted space inside and around inline links
     // 2. Zero Width No-break Space (&#xfeff;) is needed to make the last word always stick with the icon, so the icon will never become an orphan.
     // prettier-ignore
-
     const innerSlots = html`${
       this.slotMap.get('before')
         ? html`<span class="${cx(`c-bolt-link__icon`)}">&#xfeff;${this.slotify('before')}</span>`
@@ -67,11 +73,11 @@ class BoltLink extends BoltActionElement {
 
     // [1]
     // prettier-ignore
-    return html`<a
-      ...="${spread(this.rootElementAttributes)}"
-      href="${ifDefined(this.url ? this.url : undefined)}"
-      class="${classes}"
-      target="${ifDefined(this.target ? this.target : undefined)}">${innerSlots}</a>`;
+    return html`
+      ${this.url
+        ? html`<a ...="${spread(allAttributes)}">${innerSlots}</a>`
+        : html`<button ...="${spread(allAttributes)}">${innerSlots}</button>`}
+    `;
   }
 }
 

--- a/packages/components/bolt-link/src/link.js
+++ b/packages/components/bolt-link/src/link.js
@@ -73,11 +73,9 @@ class BoltLink extends BoltActionElement {
 
     // [1]
     // prettier-ignore
-    return html`
-      ${this.url
-        ? html`<a ...="${spread(allAttributes)}">${innerSlots}</a>`
-        : html`<button ...="${spread(allAttributes)}">${innerSlots}</button>`}
-    `;
+    return html`${this.url
+      ? html`<a ...="${spread(allAttributes)}">${innerSlots}</a>`
+      : html`<button ...="${spread(allAttributes)}">${innerSlots}</button>`}`;
   }
 }
 

--- a/packages/components/bolt-link/src/link.js
+++ b/packages/components/bolt-link/src/link.js
@@ -50,10 +50,12 @@ class BoltLink extends BoltActionElement {
       [`c-bolt-link--headline`]: this.isHeadline,
     });
 
+    const isAnchor = this.url || this?.rootElement?.firstChild?.tagName === 'A';
+
     const allAttributes = {
       ...this.rootElementAttributes,
       ...(this.url && { href: this.url }),
-      ...(this.target && { target: this.target }),
+      ...(isAnchor && this.target && { target: this.target }),
       class: classes,
     };
 
@@ -73,7 +75,7 @@ class BoltLink extends BoltActionElement {
 
     // [1]
     // prettier-ignore
-    return html`${this.url
+    return html`${isAnchor
       ? html`<a ...="${spread(allAttributes)}">${innerSlots}</a>`
       : html`<button ...="${spread(allAttributes)}">${innerSlots}</button>`}`;
   }

--- a/packages/components/bolt-link/src/link.scss
+++ b/packages/components/bolt-link/src/link.scss
@@ -42,6 +42,10 @@ $bolt-link-spacing: 'xxsmall';
   }
 }
 
+button.c-bolt-link {
+  font-size: inherit;
+}
+
 .c-bolt-link--display-flex {
   display: inline-flex;
 

--- a/packages/components/bolt-link/src/link.twig
+++ b/packages/components/bolt-link/src/link.twig
@@ -95,6 +95,7 @@ Sort classes passed in via attributes into two groups:
     {% else %}
       type="button"
     {% endif %}
+    is="shadow-root"
     class="{{ inner_classes|join(' ') }}"
     {{ filtered_attributes|without('id') }}
   >

--- a/packages/components/bolt-link/src/link.twig
+++ b/packages/components/bolt-link/src/link.twig
@@ -70,6 +70,8 @@ Sort classes passed in via attributes into two groups:
 {# Filter out attributes assigned above #}
 {% set filtered_attributes = attributes | without("url") | without("href") | without("target") | without("class") %}
 
+{% set tagName = url ? "a" : "button" %}
+
 {# link component's custom element wrapper #}
 {% spaceless %}<bolt-link
   {% if display %} display="{{ display }}" {% endif %}
@@ -85,11 +87,14 @@ Sort classes passed in via attributes into two groups:
 
   {{ filtered_attributes }}
 >
-  {# Add semantic <a> tag for better accessibility #}
-  <a
-    {% if url %} href="{{ url }}" {% endif %}
-    {% if target %} target="{{ target }}" {% endif %}
-    is="shadow-root"
+  {# For accessibility, use <a> tag if `url` provided. Otherwise use `<button type="button">`. #}
+  <{{ tagName }}
+    {% if url %}
+      href="{{ url }}" 
+      {% if target %}target="{{ target }}" {% endif %}
+    {% else %}
+      type="button"
+    {% endif %}
     class="{{ inner_classes|join(' ') }}"
     {{ filtered_attributes|without('id') }}
   >
@@ -98,5 +103,5 @@ Sort classes passed in via attributes into two groups:
       {{- text | default(label) | default("Learn More") -}}
     </ssr-keep>
     {{ macros.slotted_icon(icon, icon_position, "after") }}
-  </a>
+  </{{ tagName }}>
 </bolt-link>{% endspaceless %}


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-2057

## Summary

Allows Link to be used as a trigger for Popover.

## Details

Currently, if you pass `<bolt-link>` as a trigger for Popover it results in nested anchor tags, which is invalid and breaks the layout. This happens because Twig wraps the trigger in an anchor to make the Popover accessible when JS is off.

We want to use Link with Popover, and we want to keep our current no-JS solution. So, the fix was to make Link internally render a `<button>` when no `url` is provided. Semantically, this is better than outputting an `<a>` that is not actually an anchor, and it solves the nested anchor problem.

## How to test
- Review code changes
- See the [Link with Button element](https://feature-link-as-popover-trigger.boltdesignsystem.com/pattern-lab/?p=components-link-with-button-element) demo page
- Locally, open the [basic popover demo](https://github.com/boltdesignsystem/bolt/blob/master/docs-site/src/pages/pattern-lab/_patterns/02-components/popover/05-popover.twig#L9-L12) and replace the button trigger with a link without `url`:
```
  {% include "@bolt-components-link/link.twig" with {
    text: "This triggers a popover"
  } only %}
```
- Verify it works (with and without JS)
- Locally, open the [web component popover demo](https://github.com/boltdesignsystem/bolt/blob/master/docs-site/src/pages/pattern-lab/_patterns/02-components/popover/999-popover-with-web-component.twig#L23-L25) and in the `popover_demo` example, replace `<bolt-button>` with:
```
  <bolt-link >
    This triggers a popover
  </bolt-link>
```
- Verify it works (with JS only)
- Review [Link demos](https://feature-link-as-popover-trigger.boltdesignsystem.com/pattern-lab/?p=viewall-components-link) and verify no other regressions