### PR TITLE
DS-184: Video error message styling doesn't always work

### DIFF
--- a/packages/components/bolt-video/src/_videojs-enhancements.scss
+++ b/packages/components/bolt-video/src/_videojs-enhancements.scss
@@ -367,6 +367,7 @@ $bolt-video-js-button-shadow-level-hover: 'level-40';
       }
 
       .vjs-errors-headline,
+      .vjs-errors-message,
       .vjs-errors-ref-id {
         display: block;
         width: 100%;
@@ -384,6 +385,19 @@ $bolt-video-js-button-shadow-level-hover: 'level-40';
 
       .vjs-errors-headline + div {
         font-size: var(--bolt-type-font-size-xsmall);
+      }
+
+      .vjs-errors-details {
+        margin-top: 4px;
+        font-size: 0;
+      }
+
+      .vjs-errors-message {
+        margin: 0;
+        padding: 0;
+        font-size: var(--bolt-type-font-size-xsmall);
+        border: 0;
+        background-color: transparent;
       }
 
       .vjs-errors-ref-id {


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-184

## Summary

Updated the brightcove video styles to style the details section

## Details

CSS changes to fix the brightcove error message.

## How to test

Unfortunately I am not sure how to set this up to test without manually updating the DOM in the inspector. I have attached a screenshot of the styled message (the "The media could not be loaded, either because the server or network failed or because the format is not supported." is the additional styled bit).

<img width="808" alt="Screen Shot 2020-09-28 at 1 21 06 PM" src="https://user-images.githubusercontent.com/1932313/94466104-e42bed80-018e-11eb-94ef-7dd9b80338a4.png">



