### PR TITLE
WWW-209: make animation wait till JS is loaded

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/55-d8-calculator/00-d8-calculator.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/55-d8-calculator/00-d8-calculator.twig
@@ -6,6 +6,17 @@
 {% set content %}
   {#
   /**
+   * NO-JS alert
+   */
+  #}
+  <noscript>
+    <div class="c-www-calculator-nojs-alert">
+      <p><strong>Note: the calculator requires JavaScript to run, please turn it on and reload the page.</strong></p>
+    </div>
+  </noscript>
+
+  {#
+  /**
    * Logo
    */
   #}
@@ -23,8 +34,6 @@
      */
     #}
     <div class="o-bolt-grid__cell u-bolt-width-12/12 u-bolt-width-9/12@small">
-      <noscript><p>JS is not enabled</p></noscript>
-
       {% include "@bolt-components-headline/headline.twig" with {
         text: "Real-time Decisioning Revenue Calculator",
         size: "xxxlarge",

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/55-d8-calculator/00-d8-calculator.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/55-d8-calculator/00-d8-calculator.twig
@@ -1,3 +1,11 @@
+<script>
+  window.addEventListener('load', showPage);
+
+  function showPage() {
+    document.body.classList.add('js-loaded');
+  }
+</script>
+
 {#
 /**
  * Content band and custom background block

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/55-d8-calculator/00-d8-calculator.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/55-d8-calculator/00-d8-calculator.twig
@@ -1,11 +1,3 @@
-<script>
-  window.addEventListener('load', showPage);
-
-  function showPage() {
-    document.body.classList.add('js-loaded');
-  }
-</script>
-
 {#
 /**
  * Content band and custom background block
@@ -31,6 +23,8 @@
      */
     #}
     <div class="o-bolt-grid__cell u-bolt-width-12/12 u-bolt-width-9/12@small">
+      <noscript><p>JS is not enabled</p></noscript>
+
       {% include "@bolt-components-headline/headline.twig" with {
         text: "Real-time Decisioning Revenue Calculator",
         size: "xxxlarge",

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/55-d8-calculator/00-d8-results.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/55-d8-calculator/00-d8-results.twig
@@ -176,10 +176,12 @@
   {% endset %}
   {% set total_benefit_tooltip %}
     {% include "@bolt-components-tooltip/tooltip.twig" with {
-      trigger: "$" ~ total_benefit|number_format(2, ".", ","),
+      trigger: "$" ~ total_benefit|number_format(0, "ceil") ~ "&nbsp;<sup>" ~ info_icon ~ "</sup>",
       content: tooltip_content,
+      attributes: {
+        style: "cursor: help;"
+      }
     } only %}
-    <sup>{{ info_icon }}</sup>
   {% endset %}
   {% include "@bolt-components-headline/headline.twig" with {
     text: total_benefit_tooltip,
@@ -273,7 +275,7 @@
         {# Flag 3 #}
         {% set flag_3_figure %}
           {% include "@bolt-components-icon/icon.twig" with {
-            name: "asset-data",
+            name: "reporting",
             size: "large",
             color: "teal",
             attributes: {
@@ -330,7 +332,7 @@
         {# Flag 1 #}
         {% set flag_1_figure %}
           {% include "@bolt-components-icon/icon.twig" with {
-            name: "asset-data",
+            name: "reporting",
             size: "large",
             color: "teal",
             attributes: {
@@ -341,7 +343,7 @@
         {% set flag_1_content %}
           <p class="c-www-results-stat">
             <span class="c-www-results-stat__text">Percent increase in customer value from improved upsell/cross-sell presentation and conversion rates</span>
-            <span class="c-www-results-stat__headline">{{ customer_value_increase|number_format(1, ".", ",") }}%</span>
+            <span class="c-www-results-stat__headline">{{ customer_value_increase|number_format(0, "ceil") }}%</span>
           </p>
         {% endset %}
         {% include "@bolt/flag.twig" with {

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/55-d8-calculator/calculator.scss
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/55-d8-calculator/calculator.scss
@@ -30,6 +30,7 @@ $www-calculator-logo-spacing-size: 3px; // Hard px is used to avoid subpixel iss
 
     @at-root bolt-band.is-ready #{&} {
       animation: 3s ease-in-out 0.5s forwards a-www-calculator-logo-spin;
+      animation-delay: 250ms;
     }
 
     @media (prefers-reduced-motion) {
@@ -65,6 +66,7 @@ $www-calculator-logo-spacing-size: 3px; // Hard px is used to avoid subpixel iss
   .o-bolt-grid__cell {
     opacity: 0;
     transform: translate3d(0, -10px, 0);
+    transition: transform $bolt-transition, opacity $bolt-transition;
 
     @at-root bolt-band.is-ready #{&} {
       animation: 0.5s ease-in-out 0.5s forwards a-www-calculator-fade-in-down;
@@ -202,4 +204,22 @@ $www-calculator-logo-spacing-size: 3px; // Hard px is used to avoid subpixel iss
     width: 75vw;
     max-width: 1080px;
   }
+}
+
+.c-www-calculator-nojs-alert {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  top: 0;
+  right: var(--bolt-spacing-x-medium);
+  bottom: 0;
+  left: var(--bolt-spacing-x-medium);
+  z-index: 1; // Moves the stacking order above the band content.
+  padding: var(--bolt-spacing-y-medium) var(--bolt-spacing-x-medium);
+  color: bolt-color(black);
+  text-align: center;
+  border-left: 3px solid bolt-color(warning);
+  border-radius: bolt-border-radius(small);
+  background-color: bolt-color(warning, light);
 }

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/55-d8-calculator/calculator.scss
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/55-d8-calculator/calculator.scss
@@ -28,7 +28,7 @@ $www-calculator-logo-spacing-size: 3px; // Hard px is used to avoid subpixel iss
     background-color: bolt-color(white);
     transition: transform $bolt-transition;
 
-    @at-root body.js-loaded #{&} {
+    @at-root bolt-band.is-ready #{&} {
       animation: 3s ease-in-out 0.5s forwards a-www-calculator-logo-spin;
     }
 
@@ -66,7 +66,7 @@ $www-calculator-logo-spacing-size: 3px; // Hard px is used to avoid subpixel iss
     opacity: 0;
     transform: translate3d(0, -10px, 0);
 
-    @at-root body.js-loaded #{&} {
+    @at-root bolt-band.is-ready #{&} {
       animation: 0.5s ease-in-out 0.5s forwards a-www-calculator-fade-in-down;
     }
 

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/55-d8-calculator/calculator.scss
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/55-d8-calculator/calculator.scss
@@ -6,14 +6,10 @@ $www-calculator-logo-spacing-size: 3px; // Hard px is used to avoid subpixel iss
   flex-wrap: wrap;
   justify-content: space-between;
   align-content: space-around;
-  width: calc(
-    #{$www-calculator-logo-icon-size} * 2 + #{$www-calculator-logo-spacing-size} *
-      4
-  );
-  height: calc(
-    #{$www-calculator-logo-icon-size} * 2 + #{$www-calculator-logo-spacing-size} *
-      4
-  );
+  width: $www-calculator-logo-icon-size * 2 + $www-calculator-logo-spacing-size *
+    4;
+  height: $www-calculator-logo-icon-size * 2 + $www-calculator-logo-spacing-size *
+    4;
   margin-bottom: var(--bolt-spacing-y-medium);
   color: bolt-color(navy);
 
@@ -23,23 +19,22 @@ $www-calculator-logo-spacing-size: 3px; // Hard px is used to avoid subpixel iss
 
   span {
     transform: scale(0) rotate(0deg);
-    width: calc(
-      #{$www-calculator-logo-icon-size} + #{$www-calculator-logo-spacing-size}
-    );
-    height: calc(
-      #{$www-calculator-logo-icon-size} + #{$www-calculator-logo-spacing-size}
-    );
+    width: $www-calculator-logo-icon-size + $www-calculator-logo-spacing-size;
+    height: $www-calculator-logo-icon-size + $www-calculator-logo-spacing-size;
     font-size: $www-calculator-logo-icon-size;
     line-height: 1;
     text-align: center;
     border-radius: bolt-border-radius(full);
     background-color: bolt-color(white);
     transition: transform $bolt-transition;
-    animation: 3s ease-in-out 0.5s forwards a-www-calculator-logo-spin;
+
+    @at-root body.js-loaded #{&} {
+      animation: 3s ease-in-out 0.5s forwards a-www-calculator-logo-spin;
+    }
 
     @media (prefers-reduced-motion) {
-      transform: none;
-      animation: none; // Do not animate if the user has expressed their preference for reduced motion.
+      transform: none !important;
+      animation: none !important; // Do not animate if the user has expressed their preference for reduced motion.
     }
 
     &:nth-child(2) {
@@ -70,12 +65,15 @@ $www-calculator-logo-spacing-size: 3px; // Hard px is used to avoid subpixel iss
   .o-bolt-grid__cell {
     opacity: 0;
     transform: translate3d(0, -10px, 0);
-    animation: 0.5s ease-in-out 0.5s forwards a-www-calculator-fade-in-down;
+
+    @at-root body.js-loaded #{&} {
+      animation: 0.5s ease-in-out 0.5s forwards a-www-calculator-fade-in-down;
+    }
 
     @media (prefers-reduced-motion) {
       opacity: 1;
-      transform: none;
-      animation: none; // Do not animate if the user has expressed their preference for reduced motion.
+      transform: none !important;
+      animation: none !important; // Do not animate if the user has expressed their preference for reduced motion.
     }
   }
 }


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/WWW-209

## Summary

Fixes an issue where the calculator content flashes while it's loading.

## Details

1. Updated CSS animation to wait for the bolt-band to become ready first.
1. `<noscript>` markup is added to show a message saying calculator requires JS to load.

## How to test

Run the branch locally and navigate to the calculator page. Use your browser's dev tool to run the page using fast 3G speed, make sure the content of the page slowly animates in without any flickering.