### PR TITLE
DS-169: Fix broken icons in Micro Journeys

### DIFF
--- a/packages/base-element/src/lib/decorators/json-schema-props.js
+++ b/packages/base-element/src/lib/decorators/json-schema-props.js
@@ -33,13 +33,17 @@ const jsonSchemaPropsDecorator = clazz => {
       for (const key in this.schema.properties) {
         let property = this.schema.properties[key];
 
-        // skip any schema properties marked as being deprecated
-        if (
-          !property.title ||
-          (!property.title.includes('deprecated') &&
-            !property.title.includes('DEPRECATED'))
-        ) {
-          // @todo: skip any twig only schema properties such as `attributes`, `content`, `items`
+        // Bolt uses `title` to mark properties as deprecated
+        const isDeprecated = property.title
+          ?.toLowerCase()
+          .includes('deprecated');
+
+        // these schema props are never used by Web Components, only by Twig
+        const twigOnlyProps = ['attributes', 'content', 'items'];
+        const isTwigOnly = twigOnlyProps.includes(key.toLowerCase());
+
+        // skip deprecated and Twig-only props
+        if (!isDeprecated && !isTwigOnly) {
           const propName = camelCase(key);
 
           if (property.default || property.default === 0) {


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-169

## Summary

Fix broken icons in Micro Journeys GrapesJS editor.

## Details

The bug was introduced when Icon was refactored to use `BoltElement` as its renderer in #1861.

The underlying issue was not `BoltElement` itself but one of the custom decorator functions used by `BoltElement`.

[The `jsonSchemaProps` function](https://github.com/boltdesignsystem/bolt/blob/master/packages/base-element/src/lib/decorators/json-schema-props.js#L33-L88) loops through the schema and automatically adds schema props to Web Components. It was also adding Twig-only props like `attributes`, `content`, `items`. Everywhere else, having these Twig-only props defined on our Web Components is harmless. However, GrapesJS uses its own `attributes` prop to store data on each element. When the editor loads, GrapesJS tries to write to `element.attributes` which LitElement is already using as a prop. GrapesJS fails to write its data to the element and/or the web component's own internal schema blows up, or some of both.

We intended to [filter out these props](https://github.com/boltdesignsystem/bolt/blob/master/packages/base-element/src/lib/decorators/json-schema-props.js#L42) anyway. So that's what I did and it fixes the issue.

## How to test

To see the bug, go to [Micro Journeys demo on latest release](https://boltdesignsystem.com/pattern-lab/?p=experiments-micro-journeys). Click the "edit" button and notice how the "asset-presentation" icon disappears (it's next to the text, "It’s not mind-reading. It’s signals").

Checkout this branch and view [the same page locally](http://localhost:3000/pattern-lab/?p=experiments-micro-journeys). Verify the icon does not disappear and it persists on save.