### PR TITLE
Add "modules" to Bolt Core

### DIFF
--- a/packages/core-v3.x/index.js
+++ b/packages/core-v3.x/index.js
@@ -1,4 +1,5 @@
 import './elements/index.js';
+import './modules/index.js';
 
 // import './elements';
 // import { getData } from './data/get-data';

--- a/packages/core-v3.x/modules/click-handler.js
+++ b/packages/core-v3.x/modules/click-handler.js
@@ -1,0 +1,21 @@
+import { declarativeClickHandler } from '@bolt/core-v3.x/utils';
+
+export default class ClickHandler {
+  constructor(el) {
+    this.el = el;
+    this.setupClickHandler();
+  }
+
+  setupClickHandler() {
+    // The original `declarativeClickHandler` was designed for web components,
+    // where props are automatically turned into node data. We're adapting it
+    // to work with non-WCs by manually setting that data from attributes.
+
+    this.el.onClick = this.el.getAttribute('on-click');
+    this.el.onClickTarget = this.el.getAttribute('on-click-target');
+
+    this.el.addEventListener('click', () => {
+      declarativeClickHandler(this.el);
+    });
+  }
+}

--- a/packages/core-v3.x/modules/index.js
+++ b/packages/core-v3.x/modules/index.js
@@ -1,0 +1,1 @@
+import(/* webpackChunkName: 'bolt-modules' */ './modules');

--- a/packages/core-v3.x/modules/modules.js
+++ b/packages/core-v3.x/modules/modules.js
@@ -1,0 +1,19 @@
+// Note: These modules are included everywhere, so keep it light. Otherwise,
+// consider adding to a component where JS will be loaded only when needed.
+import ClickHandler from './click-handler';
+
+const Modules = { ClickHandler };
+const elements = document.querySelectorAll('[data-module]');
+
+/**
+ * Instantiates a Class on DOM element with matching`[data-module]` attribute.
+ * @example
+ * // Instantiates Class `Foo()` on `<div>`
+ * <div data-module="Foo"></div>
+ */
+Array.from(elements).forEach(el => {
+  const Module = Modules[el.dataset.module];
+  if (typeof Module === 'function') {
+    const dataModule = new Module(el);
+  }
+});

--- a/packages/core-v3.x/modules/modules.js
+++ b/packages/core-v3.x/modules/modules.js
@@ -1,6 +1,6 @@
 // Note: These modules are included everywhere, so keep it light. Otherwise,
 // consider adding to a component where JS will be loaded only when needed.
-import ClickHandler from './click-handler';
+import ClickHandler from './src/click-handler';
 
 const Modules = { ClickHandler };
 const elements = document.querySelectorAll('[data-module]');

--- a/packages/core-v3.x/modules/src/click-handler.js
+++ b/packages/core-v3.x/modules/src/click-handler.js
@@ -11,8 +11,8 @@ export default class ClickHandler {
     // where props are automatically turned into node data. We're adapting it
     // to work with non-WCs by manually setting that data from attributes.
 
-    this.el.onClick = this.el.getAttribute('on-click');
-    this.el.onClickTarget = this.el.getAttribute('on-click-target');
+    this.el.onClick = this.el.dataset.onClick;
+    this.el.onClickTarget = this.el.dataset.onClickTarget;
 
     this.el.addEventListener('click', () => {
       declarativeClickHandler(this.el);


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-24

## Summary

Add "modules" to Bolt Core, a place to add JS outside of web components.

## Details

Currently the way we ship JS in the design system is with web components (Example: `bolt-carousel`). Going forward, we're adopting a hybrid approach, where we use WCs when appropriate but we also have the option to ship JS functionality without requiring the use of WCs. Basically, we want progressive enhancement without requiring a new custom element. To solve this we're trying out a system where JS modules are instantiated on a DOM element via data attribute.

As an initial example, I setup a `ClickHandler` module, which is JS functionality from Link and Button that will be dropped when converted to an "element".

Other JS functionality that might make sense as a "module":
- Truncation
- Smooth scroll
- Form validation

We will need docs for each Module with example usage. For now, this is just a proposal for the overall approach. I still see web components as the best option for our most complex components. This is an alternative.

## How to test

- Review changes
- Add the following Twig snippet to verify `ClickHandler` module works:
```
{% include "@bolt-components-modal/modal.twig" with {
  content: "Lorem ipsum dolor sit, amet consectetur adipisicing elit.",
  attributes: {
    class: "js-bolt-modal",
  },
} only %}

<button type="button" data-module="ClickHandler" data-on-click="toggle" data-on-click-target="js-bolt-modal">Open Modal</button>
<button type="button" data-module="MissingModule" data-on-click="toggle" data-on-click-target="js-bolt-modal">Do Nothing</button>
```
- Any feedback on the overall approach? Suggestions?
