### PR TITLE
MicroJourneys: Remove calling `main.js` file with a chunkname; Add missing dependency

### DIFF
--- a/packages/experimental/micro-journeys/index.js
+++ b/packages/experimental/micro-journeys/index.js
@@ -1,5 +1,5 @@
 import { lazyQueue } from '@bolt/lazy-queue';
 
 lazyQueue(['bolt-interactive-pathway'], async () => {
-  await import(/* webpackChunkName: "bolt-micro-journeys" */ './main');
+  await import('./main');
 });

--- a/packages/experimental/micro-journeys/index.js
+++ b/packages/experimental/micro-journeys/index.js
@@ -1,5 +1,5 @@
 import { lazyQueue } from '@bolt/lazy-queue';
 
 lazyQueue(['bolt-interactive-pathway'], async () => {
-  await import('./main');
+  await import(/* webpackChunkName: "bolt-interactive-pathway" */ './main');
 });

--- a/packages/experimental/micro-journeys/index.js
+++ b/packages/experimental/micro-journeys/index.js
@@ -1,3 +1,4 @@
+import 'regenerator-runtime/runtime.js';
 import { lazyQueue } from '@bolt/lazy-queue';
 
 lazyQueue(['bolt-interactive-pathway'], async () => {

--- a/packages/experimental/micro-journeys/package.json
+++ b/packages/experimental/micro-journeys/package.json
@@ -15,6 +15,7 @@
   "style": "index.scss",
   "directories": {},
   "dependencies": {
+    "@bolt/build-tools": "^2.24.1",
     "@bolt/components-dropdown": "^2.24.1",
     "@bolt/components-icon": "^2.24.1",
     "@bolt/core-v3.x": "^2.24.0",


### PR DESCRIPTION
## Jira

WWWD-4473

## Summary

A bolt-release release process based on webpack create a chunkName based on a name defined in package.json.
During that process, from name, there are removed special characters.
The cleaned name match a chunkName was used on `index.js` file, that cause duplicate chunkName error:

`It's not allowed to load an initial chunk on demand. The chunk name "bolt-micro-journeys" is already used by an entrypoint.`