### PR TITLE
Update Chromedriver

### DIFF
--- a/packages/testing/testing-nightwatch/package.json
+++ b/packages/testing/testing-nightwatch/package.json
@@ -18,7 +18,7 @@
   "main": "nightwatch.js",
   "dependencies": {
     "@zeit/fetch-retry": "^4.0.1",
-    "chromedriver": "^84.0.0",
+    "chromedriver": "^86.0.0",
     "ci-utils": "^0.6.0",
     "geckodriver": "^1.16.2",
     "globby": "^10.0.1",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -23,7 +23,7 @@
     "querystring": "^0.2.0"
   },
   "optionalDependencies": {
-    "chromedriver": "^84.0.0",
+    "chromedriver": "^86.0.0",
     "geckodriver": "^1.19.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5631,10 +5631,10 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@^84.0.0:
-  version "84.0.1"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-84.0.1.tgz#eaca7723f1a58c262a5c521b8596769af40b0d4f"
-  integrity sha512-iJ6Y680yp58+KlAPS5YgYe3oePVFf8jY5k4YoczhXkT0p/mQZKfGNkGG/Xc0LjGWDQRTgZwXg66hOXoApIQecg==
+chromedriver@^86.0.0:
+  version "86.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-86.0.0.tgz#4b9504d5bbbcd4c6bd6d6fd1dd8247ab8cdeca67"
+  integrity sha512-byLJWhAfuYOmzRYPDf4asJgGDbI4gJGHa+i8dnQZGuv+6WW1nW1Fg+8zbBMOfLvGn7sKL41kVdmCEVpQHn9oyg==
   dependencies:
     "@testim/chrome-version" "^1.0.7"
     axios "^0.19.2"


### PR DESCRIPTION
## Jira

n/a

## Summary

Update Chromedriver to fix failing Nightwatch tests on Travis.

## Details

A new stable Chromedriver version was released a few hours ago: https://github.com/giggio/node-chromedriver/tags

Travis uses latest stable and we lock ours down. Manually update our local Chromedrivers to be compatible with what's running on Travis.

## How to test

Tests are passing.