### PR TITLE
DS-198: Rename `update` to `updateLayout`

### DIFF
--- a/packages/components/bolt-accordion/src/accordion.js
+++ b/packages/components/bolt-accordion/src/accordion.js
@@ -180,7 +180,7 @@ class BoltAccordion extends withContext(BoltElement) {
       const elementsToUpdate = this.querySelectorAll('[will-update]');
       if (elementsToUpdate.length) {
         elementsToUpdate.forEach(el => {
-          el.update && el.update();
+          el.updateLayout && el.updateLayout();
         });
       }
     });

--- a/packages/components/bolt-carousel/src/carousel.js
+++ b/packages/components/bolt-carousel/src/carousel.js
@@ -409,6 +409,11 @@ class BoltCarousel extends BoltElement {
     }
   }
 
+  // Public method called by Tabs and Accordion when DOM changes and Carousel needs to update
+  updateLayout() {
+    this.swiper?.update();
+  }
+
   onSlideChange() {
     this.disableSwipingIfAllSlidesAreVisible();
   }

--- a/packages/components/bolt-tabs/src/tabs.js
+++ b/packages/components/bolt-tabs/src/tabs.js
@@ -211,7 +211,7 @@ class BoltTabs extends withContext(withLitHtml) {
         const elementsToUpdate = this.querySelectorAll('[will-update]');
         if (elementsToUpdate.length) {
           elementsToUpdate.forEach(el => {
-            el.update && el.update();
+            el.updateLayout && el.updateLayout();
           });
         }
       }, 0);
@@ -542,7 +542,8 @@ class BoltTabs extends withContext(withLitHtml) {
     );
   }
 
-  update() {
+  // Public method called by Accordion when DOM changes and Tabs needs to update
+  updateLayout() {
     this._resizeMenu();
   }
 


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-198

## Summary

Rename `update` to `updateLayout` to prevent conflict with the [Lit Element's `update` method](https://lit-element.polymer-project.org/guide/lifecycle#update).

## Details

We have been using a custom method called `update` on components that need to "update" their layout when a parent component changes state. For example, when an Accordion item that contains a Carousel opens, the Accordion component calls `update` on the Carousel to tell it to resize itself.

LitElement already has a method called `update`, so I'm renaming ours to `updateLayout`. Tabs is the first component where there will be a conflict between the two. So, I'm making this change separately before including the Tabs renderer upgrade changes.

## How to test
- Checkout code locally.
- Go to Accordion demo: `/pattern-lab/patterns/40-components-accordion-40-accordion-content-variations/40-components-accordion-40-accordion-content-variations.html`
- Go to Tabs demo: `/pattern-lab/patterns/40-components-tabs-30-tabs-content/40-components-tabs-30-tabs-content.html`
- On each open the Tabs/Items that contain Accordion, Tabs, and Carousel. Verify this content renders properly and fits into the parent component as it does currently on master (or better, as in the case of Carousel inside Accordion where it fixes a bug).