### PR TITLE
Rate This Mission Blueprint Layout Fix for Safari / Firefox

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/index.scss
+++ b/docs-site/src/pages/pattern-lab/_patterns/03-blueprints/index.scss
@@ -60,6 +60,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  width: 100%; // fix for Firefox and Safari wrapping behavior
 }
 
 .c-bolt-rating__helper-text {


### PR DESCRIPTION
## Jira
http://vjira2:8080/browse/AC-727

## Summary
Tiny CSS update to fix a layout issue in Safari and Firefox.

![image](https://user-images.githubusercontent.com/1617209/81186142-79300f00-8f80-11ea-9ea4-8dbb020fbd97.png)

![image](https://user-images.githubusercontent.com/1617209/81186186-83eaa400-8f80-11ea-8988-9a29604a78d7.png)

![image](https://user-images.githubusercontent.com/1617209/81186236-92d15680-8f80-11ea-803a-198567e3ed05.png)

![image](https://user-images.githubusercontent.com/1617209/81186309-a4b2f980-8f80-11ea-9a37-9e969c17dcbe.png)


## How to test
Confirm that compared to the [previous release](https://v2-22-1.boltdesignsystem.com/pattern-lab/?p=blueprints-t1-mission-landing--test-with-modal), the updated [Mission Landing Test w/ Modal page](http://localhost:3000/pattern-lab/?p=blueprints-t1-mission-landing--test-with-modal) no longer wraps to multiple lines unexpectedly in Safari and Firefox on larger screens + looks the same in Chrome / Edge. 
