### PR TITLE
DS-171 Remove redundant and incorrect schema validation for headline

### DIFF
--- a/packages/components/bolt-band/__tests__/__snapshots__/band.js.snap
+++ b/packages/components/bolt-band/__tests__/__snapshots__/band.js.snap
@@ -141,7 +141,6 @@ exports[`<bolt-band> Component Nested bands usage 1`] = `
           
                                           
 
-
  
   
 

--- a/packages/components/bolt-blockquote/__tests__/__snapshots__/blockquote.js.snap
+++ b/packages/components/bolt-blockquote/__tests__/__snapshots__/blockquote.js.snap
@@ -22,7 +22,6 @@ exports[`<bolt-blockquote> component <bolt-blockquote> align variations: center 
   
             
 
-
  
   
 
@@ -51,7 +50,6 @@ exports[`<bolt-blockquote> component <bolt-blockquote> align variations: center 
   
           
             
-
 
  
   
@@ -143,7 +141,6 @@ exports[`<bolt-blockquote> component <bolt-blockquote> align variations: left 1`
       
               
 
-
  
   
 
@@ -198,7 +195,6 @@ exports[`<bolt-blockquote> component <bolt-blockquote> align variations: left 1`
         
             
 
-
  
   
 
@@ -237,7 +233,6 @@ exports[`<bolt-blockquote> component <bolt-blockquote> align variations: left 1`
       >
         
             
-
 
  
   
@@ -338,7 +333,6 @@ exports[`<bolt-blockquote> component <bolt-blockquote> align variations: right 1
   
             
 
-
  
   
 
@@ -367,7 +361,6 @@ exports[`<bolt-blockquote> component <bolt-blockquote> align variations: right 1
   
           
             
-
 
  
   

--- a/packages/components/bolt-headline/src/_typography.twig
+++ b/packages/components/bolt-headline/src/_typography.twig
@@ -1,7 +1,3 @@
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema('@bolt-components-headline/headline.schema.js', _self) | raw }}
-{% endif %}
-
 {% set schema = bolt.data.components['@bolt-components-headline'].schema %}
 
 {% if enable_json_schema_validation %}


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-171

## Summary

Fix fatal error in Drupal when twig debugging is enabled

## Details

Schema validation is duplicated in the headline component (the result of a botched merge?).  It wasn't a problem until we changed our schema to js, at which point it uncovered another bug in Basalt twig tools.  This PR is the easiest path to fixing.

## How to test

- Run Bolt 2.26 (or probably 2.25) in Drupal
- Enable twig debugging by adding or uncommenting the following lines in docroot/sites/development.services.yml
  ```
  parameters:
    twig.config:
      debug: true
  ```
- Refresh the homepage of the site.  You should see a fatal error
- Apply the patch in this PR to make it go away.
