### PR TITLE
WWW-171 Add workaround for tabs bug in older Edge

### DIFF
--- a/packages/components/bolt-tabs/src/tabs.scss
+++ b/packages/components/bolt-tabs/src/tabs.scss
@@ -248,8 +248,11 @@ bolt-tabs {
     .c-bolt-tabs--inset {
       .c-bolt-tabs__label--spacing-#{$size-name} {
         .c-bolt-tabs__label-text {
-          padding: calc(var(--bolt-spacing-y-#{$size-name}) / 2)
-            var(--bolt-spacing-x-#{$size-name});
+          // Use longhand instead of short hand to fix a bug with older versions of Edge (e.g. 42, 17).
+          padding-top: calc(var(--bolt-spacing-y-#{$size-name}) / 2);
+          padding-right: var(--bolt-spacing-x-#{$size-name});
+          padding-bottom: calc(var(--bolt-spacing-y-#{$size-name}) / 2);
+          padding-left: var(--bolt-spacing-x-#{$size-name});
         }
       }
     }


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/WWW-171

## Summary

Fixes padding issues in Edge 17, Edge 42, etc. on tabs

## Details

It's unclear why this works and why it's not a problem in other places.  We need to follow up with a bigger discussion with marketing.

## How to test

- Open https://boltdesignsystem.com/pattern-lab/?p=components-tabs in Browserstack using Edge 17
- Confirm that the tabs are smooshed together
- Open the same page on this branch and confirm the bug is fixed.