### PR TITLE
Fix Table overflowing List bug

### DIFF
--- a/packages/components/bolt-list/src/list.scss
+++ b/packages/components/bolt-list/src/list.scss
@@ -6,6 +6,10 @@
 
 // Custom element display and built-in spacing
 @include bolt-repeat-rule(('bolt-list', ':host')) {
+  // Clear-fix required to prevent margin collapse due to negative margin on Bolt List.
+  // Happens when List is inside Stack component, for example.
+  // https://css-tricks.com/snippets/css/clear-fix/
+  @include bolt-clearfix;
   @include bolt-margin-bottom(medium);
 
   display: block;
@@ -13,13 +17,6 @@
   &:last-child {
     @include bolt-margin-bottom(0);
   }
-}
-
-bolt-list {
-  // Clear-fix required to prevent margin collapse due to negative margin on Bolt List.
-  // Happens when List is inside Stack component, for example.
-  // https://css-tricks.com/snippets/css/clear-fix/
-  @include bolt-clearfix;
 }
 
 // List base styles

--- a/packages/components/bolt-list/src/list.scss
+++ b/packages/components/bolt-list/src/list.scss
@@ -15,6 +15,13 @@
   }
 }
 
+bolt-list {
+  // Clear-fix required to prevent margin collapse due to negative margin on Bolt List.
+  // Happens when List is inside Stack component, for example.
+  // https://css-tricks.com/snippets/css/clear-fix/
+  @include bolt-clearfix;
+}
+
 // List base styles
 //
 // 1. Reset typography so it doesn't inherit from a higher level container.
@@ -34,8 +41,7 @@
 
 // Display Prop
 .c-bolt-list--display-block {
-  display: flex;
-  flex-flow: column wrap;
+  display: block;
 }
 
 .c-bolt-list--display-inline {


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/ACD-17

## Summary

Fixes bug where Table inside a List is not properly responsive.

## Details

Bug is caused by the List being set to display `flex`. This allows the Table to overflow the container and the horizontal scroll bar on the Table never kicks in.

After setting List to `block`, I noticed the negative margin used on list was collapsing the margin around the List. For example, if you put a List inside a Stack, the space provided by the Stack collapses. This I fixed with a pseudo element clearfix.

## How to test

- Review files changed.
- Review List demos, especially "display" and "spacing", and check for any regressions.
- Copy this demo code into PL and verify:
  - Table is responsive inside the List
  - There is proper space between each Stack

```
<h3>Test 1: Table in List is responsive</h3>

{% set table %}
  {% include "@bolt-components-table/table.twig" with {
    rows: [
      {
        cells: [
          content,
          content,
          content,
        ]
      },
      {
        cells: [
          content,
          content,
          content,
        ]
      },
      {
        cells: [
          content,
          content,
          content,
        ]
      }
    ],
  } only %}
{% endset %}

{% include "@bolt-components-list/list.twig" with {
  items: [
    table,
    table,
    table,
  ],
  spacing: "large"
} only %}


<h3>Test 2: There is space between Stack components</h3>

{% set content = "Lorem ipsum dolor, long link: https://www.pega.com/insights/resources/royal-bank-scotland-delivering-personalization-scale" %}

{% set list %}
  {% include "@bolt-components-list/list.twig" with {
    items: [
      content,
      content,
      content,
    ],
    spacing: "large"
  } only %}
{% endset %}

{% include "@bolt-components-stack/stack.twig" with {
  content: list,
  spacing: "medium"
} only %}
{% include "@bolt-components-stack/stack.twig" with {
  content: list,
  spacing: "medium"
} only %}
{% include "@bolt-components-stack/stack.twig" with {
  content: list,
  spacing: "medium"
} only %}
```