### PR TITLE
DS-149 Fix Modal focus

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/modal/52-modal-usage-persistent.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/modal/52-modal-usage-persistent.twig
@@ -9,8 +9,7 @@
     inputAttributes: {
       placeholder: "Enter your email address",
       type: "email",
-      required: true,
-      autofocus: true,
+      required: true
     },
     labelDisplayType: "floating"
   } only %}
@@ -68,6 +67,9 @@
           name: "chevron-left",
           position: "before"
         },
+        attributes: {
+          "autofocus": ""
+        }
       } only %}
     {% endcell %}
   {% endgrid %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/modal/52-modal-usage-persistent.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/modal/52-modal-usage-persistent.twig
@@ -68,7 +68,7 @@
           position: "before"
         },
         attributes: {
-          "autofocus": ""
+          "data-bolt-autofocus": ""
         }
       } only %}
     {% endcell %}

--- a/packages/components/bolt-modal/__tests__/__snapshots__/modal.js.snap
+++ b/packages/components/bolt-modal/__tests__/__snapshots__/modal.js.snap
@@ -83,12 +83,10 @@ exports[`<bolt-modal> Component Long content usage <bolt-modal> w/o Shadow DOM r
                       
       
             <bolt-trigger
-              autofocus=""
               class="js-close-button-fallback"
               display="block"
               no-outline=""
               style=""
-              tabindex="0"
             >
               
         
@@ -363,12 +361,10 @@ exports[`<bolt-modal> Component Simple usage <bolt-modal> w/o Shadow DOM renders
                       
       
             <bolt-trigger
-              autofocus=""
               class="js-close-button-fallback"
               display="block"
               no-outline=""
               style=""
-              tabindex="0"
             >
               
         

--- a/packages/components/bolt-modal/src/modal.js
+++ b/packages/components/bolt-modal/src/modal.js
@@ -267,8 +267,8 @@ class BoltModal extends BoltElement {
   }
 
   /**
-   * Set focus on the close button, the first element with `autofocus`, or the
-   * first focusable element in the modal (in that order)
+   * Set focus on the close button, the first element with `data-bolt-autofocus`,
+   * `autofocus`, or the first focusable element in the modal (in that order)
    */
   async setFocusToFirstItem() {
     const closeButton = this.renderRoot.querySelector(

--- a/packages/components/bolt-modal/src/modal.js
+++ b/packages/components/bolt-modal/src/modal.js
@@ -63,7 +63,7 @@ class BoltModal extends BoltElement {
       if (propName === 'open') {
         if (this.open) {
           this.focusTrap.active = true;
-          this.setFocusToFirstItem(this.renderRoot);
+          this.setFocusToFirstItem();
           this.ready = true;
         }
       }
@@ -253,16 +253,6 @@ class BoltModal extends BoltElement {
     }
   }
 
-  _handleTriggerFocus(e) {
-    const closeButton = e.target.closest('.c-bolt-modal__close-button');
-    closeButton.classList.add('c-bolt-modal__close-button--focus-within');
-  }
-
-  _handleTriggerBlur(e) {
-    const closeButton = e.target.closest('.c-bolt-modal__close-button');
-    closeButton.classList.remove('c-bolt-modal__close-button--focus-within');
-  }
-
   _setScrollbar() {
     BoltModal.bodyHasScrollbar &&
       setScrollbarPadding(document.body, BoltModal.scrollbarWidth);
@@ -277,33 +267,28 @@ class BoltModal extends BoltElement {
   }
 
   /**
-   * Set the focus to the first element with `autofocus` or the first focusable
-   * child of the given element
-   *
-   * @param {Element} node
+   * Set focus on the close button, the first element with `autofocus`, or the
+   * first focusable element in the modal (in that order)
    */
-  async setFocusToFirstItem(node) {
-    const focusableChildren = this.getFocusableChildren(node);
-    const childToBeFocused =
-      node.querySelector('[autofocus]') || focusableChildren[0];
+  async setFocusToFirstItem() {
+    const closeButton = this.renderRoot.querySelector(
+      '.js-close-button-fallback',
+    );
+    const autofocusEl = this.querySelector('[autofocus]');
 
-    if (childToBeFocused) {
-      // If child is Bolt Element, wait for it to finish updating, or it will not receive focus.
-      if (typeof childToBeFocused.render === 'function') {
-        await childToBeFocused.updateComplete;
-      }
-      childToBeFocused.focus();
+    const initialEl = closeButton || autofocusEl || tabbable(this)[0];
+
+    if (!initialEl) return;
+
+    const tagName = initialEl.tagName.toLowerCase();
+
+    if (tagName.includes('bolt-') && customElements.get(tagName)) {
+      // Wait for component to update or renderRoot can be undefined.
+      await initialEl.updateComplete;
+      tabbable(initialEl.renderRoot)[0].focus();
+    } else {
+      initialEl.focus();
     }
-  }
-
-  /**
-   * Get the focusable children of the given element
-   *
-   * @param {Element} node
-   * @return {Array<Element>}
-   */
-  getFocusableChildren(node) {
-    return tabbable(node);
   }
 
   /**
@@ -395,28 +380,12 @@ class BoltModal extends BoltElement {
         this.theme && (this.theme === 'light' || this.theme === 'xlight'),
     });
 
-    const delegateFocus = e => {
-      if (!this.useShadow) {
-        const button = e.target.renderRoot.querySelector('button');
-        button && button.focus();
-      }
-    };
-
-    // <button> element is included here to set a required style inside the Shadow DOM.
-    // Button's default transition 'all' property delays 'visibility: visible'
-    // and thus prevents it from getting focus on 'rendered'.
-    // @todo: Can we safely fix this from within the button component itself?
     const defaultCloseButton = html`
       <bolt-trigger
         class="js-close-button-fallback"
         @click=${e => this.hide(e)}
-        @focus=${e => delegateFocus(e)}
-        @trigger:focus=${e => this._handleTriggerFocus(e)}
-        @trigger:blur=${e => this._handleTriggerBlur(e)}
         display="block"
         no-outline
-        autofocus
-        tabindex="0"
       >
         <span class="c-bolt-modal__close-button__text"
           >Close this dialog window</span

--- a/packages/components/bolt-modal/src/modal.js
+++ b/packages/components/bolt-modal/src/modal.js
@@ -274,9 +274,11 @@ class BoltModal extends BoltElement {
     const closeButton = this.renderRoot.querySelector(
       '.js-close-button-fallback',
     );
+    const boltAutofocusEl = this.querySelector('[data-bolt-autofocus]');
     const autofocusEl = this.querySelector('[autofocus]');
 
-    const initialEl = closeButton || autofocusEl || tabbable(this)[0];
+    const initialEl =
+      closeButton || boltAutofocusEl || autofocusEl || tabbable(this)[0];
 
     if (!initialEl) return;
 


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-149

## Summary

Properly set initial focus when modal first opens.

## Details

On open, modal now focuses on 1) the built-in close button 2) the first element with `autofocus` attribute or 3) the first focusable element, in that order.

I updated the persistent modal demo so that the custom close button has `autofocus`.

> Note: @mikemai2awesome in the persistent demo the custom close button _does_ get focus, but the focus style doesn't seem to apply unless you tab onto it. If I add an explicit `.c-bolt-link:focus` style to the Link SCSS that style _does_ work.

## How to test

- Review code changes
- Review Modal demos and verify the expected element gets focus on open.