### PR TITLE
Hotfix: sass warnings drupal build issues

### DIFF
--- a/auto-release.js
+++ b/auto-release.js
@@ -119,12 +119,9 @@ async function init() {
     }
   } else if (isFullRelease) {
     try {
-      // const version = await shell
-      //   .exec(`auto version --from v${currentVersion}`, { silent: true })
-      //   .stdout.trim();
-
-      // Temporarily hard-code 'version' since auto is failing.
-      const version = 'minor';
+      const version = await shell
+        .exec(`auto version --from v${currentVersion}`, { silent: true })
+        .stdout.trim();
       const nextVersion = await semver.inc(currentVersion, version);
 
       if (

--- a/packages/core-v3.x/styles/02-tools/tools-font-family/_tools-font-family.scss
+++ b/packages/core-v3.x/styles/02-tools/tools-font-family/_tools-font-family.scss
@@ -15,7 +15,7 @@
 ///    @include bolt-font-family(body);
 /// }
 @mixin bolt-font-family($type, $is_root: false) {
-  @warn 'This scss mixin is being deprecated. Please convert to use global CSS vars -> var(--bolt-type-font-family-*)';
+  // @warn 'This scss mixin is being deprecated. Please convert to use global CSS vars -> var(--bolt-type-font-family-*)';
 
   $fallback-font-family: map-get-deep(
     $bolt-font-families,

--- a/packages/core-v3.x/styles/02-tools/tools-font-size/_tools-font-size.scss
+++ b/packages/core-v3.x/styles/02-tools/tools-font-size/_tools-font-size.scss
@@ -16,7 +16,7 @@
 ///    @include bolt-font-size(large);
 /// }
 @mixin bolt-font-size($size, $leading: regular) {
-  @warn 'This scss mixin is being deprecated. Please convert to use global CSS vars -> var(--bolt-type-font-size-*)';
+  // @warn 'This scss mixin is being deprecated. Please convert to use global CSS vars -> var(--bolt-type-font-size-*)';
 
   $font-size: map-get-deep($bolt-font-sizes, 'font-sizes', $size, 'font-size');
 

--- a/packages/core-v3.x/styles/02-tools/tools-font-weight/_tools-font-weight.scss
+++ b/packages/core-v3.x/styles/02-tools/tools-font-weight/_tools-font-weight.scss
@@ -30,13 +30,13 @@
 ///    font-weight: 800;
 /// }
 @mixin bolt-font-weight($weight) {
-  @warn 'This scss mixin is being deprecated. Please convert to use global CSS vars -> var(--bolt-type-font-weight-*)';
+  // @warn 'This scss mixin is being deprecated. Please convert to use global CSS vars -> var(--bolt-type-font-weight-*)';
 
   font-weight: bolt-font-weight($weight);
 }
 
 @function bolt-font-weight($weight) {
-  @warn 'This scss function is being deprecated. Please convert to use global CSS vars -> var(--bolt-type-font-weight-*)';
+  // @warn 'This scss function is being deprecated. Please convert to use global CSS vars -> var(--bolt-type-font-weight-*)';
 
   @if bolt-map-deep-exists($bolt-font-weights, 'font-weights', $weight) {
     @return map-get-deep($bolt-font-weights, 'font-weights', $weight);

--- a/packages/core-v3.x/styles/02-tools/tools-spacing/_tools-spacing.scss
+++ b/packages/core-v3.x/styles/02-tools/tools-spacing/_tools-spacing.scss
@@ -44,7 +44,7 @@ $bolt-spacing-sizes: _bolt-create-spacing-map($bolt-spacing-values);
 ///   min-height: bolt-spacing(large);
 /// }
 @function bolt-spacing($size) {
-  @warn 'This scss function is being deprecated. Please convert to use global CSS vars -> var(--bolt-spacing-x-*).';
+  // @warn 'This scss function is being deprecated. Please convert to use global CSS vars -> var(--bolt-spacing-x-*).';
   @return map-get($bolt-spacing-sizes, nth($size, 1));
 }
 
@@ -61,7 +61,7 @@ $bolt-spacing-sizes: _bolt-create-spacing-map($bolt-spacing-values);
 ///   width: bolt-v-spacing(xsmall);
 /// }
 @function bolt-v-spacing($size, $modifier: null) {
-  @warn 'This scss function is being deprecated. Please convert to use global CSS vars -> var(--bolt-spacing-y-*).';
+  // @warn 'This scss function is being deprecated. Please convert to use global CSS vars -> var(--bolt-spacing-y-*).';
 
   @if ($modifier == 'squished') {
     $modifier: $bolt-spacing-squished;
@@ -85,7 +85,7 @@ $bolt-spacing-sizes: _bolt-create-spacing-map($bolt-spacing-values);
 ///   width: bolt-vertical-spacing(xsmall);
 /// }
 @function bolt-vertical-spacing($size) {
-  @warn 'This scss function is being deprecated. Please convert to use global CSS vars -> var(--bolt-spacing-y-*).';
+  // @warn 'This scss function is being deprecated. Please convert to use global CSS vars -> var(--bolt-spacing-y-*).';
 
   @return bolt-v-spacing($size);
 }

--- a/packages/core-v3.x/styles/02-tools/tools-spacing/libs/_tools-spacing-margin.scss
+++ b/packages/core-v3.x/styles/02-tools/tools-spacing/libs/_tools-spacing-margin.scss
@@ -30,14 +30,14 @@
 // @mixin spacing($)
 
 @mixin bolt-margin($sizes, $type: false, $important: null) {
-  @warn 'This scss mixin is being deprecated. Please convert to use global CSS vars -> var(--bolt-spacing-x-*) and var(--bolt-spacing-y-*).';
+  // @warn 'This scss mixin is being deprecated. Please convert to use global CSS vars -> var(--bolt-spacing-x-*) and var(--bolt-spacing-y-*).';
 
   $sizes: _bolt-normalize-spacing-sizes($sizes, $type);
   @include _bolt-directional-property(margin, false, $sizes, $important);
 }
 
 @mixin bolt-margin-top($sizes, $important: null) {
-  @warn 'This scss mixin is being deprecated. Please convert to use global CSS vars -> var(--bolt-spacing-x-*) and var(--bolt-spacing-y-*).';
+  // @warn 'This scss mixin is being deprecated. Please convert to use global CSS vars -> var(--bolt-spacing-x-*) and var(--bolt-spacing-y-*).';
 
   $sizes: _bolt-normalize-spacing-sizes($sizes, null);
   $sizes: nth($sizes, 1) null null null;
@@ -45,7 +45,7 @@
 }
 
 @mixin bolt-margin-right($sizes, $important: null) {
-  @warn 'This scss mixin is being deprecated. Please convert to use global CSS vars -> var(--bolt-spacing-x-*) and var(--bolt-spacing-y-*).';
+  // @warn 'This scss mixin is being deprecated. Please convert to use global CSS vars -> var(--bolt-spacing-x-*) and var(--bolt-spacing-y-*).';
 
   $sizes: _bolt-normalize-spacing-sizes($sizes, null);
   $sizes: null nth($sizes, 2) null null;
@@ -53,7 +53,7 @@
 }
 
 @mixin bolt-margin-bottom($sizes, $important: null) {
-  @warn 'This scss mixin is being deprecated. Please convert to use global CSS vars -> var(--bolt-spacing-x-*) and var(--bolt-spacing-y-*).';
+  // @warn 'This scss mixin is being deprecated. Please convert to use global CSS vars -> var(--bolt-spacing-x-*) and var(--bolt-spacing-y-*).';
 
   $sizes: _bolt-normalize-spacing-sizes($sizes, null);
   $sizes: null null nth($sizes, 1) null;
@@ -61,7 +61,7 @@
 }
 
 @mixin bolt-margin-left($sizes, $important: null) {
-  @warn 'This scss mixin is being deprecated. Please convert to use global CSS vars -> var(--bolt-spacing-x-*) and var(--bolt-spacing-y-*).';
+  // @warn 'This scss mixin is being deprecated. Please convert to use global CSS vars -> var(--bolt-spacing-x-*) and var(--bolt-spacing-y-*).';
 
   $sizes: _bolt-normalize-spacing-sizes($sizes, null);
   $sizes: null null null nth($sizes, 2);

--- a/packages/core-v3.x/styles/02-tools/tools-spacing/libs/_tools-spacing-padding.scss
+++ b/packages/core-v3.x/styles/02-tools/tools-spacing/libs/_tools-spacing-padding.scss
@@ -1,14 +1,14 @@
 // @mixin spacing($)
 
 @mixin bolt-padding($sizes, $type: false, $important: null) {
-  @warn 'This scss mixin is being deprecated. Please convert to use global CSS vars -> var(--bolt-spacing-x-*) and var(--bolt-spacing-y-*).';
+  // @warn 'This scss mixin is being deprecated. Please convert to use global CSS vars -> var(--bolt-spacing-x-*) and var(--bolt-spacing-y-*).';
 
   $sizes: _bolt-normalize-spacing-sizes($sizes, $type);
   @include _bolt-directional-property(padding, false, $sizes, $important);
 }
 
 @mixin bolt-padding-top($sizes, $important: null) {
-  @warn 'This scss mixin is being deprecated. Please convert to use global CSS vars -> var(--bolt-spacing-x-*) and var(--bolt-spacing-y-*).';
+  // @warn 'This scss mixin is being deprecated. Please convert to use global CSS vars -> var(--bolt-spacing-x-*) and var(--bolt-spacing-y-*).';
 
   $sizes: _bolt-normalize-spacing-sizes($sizes, null);
   $sizes: nth($sizes, 1) null null null;
@@ -16,7 +16,7 @@
 }
 
 @mixin bolt-padding-right($sizes, $important: null) {
-  @warn 'This scss mixin is being deprecated. Please convert to use global CSS vars -> var(--bolt-spacing-x-*) and var(--bolt-spacing-y-*).';
+  // @warn 'This scss mixin is being deprecated. Please convert to use global CSS vars -> var(--bolt-spacing-x-*) and var(--bolt-spacing-y-*).';
 
   $sizes: _bolt-normalize-spacing-sizes($sizes, null);
   $sizes: null nth($sizes, 2) null null;
@@ -24,7 +24,7 @@
 }
 
 @mixin bolt-padding-bottom($sizes, $important: null) {
-  @warn 'This scss mixin is being deprecated. Please convert to use global CSS vars -> var(--bolt-spacing-x-*) and var(--bolt-spacing-y-*).';
+  // @warn 'This scss mixin is being deprecated. Please convert to use global CSS vars -> var(--bolt-spacing-x-*) and var(--bolt-spacing-y-*).';
 
   $sizes: _bolt-normalize-spacing-sizes($sizes, null);
   $sizes: null null nth($sizes, 1) null;
@@ -32,7 +32,7 @@
 }
 
 @mixin bolt-padding-left($sizes, $important: null) {
-  @warn 'This scss mixin is being deprecated. Please convert to use global CSS vars -> var(--bolt-spacing-x-*) and var(--bolt-spacing-y-*).';
+  // @warn 'This scss mixin is being deprecated. Please convert to use global CSS vars -> var(--bolt-spacing-x-*) and var(--bolt-spacing-y-*).';
 
   $sizes: _bolt-normalize-spacing-sizes($sizes, null);
   $sizes: null null null nth($sizes, 2);


### PR DESCRIPTION
## Jira

N/A

## Summary

Builds on the Drupal side are stalling (e.g. http://vbamboo:8085/browse/BOLT-RPKG84-2)

## Details

It seems that the problem started happening when we added the sass warnings.  I suspect the warnings are causing memory issues or similar.

## How to test

- Create a build locally using the tip of this branch and the bolt-release-build project:
`git clone git@vstash:7999/bolt/bolt-release-build.git` (must be on VPN)
`cd bolt-release-build`
`yarn gulp --bolt-version=2fbf8680`

- Confirm no errors

- To reproduce and/or troubleshooting the problem, try building with Bolt version 2.25.0
`yarn gulp --bolt-version=v2.25.0`