### PR TITLE
DS-231 Update Menu 'core' dependency, JS conventions

### DIFF
--- a/packages/components/bolt-menu/package.json
+++ b/packages/components/bolt-menu/package.json
@@ -19,7 +19,7 @@
   "style": "index.scss",
   "dependencies": {
     "@bolt/components-trigger": "^2.28.0",
-    "@bolt/core": "^2.28.0",
+    "@bolt/core-v3.x": "^2.28.0",
     "@bolt/lazy-queue": "^2.23.0",
     "wc-context": "^0.9.0"
   },

--- a/packages/components/bolt-menu/src/_menu-item.js
+++ b/packages/components/bolt-menu/src/_menu-item.js
@@ -2,27 +2,25 @@ import {
   customElement,
   BoltElement,
   html,
-  styleMap,
   unsafeCSS,
   ifDefined,
 } from '@bolt/element';
 import classNames from 'classnames/dedupe';
-import { withContext } from 'wc-context';
+import { withContext } from 'wc-context/lit-element';
 import menuStyles from './_menu-item.scss';
 import schema from '../menu.schema';
 
 let cx = classNames.bind(menuStyles);
 
-/*
- * 1 - @todo: remove SSR Hydration from this file, move to base
- */
-
 @customElement('bolt-menu-item')
 class BoltMenuItem extends withContext(BoltElement) {
+  static schema = schema;
+
   static get properties() {
+    const { url, spacing } = this.props;
     return {
-      url: String,
-      spacing: String,
+      url,
+      spacing,
       role: {
         type: String,
         reflect: true,
@@ -38,45 +36,13 @@ class BoltMenuItem extends withContext(BoltElement) {
     this[name] = value;
   }
 
-  constructor() {
-    super();
-    this.role = 'presentation';
-  }
-
   static get styles() {
     return [unsafeCSS(menuStyles)];
   }
 
-  /* [1] */
-  connectedCallback() {
-    super.connectedCallback && super.connectedCallback();
-
-    // Check if any `<ssr-keep>` elements have registered themselves here. If so, kick off the one-time hydration prep task.
-    if (this.ssrKeep && !this.ssrPrepped) {
-      this.ssrHydrationPrep();
-    }
-  }
-
-  /* [1] */
-  ssrHydrationPrep() {
-    // @todo: Move this to base-element, possibly as decorator
-    this.nodesToKeep = [];
-
-    this.ssrKeep.forEach(item => {
-      while (item.firstChild) {
-        this.nodesToKeep.push(item.firstChild); // track the nodes that will be preserved
-        this.appendChild(item.firstChild);
-      }
-    });
-
-    // Remove all children not in the "keep" array
-    Array.from(this.children)
-      .filter(item => !this.nodesToKeep.includes(item))
-      .forEach(node => {
-        node.parentElement.removeChild(node);
-      });
-
-    this.ssrPrepped = true;
+  constructor() {
+    super();
+    this.role = 'presentation';
   }
 
   get parentComponent() {

--- a/packages/components/bolt-menu/src/_menu-item.scss
+++ b/packages/components/bolt-menu/src/_menu-item.scss
@@ -2,7 +2,7 @@
    Menu
 \* ------------------------------------ */
 
-@import '@bolt/core';
+@import '@bolt/core-v3.x';
 @import './_menu-settings-and-tools.scss';
 
 // Register Custom Block Element

--- a/packages/components/bolt-menu/src/menu.js
+++ b/packages/components/bolt-menu/src/menu.js
@@ -1,13 +1,6 @@
-import { supportsCSSVars } from '@bolt/core/utils';
 import classNames from 'classnames/dedupe';
-import {
-  customElement,
-  BoltElement,
-  html,
-  styleMap,
-  unsafeCSS,
-} from '@bolt/element';
-import { withContext } from 'wc-context';
+import { customElement, BoltElement, html, unsafeCSS } from '@bolt/element';
+import { withContext } from 'wc-context/lit-element';
 import menuStyles from './menu.scss';
 import schema from '../menu.schema';
 
@@ -29,8 +22,12 @@ class BoltMenu extends withContext(BoltElement) {
 
   static get providedContexts() {
     return {
-      spacing: { value: schema.properties.spacing.default },
+      spacing: { property: 'spacing' },
     };
+  }
+
+  static get styles() {
+    return [unsafeCSS(menuStyles)];
   }
 
   constructor() {
@@ -38,26 +35,9 @@ class BoltMenu extends withContext(BoltElement) {
     this.role = 'menu';
   }
 
-  static get styles() {
-    return [unsafeCSS(menuStyles)];
-  }
-
-  connectedCallback() {
-    super.connectedCallback && super.connectedCallback();
-
-    this.updateProvidedContext(
-      'spacing',
-      this.spacing || schema.properties.spacing.default,
-    );
-  }
-
   render() {
-    // @todo: automatic schema validation?
-    const spacing = this.spacing || schema.properties.spacing.default;
-    this.updateProvidedContext('spacing', spacing);
-
     const classes = cx('c-bolt-menu__title', {
-      [`c-bolt-menu__title--spacing-${spacing}`]: spacing,
+      [`c-bolt-menu__title--spacing-${this.spacing}`]: this.spacing,
     });
 
     return html`

--- a/packages/components/bolt-menu/src/menu.scss
+++ b/packages/components/bolt-menu/src/menu.scss
@@ -2,7 +2,7 @@
    Menu
 \* ------------------------------------ */
 
-@import '@bolt/core';
+@import '@bolt/core-v3.x';
 @import './_menu-settings-and-tools.scss';
 
 // Register Custom Block Element


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-231

## Summary

Update Menu 'core' dependency to `@bolt/core-v3.x`. Update Menu JS to use the latest conventions.

## Details

- Update to `@bolt/core-v3.x`. All components should use this now. It was an oversight that it used the old `@bolt/core` when first created.
- Switch from `wc-context` to `wc-context/lit-element`.
- Remove `ssrHydrationPrep()`. This is now in the base class.

> Note: this is the last known use of `@bolt/core` in the repo. Upgrading this allows us to consolidate 'core' in `v3.0`.

## How to test

- Review code changes.
- Test Menu demos on feature branch for regressions.
