### PR TITLE
DS-140: setup "elements" and "layouts" namespaces

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -31,7 +31,7 @@ module.exports = {
   },
   transformIgnorePatterns: [
     'node_modules/(?!(lit-html|@bolt|@open-wc)/)', // add any additional packages in node_modules that need to be transpiled for Jest
-    'packages/(?!(components|core|analytics|config|testing|generators|experimental)/)', // add any additional packages in node_modules that need to be transpiled for Jest
+    'packages/(?!(elements|layouts|components|core|analytics|config|testing|generators|experimental)/)', // add any additional packages in node_modules that need to be transpiled for Jest
     './scripts/monorepo.test.js',
   ],
   globalSetup: './packages/testing/testing-jest/jest-global-setup.js',

--- a/packages/base-starter-kit/.boltrc.js
+++ b/packages/base-starter-kit/.boltrc.js
@@ -64,6 +64,8 @@ module.exports = {
       '@bolt/components-typeahead',
       '@bolt/components-ul',
       '@bolt/components-video',
+      '@bolt/elements-link',
+      '@bolt/layouts-list',
       '@bolt/analytics-autolink',
     ],
     individual: [

--- a/packages/base-starter-kit/package.json
+++ b/packages/base-starter-kit/package.json
@@ -77,7 +77,9 @@
     "@bolt/components-ul": "^2.25.1",
     "@bolt/components-video": "^2.25.1",
     "@bolt/critical-path-polyfills": "^2.19.0",
-    "@bolt/global": "^2.25.1"
+    "@bolt/elements-link": "^2.25.1",
+    "@bolt/global": "^2.25.1",
+    "@bolt/layouts-list": "^2.25.1"
   },
   "devDependencies": {
     "deepmerge": "^4.2.2",

--- a/packages/elements/bolt-link/__tests__/__snapshots__/link.js.snap
+++ b/packages/elements/bolt-link/__tests__/__snapshots__/link.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`link basic link 1`] = `
+<bolt-link display="inline"
+           valign="center"
+           url="https://pega.com"
+>
+  <a href="https://pega.com"
+     is="shadow-root"
+     class="c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center"
+  >
+    <ssr-keep for="bolt-link"
+              class="c-bolt-link__text"
+    >
+      Hello World
+    </ssr-keep>
+  </a>
+</bolt-link>
+`;

--- a/packages/elements/bolt-link/__tests__/link.js
+++ b/packages/elements/bolt-link/__tests__/link.js
@@ -1,0 +1,42 @@
+import {
+  isConnected,
+  render,
+  renderString,
+  stopServer,
+  html,
+} from '../../../testing/testing-helpers';
+import schema from '../link.schema';
+const { display, valign } = schema.properties;
+
+const timeout = 90000;
+
+describe('link', () => {
+  let page;
+
+  afterAll(async () => {
+    await stopServer();
+    await page.close();
+  });
+
+  beforeEach(async () => {
+    await page.evaluate(() => {
+      document.body.innerHTML = '';
+    });
+  }, timeout);
+
+  beforeAll(async () => {
+    page = await global.__BROWSER__.newPage();
+    await page.goto('http://127.0.0.1:4444/', {
+      timeout: 0,
+    });
+  }, timeout);
+
+  test('basic link', async () => {
+    const results = await render('@bolt-elements-link/link.twig', {
+      text: 'Hello World',
+      url: 'https://pega.com',
+    });
+    expect(results.ok).toBe(true);
+    expect(results.html).toMatchSnapshot();
+  });
+});

--- a/packages/elements/bolt-link/index.js
+++ b/packages/elements/bolt-link/index.js
@@ -1,0 +1,5 @@
+import { lazyQueue } from '@bolt/lazy-queue';
+
+lazyQueue(['bolt-link'], async () => {
+  await import(/* webpackChunkName: 'bolt-link' */ './src/link');
+});

--- a/packages/elements/bolt-link/index.scss
+++ b/packages/elements/bolt-link/index.scss
@@ -1,0 +1,1 @@
+@import 'src/link.scss';

--- a/packages/elements/bolt-link/link.schema.js
+++ b/packages/elements/bolt-link/link.schema.js
@@ -1,0 +1,71 @@
+const iconSchema = require('@bolt/components-icon/icon.schema.json');
+const elementSchemas = require('@bolt/element/element.schemas');
+
+iconSchema.properties = {
+  position: {
+    description: 'Where to position the icon within the link.',
+    type: 'string',
+    default: 'after',
+    enum: ['before', 'after'],
+  },
+  ...iconSchema.properties,
+};
+
+iconSchema.description =
+  'Icon data as expected by the icon component. Accepts an additional position prop that determines placement within the link.';
+
+// @TODO Move the 'disabled' prop out of BoltActionElement and into button instead. For now, simply omit it here.
+const {
+  url,
+  target,
+  disabled,
+  ...onClickProps
+} = elementSchemas.boltActionElement.properties;
+
+module.exports = {
+  $schema: 'http://json-schema.org/draft-04/schema#',
+  title: 'Link',
+  description: 'Text link.',
+  type: 'object',
+  not: {
+    required: ['href'],
+  },
+  properties: {
+    attributes: {
+      type: 'object',
+      description:
+        'A Drupal-style attributes object with extra attributes to append to this component.',
+    },
+    text: {
+      type: ['string', 'object', 'array'],
+      description:
+        'Renderable content (i.e. a string, render array, or included pattern) for the link.',
+    },
+    url,
+    target,
+    display: {
+      type: 'string',
+      description:
+        'Display either an inline link or flex link (icons can hang on either side).',
+      enum: ['inline', 'flex', 'block'],
+      default: 'inline',
+    },
+    valign: {
+      type: 'string',
+      description: 'Controls the vertical alignment of text and icon.',
+      enum: ['center', 'start'],
+      default: 'center',
+    },
+    isHeadline: {
+      type: 'boolean',
+      description:
+        'Whether this link should get special headline styling treatment.',
+    },
+    icon: iconSchema,
+    ...onClickProps,
+    href: {
+      title: 'DEPRECATED',
+      description: 'Use url instead.',
+    },
+  },
+};

--- a/packages/elements/bolt-link/package.json
+++ b/packages/elements/bolt-link/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@bolt/elements-link",
+  "version": "2.25.1",
+  "private": true,
+  "description": "Pega branded actionable text.",
+  "keywords": [
+    "eyeglass-module",
+    "bolt design system",
+    "bolt",
+    "ui toolkit",
+    "design system"
+  ],
+  "homepage": "https://boltdesignsystem.com",
+  "bugs": "https://github.com/bolt-design-system/bolt/issues",
+  "repository": "https://github.com/bolt-design-system/bolt/tree/master/packages/components/bolt-link",
+  "license": "MIT",
+  "author": "Salem Ghoweri",
+  "main": "index.js",
+  "style": "index.scss",
+  "dependencies": {
+    "@bolt/components-icon": "^2.25.1",
+    "@bolt/core-v3.x": "^2.25.1",
+    "@bolt/lazy-queue": "^2.23.0"
+  },
+  "gitHead": "d41aa75ae3d195d9d7fb3952eed5e0ae80988133",
+  "schema": "link.schema.js",
+  "twig": "src/link.twig"
+}

--- a/packages/elements/bolt-link/src/_link-macros.twig
+++ b/packages/elements/bolt-link/src/_link-macros.twig
@@ -1,0 +1,12 @@
+{% macro slotted_icon(icon, icon_position, slot_name) %}
+  {% if icon and icon_position == slot_name %}
+    <ssr-keep for="bolt-link" class="c-bolt-link__icon">
+      {% set icon = icon | merge({
+        attributes: {
+          slot: slot_name
+        }
+      }) %}
+      {% include "@bolt-components-icon/icon.twig" with icon only %}
+    </ssr-keep>
+  {% endif %}
+{% endmacro %}

--- a/packages/elements/bolt-link/src/link.js
+++ b/packages/elements/bolt-link/src/link.js
@@ -1,0 +1,84 @@
+import {
+  BoltActionElement,
+  unsafeCSS,
+  render,
+  html,
+  ifDefined,
+  customElement,
+  convertInitialTags,
+  spread,
+} from '@bolt/element';
+import classNames from 'classnames/bind';
+import linkStyles from './link.scss';
+import schema from '../link.schema';
+
+let cx = classNames.bind(linkStyles);
+
+@customElement('bolt-link')
+@convertInitialTags(['button', 'a'])
+class BoltLink extends BoltActionElement {
+  static get styles() {
+    return [unsafeCSS(linkStyles)];
+  }
+
+  static get properties() {
+    return {
+      ...BoltActionElement.properties,
+      display: String,
+      valign: String,
+      isHeadline: {
+        type: Boolean,
+        attribute: 'is-headline',
+      },
+    };
+  }
+
+  // https://github.com/WebReflection/document-register-element#upgrading-the-constructor-context
+  constructor(self) {
+    self = super(self);
+    self.schema = schema;
+    self.display = schema.properties.display.default;
+    self.valign = schema.properties.valign.default;
+    self.target = schema.properties.target.default; // @todo: remove once https://github.com/boltdesignsystem/bolt/pull/1795 lands
+    return self;
+  }
+
+  render() {
+    const classes = cx('c-bolt-link', {
+      [`c-bolt-link--display-${this.display}`]: this.display,
+      [`c-bolt-link--valign-${this.valign}`]: this.valign,
+      [`c-bolt-link--headline`]: this.isHeadline,
+    });
+
+    const isAnchor = this.url || this?.rootElement?.firstChild?.tagName === 'A';
+
+    const allAttributes = {
+      ...this.rootElementAttributes,
+      ...(this.url && { href: this.url }),
+      ...(isAnchor && this.target && { target: this.target }),
+      class: classes,
+    };
+
+    // 1. Remove line breaks before and after lit-html template tags, causes unwanted space inside and around inline links
+    // 2. Zero Width No-break Space (&#xfeff;) is needed to make the last word always stick with the icon, so the icon will never become an orphan.
+    // prettier-ignore
+    const innerSlots = html`${
+      this.slotMap.get('before')
+        ? html`<span class="${cx(`c-bolt-link__icon`)}">&#xfeff;${this.slotify('before')}</span>`
+        : html`<slot name="before" />`}${
+      this.slotMap.get('default')
+        ? html`<span class="${cx(`c-bolt-link__text`)}">${this.slotify('default')}</span>`
+        : html`<slot />`}${
+      this.slotMap.get('after')
+        ? html`<span class="${cx(`c-bolt-link__icon`)}">&#xfeff;${this.slotify('after')}</span>`
+        : html`<slot name="after" />`}`;
+
+    // [1]
+    // prettier-ignore
+    return html`${isAnchor
+      ? html`<a ...="${spread(allAttributes)}">${innerSlots}</a>`
+      : html`<button ...="${spread(allAttributes)}">${innerSlots}</button>`}`;
+  }
+}
+
+export { BoltLink };

--- a/packages/elements/bolt-link/src/link.scss
+++ b/packages/elements/bolt-link/src/link.scss
@@ -1,0 +1,90 @@
+/* ------------------------------------ *\
+   Links
+\* ------------------------------------ */
+
+// Dev Notes
+// 1. [Mai] Reset button and input tag browser defaults.
+// 2. [Mai] All the theming stuff is an interim fix until the bolt-text is refactored, which will cover all the text link styles as well.
+// 3. [Morse] This mixin outputs a separate ruleset for each selector to prevent IE from failing on unrecognized selectors like `:host`. It is not a substitute for comma-separated selectors.
+// 4. [Morse] Bolt-link delegates focus to inner element.
+
+@import '@bolt/core-v3.x';
+
+// Component variables
+$bolt-link-transition: $bolt-transition;
+$bolt-link-spacing: 'xxsmall';
+
+// Custom element styles
+@include bolt-repeat-rule(('bolt-link', ':host')) {
+  // [3]
+  outline: none; // [4]
+}
+
+// Component styles
+.c-bolt-link {
+  @include bolt-button-reset; // [1]
+  display: inline;
+  opacity: bolt-opacity(100);
+  margin-left: bolt-spacing(#{$bolt-link-spacing}) * -1;
+  color: bolt-theme(link);
+  text-decoration: underline;
+  cursor: pointer;
+  border: none; // [1]
+  transition: all $bolt-link-transition;
+
+  &:hover {
+    opacity: $bolt-global-link-hover-opacity;
+  }
+
+  &:active,
+  &:focus:active {
+    opacity: $bolt-global-link-active-opacity;
+  }
+}
+
+button.c-bolt-link {
+  font-size: inherit;
+}
+
+.c-bolt-link--display-flex {
+  display: inline-flex;
+
+  &.c-bolt-link--valign-start {
+    align-items: flex-start;
+  }
+
+  &.c-bolt-link--valign-center {
+    align-items: center;
+  }
+}
+
+.c-bolt-link--display-inline {
+  .c-bolt-link__icon {
+    display: inline;
+    white-space: nowrap; // Combine this with Zero Width No-break Space (&#xfeff; in the markup), it fixes the orphan icon issue. The last word will always wrap with the icon.
+  }
+}
+
+.c-bolt-link--display-block {
+  display: block;
+}
+
+.c-bolt-link__icon,
+.c-bolt-link__text {
+  @include bolt-padding-left(#{$bolt-link-spacing});
+}
+
+.c-bolt-link__text {
+  display: inline;
+  max-width: 100%; // required so the Link doesn't overflow parent containers w/ a max-width specified
+}
+
+// Changes the underline styles when a link is also a headline, chevrons are added to headline links by default.
+.c-bolt-link--headline {
+  color: bolt-theme(headline-link);
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}

--- a/packages/elements/bolt-link/src/link.twig
+++ b/packages/elements/bolt-link/src/link.twig
@@ -1,0 +1,108 @@
+{% import "@bolt-elements-link/_link-macros.twig" as macros %}
+
+{% set schema = bolt.data.components["@bolt-elements-link"].schema %}
+
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(schema, _self) | raw }}
+{% endif %}
+
+{# set up psuedo self-validation by limiting param values to what's specifically allowed in the component schema #}
+{% set icon_positions = schema.properties.icon.properties.position.enum %}
+
+{# Variables #}
+{% set base_class = "c-bolt-link" %}
+{% set attributes = create_attribute(attributes | default(attributes) | default({})) %}
+{% set attributes = attributes.addClass(classes) %}
+
+{% if icon %}
+  {% set icon_position = icon.position in icon_positions ? icon.position : schema.properties.icon.properties.position.default %}
+{% endif %}
+
+{% if url or attributes["url"] %}
+  {% set url = url | default(attributes["url"]) %}
+{% elseif href or attributes["href"] %}
+  {% set url = href | default(attributes["href"]) %}
+{% endif %}
+
+{% if target or attributes["target"] %}
+  {% set target = target | default(attributes["target"]) %}
+{% endif %}
+
+{% if onClick or attributes["on-click"] %}
+  {% set onClick = onClick | default(attributes["on-click"]) %}
+{% endif %}
+
+{% if onClickTarget or attributes["on-click-target"] %}
+  {% set onClickTarget = onClickTarget | default(attributes["on-click-target"]) %}
+{% endif %}
+
+{# Set up checks to validate that the component's prop values are allowed, based on the component's schema. #}
+{% set display_options = schema.properties.display.enum %}
+{% set valign_options = schema.properties.valign.enum %}
+
+{# Check that the component's current prop values are valid. If not, default to the schema default #}
+{% set display = display in display_options ? display : schema.properties.display.default %}
+{% set valign = valign in valign_options ? valign : schema.properties.valign.default %}
+
+{% set classes = [
+  base_class,
+  isHeadline ? "c-bolt-link--headline" : "",
+  display in display_options ? "#{base_class}--display-#{display}" : "",
+  valign in valign_options ? "#{base_class}--valign-#{valign}" : "",
+] %}
+
+{#
+Sort classes passed in via attributes into two groups:
+1. Those that should be applied to the inner tag (namely, "is-" and "has-" classes)
+2. Those that should be applied to the outer custom element (everything else EXCEPT c-bolt-* classes, which should never be passed in via atttributes)
+#}
+{% set outer_classes = [] %}
+{% set inner_classes = classes %}
+
+{% for class in attributes["class"] %}
+  {% if class starts with "is-" or class starts with "has-" %}
+    {% set inner_classes = inner_classes|merge([class]) %}
+  {% elseif class starts with "c-bolt-" == false %}
+    {% set outer_classes = outer_classes|merge([class]) %}
+  {% endif %}
+{% endfor %}
+
+{# Filter out attributes assigned above #}
+{% set filtered_attributes = attributes | without("url") | without("href") | without("target") | without("class") %}
+
+{% set tagName = url ? "a" : "button" %}
+
+{# link component's custom element wrapper #}
+{% spaceless %}<bolt-link
+  {% if display %} display="{{ display }}" {% endif %}
+  {% if valign %} valign="{{ valign }}" {% endif %}
+  {% if url %} url="{{ url }}" {% endif %}
+  {% if target %} target="{{ target }}" {% endif %}
+  {% if isHeadline %} is-headline="true" {% endif %}
+  {% if outer_classes %} class="{{ outer_classes|join(' ') }}" {% endif %}
+
+  {# todo: rename on-click + on-click-target to only allow onClick + onClickTarget to unify the prop syntax; deprecate adding these via attributes #}
+  {% if onClick %} on-click="{{ onClick }}" {% endif %}
+  {% if onClickTarget %} on-click-target="{{ onClickTarget }}" {% endif %}
+
+  {{ filtered_attributes }}
+>
+  {# For accessibility, use <a> tag if `url` provided. Otherwise use `<button type="button">`. #}
+  <{{ tagName }}
+    {% if url %}
+      href="{{ url }}" 
+      {% if target %}target="{{ target }}" {% endif %}
+    {% else %}
+      type="button"
+    {% endif %}
+    is="shadow-root"
+    class="{{ inner_classes|join(' ') }}"
+    {{ filtered_attributes|without('id') }}
+  >
+    {{ macros.slotted_icon(icon, icon_position, "before") }}
+    <ssr-keep for="bolt-link" class="{{ "#{base_class}__text" }}">
+      {{- text | default(label) | default("Learn More") -}}
+    </ssr-keep>
+    {{ macros.slotted_icon(icon, icon_position, "after") }}
+  </{{ tagName }}>
+</bolt-link>{% endspaceless %}

--- a/packages/layouts/bolt-list/__tests__/__snapshots__/list.js.snap
+++ b/packages/layouts/bolt-list/__tests__/__snapshots__/list.js.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<bolt-list> Component basic usage 1`] = `
+<bolt-list tag="ul"
+           display="block"
+           spacing="xsmall"
+           separator="none"
+           align="start"
+           valign="center"
+>
+  <ssr-keep for="bolt-list"
+            role="list"
+            class="c-bolt-list c-bolt-list--display-block c-bolt-list--spacing-xsmall c-bolt-list--align-start c-bolt-list--valign-center"
+  >
+    <bolt-list-item role="presentation">
+      <ssr-keep for="bolt-list-item"
+                role="listitem"
+                class="c-bolt-list-item c-bolt-list-item--display-block c-bolt-list-item--spacing-xsmall c-bolt-list-item--align-start"
+      >
+        item 1
+      </ssr-keep>
+    </bolt-list-item>
+    <bolt-list-item role="presentation">
+      <ssr-keep for="bolt-list-item"
+                role="listitem"
+                class="c-bolt-list-item c-bolt-list-item--display-block c-bolt-list-item--spacing-xsmall c-bolt-list-item--align-start"
+      >
+        item 2
+      </ssr-keep>
+    </bolt-list-item>
+    <bolt-list-item last
+                    role="presentation"
+    >
+      <ssr-keep for="bolt-list-item"
+                role="listitem"
+                class="c-bolt-list-item c-bolt-list-item--display-block c-bolt-list-item--spacing-xsmall c-bolt-list-item--align-start c-bolt-list-item--last-item"
+      >
+        item 3
+      </ssr-keep>
+    </bolt-list-item>
+  </ssr-keep>
+</bolt-list>
+`;

--- a/packages/layouts/bolt-list/__tests__/list.js
+++ b/packages/layouts/bolt-list/__tests__/list.js
@@ -1,0 +1,51 @@
+import {
+  isConnected,
+  render,
+  renderString,
+  stopServer,
+  html,
+  vrtDefaultConfig,
+} from '../../../testing/testing-helpers';
+import schema from '../list.schema';
+const {
+  display,
+  spacing,
+  separator,
+  inset,
+  align,
+  valign,
+  tag,
+  nowrap,
+} = schema.properties;
+
+const timeout = 120000;
+
+describe('<bolt-list> Component', () => {
+  let page;
+
+  afterAll(async () => {
+    await stopServer();
+    await page.close();
+  });
+
+  beforeEach(async () => {
+    await page.evaluate(() => {
+      document.body.innerHTML = '';
+    });
+  }, timeout);
+
+  beforeAll(async () => {
+    page = await global.__BROWSER__.newPage();
+    await page.goto('http://127.0.0.1:4444/', {
+      timeout: 0,
+    });
+  }, timeout);
+
+  test('basic usage', async () => {
+    const results = await render('@bolt-layouts-list/list.twig', {
+      items: ['item 1', 'item 2', 'item 3'],
+    });
+    expect(results.ok).toBe(true);
+    expect(results.html).toMatchSnapshot();
+  });
+});

--- a/packages/layouts/bolt-list/index.js
+++ b/packages/layouts/bolt-list/index.js
@@ -1,0 +1,5 @@
+import { lazyQueue } from '@bolt/lazy-queue';
+
+lazyQueue(['bolt-list'], async () => {
+  await import(/*  webpackChunkName: 'bolt-list' */ './main');
+});

--- a/packages/layouts/bolt-list/index.scss
+++ b/packages/layouts/bolt-list/index.scss
@@ -1,0 +1,2 @@
+@import 'src/list.scss';
+@import 'src/_list-item.scss';

--- a/packages/layouts/bolt-list/list.schema.js
+++ b/packages/layouts/bolt-list/list.schema.js
@@ -1,0 +1,77 @@
+module.exports = {
+  $schema: 'http://json-schema.org/draft-04/schema#',
+  title: 'List',
+  description: 'Minimal list component for laying out a group of items.',
+  type: 'object',
+  // required: ['items'],
+  properties: {
+    attributes: {
+      type: 'object',
+      description:
+        'A Drupal-style attributes object with extra attributes to append to this component.',
+    },
+    items: {
+      type: 'array',
+      description:
+        'Generates an array of items, each can contain renderable content (i.e. a string, render array, or included pattern).',
+    },
+    tag: {
+      type: 'string',
+      description: 'Apply the semantic tag for the list.',
+      default: 'ul',
+      enum: ['ul', 'ol', 'div', 'span'],
+    },
+    display: {
+      type: 'string',
+      description:
+        'Display either an inline list of items or a block (stacked) list of items. Responsive options are also available for transforming from block to inline at specific breakpoints.',
+      default: 'block',
+      enum: [
+        'block',
+        'flex',
+        'inline',
+        'inline@xxsmall',
+        'inline@xsmall',
+        'inline@small',
+        'inline@medium',
+      ],
+    },
+    spacing: {
+      type: 'string',
+      description: 'Control the spacing in between items.',
+      default: 'xsmall',
+      enum: ['none', 'xxsmall', 'xsmall', 'small', 'medium', 'large', 'xlarge'],
+    },
+    separator: {
+      type: 'string',
+      description: 'Display a separator in between items.',
+      default: 'none',
+      enum: ['none', 'solid', 'dashed'],
+    },
+    inset: {
+      type: 'boolean',
+      description: 'Turn spacing to the inside of each item.',
+      default: false,
+      enum: [true, false],
+    },
+    align: {
+      type: 'string',
+      description: 'Control the horizontal alignment of items.',
+      default: 'start',
+      enum: ['start', 'center', 'end', 'justify'],
+    },
+    valign: {
+      type: 'string',
+      description: 'Control the vertical alignment of items.',
+      default: 'center',
+      enum: ['start', 'center', 'end'],
+    },
+    nowrap: {
+      type: 'boolean',
+      description:
+        'Prevent inline/flex list items from wrapping to a second line.',
+      default: false,
+      enum: [true, false],
+    },
+  },
+};

--- a/packages/layouts/bolt-list/main.js
+++ b/packages/layouts/bolt-list/main.js
@@ -1,0 +1,2 @@
+import './src/list';
+import './src/_list-item';

--- a/packages/layouts/bolt-list/package.json
+++ b/packages/layouts/bolt-list/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@bolt/layouts-list",
+  "version": "2.25.1",
+  "private": true,
+  "description": "Minimal layout container for displaying a group of items.",
+  "keywords": [
+    "bolt design system",
+    "bolt",
+    "css framework",
+    "design system",
+    "components"
+  ],
+  "homepage": "https://boltdesignsystem.com",
+  "bugs": {
+    "url": "https://github.com/bolt-design-system/bolt/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bolt-design-system/bolt/"
+  },
+  "license": "MIT",
+  "main": "index.js",
+  "style": "index.scss",
+  "dependencies": {
+    "@bolt/core-v3.x": "^2.25.1",
+    "@bolt/lazy-queue": "^2.23.0"
+  },
+  "gitHead": "d41aa75ae3d195d9d7fb3952eed5e0ae80988133",
+  "maintainers": [
+    {
+      "name": "Salem Ghoweri",
+      "email": "me@salemghoweri.com",
+      "web": "https://github.com/sghoweri"
+    },
+    {
+      "name": "Mike Mai",
+      "email": "boss@mikemai.net",
+      "web": "http://mikemai.net/"
+    }
+  ],
+  "schema": "list.schema.js",
+  "twig": "src/list.twig"
+}

--- a/packages/layouts/bolt-list/src/_list-item.js
+++ b/packages/layouts/bolt-list/src/_list-item.js
@@ -1,0 +1,62 @@
+import { html, customElement } from '@bolt/element';
+import { withContext, props } from '@bolt/core-v3.x/utils';
+import classNames from 'classnames/bind';
+import { withLitHtml } from '@bolt/core-v3.x/renderers/renderer-lit-html';
+import styles from './_list-item.scss';
+import { ListContext } from './list';
+
+let cx = classNames.bind(styles);
+
+@customElement('bolt-list-item')
+class BoltListItem extends withContext(withLitHtml) {
+  static props = {
+    last: props.boolean,
+  };
+
+  // subscribe to specific props that are defined and available on the parent container
+  // (context + subscriber idea originally from https://codepen.io/trusktr/project/editor/XbEOMk)
+  static get consumes() {
+    return [
+      [ListContext, 'spacing'],
+      [ListContext, 'tag'],
+      [ListContext, 'inset'],
+      [ListContext, 'separator'],
+      [ListContext, 'display'],
+      [ListContext, 'align'],
+    ];
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.context = this.contexts.get(ListContext);
+  }
+
+  render() {
+    const { tag, spacing, inset, separator, display, align } = this.context;
+    const { last } = this.props;
+
+    const classes = cx('c-bolt-list-item', {
+      [`c-bolt-list-item--display-${display}`]: display,
+      [`c-bolt-list-item--spacing-${spacing}`]: spacing !== 'none',
+      [`c-bolt-list-item--separator-${separator}`]: separator !== 'none',
+      [`c-bolt-list-item--align-${align}`]: align,
+      [`c-bolt-list-item--last-item`]: last,
+      [`c-bolt-list-item--inset`]: inset,
+    });
+
+    return html`
+      ${this.addStyles([styles])}
+      ${tag === 'ul' || tag === 'ol'
+        ? html`
+            <div class="${classes}" role="listitem">
+              ${this.slot('default')}
+            </div>
+          `
+        : html`
+            <span class="${classes}">${this.slot('default')} </span>
+          `}
+    `;
+  }
+}
+
+export { BoltListItem };

--- a/packages/layouts/bolt-list/src/_list-item.scss
+++ b/packages/layouts/bolt-list/src/_list-item.scss
@@ -1,0 +1,118 @@
+@import '@bolt/core-v3.x';
+
+/* ------------------------------------ *\
+   List Item
+\* ------------------------------------ */
+
+// Variables
+$bolt-list-item-border-width: $bolt-border-width;
+$bolt-list-item-border-color: bolt-theme(border, 0.2);
+
+// Item base styles
+.c-bolt-list-item {
+  @include bolt-margin(0);
+  @include bolt-padding(0);
+
+  display: block;
+}
+
+// Spacing Prop
+@each $spacing-value in $bolt-spacing-values {
+  $spacing-value-name: nth($spacing-value, 1);
+
+  .c-bolt-list-item--spacing-#{$spacing-value-name} {
+    @include bolt-margin-left(#{$spacing-value-name});
+    @include bolt-margin-bottom(#{$spacing-value-name});
+
+    &.c-bolt-list-item--inset {
+      @include bolt-margin-left(0);
+      @include bolt-margin-bottom(0);
+      @include bolt-padding-top(#{$spacing-value-name});
+      @include bolt-padding-right(#{$spacing-value-name});
+      @include bolt-padding-bottom(#{$spacing-value-name});
+      @include bolt-padding-left(#{$spacing-value-name});
+    }
+  }
+}
+
+// Separator Prop
+$bolt-list-separator-styles: solid, dashed;
+
+@each $separator-style in $bolt-list-separator-styles {
+  .c-bolt-list-item--separator-#{$separator-style} {
+    border-width: 0;
+    border-style: #{$separator-style};
+    border-color: $bolt-list-item-border-color; // @todo: remove once we drop IE11 support
+    border-color: var(
+      --bolt-list-item-border-color,
+      $bolt-list-item-border-color
+    );
+  }
+}
+
+[class*='c-bolt-list-item--separator'] {
+  &.c-bolt-list-item--display-block {
+    &:not(.c-bolt-list-item--last-item) {
+      border-bottom-width: $bolt-list-item-border-width;
+    }
+  }
+
+  &.c-bolt-list-item--display-inline,
+  &.c-bolt-list-item--display-flex {
+    &:not(.c-bolt-list-item--last-item) {
+      border-right-width: $bolt-list-item-border-width;
+    }
+  }
+
+  @each $breakpoint in $bolt-breakpoints {
+    $breakpoint-name: nth($breakpoint, 1);
+
+    &.c-bolt-list-item--display-inline\@#{$breakpoint-name} {
+      &:not(.c-bolt-list-item--last-item) {
+        border-bottom-width: $bolt-list-item-border-width;
+
+        @include bolt-mq($breakpoint-name) {
+          border-right-width: $bolt-list-item-border-width;
+          border-bottom-width: 0;
+        }
+      }
+    }
+  }
+}
+
+// Specific settings for when the separator prop interacts with other props. This is where things get really crazy.
+[class*='c-bolt-list-item--separator'] {
+  @each $spacing-value in $bolt-spacing-values {
+    $spacing-value-name: nth($spacing-value, 1);
+
+    &.c-bolt-list-item--spacing-#{$spacing-value-name} {
+      &:not(.c-bolt-list-item--last-item) {
+        &.c-bolt-list-item--display-block {
+          @include bolt-padding-bottom(#{$spacing-value-name});
+        }
+
+        &.c-bolt-list-item--display-inline,
+        &.c-bolt-list-item--display-flex {
+          @include bolt-padding-right(#{$spacing-value-name});
+        }
+      }
+    }
+
+    &:not(.c-bolt-list-item--inset) {
+      @each $breakpoint in $bolt-breakpoints {
+        $breakpoint-name: nth($breakpoint, 1);
+
+        &.c-bolt-list-item--spacing-#{$spacing-value-name} {
+          &.c-bolt-list-item--display-inline\@#{$breakpoint-name} {
+            @include bolt-padding-bottom(#{$spacing-value-name});
+
+            @include bolt-mq($breakpoint-name) {
+              @include bolt-padding-right(#{$spacing-value-name});
+              @include bolt-padding-bottom(0);
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/layouts/bolt-list/src/_list-item.twig
+++ b/packages/layouts/bolt-list/src/_list-item.twig
@@ -1,0 +1,33 @@
+{# Variables #}
+{% set base_class = "c-bolt-list-item" %}
+{% set attributes = create_attribute(item.attributes|default({})) %}
+{% set inner_attributes = create_attribute({}) %}
+
+{% set last = loop.last %}
+{% set classes = [
+  base_class,
+  display in display_options ? "#{base_class}--display-#{display}" : "",
+  spacing in spacing_options ? "#{base_class}--spacing-#{spacing}" : "",
+  separator in separator_options ? "#{base_class}--separator-#{separator}" : "",
+  align in align_options ? "#{base_class}--align-#{align}" : "",
+  last ? "#{base_class}--last-item",
+  inset ? "#{base_class}--inset",
+] %}
+
+<bolt-list-item
+  {% if last %} last {% endif %}
+  {% if list_item_role %} role="presentation" {% endif %}
+  {{ attributes }}
+>
+  <ssr-keep
+    for="bolt-list-item"
+    {% if list_item_role %} role="{{ list_item_role }}" {% endif %}
+    {{ inner_attributes.addClass(classes) }}
+  >
+    {% if item.content %}
+      {{ item.content }}
+    {% else %}
+      {{ item }}
+    {% endif %}
+  </ssr-keep>
+</bolt-list-item>

--- a/packages/layouts/bolt-list/src/list.js
+++ b/packages/layouts/bolt-list/src/list.js
@@ -1,0 +1,131 @@
+import { html, customElement } from '@bolt/element';
+import {
+  defineContext,
+  withContext,
+  props,
+  define,
+  hasNativeShadowDomSupport,
+} from '@bolt/core-v3.x/utils';
+import classNames from 'classnames/bind';
+import { withLitHtml } from '@bolt/core-v3.x/renderers/renderer-lit-html';
+
+import themes from '@bolt/global/styles/06-themes/_themes.all.scss';
+import styles from './list.scss';
+import schema from '../list.schema';
+
+let cx = classNames.bind(styles);
+
+// define which specific props to provide to children that subscribe
+export const ListContext = defineContext({
+  tag: 'ul',
+  display: 'inline',
+  spacing: 'none',
+  inset: false,
+  nowrap: false,
+  align: 'start',
+  separator: 'none',
+});
+
+@customElement('bolt-list')
+class BoltList extends withContext(withLitHtml) {
+  // provide context info to children that subscribe
+  // (context + subscriber idea originally from https://codepen.io/trusktr/project/editor/XbEOMk)
+  static get provides() {
+    return [ListContext];
+  }
+
+  static props = {
+    tag: props.string, // ul | ol | div | span
+    display: props.string, // inline | block | flex | inline@xxsmall | inline@xsmall | inline@small | inline@medium
+    spacing: props.string, // none | xsmall | small | medium | large | xlarge
+    separator: props.string, // none | solid | dashed
+    inset: props.boolean, // true | false
+    nowrap: props.boolean, // true | false
+    align: props.string, // start | center | end
+    valign: props.string, // start | center | end
+  };
+
+  constructor(self) {
+    self = super(self);
+    self.useShadow = hasNativeShadowDomSupport;
+    this.schema = schema;
+    return self;
+  }
+
+  render() {
+    const {
+      tag,
+      display,
+      spacing,
+      separator,
+      inset,
+      nowrap,
+      align,
+      valign,
+    } = this.validateProps(this.props);
+    this.contexts.get(ListContext).tag = tag || this.props.tag;
+    this.contexts.get(ListContext).display = display || this.props.display;
+    this.contexts.get(ListContext).spacing = spacing || this.props.spacing;
+    this.contexts.get(ListContext).inset = inset || this.props.inset;
+    this.contexts.get(ListContext).nowrap = nowrap || this.props.nowrap;
+    this.contexts.get(ListContext).align = align || this.props.align;
+    this.contexts.get(ListContext).separator =
+      separator || this.props.separator;
+
+    const classes = cx('c-bolt-list', {
+      [`c-bolt-list--display-${display}`]: display,
+      [`c-bolt-list--spacing-${spacing}`]: spacing !== 'none',
+      [`c-bolt-list--separator-${separator}`]: separator !== 'none',
+      [`c-bolt-list--align-${align}`]: align,
+      [`c-bolt-list--valign-${valign}`]: valign,
+      [`c-bolt-list--inset`]: inset,
+      [`c-bolt-list--nowrap`]: nowrap,
+    });
+
+    if (this.slots.default) {
+      const updatedDefaultSlot = this.slots.default.filter(
+        item => item.tagName,
+      );
+      const updatedSlotsLength = updatedDefaultSlot.length;
+      const lastSlotItem = updatedDefaultSlot[updatedDefaultSlot.length - 1];
+
+      if (updatedSlotsLength > 0 && !lastSlotItem.attributes.last) {
+        lastSlotItem.setAttribute('last', '');
+      }
+    }
+
+    let renderedList;
+
+    switch (tag) {
+      case 'ol':
+        renderedList = html`
+          <div class="${classes}" role="list">
+            ${this.slot('default')}
+          </div>
+        `;
+        break;
+      case 'div':
+        renderedList = html`
+          <div class="${classes}">${this.slot('default')}</div>
+        `;
+        break;
+      case 'span':
+        renderedList = html`
+          <span class="${classes}"> ${this.slot('default')} </span>
+        `;
+        break;
+      default:
+        renderedList = html`
+          <div class="${classes}" role="list">
+            ${this.slot('default')}
+          </div>
+        `;
+    }
+
+    return html`
+      ${this.addStyles([styles, themes])} ${renderedList}
+    `;
+  }
+}
+
+export { BoltList };

--- a/packages/layouts/bolt-list/src/list.scss
+++ b/packages/layouts/bolt-list/src/list.scss
@@ -1,0 +1,210 @@
+@import '@bolt/core-v3.x';
+
+/* ------------------------------------ *\
+   List
+\* ------------------------------------ */
+
+// Custom element display and built-in spacing
+@include bolt-repeat-rule(('bolt-list', ':host')) {
+  // Clear-fix required to prevent margin collapse due to negative margin on Bolt List.
+  // Happens when List is inside Stack component, for example.
+  // https://css-tricks.com/snippets/css/clear-fix/
+  @include bolt-clearfix;
+  @include bolt-margin-bottom(medium);
+
+  display: block;
+
+  &:last-child {
+    @include bolt-margin-bottom(0);
+  }
+}
+
+// List base styles
+//
+// 1. Reset typography so it doesn't inherit from a higher level container.
+// 2. Reset text-align so it doesn't conflict with the align prop which handles the horizontal alignment of inline items in a list, not the text-align within.
+// 3. Width must be defined in order for the list to dislay correctly in Firefox.
+.c-bolt-list {
+  @include bolt-margin(0);
+  @include bolt-padding(0);
+  @include bolt-font-family(body); // [1]
+  @include bolt-font-size(medium); // [1]
+  @include bolt-font-weight(regular); // [1]
+
+  list-style: none;
+  text-align: left; // [2]
+  text-align: start; // [2]
+}
+
+// Display Prop
+.c-bolt-list--display-block {
+  display: block;
+}
+
+.c-bolt-list--display-inline {
+  display: inline-flex;
+  flex-flow: row wrap;
+}
+
+.c-bolt-list--display-flex {
+  display: flex;
+  flex-flow: row wrap;
+}
+
+@include bolt-repeat-rule(
+  (
+    '.c-bolt-list--display-flex bolt-list-item',
+    '.c-bolt-list--display-flex ::slotted(bolt-list-item)'
+  )
+) {
+  flex: 1;
+}
+
+@each $breakpoint in $bolt-breakpoints {
+  $breakpoint-name: nth($breakpoint, 1);
+
+  .c-bolt-list--display-inline\@#{$breakpoint-name} {
+    display: flex;
+    flex-flow: column wrap;
+
+    @include bolt-mq($breakpoint-name) {
+      display: inline-flex;
+      flex-flow: row wrap;
+    }
+  }
+}
+
+// Spacing Prop
+@each $spacing-value in $bolt-spacing-values {
+  $spacing-value-name: nth($spacing-value, 1);
+
+  .c-bolt-list--spacing-#{$spacing-value-name}:not(.c-bolt-list--inset) {
+    margin-bottom: bolt-v-spacing(#{$spacing-value-name}) * -1;
+    margin-left: bolt-spacing(#{$spacing-value-name}) * -1;
+  }
+
+  // CSS hack targeting any Firefox version: https://css-tricks.com/snippets/css/css-hacks-targeting-firefox/
+  @-moz-document url-prefix('') {
+    .c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--inset {
+      // The inline here is talking about the items inside, the List component itself is still a block level element that would fill up the space of any container.
+      &.c-bolt-list--display-inline,
+      &.c-bolt-list--display-flex {
+        width: 100%; // [3]
+      }
+
+      @each $breakpoint in $bolt-breakpoints {
+        $breakpoint-name: nth($breakpoint, 1);
+
+        &.c-bolt-list--display-inline\@#{$breakpoint-name} {
+          @include bolt-mq($breakpoint-name) {
+            width: 100%; // [3]
+          }
+        }
+      }
+    }
+
+    .c-bolt-list--spacing-#{$spacing-value-name}:not(.c-bolt-list--inset) {
+      // The inline here is talking about the items inside, the List component itself is still a block level element that would fill up the space of any container.
+      &.c-bolt-list--display-inline,
+      &.c-bolt-list--display-flex {
+        width: calc(100% + #{bolt-spacing($spacing-value-name)}); // [3]
+      }
+
+      @each $breakpoint in $bolt-breakpoints {
+        $breakpoint-name: nth($breakpoint, 1);
+
+        &.c-bolt-list--display-inline\@#{$breakpoint-name} {
+          @include bolt-mq($breakpoint-name) {
+            width: calc(100% + #{bolt-spacing($spacing-value-name)}); // [3]
+          }
+        }
+      }
+    }
+  }
+
+  .c-bolt-list--spacing-#{$spacing-value-name}.c-bolt-list--inset {
+    @include bolt-margin-bottom(0);
+    @include bolt-margin-left(0);
+  }
+}
+
+// Align options
+$bolt-list-alignments: start, center, end, justify;
+
+@each $alignment in $bolt-list-alignments {
+  .c-bolt-list--align-#{$alignment} {
+    &.c-bolt-list--display-inline {
+      @if $alignment != center and $alignment != justify {
+        justify-content: flex-#{$alignment};
+      } @else if $alignment == justify {
+        justify-content: space-between;
+      } @else {
+        justify-content: #{$alignment};
+      }
+    }
+
+    @each $breakpoint in $bolt-breakpoints {
+      $breakpoint-name: nth($breakpoint, 1);
+
+      &.c-bolt-list--display-inline\@#{$breakpoint-name} {
+        @include bolt-mq($breakpoint-name) {
+          @if $alignment != center and $alignment != justify {
+            justify-content: flex-#{$alignment};
+          } @else if $alignment == justify {
+            justify-content: space-between;
+          } @else {
+            justify-content: #{$alignment};
+          }
+        }
+      }
+    }
+  }
+}
+
+// Valign options
+$bolt-list-valignments: start, center, end;
+
+@each $alignment in $bolt-list-valignments {
+  .c-bolt-list--valign-#{$alignment} {
+    &.c-bolt-list--display-inline,
+    &.c-bolt-list--display-flex {
+      @if $alignment != center {
+        align-items: flex-#{$alignment};
+      } @else {
+        align-items: #{$alignment};
+      }
+    }
+
+    @each $breakpoint in $bolt-breakpoints {
+      $breakpoint-name: nth($breakpoint, 1);
+
+      &.c-bolt-list--display-inline\@#{$breakpoint-name} {
+        @include bolt-mq($breakpoint-name) {
+          @if $alignment != center {
+            align-items: flex-#{$alignment};
+          } @else {
+            align-items: #{$alignment};
+          }
+        }
+      }
+    }
+  }
+}
+
+// Nowrap
+.c-bolt-list--nowrap {
+  &.c-bolt-list--display-inline,
+  &.c-bolt-list--display-flex {
+    flex-flow: row nowrap;
+  }
+
+  @each $breakpoint in $bolt-breakpoints {
+    $breakpoint-name: nth($breakpoint, 1);
+
+    &.c-bolt-list--display-inline\@#{$breakpoint-name} {
+      @include bolt-mq($breakpoint-name) {
+        flex-flow: row nowrap;
+      }
+    }
+  }
+}

--- a/packages/layouts/bolt-list/src/list.twig
+++ b/packages/layouts/bolt-list/src/list.twig
@@ -1,0 +1,75 @@
+{% set schema = bolt.data.components["@bolt-layouts-list"].schema %}
+
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(schema, _self) | raw }}
+{% endif %}
+
+{# Variables #}
+{% set base_class = "c-bolt-list" %}
+{% set attributes = create_attribute(attributes|default({})) %}
+{% set inner_attributes = create_attribute({}) %}
+
+{# Set up checks to validate that the component's prop values are allowed, based on the component's schema. #}
+{% set tag_options = schema.properties.tag.enum %}
+{% set display_options = schema.properties.display.enum %}
+{% set spacing_options = schema.properties.spacing.enum %}
+{% set separator_options = schema.properties.separator.enum %}
+{% set align_options = schema.properties.align.enum %}
+{% set valign_options = schema.properties.valign.enum %}
+
+{# Check that the component's current prop values are valid. If not, default to the schema default #}
+{% set tag = tag in tag_options ? tag : schema.properties.tag.default %}
+{% set display = display in display_options ? display : schema.properties.display.default %}
+{% set spacing = spacing in spacing_options ? spacing : schema.properties.spacing.default %}
+{% set separator = separator in separator_options ? separator : schema.properties.separator.default %}
+{% set align = align in align_options ? align : schema.properties.align.default %}
+{% set valign = valign in valign_options ? valign : schema.properties.valign.default %}
+{% set inset = inset is sameas(true) or inset is sameas(false) ? inset : schema.properties.inset.default %}
+{% set nowrap = nowrap is sameas(true) or nowrap is sameas(false) ? nowrap : schema.properties.nowrap.default %}
+
+{# Conditions for the semantic tag usage #}
+{% if tag == "ol" or tag == "ul" %}
+  {% set list_role = "list" %}
+  {% set list_item_role = "listitem" %}
+{% endif %}
+
+{# List component's custom element wrapper. #}
+<bolt-list
+  {% if tag %} tag="{{ tag }}" {% endif %}
+  {% if display %} display="{{ display }}" {% endif %}
+  {% if spacing %} spacing="{{ spacing }}" {% endif %}
+  {% if separator %} separator="{{ separator }}" {% endif %}
+  {% if align %} align="{{ align }}" {% endif %}
+  {% if valign %} valign="{{ valign }}" {% endif %}
+  {% if inset %} inset {% endif %}
+  {% if nowrap %} nowrap {% endif %}
+  {{ attributes }}
+>
+  {# This sets none values to not render anything. #}
+  {% set spacing = spacing == "none" ? false : spacing %}
+  {% set separator = separator == "none" ? false : separator %}
+
+  {# Array of classes based on the defined + default props. #}
+  {% set classes = [
+    base_class,
+    display in display_options ? "#{base_class}--display-#{display}" : "",
+    spacing in spacing_options ? "#{base_class}--spacing-#{spacing}" : "",
+    separator in separator_options ? "#{base_class}--separator-#{separator}" : "",
+    align in align_options ? "#{base_class}--align-#{align}" : "",
+    valign in valign_options ? "#{base_class}--valign-#{valign}" : "",
+    inset ? "#{base_class}--inset",
+    nowrap ? "#{base_class}--nowrap",
+  ] %}
+
+  <ssr-keep
+    for="bolt-list"
+    {% if list_role %} role="{{ list_role }}" {% endif %}
+    {{ inner_attributes.addClass(classes) }}
+  >
+    {% for item in items %}
+      {% if item %}
+        {% include "@bolt-layouts-list/_list-item.twig" %}
+      {% endif %}
+    {% endfor %}
+  </ssr-keep>
+</bolt-list>


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-140

## Summary

Setup initial "elements" and "layouts" namespaces in Bolt. Add _private_ Link element and List layout as starting point.

## Details

For the most part, adding "elements" and "layouts" requires no config changes, just adding new packages with the appropriate name, e.g. `@bolt/elements-*`. The only config change required was Jest, adding `elements` and `layouts` to the list of directories that are compiled by Babel before running tests.

At the moment, "elements" and "layouts" are top-level directories within the "packages" folder. It would be nicer if they were grouped together with "components", but as that would require moving _every single component_ I suggest we wait and reevaluate once we're ready to ship our first "element" and/or "layout".

Note:
- The Link (element) and List (layout) packages are private for now, so this is safe to merge.
- There is not yet a corresponding Pattern Lab section for these new namespaces, will be handled separately.

## How to test

- Checkout branch, run `yarn setup`, and verify site builds and runs properly.
- Try changing one of the Link Twig demos to use the `@bolt-elements-link/link.twig` template and verify it works.