### PR TITLE
DS-139: fix spacing utils

### DIFF
--- a/packages/core-v3.x/styles/02-tools/tools-spacing/_tools-spacing.scss
+++ b/packages/core-v3.x/styles/02-tools/tools-spacing/_tools-spacing.scss
@@ -1,89 +1,24 @@
-////
-/// @group Tools: Layout
-/// @author Salem Ghoweri
-////
-
-/// Private bolt function to generate default spacing scale, based off of the base font size
-/// @param {list} $sizes - Sizes to iterate over
-/// @param {string} $char [''] - String to append to $keyName setting
-/// @return {map} $map
-/// @access private
-/// @requires $bolt-spacing-gutter
-/// @see $bolt-spacing-sizes
-/// @example scss - $bolt-spacing-values not shown
-///   $bolt-spacing-sizes: _bolt-create-spacing-map($bolt-spacing-values);
-@function _bolt-create-spacing-map($sizes, $char: '') {
-  $map: ();
-  @each $name, $value in $sizes {
-    $keyName: $name;
-    @if ($char != '' and $keyName != null) {
-      $keyName: $char + $keyName;
-    }
-    $keyValue: $value * $bolt-spacing-gutter;
-    $map: map-merge(
-      $map,
-      (
-        $keyName: $keyValue,
-      )
-    );
-  }
-  @return $map;
-}
-/// A map created from $bolt-spacing-values
-/// @see $bolt-spacing-values
-$bolt-spacing-sizes: _bolt-create-spacing-map($bolt-spacing-values);
-
-@include export-data('spacing/sizes.bolt.json', $bolt-spacing-sizes);
-
-/// Convenience function for pulling data from $bolt-spacing-sizes
-/// @param {string} $size - T-shirt size to pull
-/// @requires $bolt-spacing-sizes
-/// @return {number} A spacing unit
-/// @example scss
-/// .element {
-///   min-height: bolt-spacing(large);
-/// }
 @function bolt-spacing($size) {
   // @warn 'This scss function is being deprecated. Please convert to use global CSS vars -> var(--bolt-spacing-x-*).';
-  @return map-get($bolt-spacing-sizes, nth($size, 1));
+  @return var(--bolt-spacing-x-#{$size});
 }
 
-/// Convert shirt sizes in baseline-optimized sizes
-/// @param {string} $size - T-shirt size
-/// @param {string} $modifier [null] - Unit to multiply ending result by
-/// @return {number}
-/// @requires $bolt-spacing-squished
-/// @requires $bolt-spacing-stretched
-/// @requires $bolt-spacing-gutter
-/// @requires $bolt-spacing-leading
-/// @example scss
-/// .element {
-///   width: bolt-v-spacing(xsmall);
-/// }
 @function bolt-v-spacing($size, $modifier: null) {
   // @warn 'This scss function is being deprecated. Please convert to use global CSS vars -> var(--bolt-spacing-y-*).';
 
+  $v-spacing: '';
+
   @if ($modifier == 'squished') {
-    $modifier: $bolt-spacing-squished;
+    $v-spacing: calc(var(--bolt-spacing-y-#{$size}) * 0.5);
   } @else if ($modifier == 'stretched') {
-    $modifier: $bolt-spacing-stretched;
+    $v-spacing: calc(var(--bolt-spacing-y-#{$size}) * 1.5);
   } @else {
-    $modifier: 1;
+    $v-spacing: var(--bolt-spacing-y-#{$size});
   }
 
-  @return (bolt-spacing($size) / bolt-strip-unit($bolt-spacing-gutter)) *
-    $bolt-spacing-leading * $modifier;
+  @return $v-spacing;
 }
 
-/// An alias for @function bolt-v-spacing
-/// @alias bolt-v-spacing
-/// @param {string} $size - T-shirt size
-/// @return {number}
-/// @requires bolt-v-spacing
-/// @example scss
-/// .element {
-///   width: bolt-vertical-spacing(xsmall);
-/// }
 @function bolt-vertical-spacing($size) {
   // @warn 'This scss function is being deprecated. Please convert to use global CSS vars -> var(--bolt-spacing-y-*).';
 

--- a/packages/core-v3.x/styles/02-tools/tools-spacing/libs/_tools-spacing-margin.scss
+++ b/packages/core-v3.x/styles/02-tools/tools-spacing/libs/_tools-spacing-margin.scss
@@ -1,34 +1,3 @@
-// @mixin bolt-margin($sizes, $type: false, $important: null) {
-//   $sizes: _bolt-normalize-spacing-sizes($sizes, $type);
-//   @include _bolt-directional-property(margin, false, $sizes, $important);
-// }
-
-// @mixin bolt-margin-top($sizes, $important: null) {
-//   $sizes: _bolt-normalize-spacing-sizes($sizes, null);
-//   $sizes: nth($sizes, 1) null null null;
-//   @include _bolt-directional-property(margin, false, $sizes, $important);
-// }
-
-// @mixin bolt-margin-right($sizes, $important: null) {
-//   $sizes: _bolt-normalize-spacing-sizes($sizes, null);
-//   $sizes: null nth($sizes, 2) null null;
-//   @include _bolt-directional-property(margin, false, $sizes, $important);
-// }
-
-// @mixin bolt-margin-bottom($sizes, $important: null) {
-//   $sizes: _bolt-normalize-spacing-sizes($sizes, null);
-//   $sizes: null null nth($sizes, 1) null;
-//   @include _bolt-directional-property(margin, false, $sizes, $important);
-// }
-
-// @mixin bolt-margin-left($sizes, $important: null) {
-//   $sizes: _bolt-normalize-spacing-sizes($sizes, null);
-//   $sizes: null null null nth($sizes, 1);
-//   @include _bolt-directional-property(margin, false, $sizes, $important);
-// }
-
-// @mixin spacing($)
-
 @mixin bolt-margin($sizes, $type: false, $important: null) {
   // @warn 'This scss mixin is being deprecated. Please convert to use global CSS vars -> var(--bolt-spacing-x-*) and var(--bolt-spacing-y-*).';
 

--- a/packages/global/styles/05-objects/objects-grid/_objects-grid.scss
+++ b/packages/global/styles/05-objects/objects-grid/_objects-grid.scss
@@ -142,11 +142,16 @@ $bolt-object-grid-sizes: xsmall, small, large, xlarge;
   }
 
   @each $size in $bolt-object-grid-sizes {
-    &.o-bolt-grid--#{$size} {
-      margin-bottom: calc(var(--bolt-spacing-y-#{$size}) * -1);
+    // @todo: [Mai] ommitting xlarge to prevent breaking changes. Grid will be reworked into the Layouts folder. Only introduce breaking changes then.
+    @if (
+      $size != 'xlarge'
+    ) {
+      &.o-bolt-grid--#{$size} {
+        margin-bottom: calc(var(--bolt-spacing-y-#{$size}) * -1);
 
-      > .o-bolt-grid__cell {
-        padding-bottom: var(--bolt-spacing-y-#{$size});
+        > .o-bolt-grid__cell {
+          padding-bottom: var(--bolt-spacing-y-#{$size});
+        }
       }
     }
   }

--- a/packages/global/styles/07-utilities/_utilities-spacing.scss
+++ b/packages/global/styles/07-utilities/_utilities-spacing.scss
@@ -145,11 +145,11 @@ $bolt-spacing-system-extras: (
 @each $direction in $bolt-spacing-direction-system {
   .u-bolt-margin-#{$direction} {
     /* stylelint-disable-next-line */
-    @extend .u-bolt-margin-medium;
+    @extend .u-bolt-margin-#{$direction}-medium;
   }
 
   .u-bolt-padding-#{$direction} {
     /* stylelint-disable-next-line */
-    @extend .u-bolt-padding-medium;
+    @extend .u-bolt-padding-#{$direction}-medium;
   }
 }

--- a/packages/global/styles/07-utilities/_utilities-spacing.scss
+++ b/packages/global/styles/07-utilities/_utilities-spacing.scss
@@ -132,24 +132,27 @@ $bolt-spacing-system-extras: (
 /**
  * @todo: [Mai] deprecate these sizeless names.
  */
-.u-bolt-margin {
-  /* stylelint-disable-next-line */
-  @extend .u-bolt-margin-medium;
-}
+@each $prop in $bolt-spacing-prop-system {
+  $prop-name: nth($prop, 1);
 
-.u-bolt-padding {
-  /* stylelint-disable-next-line */
-  @extend .u-bolt-padding-medium;
-}
-
-@each $direction in $bolt-spacing-direction-system {
-  .u-bolt-margin-#{$direction} {
-    /* stylelint-disable-next-line */
-    @extend .u-bolt-margin-#{$direction}-medium;
+  .u-bolt-#{$prop-name} {
+    #{$prop-name}: var(--bolt-spacing-y-medium)
+        var(--bolt-spacing-x-medium) !important;
   }
 
-  .u-bolt-padding-#{$direction} {
-    /* stylelint-disable-next-line */
-    @extend .u-bolt-padding-#{$direction}-medium;
+  @each $direction in $bolt-spacing-direction-system {
+    $axis: '';
+
+    @if $direction != top and $direction != bottom {
+      $axis: 'x';
+    } @else {
+      $axis: 'y';
+    }
+
+    .u-bolt-#{$prop-name}-#{$direction} {
+      #{$prop-name}-#{$direction}: var(
+        --bolt-spacing-#{$axis}-medium
+      ) !important;
+    }
   }
 }

--- a/packages/global/styles/07-utilities/_utilities-spacing.scss
+++ b/packages/global/styles/07-utilities/_utilities-spacing.scss
@@ -130,7 +130,7 @@ $bolt-spacing-system-extras: (
 }
 
 /**
- * @todo: [Mai] deprecate these sizeless names.
+ * @todo: [Mai] We need to deprecate these sizeless names.
  */
 @each $prop in $bolt-spacing-prop-system {
   $prop-name: nth($prop, 1);
@@ -153,6 +153,31 @@ $bolt-spacing-system-extras: (
       #{$prop-name}-#{$direction}: var(
         --bolt-spacing-#{$axis}-medium
       ) !important;
+    }
+  }
+}
+
+/**
+ * @todo: [Mai] We need to deprecate these magic options.
+ */
+@each $size in $bolt-spacing-multiplier-system {
+  $size-name: nth($size, 1);
+
+  // All directions
+  .u-bolt-padding-#{$size-name}-squished {
+    padding: calc(var(--bolt-spacing-y-#{$size-name}) / 2)
+      var(--bolt-spacing-x-#{$size-name}) !important;
+  }
+
+  // Responsive all directions
+  @each $breakpoint in $bolt-breakpoints {
+    $breakpoint-name: nth($breakpoint, 1);
+
+    @include bolt-mq(#{$breakpoint-name}) {
+      .u-bolt-padding-#{$size-name}-squished\@#{$breakpoint-name} {
+        padding: calc(var(--bolt-spacing-y-#{$size-name}) / 2)
+          var(--bolt-spacing-x-#{$size-name}) !important;
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixed a bug where one direction `.u-bolt-margin-*` and `.u-bolt-padding-*` utils were adding spacing to all directions.

## Details

1. Fixes an incorrect logic in the spacing util CSS.
1. Converted spacing mixin and functions to also use CSS vars.
1. Reverted a change on xlarge grid to only increase gutter spacing and not row gutter spacing.

## How to test

Run the branch locally and do the following
1. Make sure one direction `.u-bolt-margin-*` and `.u-bolt-padding-*` utils are only adding spacing to specified direction.
1. Use a dummy component to test out `bolt-margin()` and `bolt-padding()` mixins and `bolt-spacing` and `bolt-v-spacing` functions. Make sure they are rendering css vars.
1. Change a grid modifier on any page under "Pages", see if xlarge grid spacing (when cells stack vertically) is exactly the same as last release.