### PR TITLE
DS-183: Store and test VRT urls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,7 @@ jobs:
         - export NOW_URL=$(./scripts/get-latest-deploy.js)
         - travis_retry yarn gds -a success -e ${TRAVIS_BRANCH}--${GIT_SHA}--commit-preview -r ${TRAVIS_BRANCH} -l ${NOW_URL}
         - travis_retry yarn run test:e2e:quick-local
+        - travis_retry yarn run test:vrt-urls
         # - lhci autorun --collect.numberOfRuns=3 --collect.url=$NOW_URL --collect.url=$NOW_URL/pattern-lab/patterns/50-pages-10-d8-product-pages-product-t2/50-pages-10-d8-product-pages-product-t2.html --collect.url=$NOW_URL/pattern-lab/patterns/999-experiments-micro-journeys-90-micro-journeys/999-experiments-micro-journeys-90-micro-journeys.html
       after_success:
         - travis_retry yarn gds -a create -e ${TRAVIS_BRANCH}--branch-preview -r ${TRAVIS_BRANCH}
@@ -142,6 +143,7 @@ jobs:
         - travis_retry yarn gds -a create -e ${TRAVIS_BRANCH}--branch-preview -r ${TRAVIS_BRANCH}
         - travis_retry yarn gds -a in_progress -e ${TRAVIS_BRANCH}--branch-preview -r ${TRAVIS_BRANCH}
         - travis_retry yarn run test:e2e:full
+        - travis_retry yarn run test:vrt-urls
       after_success:
         - ./scripts/deploy-branch-alias.js
         - export NOW_BRANCH_URL=$(./scripts/get-branch-alias.js)

--- a/docs-site/__tests__/__snapshots__/vrt-urls.js.snap
+++ b/docs-site/__tests__/__snapshots__/vrt-urls.js.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Bolt VRT URLs VRT URL file exists and matches snapshot 1`] = `
+"{
+  \\"components\\": [
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-accordion/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-action-blocks/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-background/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-backgrounds-shapes/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-band/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-banner/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-block-list/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-blockquote/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-breadcrumb/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-button/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-card-replacement/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-carousel/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-chip/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-chips-list/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-code-snippet/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-copy-to-clipboard/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-device-viewer/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-figure/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-form/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-headline/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-hero/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-icon/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-image/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-link/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-list/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-logo/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-menu/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-modal/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-nav-priority/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-navbar/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-ol/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-pagination/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-popover/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-progress-bar/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-ratio/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-share/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-stack/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-sticky/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-table/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-tabs/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-teaser/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-text/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-toc/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-tooltip/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-trigger/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-typeahead/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-ul/index.html\\",
+    \\"https://boltdesignsystem.com/pattern-lab/patterns/40-components-video/index.html\\"
+  ]
+}
+"
+`;

--- a/docs-site/__tests__/vrt-urls.js
+++ b/docs-site/__tests__/vrt-urls.js
@@ -1,0 +1,33 @@
+const path = require('path');
+const fs = require('fs-extra');
+const prettier = require('prettier');
+const { getConfig } = require('@bolt/build-utils/config-store');
+
+async function getVrtUrlsPath() {
+  const config = await getConfig();
+
+  return path.resolve(
+    path.join(config.wwwDir, 'build/data/vrt-urls.bolt.json'),
+  );
+}
+
+describe('Bolt VRT URLs', () => {
+  test('VRT URL file exists and matches snapshot', async () => {
+    const vrtUrlsPath = await getVrtUrlsPath();
+
+    expect(
+      fs.existsSync(vrtUrlsPath),
+      'You may not have built Pattern Lab yet. Try running `yarn start` or `yarn build` to generate the missing file.',
+    ).toBe(true);
+
+    const results = fs.readFileSync(vrtUrlsPath, 'utf8');
+    const formattedJSON = prettier.format(results, {
+      parser: 'json',
+    });
+
+    expect(
+      formattedJSON,
+      'If changes are expected, run `yarn test:vrt-urls -u` from the project root to update snapshot. Then, inform the QA team of these changes.',
+    ).toMatchSnapshot();
+  });
+});

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -26,7 +26,13 @@
     "start:lang": "bolt start --i18n",
     "start:prod": "bolt start --prod",
     "test:links": "blc http://localhost:3000 --recursive --ordered --filter-level 2",
+    "test:vrt-urls": "npx jest ./vrt-urls.js",
     "watch": "bolt watch"
+  },
+  "jest": {
+    "setupFilesAfterEnv": [
+      "jest-expect-message"
+    ]
   },
   "dependencies": {
     "@bolt/analytics-autotrack": "^2.19.0",
@@ -45,6 +51,7 @@
     "choices.js": "^7.0.0",
     "deepmerge": "^4.2.2",
     "iframe-resizer": "^4.1.1",
+    "jest-expect-message": "^1.0.2",
     "list.js": "^1.5.0",
     "resolve": "^1.15.0",
     "yargs": "^15.1.0"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
     "test:monorepo": "jest ./__tests__/monorepo -c jest.config.quick.js --noStackTrace",
     "test:php": "cd packages/twig-integration/twig-extensions-shared && composer run test",
     "test:pkgs": "npx lerna run test --ignore=@bolt/uikit-* --ignore=@bolt/build-tools--* --stream",
-    "test:types": "tsc"
+    "test:types": "tsc",
+    "test:vrt-urls": "cd docs-site && yarn run test:vrt-urls"
   },
   "husky": {
     "hooks": {

--- a/packages/build-tools/tasks/api-tasks/bolt-vrt-urls.js
+++ b/packages/build-tools/tasks/api-tasks/bolt-vrt-urls.js
@@ -3,127 +3,109 @@ const fs = require('fs');
 const { getConfig } = require('@bolt/build-utils/config-store');
 const path = require('path');
 const shell = require('shelljs');
-const { getBoltTags } = require('./bolt-versions');
 
 async function generateVrtUrls() {
   const config = await getConfig();
 
+  // Get all PL data
   const data = require(path.resolve(
     path.join(
       config.wwwDir,
       'pattern-lab/styleguide/data/patternlab-data-all.js',
     ),
   ));
-  let boltUrls = data.globalData.link;
+
+  // Get just the links, the paths to each page in PL
+  let demoUrls = data.globalData.link;
 
   const filteredUrls = {
-    patterns: {},
-    // pages: [],
+    components: [],
   };
 
+  // Get every Bolt package in the repo
   const boltPackages = JSON.parse(
-    shell.exec('lerna ls --json --all', { silent: true }).stdout,
+    shell.exec('npx lerna ls --json --all', { silent: true }).stdout,
   );
 
-  const allPackages = boltPackages.filter(
+  // Get just the "components", filters out build tools, etc.
+  const allComponents = boltPackages.filter(
     pkg =>
-      pkg.name.includes('@bolt/components-image') ||
-      pkg.name.includes('@bolt/components-band') ||
-      pkg.name.includes('@bolt/components-blockquote') ||
-      pkg.name.includes('@bolt/components-teaser') ||
-      pkg.name.includes('@bolt/components-video'),
+      pkg.name.includes('@bolt/elements-') ||
+      pkg.name.includes('@bolt/layouts-') ||
+      pkg.name.includes('@bolt/components-'),
   );
 
-  getBoltTags().then(versions => {
-    const latestVersion = versions[0].name.replace(/\./g, '-');
-    const previousVersion = versions[1].name.replace(/\./g, '-');
+  // Components we do not want to test for various reasons
+  const excludePackages = [
+    '@bolt/components-radio-switch',
+    '@bolt/components-animate',
+    '@bolt/components-card',
+    '@bolt/components-critical-css-vars',
+    '@bolt/components-critical-css',
+    '@bolt/components-critical-fonts',
+    '@bolt/components-dropdown',
+    '@bolt/components-grid',
+    '@bolt/components-icons',
+    '@bolt/components-page-footer',
+    '@bolt/components-page-header',
+    '@bolt/components-placeholder',
+    '@bolt/components-search-filter',
+    '@bolt/components-site',
+    '@bolt/components-smooth-scroll',
+    '@bolt/components-toolbar',
+    '@bolt/elements-link',
+    '@bolt/components-editor',
+    '@bolt/layouts-list',
+  ];
 
-    console.log(latestVersion);
-    console.log(previousVersion);
+  const filteredComponents = allComponents.filter(
+    pkg => !excludePackages.includes(pkg.name),
+  );
 
-    // @todo: double-check each url path generated to make sure the URL path actually exists
-    // @todo: update to reference bolt-version data -- comparing the current version (already wired up) + the previous version (not yet wired up) of the design system.
-    Object.keys(boltUrls).forEach(function(url) {
-      const urlName = url;
-      const urlAddress = boltUrls[url];
+  // @todo: double-check each url path generated to make sure the URL path actually exists
+  Object.keys(demoUrls).forEach(url => {
+    const urlName = url;
+    const urlAddress = demoUrls[url];
 
-      allPackages.forEach(function(individualPackage) {
-        const name = individualPackage.name;
-        const packageName = name.replace('@bolt/', '');
+    filteredComponents.forEach(pkg => {
+      const name = pkg.name;
+      const componentName = name.replace('@bolt/', '');
 
-        if (
-          urlName.includes(packageName) &&
-          // urlName.includes('viewall') &&
-          !urlName.includes('docs')
-        ) {
-          // filteredUrls.patterns = filteredUrls.patterns
-          //   ? filteredUrls.patterns
-          //   : [];
-          filteredUrls.patterns[name] = filteredUrls.patterns[name]
-            ? filteredUrls.patterns[name]
-            : [];
-
-          if (
-            urlName.includes(packageName) &&
-            // urlName.includes('viewall') &&
-            !urlName.includes('viewall') &&
-            !urlName.includes('docs')
-          ) {
-            if (!boltUrls[url].added) {
-              filteredUrls.patterns[name].push({
-                patternVariation: urlName,
-                previousReleaseUrl: urlAddress.replace(
-                  '../../',
-                  `https://${previousVersion}.boltdesignsystem.com/pattern-lab/`,
-                ),
-                currentReleaseUrl: urlAddress.replace(
-                  '../../',
-                  `https://${latestVersion}.boltdesignsystem.com/pattern-lab/`,
-                ),
-                // nextReleaseUrl: urlAddress.replace(
-                //   '../../',
-                //   `https://master.boltdesignsystem.com/pattern-lab/`,
-                // ),
-              });
-
-              boltUrls[url].added = true;
-            }
-          } else if (urlName.includes('viewall')) {
-            if (!boltUrls[url].added) {
-              // filteredUrls.pages = filteredUrls.pages || [];
-              filteredUrls.patterns[name].push({
-                patternVariation: urlName,
-                previousReleaseUrl: urlAddress.replace(
-                  '../../',
-                  `https://${previousVersion}.boltdesignsystem.com/pattern-lab/`,
-                ),
-                currentReleaseUrl: urlAddress.replace(
-                  '../../',
-                  `https://${latestVersion}.boltdesignsystem.com/pattern-lab/`,
-                ),
-                // nextReleaseUrl: urlAddress.replace(
-                //   '../../',
-                //   `https://master.boltdesignsystem.com/pattern-lab/`,
-                // ),
-              });
-
-              boltUrls[url].added = true;
-            }
-          }
+      if (
+        // Check for exact match because of components like 'chip' and 'chip-list'
+        urlName === `viewall-${componentName}`
+      ) {
+        if (urlName.includes('viewall') && !demoUrls[url].added) {
+          filteredUrls.components.push(
+            urlAddress.replace(
+              '../../',
+              `https://boltdesignsystem.com/pattern-lab/`,
+            ),
+          );
+          demoUrls[url].added = true;
         }
-      });
+      }
     });
-
-    writeResults(latestVersion, previousVersion);
   });
 
-  async function writeResults(latestVersion, previousVersion) {
+  // Manually add these URLs which have unexpected names, like "backgrounds-shapes", until we can rename the files
+  filteredUrls.components.push(
+    'https://boltdesignsystem.com/pattern-lab/patterns/40-components-backgrounds-shapes/index.html',
+  );
+  filteredUrls.components.push(
+    'https://boltdesignsystem.com/pattern-lab/patterns/40-components-chips-list/index.html',
+  );
+
+  // Sorting only necessary because we're tacking on the components above, remove once we fix pattern names above
+  filteredUrls.components = filteredUrls.components.sort();
+
+  writeResults();
+
+  async function writeResults() {
     const config = await getConfig();
+
     fs.writeFile(
-      path.join(
-        config.dataDir,
-        `bolt-vrt-urls--${latestVersion}-vs-${previousVersion}.json`,
-      ),
+      path.join(config.dataDir, `vrt-urls.bolt.json`),
       JSON.stringify(filteredUrls),
       'utf8',
       function(err) {
@@ -131,19 +113,12 @@ async function generateVrtUrls() {
           console.log('An error occured while writing JSON Object to File.');
           return console.log(err);
         }
-        console.log('VRT testing URLs have been generated.');
-        console.log(
-          path.join(
-            config.dataDir,
-            `bolt-vrt-urls--${latestVersion}-vs-${previousVersion}.json`,
-          ),
-        );
+        // console.log('VRT testing URLs have been generated.');
+        // console.log(path.join(config.dataDir, `vrt-urls.bolt.json`));
       },
     );
   }
 }
-
-generateVrtUrls();
 
 module.exports = {
   generateVrtUrls,

--- a/packages/build-tools/tasks/api-tasks/index.js
+++ b/packages/build-tools/tasks/api-tasks/index.js
@@ -7,7 +7,7 @@ let config;
 async function generate() {
   delete require.cache[require.resolve('./bolt-status-board')];
   await require('./bolt-status-board').generateStatusBoard();
-  // require('./bolt-vrt-urls').generateVrtUrls(); @todo: re-enable once we exclude JSON file outputted from re-generating PL
+  require('./bolt-vrt-urls').generateVrtUrls();
   // require('./bolt-pkg-versions').generatePackageData(); @todo: ignore data from PL watches before we enable this -- super large file size!
 }
 

--- a/packages/build-tools/tasks/pattern-lab-tasks.js
+++ b/packages/build-tools/tasks/pattern-lab-tasks.js
@@ -197,6 +197,7 @@ async function watch() {
     path.join(plSource, globPattern),
     path.join(config.dataDir, '**/*'),
     `!${path.join(config.dataDir, 'sassdoc.bolt.json')}`,
+    `!${path.join(config.dataDir, 'vrt-urls.bolt.json')}`, // ignore to prevent PL from regenerating when this file is output
     `!${dirs.map(dir => path.join(dir, '**/*.schema.yml'))}`, // ignore watching schema files since the new schema file watcher below handles this
   ];
 


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-183

## Summary

Automates the list of VRT URLs (to be added to Applitools) and adds a test to catch any changes to the list.

## Details

There was an existing `bolt-vrt-urls.js` file that I repurposed for our current needs. It now generates a simple array of URLs. The output of this file can change according to our needs, for example if we wanted it to output both "view-all" pages and each variant page URL.

At the moment, these URLs are manually delivered to the QA team, and it might stay that way. We are early in the process.

This API task and test just reminds us when a testing URL changes that we must let QA know to update their tests.

## How to test

- Checkout branch and run `yarn`.
- Delete the `www` folder.
- Run `yarn test:vrt-urls`. You should see an error message telling you the file doesn't exist, run `yarn start`.
- Run `yarn start` to generate the missing data.
- Run `yarn test:vrt-urls` again and it should pass.
- Run `yarn cc`, add new component. Run `yarn start`.
- Run `yarn test:vrt-urls` again and it should fail because the snapshot changed.
- Run `yarn test:vrt-urls -u` and the snapshot should update.