### PR TITLE
DS-180: fix font styles on button link

### DIFF
--- a/packages/components/bolt-link/src/link.scss
+++ b/packages/components/bolt-link/src/link.scss
@@ -7,6 +7,7 @@
 // 2. [Mai] All the theming stuff is an interim fix until the bolt-text is refactored, which will cover all the text link styles as well.
 // 3. [Morse] This mixin outputs a separate ruleset for each selector to prevent IE from failing on unrecognized selectors like `:host`. It is not a substitute for comma-separated selectors.
 // 4. [Morse] Bolt-link delegates focus to inner element.
+// 5. [Mai] If a <button> tag is used, fonts styles need to reset to override browser defaults.
 
 @import '@bolt/core-v3.x';
 
@@ -43,7 +44,10 @@ $bolt-link-spacing: 'xxsmall';
 }
 
 button.c-bolt-link {
-  font-size: inherit;
+  font-family: inherit; // [5]
+  font-size: inherit; // [5]
+  font-weight: inherit; // [5]
+  line-height: inherit; // [5]
 }
 
 .c-bolt-link--display-flex {


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-180

## Summary

Fixes an issue where a button link (`<button class="c-bolt-link">`) is displaying font styles incorrectly.

## Details

1. Updated `button.c-bolt-link` specific CSS to inherit font styles from parent container.
1. Added comments about the inherit rule.

## How to test

Run the branch locally and try to pass a button link to the `text` prop of a headline. Make sure all the font styles are displayed correctly according to how the headline is configured.