### PR TITLE
BDS-2118: Investigate options for Brightcove error styling/UX

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/video/70-video-with-default-error-message.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/video/70-video-with-default-error-message.twig
@@ -1,5 +1,5 @@
 <p>
-  This is an example of a Brightcove video error message display.
+  This is an example of a Brightcove video with the default error message displayed.
 </p>
 
 {% include "@bolt/video.twig" with {

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/video/70-video-with-error-message.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/video/70-video-with-error-message.twig
@@ -1,0 +1,11 @@
+<p>
+  This is an example of a Brightcove video error message display.
+</p>
+
+{% include "@bolt/video.twig" with {
+  "videoId": "3974147489001dasasddasdsa",
+  "accountId": "1900410236",
+  "playerId": "r1CAdLzTW",
+  "showMeta": true,
+  "showMetaTitle": true
+} only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/video/71-video-with-custom-error-message.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/video/71-video-with-custom-error-message.twig
@@ -1,0 +1,12 @@
+<p>
+  This is an example of a Brightcove video with a custom error message displayed.
+</p>
+
+{% include "@bolt/video.twig" with {
+  "videoId": "3974147489001dasasddasdsa",
+  "accountId": "1900410236",
+  "playerId": "r1CAdLzTW",
+  "showMeta": true,
+  "showMetaTitle": true,
+  "errorMessage": "This is a error message override that is coming through the schema and can be a method to translating this data."
+} only %}

--- a/packages/components/bolt-video/src/_video-tag.twig
+++ b/packages/components/bolt-video/src/_video-tag.twig
@@ -71,7 +71,7 @@
 {% set attributes = attributes.setAttribute("share-description", share_description|default('Share This Video'|t)) %}
 
 {% if errorMessage %}
-  {% set attributes = attributes.setAttribute("error-message", errorMessage) %}
+  {% set attributes = attributes.setAttribute("error-message", errorMessage|default("This video didn't load correctly. Refresh page to view."|t)) %}
 {% endif %}
 
 {# @todo: `isBackgroundVideo` will be removed with Bolt v3.0 #}

--- a/packages/components/bolt-video/src/_video-tag.twig
+++ b/packages/components/bolt-video/src/_video-tag.twig
@@ -70,6 +70,10 @@
 
 {% set attributes = attributes.setAttribute("share-description", share_description|default('Share This Video'|t)) %}
 
+{% if errorMessage %}
+  {% set attributes = attributes.setAttribute("error-message", errorMessage) %}
+{% endif %}
+
 {# @todo: `isBackgroundVideo` will be removed with Bolt v3.0 #}
 {% if isBackgroundVideo %}
   {% set attributes = attributes.setAttribute("is-background-video", isBackgroundVideo) %}

--- a/packages/components/bolt-video/src/_videojs-enhancements.scss
+++ b/packages/components/bolt-video/src/_videojs-enhancements.scss
@@ -369,21 +369,12 @@ $bolt-video-js-button-shadow-level-hover: 'level-40';
         text-align: center;
       }
       .vjs-errors-headline{
+        @include bolt-font-size(small);
         display: block;
         width: 100%;
         padding-right: 0;
-        line-height:0;
-        font-size:0;
-        &:after{
-          @include bolt-font-size(small);
-          // @todo: We need to come up with a better solution to handle this through the Brightcove JS API
-          content: "This video didn't load correctly. Refresh page to view.";
-          display:block;
-        }
         @include bolt-mq(medium) {
-          &:after {
-            @include bolt-font-size(medium);
-          }
+          @include bolt-font-size(medium);
         }
       }
 

--- a/packages/components/bolt-video/src/_videojs-enhancements.scss
+++ b/packages/components/bolt-video/src/_videojs-enhancements.scss
@@ -342,7 +342,7 @@ $bolt-video-js-button-shadow-level-hover: 'level-40';
 
   &.vjs-error{
     .vjs-error-display{
-      background: rgba(bolt-color(blue), 1);
+      background: rgba(bolt-color(indigo), 1);
       &:before{
         content:'';
         display:none;
@@ -357,27 +357,35 @@ $bolt-video-js-button-shadow-level-hover: 'level-40';
         left: 0;
         padding: 0;
         border:0;
+        background:0;
       }
       .vjs-errors-content-container{
-        @include bolt-padding(40px, 40px);
+        @include bolt-padding(medium);
         display: flex;
         align-items: center;
         bottom: 15px;
         text-align: center;
       }
       .vjs-errors-headline{
-        @include bolt-font-size(medium);
         display: block;
         width: 100%;
         padding-right: 0;
+        line-height:0;
+        font-size:0;
         &:after{
-          content: '. Refreshing the page may help resolve this issue.'
+          @include bolt-font-size(medium);
+          content: 'Hmmm, we seem to be having trouble loading this video for you. Reloading the page should fix the issue.';
+          display:block;
         }
         @include bolt-mq(medium) {
-          @include bolt-font-size(large);
+          &:after {
+            @include bolt-font-size(large);
+          }
         }
         @include bolt-mq(large) {
-          @include bolt-font-size(xlarge);
+          &:after {
+            @include bolt-font-size(xlarge);
+          }
         }
       }
       .vjs-errors-ok-button-container,

--- a/packages/components/bolt-video/src/_videojs-enhancements.scss
+++ b/packages/components/bolt-video/src/_videojs-enhancements.scss
@@ -375,19 +375,14 @@ $bolt-video-js-button-shadow-level-hover: 'level-40';
         line-height:0;
         font-size:0;
         &:after{
-          @include bolt-font-size(medium);
+          @include bolt-font-size(small);
           // @todo: We need to come up with a better solution to handle this through the Brightcove JS API
           content: "This video didn't load correctly. Refresh page to view.";
           display:block;
         }
         @include bolt-mq(medium) {
           &:after {
-            @include bolt-font-size(large);
-          }
-        }
-        @include bolt-mq(large) {
-          &:after {
-            @include bolt-font-size(xlarge);
+            @include bolt-font-size(medium);
           }
         }
       }

--- a/packages/components/bolt-video/src/_videojs-enhancements.scss
+++ b/packages/components/bolt-video/src/_videojs-enhancements.scss
@@ -374,6 +374,7 @@ $bolt-video-js-button-shadow-level-hover: 'level-40';
         font-size:0;
         &:after{
           @include bolt-font-size(medium);
+          // @todo: We need to come up with a better solution to handle this through the Brightcove JS API
           content: 'We seem to be having trouble loading this video for you. Reloading the page should fix the issue.';
           display:block;
         }

--- a/packages/components/bolt-video/src/_videojs-enhancements.scss
+++ b/packages/components/bolt-video/src/_videojs-enhancements.scss
@@ -340,7 +340,6 @@ $bolt-video-js-button-shadow-level-hover: 'level-40';
     }
   }
 
-  // Error styling
   &.vjs-error{
     .vjs-error-display{
       background: rgba(bolt-color(blue), 1);
@@ -389,7 +388,6 @@ $bolt-video-js-button-shadow-level-hover: 'level-40';
     }
   }
 }
-
 
 .vjs-subs-caps-button {
   display: none; // [3]

--- a/packages/components/bolt-video/src/_videojs-enhancements.scss
+++ b/packages/components/bolt-video/src/_videojs-enhancements.scss
@@ -375,7 +375,7 @@ $bolt-video-js-button-shadow-level-hover: 'level-40';
         &:after{
           @include bolt-font-size(medium);
           // @todo: We need to come up with a better solution to handle this through the Brightcove JS API
-          content: 'We seem to be having trouble loading this video for you. Reloading the page should fix the issue.';
+          content: "This video didn't load correctly. Refresh page to view.";
           display:block;
         }
         @include bolt-mq(medium) {

--- a/packages/components/bolt-video/src/_videojs-enhancements.scss
+++ b/packages/components/bolt-video/src/_videojs-enhancements.scss
@@ -342,7 +342,7 @@ $bolt-video-js-button-shadow-level-hover: 'level-40';
 
   &.vjs-error{
     .vjs-error-display{
-      background: rgba(bolt-color(indigo), 1);
+      background: bolt-color(indigo);
       &:before{
         content:'';
         display:none;

--- a/packages/components/bolt-video/src/_videojs-enhancements.scss
+++ b/packages/components/bolt-video/src/_videojs-enhancements.scss
@@ -364,23 +364,32 @@ $bolt-video-js-button-shadow-level-hover: 'level-40';
       .vjs-errors-content-container{
         @include bolt-padding(medium);
         display: flex;
+        flex-wrap:wrap;
+        justify-content:center;
         align-items: center;
+        top:50%;
         bottom: 15px;
+        transform: translateY(-50%);
         text-align: center;
+      }
+      .vjs-errors-headline,
+      .vjs-errors-ref-id{
+        display:block;
+        width: 100%;
+        color:bolt-color(white);
       }
       .vjs-errors-headline{
         @include bolt-font-size(small);
-        display: block;
-        width: 100%;
         padding-right: 0;
         @include bolt-mq(medium) {
           @include bolt-font-size(medium);
         }
       }
-
+      .vjs-errors-ref-id{
+        align-self: flex-start;
+      }
       .vjs-errors-ok-button-container,
-      .vjs-errors-headline + div,
-      .vjs-errors-ref-id {
+      .vjs-errors-headline + div {
         @include bolt-visuallyhidden;
       }
     }

--- a/packages/components/bolt-video/src/_videojs-enhancements.scss
+++ b/packages/components/bolt-video/src/_videojs-enhancements.scss
@@ -339,7 +339,57 @@ $bolt-video-js-button-shadow-level-hover: 'level-40';
       transform: translate3d(-50%, -50%, 0);
     }
   }
+
+  // Error styling
+  &.vjs-error{
+    .vjs-error-display{
+      background: rgba(bolt-color(blue), 1);
+      &:before{
+        content:'';
+        display:none;
+      }
+      .vjs-modal-dialog-content{
+        padding: 0;
+      }
+      .vjs-errors-dialog{
+        top: 0;
+        right: 0;
+        bottom:0;
+        left: 0;
+        padding: 0;
+        border:0;
+      }
+      .vjs-errors-content-container{
+        @include bolt-padding(40px, 40px);
+        display: flex;
+        align-items: center;
+        bottom: 15px;
+        text-align: center;
+      }
+      .vjs-errors-headline{
+        @include bolt-font-size(medium);
+        display: block;
+        width: 100%;
+        padding-right: 0;
+        &:after{
+          content: '. Refreshing the page may help resolve this issue.'
+        }
+        @include bolt-mq(medium) {
+          @include bolt-font-size(large);
+        }
+        @include bolt-mq(large) {
+          @include bolt-font-size(xlarge);
+        }
+      }
+      .vjs-errors-ok-button-container,
+      .vjs-errors-headline + div,
+      .vjs-errors-ref-id{
+        @include bolt-visuallyhidden;
+      }
+    }
+  }
 }
+
 
 .vjs-subs-caps-button {
   display: none; // [3]

--- a/packages/components/bolt-video/src/_videojs-enhancements.scss
+++ b/packages/components/bolt-video/src/_videojs-enhancements.scss
@@ -374,7 +374,7 @@ $bolt-video-js-button-shadow-level-hover: 'level-40';
         font-size:0;
         &:after{
           @include bolt-font-size(medium);
-          content: 'Hmmm, we seem to be having trouble loading this video for you. Reloading the page should fix the issue.';
+          content: 'We seem to be having trouble loading this video for you. Reloading the page should fix the issue.';
           display:block;
         }
         @include bolt-mq(medium) {

--- a/packages/components/bolt-video/src/_videojs-enhancements.scss
+++ b/packages/components/bolt-video/src/_videojs-enhancements.scss
@@ -366,6 +366,7 @@ $bolt-video-js-button-shadow-level-hover: 'level-40';
         display: flex;
         flex-wrap:wrap;
         justify-content:center;
+        align-content:center;
         align-items: center;
         top:50%;
         bottom: 15px;

--- a/packages/components/bolt-video/src/video.standalone.js
+++ b/packages/components/bolt-video/src/video.standalone.js
@@ -231,12 +231,12 @@ class BoltVideo extends withPreact {
     });
 
     player.on('error', () => {
-      let errorMessage = elem.getAttribute('error-message');
-      const headlineHTML = elem.querySelectorAll('.vjs-errors-headline')
-      if (!errorMessage) {
-        errorMessage = "This video didn't load correctly. Refresh page to view."
+      const headlineHTML = elem.querySelector('.vjs-errors-headline');
+      if (headlineHTML) {
+        headlineHTML.innerHTML =
+          elem.props.errorMessage ||
+          "This video didn't load correctly. Refresh page to view.";
       }
-      headlineHTML[0].innerHTML = errorMessage
     })
   }
 

--- a/packages/components/bolt-video/src/video.standalone.js
+++ b/packages/components/bolt-video/src/video.standalone.js
@@ -231,7 +231,6 @@ class BoltVideo extends withPreact {
     });
 
     player.on('error', () => {
-      console.log(player)
       const headlineHTML = elem.querySelector('.vjs-errors-headline');
       if (headlineHTML) {
         headlineHTML.innerHTML =

--- a/packages/components/bolt-video/src/video.standalone.js
+++ b/packages/components/bolt-video/src/video.standalone.js
@@ -32,6 +32,7 @@ class BoltVideo extends withPreact {
     resetOnFinish: props.boolean,
     directToFullscreen: props.boolean,
     hideFullScreenButton: props.boolean,
+    errorMessage: props.string,
     overlayAlignment: {
       ...props.string,
       ...{ default: 'bottom' },
@@ -228,6 +229,15 @@ class BoltVideo extends withPreact {
     player.on('ended', function() {
       elem.onEnded(player);
     });
+
+    player.on('error', () => {
+      let errorMessage = elem.getAttribute('error-message');
+      const headlineHTML = elem.querySelectorAll('.vjs-errors-headline')
+      if (!errorMessage) {
+        errorMessage = "This video didn't load correctly. Refresh page to view."
+      }
+      headlineHTML[0].innerHTML = errorMessage
+    })
   }
 
   static appendScript(s) {

--- a/packages/components/bolt-video/src/video.standalone.js
+++ b/packages/components/bolt-video/src/video.standalone.js
@@ -231,6 +231,7 @@ class BoltVideo extends withPreact {
     });
 
     player.on('error', () => {
+      console.log(player)
       const headlineHTML = elem.querySelector('.vjs-errors-headline');
       if (headlineHTML) {
         headlineHTML.innerHTML =

--- a/packages/components/bolt-video/video.schema.yml
+++ b/packages/components/bolt-video/video.schema.yml
@@ -77,6 +77,9 @@ properties:
   disabled_plugins:
     type: string
     description: 'Space-separated list of any built-in `<bolt-video>` plugins for Brightcove to disable. Used to opt-out of any video plugins that are enabled by default (ex. the `playback` plugin). For example: `<bolt-video disabled-plugins="playback">`.'
+  errorMessage:
+    type: string
+    description: 'A custom message to be display upon a brigthcove error, will default to "This video didnt load correctly. Refresh page to view." is this field is left blank.'
   isBackgroundVideo:
     title: DEPRECATED
     description: Background video feature will be removed with Bolt v3.0


### PR DESCRIPTION
## Jira

BDS-2118: Investigate options for Brightcove error styling/UX

## Summary

Included an update to the display of the Brightcove error to make it closer to brand

## Details

This is a hotfix to make the Brightcove video display look better before PegWorld. This is a quick fix and a better solution should be figured out post PegaWorld.

## How to test

1. Navigate to https://feature-bds-2118.boltdesignsystem.com/pattern-lab/?p=components-video-with-error-message
2. Observe the video is now displaying with an indigo background color and white text horizontally and vertically centered.

