### PR TITLE
Dispatch 'bolt:layout-size-changed' after MicroJourney change page he…

### DIFF
--- a/packages/experimental/micro-journeys/src/interactive-pathways.js
+++ b/packages/experimental/micro-journeys/src/interactive-pathways.js
@@ -184,6 +184,14 @@ class BoltInteractivePathways extends withLitContext {
     newPathway.setActive(true);
     this.activePathwayIndex = index;
     this.triggerUpdate();
+
+    setTimeout(() => {
+      this.dispatchEvent(
+        new CustomEvent('bolt:layout-size-changed', {
+          bubbles: true,
+        }),
+      );
+    }, 0);
   }
 
   toggleDropdown(event) {


### PR DESCRIPTION
Added dispatch 'bolt:layout-size-changed' event after pathway is loaded or changed.

## Jira

WWWD-4784

## Summary

Microjourney component height interacts with offsets calculated by nav-indicator. They must be updated after pathway changed.