### PR TITLE
Component generator updates

### DIFF
--- a/docs-site/src/components/pattern-lab-utils/docs.twig
+++ b/docs-site/src/components/pattern-lab-utils/docs.twig
@@ -11,8 +11,9 @@
 {% set has_js = pkg.main %}
 {% set has_scss = pkg.sass %}
 {% set component_title = pkg.name %}
+{% set has_changelog = fileExists(change_log_file) %}
 
-{% set is_private = pkg.private or fileExists(change_log_file) == false ? true : false %}
+{% set is_private = pkg.private or not has_changelog ? true : false %}
 
 {% set usage_content %}
 {% spaceless %}
@@ -38,9 +39,11 @@
 {% endset %}
 
 {% set component_change_log %}
-  <bolt-text font-size="xsmall">
-    <bolt-link target="_blank" url="{{ github_url(change_log_file) }}">Change log</bolt-link>
-  </bolt-text>
+  {% if has_changelog %}
+    <bolt-text font-size="xsmall">
+      <bolt-link target="_blank" url="{{ github_url(change_log_file) }}">Change log</bolt-link>
+    </bolt-text>
+  {% endif %}
 {% endset %}
 
 {% set component_github %}
@@ -82,7 +85,7 @@
       component_status,
       is_private == false ? component_last_updated,
       is_private == false ? component_change_log,
-      is_private == false ? component_github,
+      is_private == false and has_changelog ? component_github,
       is_private == false ? component_npm,
     ]
   } only %}

--- a/packages/generators/yeoman-create-component/generators/component/add-bolt-package.js
+++ b/packages/generators/yeoman-create-component/generators/component/add-bolt-package.js
@@ -5,7 +5,7 @@ const sortPackageJson = require('sort-package-json');
 
 const boltPackageJsonPath = path.resolve(
   __dirname,
-  '../../../../../docs-site/package.json',
+  '../../../../../packages/base-starter-kit/package.json',
 );
 const boltPackageJson = require(boltPackageJsonPath);
 

--- a/packages/generators/yeoman-create-component/generators/component/index.js
+++ b/packages/generators/yeoman-create-component/generators/component/index.js
@@ -15,6 +15,10 @@ const { addBoltPackage } = require('./add-bolt-package');
 const currentBoltVersion = require('../../../../../docs-site/package.json')
   .version;
 
+// When there's a hotfix, Core may not match current Bolt version
+const currentBoltCoreVersion = require('../../../../../packages/core-v3.x/package.json')
+  .version;
+
 program
   .version(currentBoltVersion)
   .option('-N, --name [name]', 'button')
@@ -54,6 +58,7 @@ module.exports = class extends Generator {
     };
 
     this.boltVersion = currentBoltVersion;
+    this.boltCoreVersion = currentBoltCoreVersion;
 
     if (program.test) {
       this.testData = {
@@ -163,6 +168,7 @@ module.exports = class extends Generator {
         : this.updateComponentName(this.testData.componentName);
       this.props.gitUrl = this.gitUrl;
       this.props.boltVersion = this.boltVersion;
+      this.props.boltCoreVersion = this.boltCoreVersion;
       this.props.gitInfo = this.gitInfo;
       this.props.packageName = `@bolt/components-${this.props.name.kebabCase}`;
       this.props.dest = `${this.folders.src}/bolt-${this.props.name.kebabCase}`;

--- a/packages/generators/yeoman-create-component/generators/component/index.js
+++ b/packages/generators/yeoman-create-component/generators/component/index.js
@@ -74,6 +74,7 @@ module.exports = class extends Generator {
       this.gitInfo.email = 'test@example.org';
       this.gitInfo.github = '';
       this.boltVersion = '0.0.0';
+      this.boltCoreVersion = '0.0.0';
     }
   }
 

--- a/packages/generators/yeoman-create-component/generators/component/templates/package.json
+++ b/packages/generators/yeoman-create-component/generators/component/templates/package.json
@@ -17,7 +17,7 @@
   "main": "index.js",
   "style": "index.scss",
   "dependencies": {
-    "@bolt/core-v3.x": "^<%= props.boltVersion %>"
+    "@bolt/core-v3.x": "^<%= props.boltCoreVersion %>"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/generators/yeoman-create-component/generators/component/templates/package.tpl.json
+++ b/packages/generators/yeoman-create-component/generators/component/templates/package.tpl.json
@@ -17,7 +17,7 @@
   "main": "index.js",
   "style": "index.scss",
   "dependencies": {
-    "@bolt/core-v3.x": "^<%= props.boltVersion %>"
+    "@bolt/core-v3.x": "^<%= props.boltCoreVersion %>"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-114

## Summary

Fix component generator regressions, update to reflect recent architectural changes.

## Details

- Check that changelog file exists before using it in Twig.
- Don't assume latest Bolt release version number matches latest Bolt Core version number. In the case of a hotfix they might be different, and this causes generator to add core dependency at a version number that doesn't exist.
- We've consolidated how we include Bolt components in `.boltrc`. Instead of adding each component individually to [docs-site `.boltrc`](https://github.com/boltdesignsystem/bolt/blob/master/docs-site/.boltrc.js#L87-L119), we add them to [Starter Kit `.boltrc`](https://github.com/boltdesignsystem/bolt/blob/master/packages/base-starter-kit/.boltrc.js#L3-L68). Updated generator to reflect this change ([see file](https://github.com/boltdesignsystem/bolt/pull/1903/files#diff-ceada4237c607da1d4e97d1d83ed9351)).
- Update docs and tests.

## How to test

- Checkout branch and create a new component.
- Verify the changes to Starter Kit `.boltrc` are correct.