### PR TITLE
Fix tooltip flicker

### DIFF
--- a/packages/components/bolt-tooltip/src/tooltip.js
+++ b/packages/components/bolt-tooltip/src/tooltip.js
@@ -70,9 +70,7 @@ class BoltTooltip extends BoltElement {
       this.isHovering = false;
     }
 
-    debounce(() => {
-      this.setOpen();
-    }, 100)();
+    this.setOpen();
   }
 
   sortChildren() {

--- a/packages/components/bolt-tooltip/src/tooltip.js
+++ b/packages/components/bolt-tooltip/src/tooltip.js
@@ -1,5 +1,5 @@
 import { customElement, BoltElement, html, unsafeCSS } from '@bolt/element';
-import { isFocusable, debounce } from '@bolt/core-v3.x/utils';
+import { isFocusable } from '@bolt/core-v3.x/utils';
 import classNames from 'classnames/dedupe';
 import { createPopper } from '@popperjs/core';
 import tooltipStyles from './tooltip.scss';


### PR DESCRIPTION
## Jira

http://vjira2:8080/browse/BDS-2134

## Summary

Fix flicker when you hover over Button with Tooltip by removing debounce on mouse events.

## Details

See [demo on master](https://master.boltdesignsystem.com/pattern-lab/?p=components-tooltip-use-case-button-and-link) and hover over "Download" Button. Notice how the button begins to animate, flickers, then resumes animating.

This is an unfortunate side effect of [debouncing the Tooltip](https://github.com/boltdesignsystem/bolt/blob/master/packages/components/bolt-tooltip/src/tooltip.js#L73-L75) `mouseleave` and `mouseenter` events, which was added to fix another bug: if you mouse quickly over the Tooltip triggers on this [demo](https://fix-tooltip-flicker.boltdesignsystem.com/pattern-lab/?p=components-tooltip-placement-variations) (your mouse must enter and leave at just the right speed), the `mouseenter` event fires last, and the tooltip stays open even after you've moused out.

To fix the flicker I'm removing the fix for the Tooltip staying open. I investigated alternative fixes, but found nothing that worked as well as a debounce that didn't introduce tons of complexity to solve a relatively minor and rare bug.

If you're wondering how a debounce causes the flicker, it's because it makes the Tooltip re-render `100ms` behind the button hover animation which momentarily interrupts the animation.

## How to test

- Verify the flicker is fixed on the [feature branch demo](https://fix-tooltip-flicker.boltdesignsystem.com/pattern-lab/?p=components-tooltip-use-case-button-and-link)
- Try to reproduce the Tooltip-stuck-open bug [on master](https://master.boltdesignsystem.com/pattern-lab/?p=components-tooltip-use-case-button-and-link) to get a sense for how often this bugs happens. For me it's about 1 in 10 tries, i.e. deliberately mousing quickly over the text.
- Are you ok with this tradeoff?