### PR TITLE
WWW-269: fix calculator background overflow

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/55-d8-calculator/00-d8-calculator.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/55-d8-calculator/00-d8-calculator.twig
@@ -251,6 +251,9 @@
       {% include "@bolt-components-image/image.twig" with {
         src: "/images/backgrounds/calculator-landing-shapes-transparent.png",
         alt: "Decorative shapes.",
+        attributes: {
+          class: "c-www-calculator-background__image"
+        }
       } only %}
     </div>
   {% endblock %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/55-d8-calculator/calculator.scss
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/55-d8-calculator/calculator.scss
@@ -181,8 +181,18 @@ $www-calculator-logo-spacing-size: 3px; // Hard px is used to avoid subpixel iss
 .c-www-calculator-background {
   position: absolute;
   top: 0;
-  right: -150vw;
+  right: 0;
+  bottom: 0;
+  left: 0;
   z-index: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.c-www-calculator-background__image {
+  position: absolute;
+  top: 0;
+  right: -150vw;
   width: 300vw;
   max-width: 1000px;
   pointer-events: none;


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/WWW-269

## Summary

Fixes an issue where the calculator background image overflows.

## Details

1. Updated CSS to contain the overflow.
1. Added a class in the markup to contain the image.

## How to test

Run the branch locally and navigate to the calculator page, open it in a new tab outside of PL. Make the browser narrow (below 600px). Try to side scroll and make sure it doesn't happen.