### PR TITLE
COM-93 Fix hero center alignment

### DIFF
--- a/packages/components/bolt-hero/hero.twig
+++ b/packages/components/bolt-hero/hero.twig
@@ -46,7 +46,6 @@
             imageAlign == 'center' ? "u-bolt-margin-right-auto" : "",
             imageAlign == 'left' ? "u-bolt-margin-right-auto" : "",
             imageAlign == 'right' ? "u-bolt-margin-left-auto" : "",
-            imageAlign == 'center' ? "u-bolt-margin-#{_isImageFirstOnDesktop ? 'left' : 'right'}-none@#{_mediumBreakpoint}" : "",
           ]
         }
       } only %}


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/COM-93

## Summary

Fix hero center alignment

## Details

When you pass "center" as a value for the imageAlign prop, it doesn't work.  After this fix, it does. 

## How to test

There is no example of this in pattern lab-- you'd need to add an example with `imageAlign: 'center'` to see it in action.  Before this commit, it won't center align (it will behave the same as `imageAlign: right`).  After this commit, it should behave.
