### PR TITLE
DS-104 code snippet web component default props and text wrapping

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/code-snippet/25-code-snippet-web-component.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/code-snippet/25-code-snippet-web-component.twig
@@ -1,0 +1,7 @@
+{% set html %}{%- verbatim -%}
+<header>
+  <h1>Headline</h1>
+</header>
+{%- endverbatim -%}{% endset %}
+
+<bolt-code-snippet>{{ html }}</bolt-code-snippet>

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/code-snippet/25-code-snippet-web-component.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/code-snippet/25-code-snippet-web-component.twig
@@ -1,7 +1,0 @@
-{% set html %}{%- verbatim -%}
-<header>
-  <h1>Headline</h1>
-</header>
-{%- endverbatim -%}{% endset %}
-
-<bolt-code-snippet>{{ html }}</bolt-code-snippet>

--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/code-snippet/999-code-snippet-web-component.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/code-snippet/999-code-snippet-web-component.twig
@@ -1,0 +1,47 @@
+{% macro code_example(code) %}
+  <div class="t-bolt-light u-bolt-margin-bottom-small u-bolt-padding-medium">
+    {% grid "o-bolt-grid--center" %}
+      {% cell %}
+        {{ code }}
+      {% endcell %}
+    {% endgrid %}
+  </div>
+  <div class="u-bolt-margin-bottom-large">
+    <bolt-code-snippet syntax="dark" lang="html">{% spaceless %}
+      {{ code | replace({
+        '<': '&lt;',
+        '>': '&gt;',
+      }) | trim | raw }}
+    {% endspaceless %}</bolt-code-snippet>
+  </div>
+{% endmacro %}
+
+{% import _self as code_snippet_example %}
+
+{% set code_snippet_demo %}
+<bolt-code-snippet lang="html">
+  <header>
+    <h1>Headline</h1>
+  </header>
+</bolt-code-snippet>
+{% endset %}
+
+{% set code_snippet_prop_demo %}
+<bolt-code-snippet lang="scss" display="block" syntax="light">
+  .my-scss {
+    @include my-mixin;
+  }
+</bolt-code-snippet>
+{% endset %}
+
+<bolt-text headline>Web Component Usage</bolt-text>
+<bolt-text>
+  Bolt Code Snippet is a web component, you can simply use <bolt-code-snippet display="inline" lang="html">&lt;bolt-code-snippet&gt;</bolt-code-snippet> in the markup to make it render.
+</bolt-text>
+{% include code_snippet_example.code_example(code_snippet_demo) %}
+
+<bolt-text headline>Prop Usage</bolt-text>
+<bolt-text>
+  Configure the code snippet with the properties specified in the schema.
+</bolt-text>
+{% include code_snippet_example.code_example(code_snippet_prop_demo) %}

--- a/packages/components/bolt-code-snippet/src/_code-snippet-base.scss
+++ b/packages/components/bolt-code-snippet/src/_code-snippet-base.scss
@@ -18,9 +18,10 @@ bolt-code-snippet {
 
 .c-bolt-code-snippet,
 .c-bolt-code-snippet__code {
-  white-space: pre;
+  white-space: pre-wrap;
   word-spacing: normal;
   word-break: normal;
+  word-wrap: break-word;
   color: bolt-theme(headline);
   text-align: left;
   border-radius: $bolt-code-snippet-border-radius;

--- a/packages/components/bolt-code-snippet/src/code-snippet.standalone.js
+++ b/packages/components/bolt-code-snippet/src/code-snippet.standalone.js
@@ -55,27 +55,22 @@ class BoltCodeSnippetClass extends withPreact {
   }
 
   render() {
-    const { display, syntax } = this.props;
     const lang = this.props.lang || schema.properties.lang.default;
+    const display = this.props.display || schema.properties.display.default;
+    const syntax = this.props.syntax || schema.properties.syntax.default;
     const highlightedCode = this.highlightHTML(this.code, lang);
 
     const codeClasses = css(
       'c-bolt-code-snippet__code',
-      display
-        ? `c-bolt-code-snippet__code--${display}`
-        : 'c-bolt-code-snippet__code--block',
-      syntax
-        ? `c-bolt-code-snippet-syntax--${syntax}`
-        : 'c-bolt-code-snippet-syntax--light',
-      lang ? `language-${lang}` : 'language-html',
+      `c-bolt-code-snippet__code--${display}`,
+      `c-bolt-code-snippet-syntax--${syntax}`,
+      `language-${lang}`,
     );
 
     const preClasses = css(
       'c-bolt-code-snippet',
-      syntax
-        ? `c-bolt-code-snippet-syntax--${syntax}`
-        : 'c-bolt-code-snippet-syntax--light',
-      lang ? `language-${lang}` : 'language-html',
+      `c-bolt-code-snippet-syntax--${syntax}`,
+      `language-${lang}`,
     );
 
     if (display === 'inline') {

--- a/packages/components/bolt-code-snippet/src/code-snippet.standalone.js
+++ b/packages/components/bolt-code-snippet/src/code-snippet.standalone.js
@@ -3,6 +3,7 @@ import { props, css, hasNativeShadowDomSupport } from '@bolt/core-v3.x/utils';
 import { h, withPreact, Markup } from '@bolt/core-v3.x/renderers';
 import Prism from 'prismjs/components/prism-core';
 import styles from './code-snippet.scss';
+import schema from '../code-snippet.schema';
 
 import 'prismjs/components/prism-markup';
 import 'prismjs/components/prism-twig';
@@ -54,7 +55,8 @@ class BoltCodeSnippetClass extends withPreact {
   }
 
   render() {
-    const { lang, display, syntax } = this.props;
+    const { display, syntax } = this.props;
+    const lang = this.props.lang || schema.properties.lang.default;
     const highlightedCode = this.highlightHTML(this.code, lang);
 
     const codeClasses = css(


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-104

## Summary

Fixes default lang prop for the code snippet component

## Details

WC logic was previously such that lang was not set to the schema default by default.

## How to test

Confirm that the new web component example works without any attributes.
/pattern-lab/patterns/02-components-code-snippet-25-code-snippet-web-component/02-components-code-snippet-25-code-snippet-web-component.html
