### PR TITLE
Feature/ds 166 topside labels

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/02-components/form/15-form-label-positions.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/02-components/form/15-form-label-positions.twig
@@ -1,0 +1,45 @@
+{% extends "@bolt/form.twig" %}
+
+{% set children %}
+
+  {% set form_field_float %}
+    {% include "@pl/10-form-element-demo-input-element.twig" with {
+      title: "Email Address",
+      inputAttributes: {
+        placeholder: "Enter Email Address",
+        required: true,
+        type: "email"
+      },
+      labelDisplayType: "floating"
+    } only %}
+  {% endset %}
+
+  {% set form_field_block %}
+    {% include "@pl/10-form-element-demo-input-element.twig" with {
+      title: "Email Address",
+      inputAttributes: {
+        placeholder: "Enter Email Address",
+        required: true,
+        type: "email"
+      },
+      labelDisplayType: "block",
+      labelDisplay: "before"
+    } only %}
+  {% endset %}
+
+  <div class="u-bolt-margin-bottom-medium">
+    <h3>labelDisplayType: "floating"</h3>
+    {% include "@bolt-components-form/form.twig" with {
+      children: form_field_float
+    } only %}
+  </div>
+
+  <div class="u-bolt-margin-bottom-medium">
+    <h3>labelDisplayType: "block", labelDisplay: "before"</h3>
+    {% include "@bolt-components-form/form.twig" with {
+      children: form_field_block
+    } only %}
+  </div>
+
+
+{% endset %}

--- a/packages/components/bolt-form/src/elements/form-element.twig
+++ b/packages/components/bolt-form/src/elements/form-element.twig
@@ -17,25 +17,33 @@ Available variables:
 {% set attributes = attributes.addClass('c-bolt-input-list__item') %}
 
 <div{{ attributes }}>
-  {% if labelDisplay in ['before', 'invisible'] %}
+  {% if labelDisplay == 'before' %}
     {{ label }}
-  {% endif %}
-
-  {{ children }}
-
-  {% if labelDisplay == 'after' %}
+    <div class="c-bolt-block-input-wrapper">
+      {{ children }}
+      {% if errors %}
+        <div class="c-bolt-input-message c-bolt-input-message--invalid">
+          {{ errors }}
+        </div>
+      {% endif %}
+      {% if descriptionText %}
+        <div class="c-bolt-input-message">
+          {{ descriptionText }}
+        </div>
+      {% endif %}
+    </div>
+  {% elseif labelDisplay == 'after'%}
+    {{ children }}
     {{ label }}
-  {% endif %}
-
-  {% if errors %}
-    <div class="c-bolt-input-message c-bolt-input-message--invalid">
-      {{ errors }}
-    </div>
-  {% endif %}
-
-  {% if descriptionText %}
-    <div class="c-bolt-input-message">
-      {{ descriptionText }}
-    </div>
+    {% if errors %}
+      <div class="c-bolt-input-message c-bolt-input-message--invalid">
+        {{ errors }}
+      </div>
+    {% endif %}
+    {% if descriptionText %}
+      <div class="c-bolt-input-message">
+        {{ descriptionText }}
+      </div>
+    {% endif %}
   {% endif %}
 </div>

--- a/packages/components/bolt-form/src/elements/form-element.twig
+++ b/packages/components/bolt-form/src/elements/form-element.twig
@@ -6,7 +6,6 @@ Available variables:
   - labelDisplay (enum) - Where the label should be displayed
       before
       after
-      invisible (Not yet supported, defaults to 'before')
   - children (renderable) - The form inputs .
   - errors (string) - Server-side errors
   - descriptionText (string) - An optional description for this element

--- a/packages/components/bolt-form/src/elements/form-label.twig
+++ b/packages/components/bolt-form/src/elements/form-label.twig
@@ -8,6 +8,7 @@
  * - attributes (object) - A Drupal attributes object
  * - displayType (enum)
  *    - floating - display the label "floated" inside the input field
+      - block - display the label outside the input
  *    - inline-radio - display the label inline next to a radio button
  *    - inline-checkbox - display the label inline next to a checkbox
  *    - default - no special treatment

--- a/packages/components/bolt-form/src/elements/form-label.twig
+++ b/packages/components/bolt-form/src/elements/form-label.twig
@@ -17,6 +17,8 @@
 
 {% if displayType == "floating" %}
   {% set _classes = ["c-bolt-floating-label"] %}
+{% elseif displayType == "block" %}
+  {% set _classes = ["c-bolt-block-label"] %}
 {% elseif displayType == "inline-radio" %}
   {% set _classes = ["c-bolt-inline-label", "c-bolt-inline-label--radio"] %}
 {% elseif displayType == "inline-checkbox" %}

--- a/packages/components/bolt-form/src/form.scss
+++ b/packages/components/bolt-form/src/form.scss
@@ -668,3 +668,13 @@ $bolt-strength-indicator-transition: $bolt-transition;
   border-color: transparent;
   transition: all $bolt-input-transition;
 }
+
+.c-bolt-block-label ~ .c-bolt-block-input-wrapper {
+  position: relative;
+
+  .c-bolt-input.is-filled,
+  .c-bolt-input:focus {
+    padding-top: var(--bolt-spacing-y-small);
+    padding-bottom: var(--bolt-spacing-y-small);
+  }
+}


### PR DESCRIPTION
## Jira

[https://pegadigitalit.atlassian.net/browse/DS-166](https://pegadigitalit.atlassian.net/browse/DS-166)

## Summary

Add option to put form input labels before the input.

## Details

Edit the twig and scss to allow for a form input label variation where the label can come before the input. 

## How to test

- Pull this branch
- run yarn start
- check out the new form label position (will link once build is ready)
