### PR TITLE
DS-190 Fix tooltip placement bug

### DIFF
--- a/packages/components/bolt-tooltip/src/tooltip.js
+++ b/packages/components/bolt-tooltip/src/tooltip.js
@@ -52,6 +52,14 @@ class BoltTooltip extends BoltElement {
 
   setOpen() {
     if (this.isHovering || this.hasFocus) {
+      // `reference` is Popper's stored reference to the trigger.
+      const ref = this.popper?.state.rects.reference;
+
+      if (ref.width === 0 && ref.height === 0) {
+        // If trigger was hidden initially, call update() to recalculate Popper position
+        this.popper.update();
+      }
+
       this.open = true;
     } else {
       this.open = false;


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-190

## Summary

Fix tooltip placement bug when tooltip is hidden on load.

## Details

When a tooltip trigger is hidden on load (e.g. in an inactive tab panel), the tooltip placement is not properly set. Then, when you hover over the tooltip, nothing appears because it's positioned offscreen.

This PR adds a check before showing the tooltip to see if the position needs to be updated.

## How to test

- Reproduce the bug by going to this page: https://boltdesignsystem.com/pattern-lab/?p=visual-styles-typography-tokens
- Open the "Font-size" tab, then hover over a px value in the last column. The tooltip does not appear.
- Resize the browser window and then try again - it should work this time.
- Run the feature branch and repeat the steps above.
- Very the tooltip works the first time, without having to resize the window.