### PR TITLE
ACD-286 Academy popover overflow bug

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/02-molecules/cards/_horizontal-card.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/02-molecules/cards/_horizontal-card.twig
@@ -24,83 +24,79 @@
   {% endblock %}
 
   {% block body %}
-    {# <div class="c-bolt-card__overflow-menu c-bolt-card__overflow-menu--top c-bolt-card__overflow-menu--right">
-      <bolt-overflow-menu
-        flip-menu
-        label="Oveflow menu"
-        tip-position="left"
-        tip-alignment="center"
-      >
-        <bolt-overflow-menu-item>list item 1</bolt-overflow-menu-item>
-        <bolt-overflow-menu-item>list item 2</bolt-overflow-menu-item>
-        <bolt-overflow-menu-item>list item 3</bolt-overflow-menu-item>
-      </bolt-overflow-menu>
-    </div> #}
-
-    <div class="o-bolt-grid o-bolt-grid--flex o-bolt-grid--matrix o-bolt-grid--xsmall u-bolt-negative-margin-top-small u-bolt-negative-margin-right-small">
-      <div class="o-bolt-grid__cell u-bolt-margin-left-auto">
-      </div>
-    </div>
-
-    <div class="u-bolt-overflow-hidden">
-      {% grid "o-bolt-grid--flex o-bolt-grid--matrix o-bolt-grid--border" %}
-        {% cell "u-bolt-width-12/12 u-bolt-width-6/12@small" %}
-
-          {% set cardTextContent %}
-            {% if cardSubtitle %}
-              {% include "@bolt-components-headline/eyebrow.twig" with {
-                text: cardSubtitle,
-                weight: "semibold"
-              } only %}
-            {% endif %}
-
-            {% if cardTitle %}
-              {# {% include "@bolt-components-headline/headline.twig" with {
-                text: cardTitle,
-                size: "large",
-              } only %} #}
-              <h2>{{ cardTitle }}</h2>
-            {% endif %}
-          {% endset %}
-
-          {% include "@bolt-components-stack/stack.twig" with {
-            content: cardTextContent,
-            spacing: "xsmall"
+    {% set leftContent %}
+      {% set cardTextContent %}
+        {% if cardSubtitle %}
+          {% include "@bolt-components-headline/eyebrow.twig" with {
+            text: cardSubtitle,
+            weight: "semibold"
           } only %}
-
-          {% if cardMetaItems %}
-            {% set cardMetaContent %}
-              {% include "@bolt-components-list/list.twig" with {
-                display: "inline",
-                separator: "solid",
-                tag: "ul",
-                items: cardMetaItems
-              } only %}
-            {% endset %}
-
-            {% include "@bolt-components-stack/stack.twig" with {
-              content: cardMetaContent,
-              spacing: "xsmall"
-            } only %}
-          {% endif %}
-        {% endcell %}
-
-        {% if cardDescription %}
-          {% cell "u-bolt-width-12/12 u-bolt-width-6/12@small" %}
-            {% include "@bolt-components-headline/text.twig" with {
-              text: cardDescription,
-              size: "small",
-              attributes: {
-                class: [
-                  "u-bolt-padding-top-xsmall@small",
-                  "u-bolt-padding-bottom-xsmall@small",
-                ]
-              }
-            } only %}
-          {% endcell %}
         {% endif %}
-      {% endgrid %}
-    </div>
+
+        {% if cardTitle %}
+          <h2>{{ cardTitle }}</h2>
+        {% endif %}
+      {% endset %}
+
+      {% include "@bolt-components-stack/stack.twig" with {
+        content: cardTextContent,
+        spacing: "xsmall"
+      } only %}
+
+      {% if cardMetaItems %}
+        {% set cardMetaContent %}
+          {% include "@bolt-components-list/list.twig" with {
+            display: "inline",
+            separator: "solid",
+            tag: "ul",
+            items: cardMetaItems
+          } only %}
+        {% endset %}
+
+        {% include "@bolt-components-stack/stack.twig" with {
+          content: cardMetaContent,
+          spacing: "xsmall"
+        } only %}
+      {% endif %}
+    {% endset %}
+
+    {% set rightContent %}
+      {% if cardDescription %}
+        {% include "@bolt-components-headline/text.twig" with {
+          text: cardDescription,
+          size: "small",
+          attributes: {
+            class: [
+              "u-bolt-padding-top-xsmall@small",
+              "u-bolt-padding-bottom-xsmall@small",
+            ]
+          }
+        } only %}
+      {% endif %}
+    {% endset %}
+
+    {% include "@bolt-components-list/list.twig" with {
+      display: "inline@small",
+      separator: "solid",
+      spacing: "small",
+      attributes: {
+        class: 'o-bolt-grid--flex o-bolt-grid--matrix o-bolt-grid--border'
+      },
+      items: [
+        {
+          content: leftContent,
+          attributes: {
+            class: 'u-bolt-width-12/12 u-bolt-width-6/12@small'
+          }
+        },
+        {
+          content: rightContent,
+          attributes: {
+            class: 'u-bolt-width-12/12 u-bolt-width-6/12@small'
+          }
+        },
+      ]
+    } only %}
   {% endblock %}
 
 {% endembed %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/02-molecules/cards/_horizontal-card.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/02-molecules/cards/_horizontal-card.twig
@@ -24,58 +24,61 @@
   {% endblock %}
 
   {% block body %}
-  <ul class="c-acd-horizontal-card">
-    <li>
-      {% set cardTextContent %}
-        {% if cardSubtitle %}
-          {% include "@bolt-components-headline/eyebrow.twig" with {
-            text: cardSubtitle,
-            weight: "semibold"
-          } only %}
-        {% endif %}
+    <ul class="c-acd-horizontal-card-grid">
+      <li>
+        {% set cardTextContent %}
+          {% if cardSubtitle %}
+            {% include "@bolt-components-headline/eyebrow.twig" with {
+              text: cardSubtitle,
+              weight: "semibold"
+            } only %}
+          {% endif %}
 
-        {% if cardTitle %}
-          <h2>{{ cardTitle }}</h2>
-        {% endif %}
-      {% endset %}
-
-      {% include "@bolt-components-stack/stack.twig" with {
-        content: cardTextContent,
-        spacing: "xsmall"
-      } only %}
-
-      {% if cardMetaItems %}
-        {% set cardMetaContent %}
-          {% include "@bolt-components-list/list.twig" with {
-            display: "inline",
-            separator: "solid",
-            tag: "ul",
-            items: cardMetaItems
-          } only %}
+          {% if cardTitle %}
+            {% include "@bolt-components-headline/headline.twig" with {
+              text: cardTitle,
+              size: "xlarge"
+            } only %}
+          {% endif %}
         {% endset %}
 
         {% include "@bolt-components-stack/stack.twig" with {
-          content: cardMetaContent,
+          content: cardTextContent,
           spacing: "xsmall"
         } only %}
-      {% endif %}
-    </li>
 
-    {% if cardDescription %}
-      <li class="u-bolt-flex@small u-bolt-align-items-center">
-        {% include "@bolt-components-headline/text.twig" with {
-          text: cardDescription,
-          size: "small",
-          attributes: {
-            class: [
-              "u-bolt-padding-top-xsmall@small",
-              "u-bolt-padding-bottom-xsmall@small",
-            ]
-          }
-        } only %}
+        {% if cardMetaItems %}
+          {% set cardMetaContent %}
+            {% include "@bolt-components-list/list.twig" with {
+              display: "inline",
+              separator: "solid",
+              tag: "ul",
+              items: cardMetaItems
+            } only %}
+          {% endset %}
+
+          {% include "@bolt-components-stack/stack.twig" with {
+            content: cardMetaContent,
+            spacing: "xsmall"
+          } only %}
+        {% endif %}
       </li>
-    {% endif %}
-  </ul>
+
+      {% if cardDescription %}
+        <li class="u-bolt-flex@small u-bolt-align-items-center">
+          {% include "@bolt-components-headline/text.twig" with {
+            text: cardDescription,
+            size: "small",
+            attributes: {
+              class: [
+                "u-bolt-padding-top-xsmall@small",
+                "u-bolt-padding-bottom-xsmall@small",
+              ]
+            }
+          } only %}
+        </li>
+      {% endif %}
+    </ul>
   {% endblock %}
 
 {% endembed %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/02-molecules/cards/_horizontal-card.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/02-molecules/cards/_horizontal-card.twig
@@ -37,30 +37,50 @@
       </bolt-overflow-menu>
     </div> #}
 
+    <div class="o-bolt-grid o-bolt-grid--flex o-bolt-grid--matrix o-bolt-grid--xsmall u-bolt-negative-margin-top-small u-bolt-negative-margin-right-small">
+      <div class="o-bolt-grid__cell u-bolt-margin-left-auto">
+      </div>
+    </div>
+
     <div class="u-bolt-overflow-hidden">
       {% grid "o-bolt-grid--flex o-bolt-grid--matrix o-bolt-grid--border" %}
         {% cell "u-bolt-width-12/12 u-bolt-width-6/12@small" %}
-          {% if cardSubtitle %}
-            {% include "@bolt-components-headline/eyebrow.twig" with {
-              text: cardSubtitle,
-            } only %}
-          {% endif %}
 
-          {% if cardTitle %}
-            {% include "@bolt-components-headline/headline.twig" with {
-              text: cardTitle,
-              size: "xlarge",
-              attributes: {
-                class: "u-bolt-margin-bottom-small",
-              }
-            } only %}
-          {% endif %}
+          {% set cardTextContent %}
+            {% if cardSubtitle %}
+              {% include "@bolt-components-headline/eyebrow.twig" with {
+                text: cardSubtitle,
+                weight: "semibold"
+              } only %}
+            {% endif %}
+
+            {% if cardTitle %}
+              {# {% include "@bolt-components-headline/headline.twig" with {
+                text: cardTitle,
+                size: "large",
+              } only %} #}
+              <h2>{{ cardTitle }}</h2>
+            {% endif %}
+          {% endset %}
+
+          {% include "@bolt-components-stack/stack.twig" with {
+            content: cardTextContent,
+            spacing: "xsmall"
+          } only %}
+
           {% if cardMetaItems %}
-            {% include "@bolt-components-list/list.twig" with {
-              display: "inline",
-              separator: "solid",
-              tag: "ul",
-              items: cardMetaItems
+            {% set cardMetaContent %}
+              {% include "@bolt-components-list/list.twig" with {
+                display: "inline",
+                separator: "solid",
+                tag: "ul",
+                items: cardMetaItems
+              } only %}
+            {% endset %}
+
+            {% include "@bolt-components-stack/stack.twig" with {
+              content: cardMetaContent,
+              spacing: "xsmall"
             } only %}
           {% endif %}
         {% endcell %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/02-molecules/cards/_horizontal-card.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/02-molecules/cards/_horizontal-card.twig
@@ -25,7 +25,7 @@
 
   {% block body %}
     <ul class="c-acd-horizontal-card-grid">
-      <li>
+      <li class="c-acd-horizontal-card-grid-item">
         {% set cardTextContent %}
           {% if cardSubtitle %}
             {% include "@bolt-components-headline/eyebrow.twig" with {
@@ -65,7 +65,7 @@
       </li>
 
       {% if cardDescription %}
-        <li class="u-bolt-flex@small u-bolt-align-items-center">
+        <li class="c-acd-horizontal-card-grid-item u-bolt-flex@small u-bolt-align-items-center">
           {% include "@bolt-components-headline/text.twig" with {
             text: cardDescription,
             size: "small",

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/02-molecules/cards/_horizontal-card.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/02-molecules/cards/_horizontal-card.twig
@@ -24,7 +24,8 @@
   {% endblock %}
 
   {% block body %}
-    {% set leftContent %}
+  <ul class="c-acd-horizontal-card">
+    <li>
       {% set cardTextContent %}
         {% if cardSubtitle %}
           {% include "@bolt-components-headline/eyebrow.twig" with {
@@ -58,10 +59,10 @@
           spacing: "xsmall"
         } only %}
       {% endif %}
-    {% endset %}
+    </li>
 
-    {% set rightContent %}
-      {% if cardDescription %}
+    {% if cardDescription %}
+      <li class="u-bolt-flex@small u-bolt-align-items-center">
         {% include "@bolt-components-headline/text.twig" with {
           text: cardDescription,
           size: "small",
@@ -72,31 +73,9 @@
             ]
           }
         } only %}
-      {% endif %}
-    {% endset %}
-
-    {% include "@bolt-components-list/list.twig" with {
-      display: "inline@small",
-      separator: "solid",
-      spacing: "small",
-      attributes: {
-        class: 'o-bolt-grid--flex o-bolt-grid--matrix o-bolt-grid--border'
-      },
-      items: [
-        {
-          content: leftContent,
-          attributes: {
-            class: 'u-bolt-width-12/12 u-bolt-width-6/12@small'
-          }
-        },
-        {
-          content: rightContent,
-          attributes: {
-            class: 'u-bolt-width-12/12 u-bolt-width-6/12@small'
-          }
-        },
-      ]
-    } only %}
+      </li>
+    {% endif %}
+  </ul>
   {% endblock %}
 
 {% endembed %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/03-organisms/collections/search/_search-results--results-list.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/03-organisms/collections/search/_search-results--results-list.twig
@@ -34,9 +34,9 @@
   spacing: "medium",
   items: [
     macros.include("@bolt-academy/_horizontal-card.twig", {
-      cardUrl: "/mission/seans-multi-version-test-mission/v2",
+      cardUrl: "#!",
       cardSubtitle: "Mission",
-      cardTitle: "Sean's Multi-Version Test Mission",
+      cardTitle: bolt.faker.sentence(3),
       cardMetaItems: [
         macros.include("@bolt-components-headline/text.twig", {
           size: "small",

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/03-organisms/collections/search/_search-results--results-list.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/03-organisms/collections/search/_search-results--results-list.twig
@@ -1,6 +1,176 @@
+{% set trigger %}
+  {% include "@bolt-components-button/button.twig" with {
+    text: "Pega Customer Decision Hub 8.5",
+    size: "xsmall",
+    style: "tertiary",
+    icon: {
+      name: "chevron-down",
+      position: "after",
+      size: "xsmall"
+    }
+  } only %}
+{% endset %}
+
+{% set popoverContent %}
+  {# <bolt-list tag="ul" display="block" spacing="xsmall" separator="none" align="start" valign="center">
+    <bolt-list-item last="" role="presentation">
+      <bolt-link display="inline" valign="center" url="/mission/seans-multi-version-test-mission/v1">
+        Pega Customer Decision Hub 8.3</bolt-link>
+    </bolt-list-item>
+  </bolt-list> #}
+
+  {% include "@bolt-components-list/list.twig" with {
+    spacing: "xsmall",
+    items: [
+      "test"
+    ]
+  } only %}
+{% endset %}
+
+{% set testItem %}
+<bolt-card-replacement tag="article" spacing="medium" border-radius="small" theme="xlight" height="full" url="/mission/seans-multi-version-test-mission/v2" horizontal="">
+	<ssr-keep for="bolt-card-replacement" class="c-bolt-card-replacement c-bolt-card-replacement--horizontal c-bolt-card-replacement--border-radius-small t-bolt-xlight">
+		<bolt-card-replacement-media>
+			<ssr-keep for="bolt-card-replacement-media" class="c-bolt-card_replacement__media">
+				<div style="background: linear-gradient(180deg, var(--bolt-color-berry) 0%, var(--bolt-color-wine) 100%); position: relative;" class="u-bolt-height-full u-bolt-padding-small">
+					<bolt-icon name="launchpad" style="font-size: 3.125rem; color: white; height: 3rem; width: 3rem; position: absolute; left: 50%; transform: translateX(-50%);"></bolt-icon>
+				</div>
+			</ssr-keep>
+		</bolt-card-replacement-media>
+		<div class="c-bolt-card-replacement__horizontal-wrapper">
+			<bolt-card-replacement-body>
+				<ssr-keep for="bolt-card-replacement-body" class="c-bolt-card_replacement__body c-bolt-card_replacement__body--spacing-medium">
+					<div class="o-bolt-grid o-bolt-grid--flex o-bolt-grid--matrix o-bolt-grid--xsmall u-bolt-negative-margin-top-small u-bolt-negative-margin-right-small">
+						<div class="o-bolt-grid__cell u-bolt-margin-left-auto"></div>
+					</div>
+					<div class="u-bolt-overflow-hidden">
+						<div class="o-bolt-grid o-bolt-grid--flex o-bolt-grid--matrix o-bolt-grid--border">
+							<div class="o-bolt-grid__cell u-bolt-width-12/12 u-bolt-width-6/12@small">
+								<bolt-stack spacing="xsmall">
+									<ssr-keep for="bolt-stack" class="c-bolt-stack c-bolt-example--spacing-xsmall">
+										<p class="c-bolt-eyebrow c-bolt-eyebrow--semibold">Mission</p>
+										<h2>
+											Sean's Multi-Version Test Mission
+										</h2>
+									</ssr-keep>
+								</bolt-stack>
+								<bolt-stack spacing="xsmall">
+									<ssr-keep for="bolt-stack" class="c-bolt-stack c-bolt-example--spacing-xsmall">
+										<bolt-list tag="ul" display="inline" spacing="xsmall" separator="solid" align="start" valign="center" style="--bolt-list-item-border-color: rgba(var(--bolt-theme-border), 0.4);">
+											<ssr-keep for="bolt-list" role="list" class="c-bolt-list c-bolt-list--display-inline c-bolt-list--spacing-xsmall c-bolt-list--separator-solid c-bolt-list--align-start c-bolt-list--valign-center">
+												<bolt-list-item role="presentation">
+													<ssr-keep for="bolt-list-item" role="listitem" class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-xsmall c-bolt-list-item--separator-solid c-bolt-list-item--align-start">
+														<p class="c-bolt-text c-bolt-text--semibold c-bolt-text--normal c-bolt-text--small">1 Module</p>
+													</ssr-keep>
+												</bolt-list-item>
+												<bolt-list-item role="presentation">
+													<ssr-keep for="bolt-list-item" role="listitem" class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-xsmall c-bolt-list-item--separator-solid c-bolt-list-item--align-start">
+														<p class="stats-item c-bolt-text c-bolt-text--semibold c-bolt-text--normal c-bolt-text--small" id="stats-item--15351-completion">10 mins</p>
+													</ssr-keep>
+												</bolt-list-item>
+												<bolt-list-item last="" role="presentation">
+													<ssr-keep for="bolt-list-item" role="listitem" class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-xsmall c-bolt-list-item--separator-solid c-bolt-list-item--align-start c-bolt-list-item--last-item">
+														<bolt-popover uuid="1827225220">
+															<div class="c-bolt-popover c-bolt-popover--bottom c-bolt-popover--text-wrap c-bolt-popover--spacing-small">
+																<span id="js-bolt-popover-trigger-1827225220">
+																	<a href="#js-bolt-popover-1827225220" class="c-bolt-popover__nojs-trigger" tabindex="-1">
+																		<ssr-keep for="bolt-popover">
+																			<bolt-button size="xsmall" color="tertiary" width="auto" border-radius="regular" align="center" transform="none">
+																				<button class="c-bolt-button c-bolt-button--xsmall c-bolt-button--tertiary c-bolt-button--border-radius-regular c-bolt-button--center" is="shadow-root">
+																					<ssr-keep for="bolt-button" class="c-bolt-button__item">Pega Customer Decision Hub 8.5</ssr-keep>
+																					<ssr-keep for="bolt-button" class="c-bolt-button__icon c-bolt-button__icon-sizer">
+																						<bolt-icon slot="after" name="chevron-down" size="xsmall">
+																							<span class="c-bolt-icon c-bolt-icon--chevron-down c-bolt-icon--xsmall">
+																								<svg class="c-bolt-icon__icon c-bolt-icon__icon--xsmall" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 32 32">
+																									<path fill="var(--bolt-theme-icon, currentColor)" fill-rule="evenodd" d="M25 13c.5-.6.5-1.4 0-2-.6-.5-1.4-.5-2 0l-7 7.1-7-7a1.3 1.3 0 00-2.3.9c0 .3.1.7.4 1l8 8c.5.5 1.3.5 1.8 0l8-8z"></path>
+																								</svg>
+																							</span>
+																						</bolt-icon>
+																					</ssr-keep>
+																				</button>
+																			</bolt-button>
+																		</ssr-keep>
+																	</a>
+																</span>
+																<span class="c-bolt-popover__no-js-content" id="js-bolt-popover-1827225220">
+																	<div class="c-bolt-popover__content">
+																		<span class="c-bolt-popover__bubble ">
+																			<a href="#js-bolt-popover-trigger-1827225220" class="c-bolt-popover__nojs-close">
+																				<span aria-hidden="true">×</span>
+																				<span class="u-bolt-visuallyhidden">Close popover</span>
+																			</a>
+																			<ssr-keep for="bolt-popover">
+																				<span slot="content">
+																					<bolt-list tag="ul" display="block" spacing="xsmall" separator="none" align="start" valign="center">
+																						<ssr-keep for="bolt-list" role="list" class="c-bolt-list c-bolt-list--display-block c-bolt-list--spacing-xsmall c-bolt-list--align-start c-bolt-list--valign-center">
+																							<bolt-list-item last="" role="presentation">
+																								<ssr-keep for="bolt-list-item" role="listitem" class="c-bolt-list-item c-bolt-list-item--display-block c-bolt-list-item--spacing-xsmall c-bolt-list-item--align-start c-bolt-list-item--last-item">
+																									<bolt-link display="inline" valign="center" url="/mission/seans-multi-version-test-mission/v1">
+																										<a href="/mission/seans-multi-version-test-mission/v1" is="shadow-root" class="c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center">
+																											<ssr-keep for="bolt-link" class="c-bolt-link__text">Pega Customer Decision Hub 8.3</ssr-keep>
+																										</a>
+																									</bolt-link>
+																								</ssr-keep>
+																							</bolt-list-item>
+																						</ssr-keep>
+																					</bolt-list>
+																				</span>
+																			</ssr-keep>
+																		</span>
+																	</div>
+																</span>
+															</div>
+														</bolt-popover>
+													</ssr-keep>
+												</bolt-list-item>
+											</ssr-keep>
+										</bolt-list>
+									</ssr-keep>
+								</bolt-stack>
+							</div>
+							<div class="o-bolt-grid__cell u-bolt-width-12/12 u-bolt-width-6/12@small u-bolt-flex u-bolt-align-items-center">
+								<div class="u-bolt-padding-top-xsmall@small u-bolt-padding-bottom-xsmall@small c-bolt-text--small"></div>
+							</div>
+						</div>
+					</div>
+				</ssr-keep>
+			</bolt-card-replacement-body>
+		</div>
+	</ssr-keep>
+</bolt-card-replacement>
+{% endset %}
+
 {% include "@bolt-components-list/list.twig" with {
   spacing: "medium",
   items: [
+    testItem,
+    macros.include("@bolt-academy/_horizontal-card.twig", {
+      cardUrl: "/mission/seans-multi-version-test-mission/v2",
+      cardSubtitle: "Mission",
+      cardTitle: "Sean's Multi-Version Test Mission",
+      cardMetaItems: [
+        macros.include("@bolt-components-headline/text.twig", {
+          size: "small",
+          text: "1 Module",
+          weight: "semibold"
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
+          size: "small",
+          text: "10 mins",
+          weight: "semibold",
+          attributes: {
+            class: "stats-item",
+          },
+        }, false),
+        macros.include("@bolt-components-popover/popover.twig", {
+          trigger: trigger,
+          content: popoverContent,
+        }, false),
+      ],
+      cardGradient: "purple",
+      cardIcon: "launchpad",
+      cardDescription: ' ',
+    }, false),
     macros.include("@bolt-academy/_horizontal-card.twig", {
       cardUrl: "#!",
       cardSubtitle: "Challenge",

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/03-organisms/collections/search/_search-results--results-list.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/03-organisms/collections/search/_search-results--results-list.twig
@@ -15,16 +15,12 @@
   {% include "@bolt-components-menu/menu.twig" with {
     items: [
       {
-        content: macros.include("@bolt-components-link/link.twig", {
-          text: "Pega Customer Decision Hub 8.1",
-          url: "https://pega.com"
-        }, false),
+        content: "Pega Customer Decision Hub 8.1",
+        url: "https://pega.com"
       },
       {
-        content: macros.include("@bolt-components-link/link.twig", {
-          text: "Pega Customer Decision Hub 8.3",
-          url: "https://pega.com"
-        }, false),
+        content: "Pega Customer Decision Hub 8.3",
+        url: "https://pega.com"
       },
     ]
   } only %}
@@ -54,6 +50,7 @@
         macros.include("@bolt-components-popover/popover.twig", {
           trigger: trigger,
           content: popoverContent,
+          spacing: "none",
           placement: "top-start",
           fallbackPlacements: [
             "top",

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/03-organisms/collections/search/_search-results--results-list.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/03-organisms/collections/search/_search-results--results-list.twig
@@ -11,19 +11,36 @@
   } only %}
 {% endset %}
 
-{% set popoverContent %}
-  {# <bolt-list tag="ul" display="block" spacing="xsmall" separator="none" align="start" valign="center">
-    <bolt-list-item last="" role="presentation">
-      <bolt-link display="inline" valign="center" url="/mission/seans-multi-version-test-mission/v1">
-        Pega Customer Decision Hub 8.3</bolt-link>
-    </bolt-list-item>
-  </bolt-list> #}
+{% set placeholderLink %}
+  {% include "@bolt-components-link/link.twig" with {
+    text: "Pega Customer Decision Hub 8.3",
+    url: "https://pega.com"
+  } only %}
+{% endset %}
+{% set placeholderLink2 %}
+  {% include "@bolt-components-link/link.twig" with {
+    text: "Pega Customer Decision Hub 8.1",
+    url: "https://pega.com"
+  } only %}
+{% endset %}
 
+{% set popoverContent %}
   {% include "@bolt-components-list/list.twig" with {
-    spacing: "xsmall",
     items: [
-      "test"
+      placeholderLink,
+      placeholderLink2
     ]
+  } only %}
+{% endset %}
+
+{% set popoverContent2 %}
+  {% include "@bolt-components-stack/stack.twig" with {
+    content: placeholderLink2,
+    spacing: "xsmall"
+  } only %}
+  {% include "@bolt-components-stack/stack.twig" with {
+    content: placeholderLink,
+    spacing: "xsmall"
   } only %}
 {% endset %}
 
@@ -170,6 +187,35 @@
       cardGradient: "purple",
       cardIcon: "launchpad",
       cardDescription: ' ',
+    }, false),
+    macros.include("@bolt-academy/_horizontal-card.twig", {
+      cardUrl: "/mission/seans-multi-version-test-mission/v2",
+      cardSubtitle: "Mission",
+      cardTitle: "Sean's Multi-Version Test Mission",
+      cardMetaItems: [
+        macros.include("@bolt-components-headline/text.twig", {
+          size: "small",
+          text: "1 Module",
+          weight: "semibold"
+        }, false),
+        macros.include("@bolt-components-headline/text.twig", {
+          size: "small",
+          text: "10 mins",
+          weight: "semibold",
+          attributes: {
+            class: "stats-item",
+          },
+        }, false),
+        macros.include("@bolt-components-popover/popover.twig", {
+          trigger: trigger,
+          content: popoverContent2,
+          placement: "top-start",
+          theme: "light"
+        }, false),
+      ],
+      cardGradient: "purple",
+      cardIcon: "launchpad",
+      cardDescription: 'This one behaves the way I assume we want it to.',
     }, false),
     macros.include("@bolt-academy/_horizontal-card.twig", {
       cardUrl: "#!",

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/03-organisms/collections/search/_search-results--results-list.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/03-organisms/collections/search/_search-results--results-list.twig
@@ -26,6 +26,7 @@
 
 {% set popoverContent %}
   {% include "@bolt-components-list/list.twig" with {
+    spacing: "xsmall",
     items: [
       placeholderLink,
       placeholderLink2
@@ -34,13 +35,15 @@
 {% endset %}
 
 {% set popoverContent2 %}
-  {% include "@bolt-components-stack/stack.twig" with {
-    content: placeholderLink2,
-    spacing: "xsmall"
-  } only %}
-  {% include "@bolt-components-stack/stack.twig" with {
-    content: placeholderLink,
-    spacing: "xsmall"
+  {% include "@bolt-components-menu/menu.twig" with {
+    items: [
+      {
+        content: placeholderLink2,
+      },
+      {
+        content: placeholderLink,
+      },
+    ]
   } only %}
 {% endset %}
 
@@ -186,7 +189,6 @@
       ],
       cardGradient: "purple",
       cardIcon: "launchpad",
-      cardDescription: ' ',
     }, false),
     macros.include("@bolt-academy/_horizontal-card.twig", {
       cardUrl: "/mission/seans-multi-version-test-mission/v2",

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/03-organisms/collections/search/_search-results--results-list.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/03-organisms/collections/search/_search-results--results-list.twig
@@ -11,159 +11,28 @@
   } only %}
 {% endset %}
 
-{% set placeholderLink %}
-  {% include "@bolt-components-link/link.twig" with {
-    text: "Pega Customer Decision Hub 8.3",
-    url: "https://pega.com"
-  } only %}
-{% endset %}
-{% set placeholderLink2 %}
-  {% include "@bolt-components-link/link.twig" with {
-    text: "Pega Customer Decision Hub 8.1",
-    url: "https://pega.com"
-  } only %}
-{% endset %}
-
 {% set popoverContent %}
-  {% include "@bolt-components-list/list.twig" with {
-    spacing: "xsmall",
-    items: [
-      placeholderLink,
-      placeholderLink2
-    ]
-  } only %}
-{% endset %}
-
-{% set popoverContent2 %}
   {% include "@bolt-components-menu/menu.twig" with {
     items: [
       {
-        content: placeholderLink2,
+        content: macros.include("@bolt-components-link/link.twig", {
+          text: "Pega Customer Decision Hub 8.1",
+          url: "https://pega.com"
+        }, false),
       },
       {
-        content: placeholderLink,
+        content: macros.include("@bolt-components-link/link.twig", {
+          text: "Pega Customer Decision Hub 8.3",
+          url: "https://pega.com"
+        }, false),
       },
     ]
   } only %}
-{% endset %}
-
-{% set testItem %}
-<bolt-card-replacement tag="article" spacing="medium" border-radius="small" theme="xlight" height="full" url="/mission/seans-multi-version-test-mission/v2" horizontal="">
-	<ssr-keep for="bolt-card-replacement" class="c-bolt-card-replacement c-bolt-card-replacement--horizontal c-bolt-card-replacement--border-radius-small t-bolt-xlight">
-		<bolt-card-replacement-media>
-			<ssr-keep for="bolt-card-replacement-media" class="c-bolt-card_replacement__media">
-				<div style="background: linear-gradient(180deg, var(--bolt-color-berry) 0%, var(--bolt-color-wine) 100%); position: relative;" class="u-bolt-height-full u-bolt-padding-small">
-					<bolt-icon name="launchpad" style="font-size: 3.125rem; color: white; height: 3rem; width: 3rem; position: absolute; left: 50%; transform: translateX(-50%);"></bolt-icon>
-				</div>
-			</ssr-keep>
-		</bolt-card-replacement-media>
-		<div class="c-bolt-card-replacement__horizontal-wrapper">
-			<bolt-card-replacement-body>
-				<ssr-keep for="bolt-card-replacement-body" class="c-bolt-card_replacement__body c-bolt-card_replacement__body--spacing-medium">
-					<div class="o-bolt-grid o-bolt-grid--flex o-bolt-grid--matrix o-bolt-grid--xsmall u-bolt-negative-margin-top-small u-bolt-negative-margin-right-small">
-						<div class="o-bolt-grid__cell u-bolt-margin-left-auto"></div>
-					</div>
-					<div class="u-bolt-overflow-hidden">
-						<div class="o-bolt-grid o-bolt-grid--flex o-bolt-grid--matrix o-bolt-grid--border">
-							<div class="o-bolt-grid__cell u-bolt-width-12/12 u-bolt-width-6/12@small">
-								<bolt-stack spacing="xsmall">
-									<ssr-keep for="bolt-stack" class="c-bolt-stack c-bolt-example--spacing-xsmall">
-										<p class="c-bolt-eyebrow c-bolt-eyebrow--semibold">Mission</p>
-										<h2>
-											Sean's Multi-Version Test Mission
-										</h2>
-									</ssr-keep>
-								</bolt-stack>
-								<bolt-stack spacing="xsmall">
-									<ssr-keep for="bolt-stack" class="c-bolt-stack c-bolt-example--spacing-xsmall">
-										<bolt-list tag="ul" display="inline" spacing="xsmall" separator="solid" align="start" valign="center" style="--bolt-list-item-border-color: rgba(var(--bolt-theme-border), 0.4);">
-											<ssr-keep for="bolt-list" role="list" class="c-bolt-list c-bolt-list--display-inline c-bolt-list--spacing-xsmall c-bolt-list--separator-solid c-bolt-list--align-start c-bolt-list--valign-center">
-												<bolt-list-item role="presentation">
-													<ssr-keep for="bolt-list-item" role="listitem" class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-xsmall c-bolt-list-item--separator-solid c-bolt-list-item--align-start">
-														<p class="c-bolt-text c-bolt-text--semibold c-bolt-text--normal c-bolt-text--small">1 Module</p>
-													</ssr-keep>
-												</bolt-list-item>
-												<bolt-list-item role="presentation">
-													<ssr-keep for="bolt-list-item" role="listitem" class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-xsmall c-bolt-list-item--separator-solid c-bolt-list-item--align-start">
-														<p class="stats-item c-bolt-text c-bolt-text--semibold c-bolt-text--normal c-bolt-text--small" id="stats-item--15351-completion">10 mins</p>
-													</ssr-keep>
-												</bolt-list-item>
-												<bolt-list-item last="" role="presentation">
-													<ssr-keep for="bolt-list-item" role="listitem" class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-xsmall c-bolt-list-item--separator-solid c-bolt-list-item--align-start c-bolt-list-item--last-item">
-														<bolt-popover uuid="1827225220">
-															<div class="c-bolt-popover c-bolt-popover--bottom c-bolt-popover--text-wrap c-bolt-popover--spacing-small">
-																<span id="js-bolt-popover-trigger-1827225220">
-																	<a href="#js-bolt-popover-1827225220" class="c-bolt-popover__nojs-trigger" tabindex="-1">
-																		<ssr-keep for="bolt-popover">
-																			<bolt-button size="xsmall" color="tertiary" width="auto" border-radius="regular" align="center" transform="none">
-																				<button class="c-bolt-button c-bolt-button--xsmall c-bolt-button--tertiary c-bolt-button--border-radius-regular c-bolt-button--center" is="shadow-root">
-																					<ssr-keep for="bolt-button" class="c-bolt-button__item">Pega Customer Decision Hub 8.5</ssr-keep>
-																					<ssr-keep for="bolt-button" class="c-bolt-button__icon c-bolt-button__icon-sizer">
-																						<bolt-icon slot="after" name="chevron-down" size="xsmall">
-																							<span class="c-bolt-icon c-bolt-icon--chevron-down c-bolt-icon--xsmall">
-																								<svg class="c-bolt-icon__icon c-bolt-icon__icon--xsmall" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 32 32">
-																									<path fill="var(--bolt-theme-icon, currentColor)" fill-rule="evenodd" d="M25 13c.5-.6.5-1.4 0-2-.6-.5-1.4-.5-2 0l-7 7.1-7-7a1.3 1.3 0 00-2.3.9c0 .3.1.7.4 1l8 8c.5.5 1.3.5 1.8 0l8-8z"></path>
-																								</svg>
-																							</span>
-																						</bolt-icon>
-																					</ssr-keep>
-																				</button>
-																			</bolt-button>
-																		</ssr-keep>
-																	</a>
-																</span>
-																<span class="c-bolt-popover__no-js-content" id="js-bolt-popover-1827225220">
-																	<div class="c-bolt-popover__content">
-																		<span class="c-bolt-popover__bubble ">
-																			<a href="#js-bolt-popover-trigger-1827225220" class="c-bolt-popover__nojs-close">
-																				<span aria-hidden="true">×</span>
-																				<span class="u-bolt-visuallyhidden">Close popover</span>
-																			</a>
-																			<ssr-keep for="bolt-popover">
-																				<span slot="content">
-																					<bolt-list tag="ul" display="block" spacing="xsmall" separator="none" align="start" valign="center">
-																						<ssr-keep for="bolt-list" role="list" class="c-bolt-list c-bolt-list--display-block c-bolt-list--spacing-xsmall c-bolt-list--align-start c-bolt-list--valign-center">
-																							<bolt-list-item last="" role="presentation">
-																								<ssr-keep for="bolt-list-item" role="listitem" class="c-bolt-list-item c-bolt-list-item--display-block c-bolt-list-item--spacing-xsmall c-bolt-list-item--align-start c-bolt-list-item--last-item">
-																									<bolt-link display="inline" valign="center" url="/mission/seans-multi-version-test-mission/v1">
-																										<a href="/mission/seans-multi-version-test-mission/v1" is="shadow-root" class="c-bolt-link  c-bolt-link--display-inline c-bolt-link--valign-center">
-																											<ssr-keep for="bolt-link" class="c-bolt-link__text">Pega Customer Decision Hub 8.3</ssr-keep>
-																										</a>
-																									</bolt-link>
-																								</ssr-keep>
-																							</bolt-list-item>
-																						</ssr-keep>
-																					</bolt-list>
-																				</span>
-																			</ssr-keep>
-																		</span>
-																	</div>
-																</span>
-															</div>
-														</bolt-popover>
-													</ssr-keep>
-												</bolt-list-item>
-											</ssr-keep>
-										</bolt-list>
-									</ssr-keep>
-								</bolt-stack>
-							</div>
-							<div class="o-bolt-grid__cell u-bolt-width-12/12 u-bolt-width-6/12@small u-bolt-flex u-bolt-align-items-center">
-								<div class="u-bolt-padding-top-xsmall@small u-bolt-padding-bottom-xsmall@small c-bolt-text--small"></div>
-							</div>
-						</div>
-					</div>
-				</ssr-keep>
-			</bolt-card-replacement-body>
-		</div>
-	</ssr-keep>
-</bolt-card-replacement>
 {% endset %}
 
 {% include "@bolt-components-list/list.twig" with {
   spacing: "medium",
   items: [
-    testItem,
     macros.include("@bolt-academy/_horizontal-card.twig", {
       cardUrl: "/mission/seans-multi-version-test-mission/v2",
       cardSubtitle: "Mission",
@@ -185,39 +54,17 @@
         macros.include("@bolt-components-popover/popover.twig", {
           trigger: trigger,
           content: popoverContent,
-        }, false),
-      ],
-      cardGradient: "purple",
-      cardIcon: "launchpad",
-    }, false),
-    macros.include("@bolt-academy/_horizontal-card.twig", {
-      cardUrl: "/mission/seans-multi-version-test-mission/v2",
-      cardSubtitle: "Mission",
-      cardTitle: "Sean's Multi-Version Test Mission",
-      cardMetaItems: [
-        macros.include("@bolt-components-headline/text.twig", {
-          size: "small",
-          text: "1 Module",
-          weight: "semibold"
-        }, false),
-        macros.include("@bolt-components-headline/text.twig", {
-          size: "small",
-          text: "10 mins",
-          weight: "semibold",
-          attributes: {
-            class: "stats-item",
-          },
-        }, false),
-        macros.include("@bolt-components-popover/popover.twig", {
-          trigger: trigger,
-          content: popoverContent2,
           placement: "top-start",
+          fallbackPlacements: [
+            "top",
+            "top-end"
+          ],
           theme: "light"
         }, false),
       ],
       cardGradient: "purple",
       cardIcon: "launchpad",
-      cardDescription: 'This one behaves the way I assume we want it to.',
+      cardDescription: bolt.faker.paragraph(3),
     }, false),
     macros.include("@bolt-academy/_horizontal-card.twig", {
       cardUrl: "#!",

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/index.scss
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/index.scss
@@ -201,3 +201,36 @@
     transform: translate(-50%, -50%);
   }
 }
+
+.c-acd-horizontal-card {
+  display: grid;
+  grid-template-columns: 1fr;
+  align-items: center;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+
+  @media (min-width: 600px) {
+    grid-template-columns: 50% 1fr;
+  }
+
+  li {
+    height: 100%;
+    padding: 0 0 1rem;
+
+    + li {
+      padding: 1rem 0 0;
+      border-top: 2px solid rgba(var(--bolt-theme-border), 0.2);
+    }
+
+    @media (min-width: 600px) {
+      padding: 0 1rem 0 0;
+
+      + li {
+        padding: 0 0 0 1rem;
+        border-top: none;
+        border-left: 2px solid rgba(var(--bolt-theme-border), 0.2);
+      }
+    }
+  }
+}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/index.scss
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/index.scss
@@ -202,7 +202,7 @@
   }
 }
 
-.c-acd-horizontal-card {
+.c-acd-horizontal-card-grid {
   display: grid;
   grid-template-columns: 1fr;
   align-items: center;

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/index.scss
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/index.scss
@@ -205,7 +205,6 @@
 .c-acd-horizontal-card-grid {
   display: grid;
   grid-template-columns: 1fr;
-  align-items: center;
   margin: 0;
   padding: 0;
   list-style: none;
@@ -214,22 +213,28 @@
     grid-template-columns: 50% 1fr;
   }
 
-  li {
-    height: 100%;
-    padding: 0 0 1rem;
+  .c-acd-horizontal-card-grid-item {
+    padding-bottom: var(--bolt-spacing-y-small);
+    border-width: 0;
+    border-style: solid;
+    border-color: bolt-theme(border, 0.2);
 
-    + li {
-      padding: 1rem 0 0;
-      border-top: 2px solid rgba(var(--bolt-theme-border), 0.2);
+    + .c-acd-horizontal-card-grid-item {
+      padding-top: var(--bolt-spacing-y-small);
+      padding-bottom: 0;
+      border-top-width: 2px;
     }
 
-    @media (min-width: 600px) {
-      padding: 0 1rem 0 0;
+    @include bolt-mq($from: small) {
+      padding-right: var(--bolt-spacing-x-small);
+      padding-bottom: 0;
 
-      + li {
-        padding: 0 0 0 1rem;
-        border-top: none;
-        border-left: 2px solid rgba(var(--bolt-theme-border), 0.2);
+      + .c-acd-horizontal-card-grid-item {
+        padding-top: 0;
+        padding-right: 0;
+        padding-left: var(--bolt-spacing-x-small);
+        border-top-width: 0;
+        border-left-width: 2px;
       }
     }
   }


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/ACD-286

## Summary

Add custom Academy component to fix bug where popover gets clipped by `<div>` with overflow "hidden".

## Details

Academy's horizontal card used the grid with `--bordered` class, negative margin, and overflow "hidden" to create a layout with border-separated items. Because this layout requires overflow hidden, any popover inside the content gets clipped. This PR introduces a custom component that uses very simple css grid styles to accomplish the border-separated layout without requiring overflow "hidden".

It also adds a demo of the popover menu in search results: `/pattern-lab/patterns/50-pages-60-academy-05-pages-search-search-results-acd-search-results-page/50-pages-60-academy-05-pages-search-search-results-acd-search-results-page.html`

> Note: due to known z-index issues the popover can never be displayed in the 'bottom' position inside the card. If it is, it will fall behind the next card. I've created this ticket to address the root issue: https://pegadigitalit.atlassian.net/browse/DS-239

## How to test

- Review code changes
- Test demo, see first card in Search results template: `/pattern-lab/patterns/50-pages-60-academy-05-pages-search-search-results-acd-search-results-page/50-pages-60-academy-05-pages-search-search-results-acd-search-results-page.html`. Verify popover menu does not get clipped.