### PR TITLE
DS-183: Remove vrt-urls test from Post-deploy step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -143,7 +143,6 @@ jobs:
         - travis_retry yarn gds -a create -e ${TRAVIS_BRANCH}--branch-preview -r ${TRAVIS_BRANCH}
         - travis_retry yarn gds -a in_progress -e ${TRAVIS_BRANCH}--branch-preview -r ${TRAVIS_BRANCH}
         - travis_retry yarn run test:e2e:full
-        - travis_retry yarn run test:vrt-urls
       after_success:
         - ./scripts/deploy-branch-alias.js
         - export NOW_BRANCH_URL=$(./scripts/get-branch-alias.js)


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-183

## Summary

Remove `vrt-urls` test from "Nightwatch End-to-End (Full)" Post-deploy step.

## Details

I suspect the `vrt-urls` test is failing here because `yarn run build` is not run in this Post-deploy step. The test needs the build to be run to generate required JSON. The file is either not there or not where we expect it to be when run this way.

The test seems to be working reliably in the Pre-deploy step where `yarn run build` is always run. I'm leaving it there and removing from the Post-deploy step.

## How to test

Build is passing.