### PR TITLE
DS-198 Tabs renderer conversion

### DIFF
--- a/packages/components/bolt-tabs/__tests__/__snapshots__/tabs.js.snap
+++ b/packages/components/bolt-tabs/__tests__/__snapshots__/tabs.js.snap
@@ -3,6 +3,7 @@
 exports[`Bolt Tabs Align: center 2`] = `
 <bolt-tabs
   align="center"
+  ready=""
   style=""
 >
   
@@ -64,6 +65,7 @@ exports[`Bolt Tabs Align: center 2`] = `
 exports[`Bolt Tabs Align: end 2`] = `
 <bolt-tabs
   align="end"
+  ready=""
   style=""
 >
   
@@ -125,6 +127,7 @@ exports[`Bolt Tabs Align: end 2`] = `
 exports[`Bolt Tabs Align: start 2`] = `
 <bolt-tabs
   align="start"
+  ready=""
   style=""
 >
   
@@ -193,6 +196,7 @@ exports[`Bolt Tabs Inset: auto 2`] = `
   
     
   <bolt-tab-panel
+    selected=""
     style=""
   >
     
@@ -256,6 +260,7 @@ exports[`Bolt Tabs Inset: off 2`] = `
   
     
   <bolt-tab-panel
+    selected=""
     style=""
   >
     
@@ -319,6 +324,7 @@ exports[`Bolt Tabs Inset: on 2`] = `
   
     
   <bolt-tab-panel
+    selected=""
     style=""
   >
     
@@ -490,7 +496,6 @@ exports[`Bolt Tabs Web Component usage (Shadow DOM) 2`] = `
   
     
   <bolt-tab-panel
-    selected=""
     style=""
   >
     

--- a/packages/components/bolt-tabs/__tests__/__snapshots__/tabs.js.snap
+++ b/packages/components/bolt-tabs/__tests__/__snapshots__/tabs.js.snap
@@ -3,13 +3,11 @@
 exports[`Bolt Tabs Align: center 2`] = `
 <bolt-tabs
   align="center"
-  ready=""
   style=""
 >
   
     
   <bolt-tab-panel
-    selected=""
     style=""
   >
     
@@ -66,13 +64,11 @@ exports[`Bolt Tabs Align: center 2`] = `
 exports[`Bolt Tabs Align: end 2`] = `
 <bolt-tabs
   align="end"
-  ready=""
   style=""
 >
   
     
   <bolt-tab-panel
-    selected=""
     style=""
   >
     
@@ -129,13 +125,11 @@ exports[`Bolt Tabs Align: end 2`] = `
 exports[`Bolt Tabs Align: start 2`] = `
 <bolt-tabs
   align="start"
-  ready=""
   style=""
 >
   
     
   <bolt-tab-panel
-    selected=""
     style=""
   >
     
@@ -191,6 +185,7 @@ exports[`Bolt Tabs Align: start 2`] = `
 
 exports[`Bolt Tabs Inset: auto 2`] = `
 <bolt-tabs
+  class=""
   inset="auto"
   ready=""
   style=""
@@ -198,7 +193,6 @@ exports[`Bolt Tabs Inset: auto 2`] = `
   
     
   <bolt-tab-panel
-    selected=""
     style=""
   >
     
@@ -254,6 +248,7 @@ exports[`Bolt Tabs Inset: auto 2`] = `
 
 exports[`Bolt Tabs Inset: off 2`] = `
 <bolt-tabs
+  class=""
   inset="off"
   ready=""
   style=""
@@ -261,7 +256,6 @@ exports[`Bolt Tabs Inset: off 2`] = `
   
     
   <bolt-tab-panel
-    selected=""
     style=""
   >
     
@@ -317,6 +311,7 @@ exports[`Bolt Tabs Inset: off 2`] = `
 
 exports[`Bolt Tabs Inset: on 2`] = `
 <bolt-tabs
+  class=""
   inset="on"
   ready=""
   style=""
@@ -324,7 +319,6 @@ exports[`Bolt Tabs Inset: on 2`] = `
   
     
   <bolt-tab-panel
-    selected=""
     style=""
   >
     
@@ -485,528 +479,6 @@ exports[`Bolt Tabs Twig usage 1`] = `
       </ssr-keep>
     </div>
   </div>
-</bolt-tabs>
-`;
-
-exports[`Bolt Tabs Web Component usage (Light DOM) 1`] = `
-<bolt-tabs
-  no-shadow=""
-  ready=""
-  style=""
->
-  <!---->
-  
-       
-      
-  <div
-    class="c-bolt-tabs c-bolt-tabs--align-start c-bolt-tabs--inset"
-    style=""
-  >
-    
-        
-    <div
-      class="c-bolt-tabs__nav"
-      role="tablist"
-      style=""
-    >
-      
-          
-      <!---->
-      
-          
-      <bolt-trigger
-        aria-controls="tab-panel-12345-1"
-        aria-selected="true"
-        class="c-bolt-tabs__label c-bolt-tabs__item c-bolt-tabs__label--spacing-small"
-        display="inline"
-        id="tab-label-12345-1"
-        no-outline=""
-        role="tab"
-        style=""
-        tabindex="0"
-      >
-        
-            
-        <span
-          class="c-bolt-tabs__label-inner"
-          style=""
-        >
-          <span
-            class="c-bolt-tabs__label-text"
-            style=""
-          >
-            <!---->
-            Tab label 1
-            <!---->
-          </span>
-        </span>
-        
-          
-      </bolt-trigger>
-      
-        
-      <!---->
-      
-          
-      <bolt-trigger
-        aria-controls="tab-panel-12345-2"
-        aria-selected="false"
-        class="c-bolt-tabs__label c-bolt-tabs__item c-bolt-tabs__label--spacing-small"
-        display="inline"
-        id="tab-label-12345-2"
-        no-outline=""
-        role="tab"
-        style=""
-        tabindex="-1"
-      >
-        
-            
-        <span
-          class="c-bolt-tabs__label-inner"
-          style=""
-        >
-          <span
-            class="c-bolt-tabs__label-text"
-            style=""
-          >
-            <!---->
-            Tab label 2
-            <!---->
-          </span>
-        </span>
-        
-          
-      </bolt-trigger>
-      
-        
-      <!---->
-      
-          
-      <bolt-trigger
-        aria-controls="tab-panel-12345-3"
-        aria-selected="false"
-        class="c-bolt-tabs__label c-bolt-tabs__item c-bolt-tabs__label--spacing-small"
-        display="inline"
-        id="tab-label-12345-3"
-        no-outline=""
-        role="tab"
-        style=""
-        tabindex="-1"
-      >
-        
-            
-        <span
-          class="c-bolt-tabs__label-inner"
-          style=""
-        >
-          <span
-            class="c-bolt-tabs__label-text"
-            style=""
-          >
-            <!---->
-            Tab label 3
-            <!---->
-          </span>
-        </span>
-        
-          
-      </bolt-trigger>
-      
-        
-      <!---->
-       
-        
-      <div
-        class="c-bolt-tabs__item c-bolt-tabs__show-more"
-        style=""
-      >
-        
-          
-        <button
-          aria-expanded="false"
-          aria-haspopup="true"
-          class="c-bolt-tabs__button c-bolt-tabs__show-button"
-          style=""
-          type="button"
-        >
-          
-            
-          <span
-            class="c-bolt-tabs__show-text"
-            style=""
-          >
-            
-              More
-            
-          </span>
-          
-            
-          <span
-            class="c-bolt-tabs__show-icon"
-            style=""
-          >
-            
-              
-            <bolt-icon
-              name="chevron-down"
-              style=""
-            />
-            
-            
-          </span>
-          
-          
-        </button>
-        
-          
-        <div
-          class="c-bolt-tabs__dropdown"
-          style=""
-        >
-          
-            
-          <div
-            class="c-bolt-tabs__dropdown-list"
-            style=""
-          >
-            
-              
-            <!---->
-            
-          
-            <bolt-trigger
-              aria-controls="tab-panel-12345-1"
-              aria-selected="true"
-              class="c-bolt-tabs__label c-bolt-tabs__item c-bolt-tabs__label--spacing-small c-bolt-tabs__label--is-duplicate c-bolt-tabs__label--vertical-border"
-              display="block"
-              id="tab-dropdown-12345-1"
-              no-outline=""
-              role="tab"
-              style=""
-              tabindex="0"
-            >
-              
-            
-              <span
-                class="c-bolt-tabs__label-inner"
-                style=""
-              >
-                <span
-                  class="c-bolt-tabs__label-text"
-                  style=""
-                >
-                  <!---->
-                  Tab label 1
-                  <!---->
-                </span>
-              </span>
-              
-          
-            </bolt-trigger>
-            
-        
-            <!---->
-            
-          
-            <bolt-trigger
-              aria-controls="tab-panel-12345-2"
-              aria-selected="false"
-              class="c-bolt-tabs__label c-bolt-tabs__item c-bolt-tabs__label--spacing-small c-bolt-tabs__label--is-duplicate c-bolt-tabs__label--vertical-border"
-              display="block"
-              id="tab-dropdown-12345-2"
-              no-outline=""
-              role="tab"
-              style=""
-              tabindex="-1"
-            >
-              
-            
-              <span
-                class="c-bolt-tabs__label-inner"
-                style=""
-              >
-                <span
-                  class="c-bolt-tabs__label-text"
-                  style=""
-                >
-                  <!---->
-                  Tab label 2
-                  <!---->
-                </span>
-              </span>
-              
-          
-            </bolt-trigger>
-            
-        
-            <!---->
-            
-          
-            <bolt-trigger
-              aria-controls="tab-panel-12345-3"
-              aria-selected="false"
-              class="c-bolt-tabs__label c-bolt-tabs__item c-bolt-tabs__label--spacing-small c-bolt-tabs__label--is-duplicate c-bolt-tabs__label--vertical-border"
-              display="block"
-              id="tab-dropdown-12345-3"
-              no-outline=""
-              role="tab"
-              style=""
-              tabindex="-1"
-            >
-              
-            
-              <span
-                class="c-bolt-tabs__label-inner"
-                style=""
-              >
-                <span
-                  class="c-bolt-tabs__label-text"
-                  style=""
-                >
-                  <!---->
-                  Tab label 3
-                  <!---->
-                </span>
-              </span>
-              
-          
-            </bolt-trigger>
-            
-        
-            <!---->
-            
-            
-          </div>
-          
-          
-        </div>
-        
-        
-      </div>
-      
-      
-        
-    </div>
-    
-        
-    <div
-      class="c-bolt-tabs__panels-container"
-      style=""
-    >
-      
-          
-      <!---->
-      <!---->
-      
-    
-      <!---->
-      <bolt-tab-panel
-        no-shadow=""
-        selected=""
-        style=""
-      >
-        <!---->
-        
-       
-      
-        <div
-          class="c-bolt-tab-panel c-bolt-tab-panel--spacing-small"
-          style=""
-        >
-          <!---->
-          <!---->
-          <!---->
-          <!---->
-          <div
-            slot="label"
-            style=""
-          >
-            Tab label 1
-          </div>
-          <!---->
-          <!---->
-          <!---->
-          
-                
-          <div
-            aria-expanded="true"
-            aria-labelledby="tab-label-12345-1"
-            class="c-bolt-tab-panel__content"
-            id="tab-panel-12345-1"
-            role="tabpanel"
-            style=""
-            tabindex="0"
-          >
-            
-                  
-            <!---->
-            <!---->
-            
-      
-            <!---->
-            
-      Tab panel 1
-    
-            <!---->
-            <!---->
-            
-                
-          </div>
-          
-              
-          <!---->
-          <!---->
-        </div>
-        
-    
-    
-        <!---->
-      </bolt-tab-panel>
-      <!---->
-      
-    
-      <!---->
-      <bolt-tab-panel
-        no-shadow=""
-        style=""
-      >
-        <!---->
-        
-       
-      
-        <div
-          class="c-bolt-tab-panel c-bolt-tab-panel--spacing-small"
-          style=""
-        >
-          <!---->
-          <!---->
-          <!---->
-          <!---->
-          <div
-            slot="label"
-            style=""
-          >
-            Tab label 2
-          </div>
-          <!---->
-          <!---->
-          <!---->
-          
-                
-          <div
-            aria-expanded="false"
-            aria-labelledby="tab-label-12345-2"
-            class="c-bolt-tab-panel__content"
-            id="tab-panel-12345-2"
-            role="tabpanel"
-            style=""
-            tabindex="0"
-          >
-            
-                  
-            <!---->
-            <!---->
-            
-      
-            <!---->
-            
-      Tab panel 2
-    
-            <!---->
-            <!---->
-            
-                
-          </div>
-          
-              
-          <!---->
-          <!---->
-        </div>
-        
-    
-    
-        <!---->
-      </bolt-tab-panel>
-      <!---->
-      
-    
-      <!---->
-      <bolt-tab-panel
-        no-shadow=""
-        style=""
-      >
-        <!---->
-        
-       
-      
-        <div
-          class="c-bolt-tab-panel c-bolt-tab-panel--spacing-small"
-          style=""
-        >
-          <!---->
-          <!---->
-          <!---->
-          <!---->
-          <div
-            slot="label"
-            style=""
-          >
-            Tab label 3
-          </div>
-          <!---->
-          <!---->
-          <!---->
-          
-                
-          <div
-            aria-expanded="false"
-            aria-labelledby="tab-label-12345-3"
-            class="c-bolt-tab-panel__content"
-            id="tab-panel-12345-3"
-            role="tabpanel"
-            style=""
-            tabindex="0"
-          >
-            
-                  
-            <!---->
-            <!---->
-            
-      
-            <!---->
-            
-      Tab panel 3
-    
-            <!---->
-            <!---->
-            
-                
-          </div>
-          
-              
-          <!---->
-          <!---->
-        </div>
-        
-    
-    
-        <!---->
-      </bolt-tab-panel>
-      <!---->
-      
-  
-      <!---->
-      <!---->
-      
-        
-    </div>
-    
-      
-  </div>
-  
-    
-    
-  <!---->
 </bolt-tabs>
 `;
 

--- a/packages/components/bolt-tabs/src/TabPanel/index.js
+++ b/packages/components/bolt-tabs/src/TabPanel/index.js
@@ -55,8 +55,8 @@ class TabPanel extends withContext(BoltElement) {
   updated(changedProperties) {
     super.updated && super.updated(changedProperties);
     changedProperties.forEach((oldValue, propName) => {
-      if (propName === 'selectedTab') {
-        // Keep selected attr in sync with context, triggers re-render
+      if (propName === 'selectedTab' || propName === 'panels') {
+        // Triger if either `selectedTab` or `panels` updates to keep selected attr in sync with context, triggers re-render
         if (!this.selected && this.panelIndex === this.selectedTab - 1) {
           this.setSelectedTab();
         }

--- a/packages/components/bolt-tabs/src/TabPanel/index.js
+++ b/packages/components/bolt-tabs/src/TabPanel/index.js
@@ -1,51 +1,47 @@
-import { html, customElement } from '@bolt/element';
-import { withContext, props } from '@bolt/core-v3.x/utils';
-import { withLitHtml } from '@bolt/core-v3.x/renderers/renderer-lit-html';
+import { html, customElement, BoltElement, unsafeCSS } from '@bolt/element';
+import { withContext } from 'wc-context/lit-element';
 import classNames from 'classnames/bind';
 import styles from './tab-panel.scss';
-import { TabsContext } from '../tabs';
 
 let cx = classNames.bind(styles);
 
 @customElement('bolt-tab-panel')
-class TabPanel extends withContext(withLitHtml) {
-  static props = {
-    id: props.string,
-    selected: props.boolean,
-  };
-
-  // subscribe to specific props that are defined and available on the parent container
-  // (context + subscriber idea originally from https://codepen.io/trusktr/project/editor/XbEOMk)
-  static get consumes() {
-    return [
-      [TabsContext, 'inset'],
-      [TabsContext, 'panelSpacing'],
-      [TabsContext, 'uuid'],
-      [TabsContext, 'selectedIndex'],
-      [TabsContext, 'tabPanels'],
-    ];
+class TabPanel extends withContext(BoltElement) {
+  static get properties() {
+    return {
+      id: { type: String },
+      inset: { type: String },
+      panels: { type: Object },
+      panelSpacing: { type: String },
+      selected: { type: Boolean },
+      selectedTab: { type: Number },
+      uuid: { type: String },
+    };
   }
 
-  constructor(self) {
-    self = super(self);
-
-    return self;
+  static get observedContexts() {
+    return ['inset', 'panels', 'panelSpacing', 'selectedTab', 'uuid'];
   }
 
-  get panelIndex() {
-    // Will return undefined until parent context is ready, e.g. if you call from `connectedCallback()`
-    return (
-      this.context.tabPanels && Array.from(this.context.tabPanels).indexOf(this)
-    );
+  contextChangedCallback(name, oldValue, value) {
+    this[name] = value;
+  }
+
+  static get styles() {
+    return [unsafeCSS(styles)];
   }
 
   connectedCallback() {
     super.connectedCallback && super.connectedCallback();
-    this.context = this.contexts.get(TabsContext);
+  }
+
+  get panelIndex() {
+    // Will return undefined until parent context is ready, e.g. if you call from `connectedCallback()`
+    return this.panels && this.panels.indexOf(this);
   }
 
   setSelectedTab() {
-    Array.from(this.context.tabPanels).forEach(item => {
+    this.panels.forEach(item => {
       if (item !== this) {
         item.removeAttribute('selected');
         item.selected = false;
@@ -54,88 +50,53 @@ class TabPanel extends withContext(withLitHtml) {
         item.selected = true;
       }
     });
-
-    // @todo: Do we need this? For now, let data flow always from parent.
-    // this.dispatchEvent(
-    //   new CustomEvent('tabs:setSelectedTab', {
-    //     detail: {
-    //       selectedIndex: this.panelIndex,
-    //     },
-    //     bubbles: true,
-    //   }),
-    // );
   }
 
-  template() {
-    const { uuid, selectedIndex, panelSpacing, inset } = this.context;
-
-    const index = this.panelIndex;
-
-    // Selected prop overrides selectedTab state set on parent
-    const isSelected = index === selectedIndex;
-
-    const labelledById = this.props.id
-      ? `tab-label-${this.props.id}`
-      : `tab-label-${uuid}-${index + 1}`; // Use 1-based Id's
-    const panelId = this.props.id || `tab-panel-${uuid}-${index + 1}`; // Use 1-based Id's
-
-    const classes = cx('c-bolt-tab-panel', {
-      [`c-bolt-tab-panel--spacing-${panelSpacing}`]: panelSpacing,
-      [`c-bolt-tab-panel--inset`]: inset === 'on',
-    });
-
-    const contentClasses = cx('c-bolt-tab-panel__content');
-
-    const slotMarkup = name => {
-      switch (name) {
-        case 'label':
-          return name in this.slots
-            ? this.slot(name)
-            : html`
-                <slot name="${name}" />
-              `;
-
-        default:
-          return name in this.slots
-            ? html`
-                <div
-                  class="${contentClasses}"
-                  id="${panelId}"
-                  role="tabpanel"
-                  aria-expanded="${isSelected}"
-                  tabindex="0"
-                  aria-labelledby="${labelledById}"
-                >
-                  ${this.slot('default')}
-                </div>
-              `
-            : html`
-                <slot />
-              `;
+  updated(changedProperties) {
+    super.updated && super.updated(changedProperties);
+    changedProperties.forEach((oldValue, propName) => {
+      if (propName === 'selectedTab') {
+        // Keep selected attr in sync with context, triggers re-render
+        if (!this.selected && this.panelIndex === this.selectedTab - 1) {
+          this.setSelectedTab();
+        }
       }
-    };
-
-    const innerSlots = [slotMarkup('label'), slotMarkup('default')];
-
-    return html`
-      <div class="${classes}">${innerSlots}</div>
-    `;
-  }
-
-  rendered() {
-    super.rendered && super.rendered();
-
-    const { selected } = this.validateProps(this.props);
-
-    // Keep selected attr in sync with context, triggers re-render
-    if (!selected && this.panelIndex === this.context.selectedIndex) {
-      this.setSelectedTab();
-    }
+    });
   }
 
   render() {
+    const index = this.panelIndex;
+
+    // Selected prop overrides selectedTab state set on parent
+    const isSelected = index === this.selectedTab - 1;
+
+    const labelledById = this.id
+      ? `tab-label-${this.id}`
+      : `tab-label-${this.uuid}-${index + 1}`; // Use 1-based Id's
+    const panelId = this.id || `tab-panel-${this.uuid}-${index + 1}`; // Use 1-based Id's
+
+    const classes = cx('c-bolt-tab-panel', {
+      [`c-bolt-tab-panel--spacing-${this.panelSpacing}`]: this.panelSpacing,
+      [`c-bolt-tab-panel--inset`]: this.inset === 'on',
+    });
+
     return html`
-      ${this.addStyles([styles])} ${this.template()}
+      <div class="${classes}">
+        ${this.slotMap.get('label') && this.slotify('label')}
+        ${this.slotMap.get('default') &&
+          html`
+            <div
+              class="${cx('c-bolt-tab-panel__content')}"
+              id="${panelId}"
+              role="tabpanel"
+              aria-expanded="${isSelected}"
+              tabindex="0"
+              aria-labelledby="${labelledById}"
+            >
+              ${this.slotify('default')}
+            </div>
+          `}
+      </div>
     `;
   }
 }

--- a/packages/components/bolt-tabs/src/tabs.js
+++ b/packages/components/bolt-tabs/src/tabs.js
@@ -317,8 +317,8 @@ class BoltTabs extends withContext(BoltElement) {
   }
 
   _handleExternalClicks(e) {
-    // use path not target, target won't work in shadow dom
-    const el = this.useShadow ? e.path[0] : e.target;
+    // use composedPath not target, target won't work in shadow dom
+    const el = this.useShadow ? e.composedPath()[0] : e.target;
 
     // If not inside "show more" container OR you clicked on a different set of tabs
     if (

--- a/packages/components/bolt-tabs/src/tabs.js
+++ b/packages/components/bolt-tabs/src/tabs.js
@@ -1,15 +1,12 @@
-import { html, customElement } from '@bolt/element';
+import { customElement, BoltElement, html, unsafeCSS } from '@bolt/element';
 import {
-  defineContext,
-  withContext,
-  define,
-  props,
   containsTagName,
   getUniqueId,
   whichTransitionEvent,
   waitForTransitionEnd,
 } from '@bolt/core-v3.x/utils';
-import { withLitHtml } from '@bolt/core-v3.x/renderers/renderer-lit-html';
+import { withContext } from 'wc-context/lit-element';
+
 import { smoothScroll } from '@bolt/components-smooth-scroll/src/smooth-scroll';
 import URLSearchParams from '@ungap/url-search-params'; // URLSearchParams poly for older browsers
 import classNames from 'classnames/bind';
@@ -18,43 +15,45 @@ import schema from '../tabs.schema';
 
 import '@bolt/core-v3.x/utils/optimized-resize';
 
-// define which specific props to provide to children that subscribe
-export const TabsContext = defineContext({
-  inset: 'auto',
-  panelSpacing: 'small', // no need to pass `labelSpacing`, only used in this template
-  uuid: '',
-  selectedIndex: 0,
-});
-
 let cx = classNames.bind(styles);
 
 @customElement('bolt-tabs')
-class BoltTabs extends withContext(withLitHtml) {
-  static props = {
-    align: props.string,
-    inset: props.string,
-    labelSpacing: props.string,
-    panelSpacing: props.string,
-    variant: props.string,
-    scrollOffset: props.number,
-    scrollOffsetSelector: props.string,
-    // uuid: props.string, @todo: make `uuid` a prop, for now internal only
-    // `selectedTab` is a 1-based index, everywhere else is 0-based
-    selectedTab: {
-      ...props.number,
-      ...{ default: schema.properties.selected_tab.default },
-    },
-    menuIsOpen: {
-      ...props.boolean,
-      ...{ default: false },
-    },
-  };
+class BoltTabs extends withContext(BoltElement) {
+  static schema = schema;
 
-  constructor(self) {
-    self = super(self);
-    self.schema = this.getModifiedSchema(schema);
+  static get properties() {
+    return {
+      ...this.props,
+      menuIsOpen: { type: Boolean },
+      panels: { type: Object },
+      uuid: { type: String },
+    };
+  }
 
+  constructor() {
+    super();
+    this.uuid = bolt.config.env === 'test' ? '12345' : getUniqueId(); // Set a unique identifier for each Tabs instance
+    this.menuIsOpen = false;
     this.transitionEvent = whichTransitionEvent();
+  }
+
+  static get providedContexts() {
+    return {
+      inset: { property: 'inset' },
+      panels: { property: 'panels' },
+      panelSpacing: { property: 'panelSpacing' }, // no need to pass `labelSpacing`, only used in this template
+      selectedTab: { property: 'selectedTab' }, // 1-based
+      uuid: { property: 'uuid' },
+    };
+  }
+
+  static get styles() {
+    return [unsafeCSS(styles)];
+  }
+
+  connectedCallback() {
+    super.connectedCallback && super.connectedCallback();
+
     this._resizeMenu = this._resizeMenu.bind(this);
     this._handleExternalClicks = this._handleExternalClicks.bind(this);
     this._handleDropdownToggle = this._handleDropdownToggle.bind(this);
@@ -62,27 +61,19 @@ class BoltTabs extends withContext(withLitHtml) {
       this,
     );
 
-    return self;
+    this.setInitialTab();
   }
 
-  // provide context info to children that subscribe
-  // (context + subscriber idea originally from https://codepen.io/trusktr/project/editor/XbEOMk)
-  static get provides() {
-    return [TabsContext];
-  }
+  async setInitialTab() {
+    // Wait for `bolt-tab-panel` to finish loading or `this.tabPanels` will return empty
+    const panel = this.querySelector('bolt-tab-panel');
+    if (panel) {
+      await panel.updateComplete;
+    }
 
-  connectedCallback() {
-    super.connectedCallback && super.connectedCallback();
-
-    const { selectedTab } = this.validateProps(this.props);
-
-    const panels = this.tabPanels;
-
-    // Set a unique identifier for each tab instance. Will be different on each load. For constant and/or readable `id`s, this must be exposed as a prop.
-    this.tabsId = bolt.config.env === 'test' ? '12345' : getUniqueId();
-
-    // Convert tab index to 0-based numbering with some additional validation
-    this.selectedIndex = this.validateIndex(selectedTab - 1);
+    this.panels = Array.from(this.children).filter(
+      child => child.tagName === 'BOLT-TAB-PANEL',
+    );
 
     // Check if any panels have `selected` prop set, return index
     // const preselectedIndex = Array.from(panels).findIndex(element => {
@@ -90,21 +81,21 @@ class BoltTabs extends withContext(withLitHtml) {
     // });
 
     // @todo: replace this with the block above once `findIndex` can be safely polyfilled
-    const panelsArray = Array.from(panels);
-    const preselectedIndex = panelsArray.indexOf(
-      panelsArray.find(element => element.hasAttribute('selected')),
+    const preselectedIndex = this.panels.indexOf(
+      this.panels.find(element => element.hasAttribute('selected')),
     );
 
     // If there is a preselected panel, it overrides `selectedTab` prop
     const initialSelectedTab =
-      preselectedIndex !== -1 ? preselectedIndex : this.selectedIndex;
+      preselectedIndex !== -1
+        ? preselectedIndex
+        : this.validateIndex(this.selectedTab - 1);
 
-    // If there is a deep link in the URL (i.e. a query param with `tab` as name, `TAB_ID` as value),
-    // it overrides`initialSelectedTab`
+    // If there is a deep link in the URL (i.e. a query param with `tab` as name, `TAB_ID` as value), it overrides`initialSelectedTab`
     const urlParams = new URLSearchParams(window.location.search);
     const selectedTabParam = urlParams.get('selected-tab');
-    const selectedTabParamIndex = panelsArray.indexOf(
-      panelsArray.find(element => element.id === selectedTabParam),
+    const selectedTabParamIndex = this.panels.indexOf(
+      this.panels.find(element => element.id === selectedTabParam),
     );
 
     if (selectedTabParamIndex !== -1) {
@@ -113,56 +104,17 @@ class BoltTabs extends withContext(withLitHtml) {
     } else {
       this.setSelectedTab(initialSelectedTab);
     }
-
-    // @todo: Only need this if we want to listen for `selected` attribute changes on children. For now, just do a one-time check on setup.
-    // this.addEventListener('tabs:setSelectedTab', e => {
-    //   const newIndex = e.detail.selectedIndex;
-    //   if (this.selectedIndex !== newIndex) {
-    //     if (Array.from(panels).includes(e.target)) {
-    //       this.setSelectedTab(newIndex);
-    //     }
-    //   }
-    // });
-  }
-
-  // account for nested tabs when rendering to the Shadow DOM + Light DOM
-  get tabPanels() {
-    if (this.useShadow) {
-      return Array.from(this.children).filter(
-        child => child.tagName === 'BOLT-TAB-PANEL',
-      );
-    } else if (this.slots && this.slots.default !== undefined) {
-      return Array.from(this.slots.default).filter(
-        child => child.tagName === 'BOLT-TAB-PANEL',
-      );
-    } else {
-      return this.getElementsByTagName('bolt-tab-panel');
-    }
-  }
-
-  // Get tab labels, excluding duplicate labels in the "show more" menu
-  get tabLabels() {
-    return this.renderRoot.querySelectorAll(
-      '.c-bolt-tabs__label:not(.c-bolt-tabs__label--is-duplicate)',
-    );
-  }
-
-  // Get tab labels in the "show more" menu
-  get dropdownTabLabels() {
-    return this.renderRoot.querySelectorAll(
-      '.c-bolt-tabs__label.c-bolt-tabs__label--is-duplicate',
-    );
   }
 
   validateIndex(index) {
-    const panels = this.tabPanels;
-
-    return index < 0 ? 0 : index >= panels.length ? panels.length - 1 : index;
+    return index < 0
+      ? 0
+      : index >= this.panels.length
+      ? this.panels.length - 1
+      : index;
   }
 
   addMutationObserver() {
-    const self = this;
-
     // todo: this.useShadow is a temporary workaround until mutation observer works better with light DOM
     if (window.MutationObserver && this.useShadow) {
       // Re-generate slots + re-render when mutations are observed
@@ -171,7 +123,7 @@ class BoltTabs extends withContext(withLitHtml) {
           if (mutation.type === 'childList') {
             // @todo: add, remove, reorder
             if (containsTagName(mutation.addedNodes, 'BOLT-TAB-PANEL')) {
-              self.triggerUpdate();
+              this.triggerUpdate();
             }
           } else if (mutation.type === 'attributes') {
             // @todo: see `bolt-accordion` as reference for WIP attribute mutation handler
@@ -180,10 +132,10 @@ class BoltTabs extends withContext(withLitHtml) {
       };
 
       // Create an observer instance linked to the callback function
-      self.observer = new MutationObserver(mutationCallback);
+      this.observer = new MutationObserver(mutationCallback);
 
       // Start observing the target node for configured mutations
-      self.observer.observe(this, {
+      this.observer.observe(this, {
         attributes: true,
         childList: true,
         subtree: true,
@@ -195,11 +147,8 @@ class BoltTabs extends withContext(withLitHtml) {
   setSelectedTab(index) {
     const newIndex = this.validateIndex(index);
 
-    if (newIndex !== this.selectedIndex) {
-      this.selectedIndex = newIndex;
-
+    if (newIndex !== this.selectedTab - 1) {
       this.setAttribute('selected-tab', newIndex + 1); // Convert `selectedTab` back to 1-based scale
-      this.contexts.get(TabsContext).selectedIndex = newIndex; // Keep context 0-based
 
       // set timeout allows time for sub component to re-render, better that than putting this on the sub component where it'll be fired many more times than needed
       setTimeout(() => {
@@ -231,151 +180,51 @@ class BoltTabs extends withContext(withLitHtml) {
   }
 
   handleOnKeyup(e) {
-    const panels = this.tabPanels;
+    const index = this.selectedTab - 1;
     let newIndex;
 
     switch (e.keyCode) {
       case 35: // end key
-        newIndex = panels.length - 1;
+        newIndex = this.panels.length - 1;
         break;
       case 36: // home key
         newIndex = 0;
         break;
       case 37: // left arrow
-        newIndex = this.selectedIndex > 0 ? this.selectedIndex - 1 : 0;
+        newIndex = index > 0 ? index - 1 : 0;
         break;
       case 39: // right arrow
         newIndex =
-          this.selectedIndex < panels.length - 1
-            ? this.selectedIndex + 1
-            : panels.length - 1;
+          index < this.panels.length - 1 ? index + 1 : this.panels.length - 1;
         break;
     }
 
     // If any of the above keys were pressed, toggle the menu (if needed), update selected tab, and set focus.
     if (newIndex !== undefined) {
+      // Get tab labels, excluding duplicate labels in the "show more" menu
+      const tabLabels = this.renderRoot.querySelectorAll(
+        '.c-bolt-tabs__label:not(.c-bolt-tabs__label--is-duplicate)',
+      );
+      // Get tab labels in the "show more" menu
+      const dropdownTabLabels = this.renderRoot.querySelectorAll(
+        '.c-bolt-tabs__label.c-bolt-tabs__label--is-duplicate',
+      );
+
       // If menu button is displayed, handle keying in and out of the dropdown. Do this before setting focus, or target will be hidden and focus may not be set.
       if (!this.menuButtonIsHidden) {
-        if (this.tabLabels[newIndex].classList.contains('is-hidden')) {
+        if (tabLabels[newIndex].classList.contains('is-hidden')) {
           !this.menuIsOpen && this.openDropdown();
         } else {
           this.menuIsOpen && this.closeDropdown();
         }
       }
 
-      this.tabLabels[newIndex].classList.contains('is-hidden')
-        ? this.dropdownTabLabels[newIndex].focus()
-        : this.tabLabels[newIndex].focus();
+      tabLabels[newIndex].classList.contains('is-hidden')
+        ? dropdownTabLabels[newIndex].focus()
+        : tabLabels[newIndex].focus();
 
       this.setSelectedTab(newIndex);
     }
-  }
-
-  template() {
-    const { align, labelSpacing, panelSpacing, inset } = this.validateProps(
-      this.props,
-    );
-
-    const classes = cx('c-bolt-tabs', {
-      [`c-bolt-tabs--align-${align}`]: align,
-      [`c-bolt-tabs--inset`]: inset === 'auto' || inset === 'on',
-      [`c-bolt-tabs--show-dropdown`]: this.menuIsOpen,
-    });
-    const labelInnerClasses = cx('c-bolt-tabs__label-inner');
-    const labelTextClasses = cx('c-bolt-tabs__label-text');
-    const listClasses = cx('c-bolt-tabs__nav', {});
-    const panelsClasses = cx('c-bolt-tabs__panels-container');
-
-    const handleLabelClick = (e, index) => {
-      this.setSelectedTab(index);
-      this.menuIsOpen && this.closeDropdown();
-    };
-
-    const tabButtons = isDropdown => {
-      let buttons = [];
-
-      Array.from(this.tabPanels).forEach((item, index) => {
-        const isSelected = index === this.selectedIndex;
-        const label = item.querySelector('[slot="label"]');
-        const labelClasses = cx('c-bolt-tabs__label', 'c-bolt-tabs__item', {
-          [`c-bolt-tabs__label--spacing-${labelSpacing}`]: labelSpacing,
-          [`c-bolt-tabs__label--is-duplicate`]: isDropdown,
-          [`c-bolt-tabs__label--vertical-border`]: isDropdown,
-        });
-        const labelText = label ? label.textContent : `Tab label ${index + 1}`; // @todo: add icon support? how to handle missing labels?
-
-        // Dropdowns are duplicate labels and get different ID prefix
-        const labelPrefix = isDropdown ? 'tab-dropdown' : 'tab-label';
-
-        const labelId = item.id
-          ? `${labelPrefix}-${item.id}`
-          : `${labelPrefix}-${this.tabsId}-${index + 1}`; // Use 1-based Id's
-
-        const panelId = item.id || `tab-panel-${this.tabsId}-${index + 1}`; // Use 1-based Id's
-
-        let button = html`
-          <bolt-trigger
-            class="${labelClasses}"
-            no-outline
-            display="${isDropdown ? 'block' : 'inline'}"
-            role="tab"
-            aria-selected="${isSelected}"
-            aria-controls="${panelId}"
-            id="${labelId}"
-            tabindex="${isSelected ? 0 : -1}"
-            @click=${e => handleLabelClick(e, index)}
-            @keydown=${e => this.handleOnKeydown(e)}
-            @keyup=${e => this.handleOnKeyup(e)}
-          >
-            <span class="${labelInnerClasses}"
-              ><span class="${labelTextClasses}">${labelText}</span></span
-            >
-          </bolt-trigger>
-        `;
-
-        buttons.push(button);
-      });
-
-      return buttons;
-    };
-
-    const dropdown = () => {
-      return html`
-        <div class="${cx('c-bolt-tabs__item', 'c-bolt-tabs__show-more')}">
-          <button
-            type="button"
-            aria-haspopup="true"
-            aria-expanded="${this.menuIsOpen}"
-            class="${cx('c-bolt-tabs__button', 'c-bolt-tabs__show-button')}"
-            @keydown=${e => this.handleOnKeydown(e)}
-            @keyup=${e => this.handleOnKeyup(e)}
-          >
-            <span class="${cx('c-bolt-tabs__show-text')}">
-              ${this.props.moreText ? this.props.moreText : 'More'}
-            </span>
-            <span class="${cx('c-bolt-tabs__show-icon')}">
-              <bolt-icon name="chevron-down"></bolt-icon>
-            </span>
-          </button>
-          <div class="${cx('c-bolt-tabs__dropdown')}">
-            <div class="${cx('c-bolt-tabs__dropdown-list')}">
-              ${tabButtons(true)}
-            </div>
-          </div>
-        </div>
-      `;
-    };
-
-    return html`
-      <div class="${classes}">
-        <div class="${listClasses}" role="tablist">
-          ${tabButtons()} ${dropdown()}
-        </div>
-        <div class="${panelsClasses}">
-          ${this.slots.default ? this.slot('default') : ''}
-        </div>
-      </div>
-    `;
   }
 
   _hideLabel(el) {
@@ -476,7 +325,7 @@ class BoltTabs extends withContext(withLitHtml) {
       el.closest('.c-bolt-tabs__show-more') === null ||
       !this.renderRoot.contains(el)
     ) {
-      this.closeDropdown();
+      this.menuIsOpen && this.closeDropdown();
       document.removeEventListener('click', this._handleExternalClicks);
     }
   }
@@ -547,8 +396,8 @@ class BoltTabs extends withContext(withLitHtml) {
     this._resizeMenu();
   }
 
-  rendered() {
-    super.rendered && super.rendered();
+  firstUpdated() {
+    super.firstUpdated && super.firstUpdated();
 
     if (!this.ready) {
       // Now that the template has rendered, we can query the page for the parts we need to update after the fact
@@ -570,8 +419,7 @@ class BoltTabs extends withContext(withLitHtml) {
       this.priorityDropdown = this.renderRoot.querySelector(
         '.c-bolt-tabs__dropdown',
       );
-
-      Promise.all([customElements.whenDefined('bolt-trigger')]).then(_ => {
+      customElements.whenDefined('bolt-trigger').then(() => {
         this._resizeMenu();
       });
 
@@ -595,9 +443,15 @@ class BoltTabs extends withContext(withLitHtml) {
       }
 
       setTimeout(() => {
-        smoothScroll.animateScroll(this, 0, {
-          header: this.props.scrollOffsetSelector,
-          offset: this.props.scrollOffset,
+        // Must scroll to focusable element or smoothScroll will set tabindex="-1" on target element.
+        // @see https://github.com/cferdinandi/smooth-scroll/blob/master/src/core.js#L320
+        const targetTab = this.renderRoot.querySelector(
+          'bolt-trigger[aria-selected="true"]',
+        );
+
+        smoothScroll.animateScroll(targetTab, 0, {
+          header: this.scrollOffsetSelector,
+          offset: this.scrollOffset,
           speed: 750,
           easing: 'easeInOutCubic',
           updateURL: false,
@@ -618,8 +472,8 @@ class BoltTabs extends withContext(withLitHtml) {
     }
   }
 
-  disconnected() {
-    super.disconnected && super.disconnected();
+  disconnectedCallback() {
+    super.disconnectedCallback && super.disconnectedCallback();
 
     this.ready = false;
     this.removeAttribute('ready');
@@ -639,18 +493,104 @@ class BoltTabs extends withContext(withLitHtml) {
   }
 
   render() {
-    const { inset, panelSpacing, selectedTab } = this.validateProps(this.props);
+    const classes = cx('c-bolt-tabs', {
+      [`c-bolt-tabs--align-${this.align}`]: this.align,
+      [`c-bolt-tabs--inset`]: this.inset === 'auto' || this.inset === 'on',
+      [`c-bolt-tabs--show-dropdown`]: this.menuIsOpen,
+    });
 
-    this.selectedIndex = this.validateIndex(selectedTab - 1);
+    const handleLabelClick = (e, index) => {
+      this.setSelectedTab(index);
+      this.menuIsOpen && this.closeDropdown();
+    };
 
-    this.contexts.get(TabsContext).inset = inset;
-    this.contexts.get(TabsContext).panelSpacing = panelSpacing;
-    this.contexts.get(TabsContext).uuid = this.tabsId;
-    this.contexts.get(TabsContext).selectedIndex = this.selectedIndex;
-    this.contexts.get(TabsContext).tabPanels = this.tabPanels;
+    const tabButtons = isDropdown => {
+      let buttons = [];
+
+      this.panels.forEach((item, index) => {
+        const isSelected = index === this.selectedTab - 1;
+        const label = item.querySelector('[slot="label"]');
+        const labelClasses = cx('c-bolt-tabs__label', 'c-bolt-tabs__item', {
+          [`c-bolt-tabs__label--spacing-${this.labelSpacing}`]: this
+            .labelSpacing,
+          [`c-bolt-tabs__label--is-duplicate`]: isDropdown,
+          [`c-bolt-tabs__label--vertical-border`]: isDropdown,
+        });
+        const labelText = label ? label.textContent : `Tab label ${index + 1}`; // @todo: add icon support? how to handle missing labels?
+
+        // Dropdowns are duplicate labels and get different ID prefix
+        const labelPrefix = isDropdown ? 'tab-dropdown' : 'tab-label';
+
+        const labelId = item.id
+          ? `${labelPrefix}-${item.id}`
+          : `${labelPrefix}-${this.uuid}-${index + 1}`; // Use 1-based Id's
+
+        const panelId = item.id || `tab-panel-${this.uuid}-${index + 1}`; // Use 1-based Id's
+
+        let button = html`
+          <bolt-trigger
+            class="${labelClasses}"
+            no-outline
+            display="${isDropdown ? 'block' : 'inline'}"
+            role="tab"
+            aria-selected="${isSelected}"
+            aria-controls="${panelId}"
+            id="${labelId}"
+            tabindex="${isSelected ? 0 : -1}"
+            @click=${e => handleLabelClick(e, index)}
+            @keydown=${e => this.handleOnKeydown(e)}
+            @keyup=${e => this.handleOnKeyup(e)}
+          >
+            <span class="${cx('c-bolt-tabs__label-inner')}"
+              ><span class="${cx('c-bolt-tabs__label-text')}"
+                >${labelText}</span
+              ></span
+            >
+          </bolt-trigger>
+        `;
+
+        buttons.push(button);
+      });
+
+      return buttons;
+    };
+
+    const dropdown = () => {
+      return html`
+        <div class="${cx('c-bolt-tabs__item', 'c-bolt-tabs__show-more')}">
+          <button
+            type="button"
+            aria-haspopup="true"
+            aria-expanded="${this.menuIsOpen}"
+            class="${cx('c-bolt-tabs__button', 'c-bolt-tabs__show-button')}"
+            @keydown=${e => this.handleOnKeydown(e)}
+            @keyup=${e => this.handleOnKeyup(e)}
+          >
+            <span class="${cx('c-bolt-tabs__show-text')}">
+              ${this.moreText ? this.moreText : 'More'}
+            </span>
+            <span class="${cx('c-bolt-tabs__show-icon')}">
+              <bolt-icon name="chevron-down"></bolt-icon>
+            </span>
+          </button>
+          <div class="${cx('c-bolt-tabs__dropdown')}">
+            <div class="${cx('c-bolt-tabs__dropdown-list')}">
+              ${tabButtons(true)}
+            </div>
+          </div>
+        </div>
+      `;
+    };
 
     return html`
-      ${this.addStyles([styles])} ${this.template()}
+      <div class="${classes}">
+        <div class="${cx('c-bolt-tabs__nav')}" role="tablist">
+          ${tabButtons()} ${dropdown()}
+        </div>
+        <div class="${cx('c-bolt-tabs__panels-container')}">
+          ${this.slotMap.get('default') && this.slotify('default')}
+        </div>
+      </div>
     `;
   }
 }


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-198

## Summary

Convert Tabs component to BoltElement renderer.

## Details

Convert Tabs to use new renderer, along with new `wc-context` library.

Because `wc-context` works well with props, it made sense to convert some variables into internal props. As that conversion was underway, I noticed there was some unnecessary complexity (written by yours truly) that it made sense to simplify just to better understand how the component worked. So this PR does includes some careful rework in addition to the renderer upgrade.

Test snapshots are updated. Due to errors waiting for promises to resolve in Puppeteer, some of the updated snapshots are taken before the component finishes updating, so they're not very helpful. I commented out the Light DOM test as there's a bug with `conditional-shadow-dom` that's out of scope of this update ([ticket](https://pegadigitalit.atlassian.net/browse/DS-226)). The Tabs `no-shadow` demo works as expected, so I think it's safe to disable this test for now.

## How to test

- Review code changes (there are a lot)
- Review all Tabs demos
- Also review Accordion Content demo which has Tabs as content in an Accordion Item