### PR TITLE
Hotfix: Banner fix for v2.26.4

### DIFF
--- a/packages/build-tools/tasks/api-tasks/bolt-versions.js
+++ b/packages/build-tools/tasks/api-tasks/bolt-versions.js
@@ -171,19 +171,20 @@ async function gatherBoltVersionUrls() {
 
     const newSiteUrl = `https://${tagString}.boltdesignsystem.com`;
     const oldSiteUrl = `https://${tagString}.bolt-design-system.com`;
-
-    if (results[newSiteUrl].status === 'alive') {
-      tagUrls.push({
-        label: tag,
-        type: 'option',
-        value: newSiteUrl,
-      });
-    } else if (results[oldSiteUrl].status === 'alive') {
-      tagUrls.push({
-        label: tag,
-        type: 'option',
-        value: oldSiteUrl,
-      });
+    if (semver.valid(tag)) {
+      if (results[newSiteUrl].status === 'alive') {
+        tagUrls.push({
+          label: tag,
+          type: 'option',
+          value: newSiteUrl,
+        });
+      } else if (results[oldSiteUrl].status === 'alive') {
+        tagUrls.push({
+          label: tag,
+          type: 'option',
+          value: oldSiteUrl,
+        });
+      }
     }
   }
 

--- a/packages/components/bolt-banner/__tests__/__snapshots__/banner.js.snap
+++ b/packages/components/bolt-banner/__tests__/__snapshots__/banner.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<bolt-banner> Component Basic usage 1`] = `
 <bolt-banner>
-  <div class="c-bolt-banner c-bolt-banner--status-information   c-bolt-banner--align-center c-bolt-banner--full">
+  <div class="c-bolt-banner c-bolt-banner--status-information   c-bolt-banner--align-center">
     <ssr-keep for="bolt-banner">
       This is a banner
     </ssr-keep>
@@ -12,7 +12,7 @@ exports[`<bolt-banner> Component Basic usage 1`] = `
 
 exports[`<bolt-banner> Component Status of the banner message: error 1`] = `
 <bolt-banner status="error">
-  <div class="c-bolt-banner c-bolt-banner--status-error t-bolt-dark  c-bolt-banner--align-center c-bolt-banner--full">
+  <div class="c-bolt-banner c-bolt-banner--status-error t-bolt-dark  c-bolt-banner--align-center">
     <ssr-keep for="bolt-banner">
       This banner is trying to convey error
     </ssr-keep>
@@ -22,7 +22,7 @@ exports[`<bolt-banner> Component Status of the banner message: error 1`] = `
 
 exports[`<bolt-banner> Component Status of the banner message: information 1`] = `
 <bolt-banner status="information">
-  <div class="c-bolt-banner c-bolt-banner--status-information   c-bolt-banner--align-center c-bolt-banner--full">
+  <div class="c-bolt-banner c-bolt-banner--status-information   c-bolt-banner--align-center">
     <ssr-keep for="bolt-banner">
       This banner is trying to convey information
     </ssr-keep>
@@ -32,7 +32,7 @@ exports[`<bolt-banner> Component Status of the banner message: information 1`] =
 
 exports[`<bolt-banner> Component Status of the banner message: success 1`] = `
 <bolt-banner status="success">
-  <div class="c-bolt-banner c-bolt-banner--status-success  t-bolt-dark c-bolt-banner--align-center c-bolt-banner--full">
+  <div class="c-bolt-banner c-bolt-banner--status-success  t-bolt-dark c-bolt-banner--align-center">
     <ssr-keep for="bolt-banner">
       This banner is trying to convey success
     </ssr-keep>
@@ -42,7 +42,7 @@ exports[`<bolt-banner> Component Status of the banner message: success 1`] = `
 
 exports[`<bolt-banner> Component Status of the banner message: warning 1`] = `
 <bolt-banner status="warning">
-  <div class="c-bolt-banner c-bolt-banner--status-warning   c-bolt-banner--align-center c-bolt-banner--full">
+  <div class="c-bolt-banner c-bolt-banner--status-warning   c-bolt-banner--align-center">
     <ssr-keep for="bolt-banner">
       This banner is trying to convey warning
     </ssr-keep>
@@ -52,7 +52,7 @@ exports[`<bolt-banner> Component Status of the banner message: warning 1`] = `
 
 exports[`<bolt-banner> Component Text alignment: center 1`] = `
 <bolt-banner align="center">
-  <div class="c-bolt-banner c-bolt-banner--status-information   c-bolt-banner--align-center c-bolt-banner--full">
+  <div class="c-bolt-banner c-bolt-banner--status-information   c-bolt-banner--align-center">
     <ssr-keep for="bolt-banner">
       The text is aligned to the center
     </ssr-keep>
@@ -62,7 +62,7 @@ exports[`<bolt-banner> Component Text alignment: center 1`] = `
 
 exports[`<bolt-banner> Component Text alignment: end 1`] = `
 <bolt-banner align="end">
-  <div class="c-bolt-banner c-bolt-banner--status-information   c-bolt-banner--align-end c-bolt-banner--full">
+  <div class="c-bolt-banner c-bolt-banner--status-information   c-bolt-banner--align-end">
     <ssr-keep for="bolt-banner">
       The text is aligned to the end
     </ssr-keep>
@@ -72,7 +72,7 @@ exports[`<bolt-banner> Component Text alignment: end 1`] = `
 
 exports[`<bolt-banner> Component Text alignment: start 1`] = `
 <bolt-banner align="start">
-  <div class="c-bolt-banner c-bolt-banner--status-information   c-bolt-banner--align-start c-bolt-banner--full">
+  <div class="c-bolt-banner c-bolt-banner--status-information   c-bolt-banner--align-start">
     <ssr-keep for="bolt-banner">
       The text is aligned to the start
     </ssr-keep>

--- a/packages/components/bolt-banner/banner.schema.js
+++ b/packages/components/bolt-banner/banner.schema.js
@@ -28,11 +28,5 @@ module.exports = {
       enum: ['start', 'center', 'end'],
       default: 'center',
     },
-    full: {
-      type: 'boolean',
-      description:
-        'Sets the width of the banner to take up 100% of the screen width.',
-      default: false,
-    },
   },
 };

--- a/packages/components/bolt-banner/src/banner.js
+++ b/packages/components/bolt-banner/src/banner.js
@@ -11,10 +11,6 @@ class BoltBanner extends BoltElement {
     return {
       status: String,
       align: String,
-      full: {
-        type: Boolean,
-        reflect: true,
-      },
     };
   }
 
@@ -29,14 +25,12 @@ class BoltBanner extends BoltElement {
   render() {
     const status = this.status || schema.properties.status.default;
     const align = this.align || schema.properties.align.default;
-    const full = this.full || schema.properties.full.default;
 
     const classes = cx('c-bolt-banner', {
       [`c-bolt-banner--status-${status}`]: status,
       [`t-bolt-dark`]:
         (status && status === 'error') || (status && status === 'success'),
       [`c-bolt-banner--align-${align}`]: align,
-      [`c-bolt-banner--full`]: full,
     });
 
     return html`

--- a/packages/components/bolt-banner/src/banner.scss
+++ b/packages/components/bolt-banner/src/banner.scss
@@ -18,9 +18,10 @@
   @include bolt-padding(medium, squished);
   display: block;
 
-  &--full {
-    @include bolt-full-bleed;
-  }
+  // removed by ds-208 & pr #1973
+  // &--full {
+  //   @include bolt-full-bleed;
+  // }
 }
 
 /**

--- a/packages/components/bolt-banner/src/banner.twig
+++ b/packages/components/bolt-banner/src/banner.twig
@@ -16,7 +16,6 @@
   this.data.status.value == "error" ? "t-bolt-dark",
   this.data.status.value == "success" ? "t-bolt-dark",
   this.data.align ? base_class ~ "--align-" ~ this.data.align.value,
-  this.data.full ? base_class ~ "--full",
 ] %}
 
 {#


### PR DESCRIPTION
## Jira

https://github.com/boltdesignsystem/bolt/pull/1973
https://github.com/boltdesignsystem/bolt/pull/1953

## Summary

Cherry-pick Banner bug for for Academy which is on v2.26.3 currently. Also includes `vnull` fix which was added after `v2.26.x`.

## How to test

- Build is passing
- Banner "full" prop is removed and so Banner is natural block width not full-viewport-width when JS is turned off.

## Release notes

This hotfixes `v2.26.3` with fixes that are already on `v2.27.x` and `v2.28.x`.