### PR TITLE
DS-196: Fix Priority Nav bug in Safari

### DIFF
--- a/packages/components/bolt-nav-priority/nav-priority.js
+++ b/packages/components/bolt-nav-priority/nav-priority.js
@@ -111,19 +111,24 @@ class BoltNavPriority extends withLitHtml {
       item.classList.remove('is-hidden');
     });
 
+    // Note: below we use `getBoundingClientRect()` because it returns a decimal.
+    // Whereas `offsetWidth` returns an integer, leading to rounding errors in
+    // Safari and older Edge < 80.
+
     // hide items that won't fit in the Primary
-    let stopWidth = this.dropdownButton.offsetWidth;
+    let stopWidth = this.dropdownButton.getBoundingClientRect().width;
     let hiddenItems = [];
-    const primaryWidth = this.primaryNav.offsetWidth;
+    const primaryWidth = this.primaryNav.getBoundingClientRect().width;
 
     let hideTheRest = false; // keep track when the items in the nav stop fitting
     this.primaryItems.forEach((item, i) => {
+      // For Edge < 80 we still must round down. Otherwise, "More" menu shows
+      // when it ought to be hidden.
+      const itemWidth = item.getBoundingClientRect().width - 1;
+
       // make sure the items fit + we haven't already started to encounter items that don't
-      if (
-        primaryWidth >= stopWidth + item.offsetWidth &&
-        hideTheRest !== true
-      ) {
-        stopWidth += item.offsetWidth;
+      if (primaryWidth >= stopWidth + itemWidth && hideTheRest !== true) {
+        stopWidth += itemWidth;
       } else {
         hideTheRest = true;
         item.classList.add('is-hidden');

--- a/packages/components/bolt-nav-priority/nav-priority.js
+++ b/packages/components/bolt-nav-priority/nav-priority.js
@@ -122,8 +122,9 @@ class BoltNavPriority extends withLitHtml {
 
     let hideTheRest = false; // keep track when the items in the nav stop fitting
     this.primaryItems.forEach((item, i) => {
-      // For Edge < 80 we still must round down. Otherwise, "More" menu shows
-      // when it ought to be hidden.
+      // Subtract 1 from the width of each item to fix a bug in Edge version < 80 where
+      // it miscalculates the size of the items and/or container and always adds at least
+      // 1 item to the "More" dropdown menu.
       const itemWidth = item.getBoundingClientRect().width - 1;
 
       // make sure the items fit + we haven't already started to encounter items that don't


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-196

## Summary

Fix bug in Safari where Priority Nav "More" menu appears even when there's enough room to display all the items.

## Details

Compare [Navbar centered on master](https://master.boltdesignsystem.com/pattern-lab/patterns/40-components-navbar-05-navbar--centered/40-components-navbar-05-navbar--centered.html) to [Navbar centered on this feature branch](https://boltdesignsystem-kerxi2y1q.vercel.app/pattern-lab/patterns/40-components-navbar-05-navbar--centered/40-components-navbar-05-navbar--centered.html). On master, in Safari at medium-large screen size, you'll see that the "More" menu stays visible even when all the items fit.

I assume this is what the [`offsettolerance`](https://github.com/boltdesignsystem/bolt/commit/997998ad6e99f7420d320ef13914107f0606a697#diff-586662767726e9518a3ea196c8fabe46) was for. Though, it wasn't well commented.

To fix, I switched to `getBoundingClientRect()` which returns a more precise value (decimal) than `offsetWidth` (integer). That fixed presumed rounding errors in Safari. Then, I checked Edge 18 (a proxy for 43), and saw that it had the same issue and `getBoundingClientRect()` alone did not fix it. So, I am subtracting one pixel from each nav item in the calculation, essentially the same as adding the buffer back in, but now it's proportional to the number of nav items (and better commented).

## How to test
- Review code
- Review [Navbar demos](https://boltdesignsystem-kerxi2y1q.vercel.app/pattern-lab/?p=viewall-components-navbar) in Chrome, Safari, FF, Edge, and Edge 18. Test at various screen sizes. Verify Priority menu works as expected, hides when appropriate.