### PR TITLE
DS-106 simplify labels

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -1,6 +1,9 @@
 {
   "repo": "bolt",
-  "name": "Salem Ghoweri",
+  "author": {
+    "name": "Bolt Bot",
+    "email": "no-reply@boltdesignsystem.com",
+  },
   "baseBranch": "release/2.x",
   "plugins": [
     ["./scripts/auto-plugin.js"],
@@ -12,7 +15,6 @@
     ]
   ],
   "owner": "boltdesignsystem",
-  "email": "me@salemghoweri.com",
   "labels": [
     {
       "name": "type: feature",

--- a/.autorc
+++ b/.autorc
@@ -5,10 +5,9 @@
   "plugins": [
     ["./scripts/auto-plugin.js"],
     [
-      "released",
+      "omit-commits",
       {
-        "label": "shipped :rocket:",
-        "message": "%TYPE was released with %VERSION"
+        "subject": ["chore: version bump", "chore: update .incache", "chore(release)", "Merge"],
       }
     ]
   ],
@@ -16,91 +15,54 @@
   "email": "me@salemghoweri.com",
   "labels": [
     {
-      "name": "pushToBaseBranch",
-      "changelogTitle": "Misc 🔧"
+      "name": "type: feature",
+      "description": "List this PR in the 'Features' section of the release notes.",
+      "changelogTitle": "Features",
     },
     {
-      "name": "documentation",
+      "name": "type: bugfix",
+      "description": "List this PR in the 'Bug Fixes' section of the release notes.",
+      "changelogTitle": "Bug Fixes",
+    },
+    {
+      "name": "type: docs",
+      "description": "List this PR in the 'Docs' section of the release notes.",
       "changelogTitle": "Docs",
-      "releaseType": "none"
-    },
-    {
-      "name": "internal",
-      "releaseType": "none"
-    },
-    {
-      "name": "wip",
-      "releaseType": "none"
-    },
-    {
-      "name": "devops",
-      "releaseType": "none"
-    },
-    {
-      "name": "chore",
-      "releaseType": "none"
-    },
-    {
-      "changelogTitle": "Deprecations ⚠️",
-      "name": "deprecation"
     },
     {
       "name": "breaking change",
-      "changelogTitle": "Major Breaking Changes 🛑",
       "description": "Add this label to a PR to create a major release when merged.",
-      "releaseType": "major"
+      "releaseType": "major",
+      "changelogTitle": "Breaking Changes",
     },
     {
-      "name": "major release",
-      "changelogTitle": "Major Breaking Changes 🛑",
-      "description": "Add this label to a PR to create a major release when merged.",
-      "releaseType": "major"
+      "name": "version: major",
+      "description": "Use only on PRs to the release branch.  Increments the major version when merged.",
+      "releaseType": "major",
+      "changelogTitle": "Misc",
     },
     {
-      "name": "new component",
-      "changelogTitle": "New Components 🎉",
-      "description": "Increments the minor version when merged",
-      "releaseType": "minor"
+      "name": "version: minor",
+      "releaseType": "minor",
+      "description": "Use only on PRs to the release branch.  Increments the minor version when merged.",
+      "changelogTitle": "Misc",
     },
     {
-      "name": "minor",
-      "description": "Increments the minor version when merged",
-      "releaseType": "minor"
-    },
-    {
-      "name": "enhancement",
-      "changelogTitle": "Features & Enhancements ✨",
-      "description": "Increments the minor version when merged",
-      "releaseType": "minor"
-    },
-    {
-      "name": "new feature",
-      "changelogTitle": "Features & Enhancements ✨",
-      "description": "Increments the minor version when merged",
-      "releaseType": "minor"
-    },
-    {
-      "name": "improvement",
-      "changelogTitle": "Features & Enhancements ✨",
-      "description": "Increments the minor version when merged",
-      "releaseType": "minor"
+      "name": "version: hotfix",
+      "description": "Use only on PRs to the release branch.  Increments the patch version when merged.",
+      "releaseType": "patch",
+      "changelogTitle": "Misc",
     },
     {
       "name": "patch",
-      "description": "Increment the patch version when merged",
-      "releaseType": "patch"
+      "description": "Default release notes grouping for unlabeled PRs",
+      "changelogTitle": "Features",
+      "overwrite": true,
     },
     {
-      "name": "bug",
-      "changelogTitle": "Bug Fixes 🐛",
-      "description": "Increment the patch version when merged",
-      "releaseType": "patch"
+      "name": "pushToBaseBranch",
+      "description": "Release notes grouping for commits made directly to the release branch.",
+      "changelogTitle": "Misc"
     },
-    {
-      "name": "hotfix",
-      "changelogTitle": "Bug Fixes 🐛",
-      "description": "Increment the patch version when merged",
-      "releaseType": "patch"
-    }
   ]
 }

--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,4 @@
+'type: feature': feature/*
+'type: bugfix': bugfix/*
+'type: docs': docs/*
+'version: patch': hotfix/*

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,14 @@
+name: PR Labeler
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  pr-labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: TimonVS/pr-labeler-action@v3
+        with:
+          configuration-path: .github/pr-labeler.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-106

## Summary

Simplifies the labels and their usage in the auto release

## Details

All PRs should now only have one of three labels: `type: docs`, `type: bugfix`, or `type: feature`.  This will determine the section of the release notes in which the PR is listed.  Also, none of these labels should need to be added manually-- they should get added automatically based on the branch name.

The only label that should need to be applied manually to any normal PR (`feature/`, `bugfix/`, or `docs/`) is the the `breaking change` label, if it contains a breaking change and therefore requires a major release.

Finally, to create a release, create a PR going into the `release/2.x` branch.  Label it either `version: minor` (90% of the time), `version:hotfix` (10% of the time), or `version: major` (1% of the time).

## How to test

- Check out this branch
- Run the following command locally to show what the release notes would be
`./node_modules/.bin/auto release --dry-run --from v2.25.0 --use-version=minor`