### PR TITLE
DS-45: Add missing 'wc-context' dependencies

### DIFF
--- a/packages/components/bolt-accordion/package.json
+++ b/packages/components/bolt-accordion/package.json
@@ -22,7 +22,8 @@
     "@bolt/core-v3.x": "^2.27.0",
     "@bolt/lazy-queue": "^2.23.0",
     "@ungap/url-search-params": "^0.1.2",
-    "handorgel": "^0.4.5"
+    "handorgel": "^0.4.5",
+    "wc-context": "^0.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/components/bolt-card-replacement/package.json
+++ b/packages/components/bolt-card-replacement/package.json
@@ -24,7 +24,8 @@
     "@bolt/components-teaser": "^2.27.0",
     "@bolt/components-video": "^2.27.0",
     "@bolt/core-v3.x": "^2.27.0",
-    "@bolt/lazy-queue": "^2.23.0"
+    "@bolt/lazy-queue": "^2.23.0",
+    "wc-context": "^0.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/components/bolt-list/package.json
+++ b/packages/components/bolt-list/package.json
@@ -22,7 +22,8 @@
   "style": "index.scss",
   "dependencies": {
     "@bolt/core-v3.x": "^2.27.0",
-    "@bolt/lazy-queue": "^2.23.0"
+    "@bolt/lazy-queue": "^2.23.0",
+    "wc-context": "^0.9.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-45

## Summary

Add missing `wc-context` dependency to recently converted components, including List.

## Details

Forgot to add `wc-context` as a dependency, previously import came from core, so this was missed. Adding it now.

## How to test

Review code changes, build is passing.
