### PR TITLE
DS-191: Fix invalid version error

### DIFF
--- a/packages/build-tools/tasks/api-tasks/bolt-versions.js
+++ b/packages/build-tools/tasks/api-tasks/bolt-versions.js
@@ -171,19 +171,20 @@ async function gatherBoltVersionUrls() {
 
     const newSiteUrl = `https://${tagString}.boltdesignsystem.com`;
     const oldSiteUrl = `https://${tagString}.bolt-design-system.com`;
-
-    if (results[newSiteUrl].status === 'alive') {
-      tagUrls.push({
-        label: tag,
-        type: 'option',
-        value: newSiteUrl,
-      });
-    } else if (results[oldSiteUrl].status === 'alive') {
-      tagUrls.push({
-        label: tag,
-        type: 'option',
-        value: oldSiteUrl,
-      });
+    if (semver.valid(tag)) {
+      if (results[newSiteUrl].status === 'alive') {
+        tagUrls.push({
+          label: tag,
+          type: 'option',
+          value: newSiteUrl,
+        });
+      } else if (results[oldSiteUrl].status === 'alive') {
+        tagUrls.push({
+          label: tag,
+          type: 'option',
+          value: oldSiteUrl,
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-191

## Summary

Check that tag is valid semver before adding to array of Bolt versions.

## Details

Prevents an invalid version from causing the whole build to fail.

## How to test

- Review code
- Build + Deploy step of build is passing. Note Jest tests are currently failing for other reasons.
