### PR TITLE
Fix: font family for regular table

### DIFF
--- a/packages/components/bolt-table/src/table.scss
+++ b/packages/components/bolt-table/src/table.scss
@@ -13,7 +13,7 @@ $bolt-table-border-color: bolt-theme(disabled);
 $bolt-table-header-background-color: bolt-theme(text, 0.04375);
 $bolt-table-row-hover-background-color: bolt-theme(text, 0.025);
 
-@mixin bolt-table-border($direction){
+@mixin bolt-table-border($direction) {
   border-#{$direction}-color: $bolt-table-border-color;
   border-#{$direction}-style: $bolt-table-border-style;
   border-#{$direction}-width: $bolt-table-border-width;
@@ -31,23 +31,23 @@ $bolt-table-row-hover-background-color: bolt-theme(text, 0.025);
   vertical-align: top;
   @include bolt-table-border(right);
   @include bolt-table-border(left);
-  background:
+  background: -webkit-radial-gradient(
+        left,
+        ellipse,
+        bolt-theme(text, 0.25) 0%,
+        bolt-theme(text, 0) 75%
+      )
+      0 center,
     -webkit-radial-gradient(
-      left,
-      ellipse,
-      bolt-theme(text, 0.25) 0%,
-      bolt-theme(text, 0) 75%
-    ) 0 center,
-    -webkit-radial-gradient(
-      right,
-      ellipse,
-      bolt-theme(text, 0.25) 0%,
-      bolt-theme(text, 0) 75%
-    ) 100% center;
+        right,
+        ellipse,
+        bolt-theme(text, 0.25) 0%,
+        bolt-theme(text, 0) 75%
+      ) 100% center;
   background-attachment: scroll, scroll;
   background-color: bolt-theme(background);
   background-repeat: no-repeat;
-  background-size: .5em 100%, .5em 100%;
+  background-size: 0.5em 100%, 0.5em 100%;
   overflow-x: auto;
   border-collapse: collapse;
   border-spacing: 0;
@@ -67,14 +67,13 @@ $bolt-table-row-hover-background-color: bolt-theme(text, 0.025);
 .c-bolt-table__head,
 .c-bolt-table__body,
 .c-bolt-table__foot {
-  background:
-    linear-gradient(
-      to right,
-      bolt-theme(background, 1) 0.75em,
-      bolt-theme(background, 0) 2em,
-      bolt-theme(background, 0) calc(100% - 2em),
-      bolt-theme(background, 1) calc(100% - 0.75em)
-    );
+  background: linear-gradient(
+    to right,
+    bolt-theme(background, 1) 0.75em,
+    bolt-theme(background, 0) 2em,
+    bolt-theme(background, 0) calc(100% - 2em),
+    bolt-theme(background, 1) calc(100% - 0.75em)
+  );
 }
 
 .c-bolt-table__row {
@@ -142,7 +141,7 @@ $bolt-table-row-hover-background-color: bolt-theme(text, 0.025);
 }
 
 .c-bolt-table__cell--data {
-  @include bolt-font-family(code);
+  @include bolt-font-family(body);
   @include bolt-font-size(small);
   @include bolt-font-weight(regular);
 
@@ -171,6 +170,10 @@ $bolt-table-row-hover-background-color: bolt-theme(text, 0.025);
   .c-bolt-table__cell {
     text-align: center;
     white-space: nowrap;
+  }
+
+  .c-bolt-table__cell--data {
+    @include bolt-font-family(code);
   }
 
   > *:not(.c-bolt-table__head) .c-bolt-table__cell--header:first-child {


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/PPR-37

## Summary

Fixes an issue where the regular table is using monospace font (which is intended for numeric table only).

## Details

Updated the CSS to only use monospace under the numeric modifier.

## How to test

Run the branch locally and check the Table docs. Make sure regular tables are using Opens Sans and numeric tables are using monospace.
