### PR TITLE
Fix Git hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "github-deploy-status": "^1.4.1",
     "globby": "^10.0.1",
     "haunted": "^4.4.0",
-    "husky": "^4.2.1",
+    "husky": "3.1.0",
     "jest": "^24.8.0",
     "jsonwebtoken": "^8.5.1",
     "lerna": "^3.20.2",


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-131

## Summary
Fix pre-commit, pre-push, Git hooks.

## Details

Git hooks appeared to stop working. Actually, they are working when you commit from command line, but are skipped if you use Source Tree, as I do.

Looks like there are issues with both Husky (which we use for hooks) and Source Tree that contribute to this issue ([see issue](https://github.com/typicode/husky/issues/734)), but it can be fixed by simply downgrading Husky.

## How to test

- On master, edit [`packages/components/bolt-popover/src/popover.scss (L40-41)`](https://github.com/boltdesignsystem/bolt/blob/master/packages/components/bolt-popover/src/popover.scss#L40-L41)  and switch the order of the `display` and `position` rules, so that `position` comes first. This should produce a stylint error.
- Stage and commit the file from command line, verify pre-commit hook throws an error.
- Repeat in SourceTree, verify it successfully commits.
- Checkout this feature branch and repeat above steps, verify SourceTree now throws an error on commit. Note: be sure to run `yarn` after switching branches.
