### PR TITLE
Move layout change event to be dispatched after bolt-interactive-path…

### DIFF
--- a/packages/experimental/micro-journeys/src/interactive-pathway.js
+++ b/packages/experimental/micro-journeys/src/interactive-pathway.js
@@ -229,6 +229,11 @@ class BoltInteractivePathway extends withLitContext {
     this.triggerUpdate();
     setTimeout(async () => {
       await newActiveStep.el.triggerAnimIns();
+      this.dispatchEvent(
+        new CustomEvent('bolt:layout-size-changed', {
+          bubbles: true,
+        }),
+      );
     });
   };
 

--- a/packages/experimental/micro-journeys/src/interactive-pathways.js
+++ b/packages/experimental/micro-journeys/src/interactive-pathways.js
@@ -184,14 +184,6 @@ class BoltInteractivePathways extends withLitContext {
     newPathway.setActive(true);
     this.activePathwayIndex = index;
     this.triggerUpdate();
-
-    setTimeout(() => {
-      this.dispatchEvent(
-        new CustomEvent('bolt:layout-size-changed', {
-          bubbles: true,
-        }),
-      );
-    }, 0);
   }
 
   toggleDropdown(event) {


### PR DESCRIPTION
Move layout change event to be dispatched after bolt-interactive-pathway step rendered.

## Jira

WWWD-4784

## Summary

A page height might be updated more frequently than on pathway change, but also when step change.

I moved `bolt:layout-size-changed` to be triggered after `setActiveStep()` rendered for pathway which support both cases.
