### PR TITLE
Fix Stylelint conflict with Prettier

### DIFF
--- a/packages/configs/stylelint-config/ideal.js
+++ b/packages/configs/stylelint-config/ideal.js
@@ -398,7 +398,6 @@ module.exports = {
     'string-quotes': 'single',
     'unit-case': 'lower',
     'unit-no-unknown': true,
-    'value-list-comma-newline-after': 'always-multi-line',
     'value-list-comma-space-after': 'always-single-line',
     'value-list-comma-space-before': 'never',
   },


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-132

## Summary

Stylelint's [`value-list-comma-newline-after`](https://stylelint.io/user-guide/rules/value-list-comma-newline-after) conflicts with Prettier, so you get different results depending upon which is run last. Remove rule from Stylelint and go with Prettier.

## Details

The conflict only happens in certain scenarios, for example [this type](https://github.com/boltdesignsystem/bolt/blob/master/packages/components/bolt-carousel/src/_carousel.next-previous-buttons.scss#L51-L58) of CSS rule:

```
      box-shadow:
        0 -1px 2px bolt-theme(background),
        0 1px 2px bolt-theme(background),
        0 0 5px rgb(59, 153, 252),
        0 -1px 0.65rem rgb(59, 153, 252),
        0 1px 0.65rem rgb(59, 153, 252);
    }
```

Prettier will try to put values on the same line until a max line length is reached. Stylelint always puts on separate line.

However, elsewhere, line SASS maps, they both always make new lines:
```
$bolt-type-font-size-system: (
  'xxxlarge': 2.35rem,
  'xxlarge': 1.75rem,
  'xlarge': 1.4rem,
  'large': 1.15rem,
  'medium': 1rem,
  'small': 0.9rem,
  'xsmall': 0.8rem,
  'xxsmall': 0.7rem
) !default;
```

Since this option is not configurable in Prettier ([by design](https://prettier.io/docs/en/option-philosophy.html)) and because it's a relatively minor compromise to our overall coding style/standards, I suggest we just go with Prettier and remove the rule from Stylelint.

## How to test
- Check out branch, open [`_carousel.next-previous-buttons.scss`](https://github.com/boltdesignsystem/bolt/blob/master/packages/components/bolt-carousel/src/_carousel.next-previous-buttons.scss) and save. If you have Prettier auto-formatting set up it should fix lines 51-58. If you don't have auto-formatting set up let me know.
- Then run `yarn lint:scss`. There should be no errors.
