### PR TITLE
Allow autoplay video for iPhone/iPad when controls disabled

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/video/autoplay/-autoplay-and-loop-hide-controls.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/video/autoplay/-autoplay-and-loop-hide-controls.twig
@@ -1,5 +1,5 @@
 <p>This video has <code>autoplay</code> set to <code>true</code>, <code>loop</code> set to <code>true</code>, and <code>controls</code> set to <code>false</code>. When a video is autoplaying without any controls, it is muted by default. This is purely intended for decorations and not practical. Autoplaying video with sound is against best practices.</p>
-<p><mark>Note: videos are not expected to autoplay on iOS.</mark></p>
+<p><mark>Note: setting <code>controls</code> to <code>false</code> will mute the video and is the only currently supported way to autoplay a video on iOS.</mark></p>
 
 {% include "@bolt/video.twig" with {
   "videoId": "5780495299001",

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/video/autoplay/-autoplay-and-loop.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/video/autoplay/-autoplay-and-loop.twig
@@ -1,6 +1,5 @@
 <p>This video has <code>autoplay</code> set to <code>true</code> and <code>loop</code> set to <code>true</code>.</p>
-<p><mark>Note: videos are not expected to autoplay on iOS.</mark></p>
-
+<p><mark>Note: this example will not autoplay on iOS.  <code>controls</code> to <code>false</code> if you want iOS support.</mark></p>
 
 {% include "@bolt/video.twig" with {
   "videoId": "5780495299001",

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/video/autoplay/-autoplay.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/video/autoplay/-autoplay.twig
@@ -1,6 +1,5 @@
 <p>This video has <code>autoplay</code> set to <code>true</code>.</p>
-<p><mark>Note: videos are not expected to autoplay on iOS.</mark></p>
-
+<p><mark>Note: this example will not autoplay on iOS.  Set <code>controls</code> to <code>false</code> if you want iOS support.</mark></p>
 
 {% include "@bolt/video.twig" with {
   "videoId": "5780495299001",

--- a/packages/components/bolt-video/src/video.standalone.js
+++ b/packages/components/bolt-video/src/video.standalone.js
@@ -176,6 +176,7 @@ class BoltVideo extends withPreact {
     // If the option to show controls is set to false (meaning, no controls will be shown), make sure the video is also muted.
     if (elem.controls === false) {
       elem.player.muted(true);
+      elem.player.playsinline(true);
     }
 
     // auto-configure the social overlay config (loaded via the social plugin)

--- a/packages/components/bolt-video/src/video.standalone.js
+++ b/packages/components/bolt-video/src/video.standalone.js
@@ -173,11 +173,33 @@ class BoltVideo extends withPreact {
 
     elem.setPlayer(player);
 
-    // If the option to show controls is set to false (meaning, no controls will be shown), make sure the video is also muted.
+    // The absence of controls is what determines whether a video should be
+    // muted and have autoplay compatibility in iOS.
+    //
+    // This makes some sense in the context of iOS-- if you provide controls,
+    // this video isn't just the equivalent of an animated gif and probably
+    // should play full screen in iOS.  iOS doesn't let a full screen video
+    // autoplay.  See https://webkit.org/blog/6784/new-video-policies-for-ios/.
     if (elem.controls === false) {
+      // If controls are hidden, the video should always be muted.
       elem.player.muted(true);
+
+      // Additionally, if a video doesn't have controls, it's only logical that
+      // it's autoplaying.  Since it will also be muted (see above), it already
+      // passes 2 out of 3 requirements for autoplaying in iOS.  This
+      // 'playsinline' prop is the third.
       elem.player.playsinline(true);
     }
+    // @TODO If a video has controls and autoplay, it should also probably be
+    // muted initally-- not muting and auto playing is obnoxious.  If stakeholders
+    // insiste on unmuted autoplay, we should add a new prop to allow it
+    // (an "obnoxious" boolean?). The only thing keeping us from making that
+    // change now is respect for backwards compatibility.  Uncomment the
+    // following to enable that.
+    //
+    // else if (elem.autoplay) {
+    //   elem.player.muted(true);
+    // }
 
     // auto-configure the social overlay config (loaded via the social plugin)
     if (player.socialOverlay) {


### PR DESCRIPTION
## Jira

WWWD-4750

## Summary

Video autoplay does not work on iPhone and iPad.
Because IOS policy `<video>` tag require extra parameter `playsinline` added.

## Details

Refer docs:
- https://medium.com/code-divoire/autoplaying-inline-videos-on-iphone-ios-10-using-angular-d4e2eaba2164
- https://webkit.org/blog/6784/new-video-policies-for-ios/