### PR TITLE
DS-128: Tooltip | a11y | Enable ESC key to close and style no-js version

### DIFF
--- a/packages/components/bolt-tooltip/__tests__/__snapshots__/tooltip.js.snap
+++ b/packages/components/bolt-tooltip/__tests__/__snapshots__/tooltip.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<bolt-tooltip> Component Advanced usage: adding tooltip to button 1`] = `
 <bolt-tooltip uuid="12345">
-  <div class="c-bolt-tooltip c-bolt-tooltip--top  ">
+  <div class="c-bolt-tooltip c-bolt-tooltip--top   c-bolt-tooltip--dotted">
     <div role="button"
          tabindex="0"
          aria-describedby="js-bolt-tooltip-12345"
@@ -33,7 +33,7 @@ exports[`<bolt-tooltip> Component Advanced usage: adding tooltip to button 1`] =
 
 exports[`<bolt-tooltip> Component Basic usage 1`] = `
 <bolt-tooltip uuid="12345">
-  <div class="c-bolt-tooltip c-bolt-tooltip--top c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center">
+  <div class="c-bolt-tooltip c-bolt-tooltip--top c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
     <div role="button"
          tabindex="0"
          aria-describedby="js-bolt-tooltip-12345"
@@ -64,7 +64,7 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: auto 1`] = `
 <bolt-tooltip placement="auto"
               uuid="12345"
 >
-  <div class="c-bolt-tooltip  c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center">
+  <div class="c-bolt-tooltip  c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
     <div role="button"
          tabindex="0"
          aria-describedby="js-bolt-tooltip-12345"
@@ -95,7 +95,7 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: bottom 1`] = 
 <bolt-tooltip placement="bottom"
               uuid="12345"
 >
-  <div class="c-bolt-tooltip c-bolt-tooltip--bottom c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center">
+  <div class="c-bolt-tooltip c-bolt-tooltip--bottom c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
     <div role="button"
          tabindex="0"
          aria-describedby="js-bolt-tooltip-12345"
@@ -126,7 +126,7 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: bottom-end 1`
 <bolt-tooltip placement="bottom-end"
               uuid="12345"
 >
-  <div class="c-bolt-tooltip c-bolt-tooltip--bottom-end c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center">
+  <div class="c-bolt-tooltip c-bolt-tooltip--bottom-end c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
     <div role="button"
          tabindex="0"
          aria-describedby="js-bolt-tooltip-12345"
@@ -157,7 +157,7 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: bottom-start 
 <bolt-tooltip placement="bottom-start"
               uuid="12345"
 >
-  <div class="c-bolt-tooltip c-bolt-tooltip--bottom-start c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center">
+  <div class="c-bolt-tooltip c-bolt-tooltip--bottom-start c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
     <div role="button"
          tabindex="0"
          aria-describedby="js-bolt-tooltip-12345"
@@ -188,7 +188,7 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: left 1`] = `
 <bolt-tooltip placement="left"
               uuid="12345"
 >
-  <div class="c-bolt-tooltip c-bolt-tooltip--left c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center">
+  <div class="c-bolt-tooltip c-bolt-tooltip--left c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
     <div role="button"
          tabindex="0"
          aria-describedby="js-bolt-tooltip-12345"
@@ -219,7 +219,7 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: left-end 1`] 
 <bolt-tooltip placement="left-end"
               uuid="12345"
 >
-  <div class="c-bolt-tooltip c-bolt-tooltip--left-end c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center">
+  <div class="c-bolt-tooltip c-bolt-tooltip--left-end c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
     <div role="button"
          tabindex="0"
          aria-describedby="js-bolt-tooltip-12345"
@@ -250,7 +250,7 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: left-start 1`
 <bolt-tooltip placement="left-start"
               uuid="12345"
 >
-  <div class="c-bolt-tooltip c-bolt-tooltip--left-start c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center">
+  <div class="c-bolt-tooltip c-bolt-tooltip--left-start c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
     <div role="button"
          tabindex="0"
          aria-describedby="js-bolt-tooltip-12345"
@@ -281,7 +281,7 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: right 1`] = `
 <bolt-tooltip placement="right"
               uuid="12345"
 >
-  <div class="c-bolt-tooltip c-bolt-tooltip--right c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center">
+  <div class="c-bolt-tooltip c-bolt-tooltip--right c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
     <div role="button"
          tabindex="0"
          aria-describedby="js-bolt-tooltip-12345"
@@ -312,7 +312,7 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: right-end 1`]
 <bolt-tooltip placement="right-end"
               uuid="12345"
 >
-  <div class="c-bolt-tooltip c-bolt-tooltip--right-end c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center">
+  <div class="c-bolt-tooltip c-bolt-tooltip--right-end c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
     <div role="button"
          tabindex="0"
          aria-describedby="js-bolt-tooltip-12345"
@@ -343,7 +343,7 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: right-start 1
 <bolt-tooltip placement="right-start"
               uuid="12345"
 >
-  <div class="c-bolt-tooltip c-bolt-tooltip--right-start c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center">
+  <div class="c-bolt-tooltip c-bolt-tooltip--right-start c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
     <div role="button"
          tabindex="0"
          aria-describedby="js-bolt-tooltip-12345"
@@ -374,7 +374,7 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: top 1`] = `
 <bolt-tooltip placement="top"
               uuid="12345"
 >
-  <div class="c-bolt-tooltip c-bolt-tooltip--top c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center">
+  <div class="c-bolt-tooltip c-bolt-tooltip--top c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
     <div role="button"
          tabindex="0"
          aria-describedby="js-bolt-tooltip-12345"
@@ -405,7 +405,7 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: top-end 1`] =
 <bolt-tooltip placement="top-end"
               uuid="12345"
 >
-  <div class="c-bolt-tooltip c-bolt-tooltip--top-end c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center">
+  <div class="c-bolt-tooltip c-bolt-tooltip--top-end c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
     <div role="button"
          tabindex="0"
          aria-describedby="js-bolt-tooltip-12345"
@@ -436,7 +436,7 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: top-start 1`]
 <bolt-tooltip placement="top-start"
               uuid="12345"
 >
-  <div class="c-bolt-tooltip c-bolt-tooltip--top-start c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center">
+  <div class="c-bolt-tooltip c-bolt-tooltip--top-start c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
     <div role="button"
          tabindex="0"
          aria-describedby="js-bolt-tooltip-12345"
@@ -465,7 +465,7 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: top-start 1`]
 
 exports[`<bolt-tooltip> Component UUID of the tooltip 1`] = `
 <bolt-tooltip uuid="custom-unique-id">
-  <div class="c-bolt-tooltip c-bolt-tooltip--top c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center">
+  <div class="c-bolt-tooltip c-bolt-tooltip--top c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
     <div role="button"
          tabindex="0"
          aria-describedby="js-bolt-tooltip-custom-unique-id"

--- a/packages/components/bolt-tooltip/src/tooltip.js
+++ b/packages/components/bolt-tooltip/src/tooltip.js
@@ -81,6 +81,12 @@ class BoltTooltip extends BoltElement {
     this.setOpen();
   }
 
+  handleKeyup(e) {
+    if (e.keyCode === 27 || e.key === 'Escape' || e.key === 'Esc') {
+      this.open = false;
+    }
+  }
+
   sortChildren() {
     // @todo: add mutation observer and call this when content changes
     let hasText, hasAllowedContent, hasDisallowedContent, hasFocusableContent;
@@ -231,6 +237,7 @@ class BoltTooltip extends BoltElement {
     return html`
       <span
         class="${classes}"
+        @keyup="${this.handleKeyup}"
         @mouseenter="${this.handleHover}"
         @mouseleave="${this.handleHover}"
         @focusin="${this.handleFocus}"

--- a/packages/components/bolt-tooltip/src/tooltip.scss
+++ b/packages/components/bolt-tooltip/src/tooltip.scss
@@ -47,89 +47,14 @@ $bolt-tooltip-bubble-border-color: bolt-theme(background, bolt-opacity(20));
   z-index: bolt-z-index(tooltip);
   transition: opacity $bolt-transition;
   white-space: nowrap;
-
-  // @todo: Placement does not work without JS.
-  // @at-root .c-bolt-tooltip--top-end & {
-  //   right: 0;
-  //   bottom: 100%;
-  //   transform: translate3d(0, 0, 0);
-  // }
-
-  // @at-root .c-bolt-tooltip--top & {
-  //   bottom: 100%;
-  //   left: 50%;
-  //   transform: translate3d(-50%, 0, 0);
-  // }
-
-  // @at-root .c-bolt-tooltip--top-start & {
-  //   bottom: 100%;
-  //   left: 0;
-  //   transform: translate3d(0, 0, 0);
-  // }
-
-  // @at-root .c-bolt-tooltip--left-start & {
-  //   top: 0;
-  //   right: 100%;
-  //   transform: translate3d(0, 0, 0);
-  // }
-
-  // @at-root .c-bolt-tooltip--left & {
-  //   top: 50%;
-  //   right: 100%;
-  //   transform: translate3d(0, -50%, 0);
-  // }
-
-  // @at-root .c-bolt-tooltip--left-end & {
-  //   right: 100%;
-  //   bottom: 0;
-  //   transform: translate3d(0, 0, 0);
-  // }
-
-  // @at-root .c-bolt-tooltip--right-start & {
-  //   top: 0;
-  //   left: 100%;
-  //   transform: translate3d(0, 0, 0);
-  // }
-
-  // @at-root .c-bolt-tooltip--right & {
-  //   top: 50%;
-  //   left: 100%;
-  //   transform: translate3d(0, -50%, 0);
-  // }
-
-  // @at-root .c-bolt-tooltip--right-end & {
-  //   bottom: 0;
-  //   left: 100%;
-  //   transform: translate3d(0, 0, 0);
-  // }
-
-  // @at-root .c-bolt-tooltip--bottom-end & {
-  //   top: 100%;
-  //   right: 0;
-  //   transform: translate3d(0, 0, 0);
-  // }
-
-  // @at-root .c-bolt-tooltip--bottom & {
-  //   top: 100%;
-  //   left: 50%;
-  //   transform: translate3d(-50%, 0, 0);
-  // }
-
-  // @at-root .c-bolt-tooltip--bottom-start & {
-  //   top: 100%;
-  //   left: 0;
-  //   transform: translate3d(0, 0, 0);
-  // }
 }
 
 @include bolt-repeat-rule(
   (
-    'bolt-tooltip:not([ready]) [role=' button
-      ']:hover ~ .c-bolt-tooltip__content',
-    ':host:not([ready]) [role=' button ']:hover ~ .c-bolt-tooltip__content',
-    'bolt-tooltip:not([ready]) [role=' button
-      ']:focus ~ .c-bolt-tooltip__content',
-    ':host:not([ready]) [role=' button ']:focus ~ .c-bolt-tooltip__content',
+    'bolt-tooltip:not([ready]) [role=button]:hover ~ .c-bolt-tooltip__content',
+    ':host:not([ready]) [role=button]:hover ~ .c-bolt-tooltip__content',
+    'bolt-tooltip:not([ready]) [role=button]:focus ~ .c-bolt-tooltip__content',
+    ':host:not([ready]) [role=button]:focus ~ .c-bolt-tooltip__content',
     '.c-bolt-tooltip.is-expanded .c-bolt-tooltip__content'
   )
 ) {
@@ -140,12 +65,10 @@ $bolt-tooltip-bubble-border-color: bolt-theme(background, bolt-opacity(20));
 // @todo: Since placement doesn't work without JS, this defaults to bottom placement when there is no JS.
 @include bolt-repeat-rule(
   (
-    'bolt-tooltip:not([ready]) [role=' button
-      ']:hover ~ .c-bolt-tooltip__content',
-    ':host:not([ready]) [role=' button ']:hover ~ .c-bolt-tooltip__content',
-    'bolt-tooltip:not([ready]) [role=' button
-      ']:focus ~ .c-bolt-tooltip__content',
-    ':host:not([ready]) [role=' button ']:focus ~ .c-bolt-tooltip__content'
+    'bolt-tooltip:not([ready]) [role=button]:hover ~ .c-bolt-tooltip__content',
+    ':host:not([ready]) [role=button]:hover ~ .c-bolt-tooltip__content',
+    'bolt-tooltip:not([ready]) [role=button]:focus ~ .c-bolt-tooltip__content',
+    ':host:not([ready]) [role=button]:focus ~ .c-bolt-tooltip__content'
   )
 ) {
   top: 100%;

--- a/packages/components/bolt-tooltip/src/tooltip.scss
+++ b/packages/components/bolt-tooltip/src/tooltip.scss
@@ -22,7 +22,7 @@ $bolt-tooltip-bubble-border-color: bolt-theme(background, bolt-opacity(20));
   position: relative;
 
   // apply overflow hidden when not being interacted with to avoid no-js layout issues
-  @at-root bolt-tooltip:not([ready]):not(:hover) {
+  &:not([ready]):not(:hover):not(:focus-within) {
     overflow: hidden;
   }
 }
@@ -124,8 +124,12 @@ $bolt-tooltip-bubble-border-color: bolt-theme(background, bolt-opacity(20));
 
 @include bolt-repeat-rule(
   (
-    'bolt-tooltip:not([ready]) .c-bolt-tooltip:hover .c-bolt-tooltip__content',
-    ':host:not([ready]) .c-bolt-tooltip:hover .c-bolt-tooltip__content',
+    'bolt-tooltip:not([ready]) [role=' button
+      ']:hover ~ .c-bolt-tooltip__content',
+    ':host:not([ready]) [role=' button ']:hover ~ .c-bolt-tooltip__content',
+    'bolt-tooltip:not([ready]) [role=' button
+      ']:focus ~ .c-bolt-tooltip__content',
+    ':host:not([ready]) [role=' button ']:focus ~ .c-bolt-tooltip__content',
     '.c-bolt-tooltip.is-expanded .c-bolt-tooltip__content'
   )
 ) {
@@ -136,8 +140,12 @@ $bolt-tooltip-bubble-border-color: bolt-theme(background, bolt-opacity(20));
 // @todo: Since placement doesn't work without JS, this defaults to bottom placement when there is no JS.
 @include bolt-repeat-rule(
   (
-    'bolt-tooltip:not([ready]) .c-bolt-tooltip:hover .c-bolt-tooltip__content',
-    ':host:not([ready]) .c-bolt-tooltip:hover .c-bolt-tooltip__content'
+    'bolt-tooltip:not([ready]) [role=' button
+      ']:hover ~ .c-bolt-tooltip__content',
+    ':host:not([ready]) [role=' button ']:hover ~ .c-bolt-tooltip__content',
+    'bolt-tooltip:not([ready]) [role=' button
+      ']:focus ~ .c-bolt-tooltip__content',
+    ':host:not([ready]) [role=' button ']:focus ~ .c-bolt-tooltip__content'
   )
 ) {
   top: 100%;

--- a/packages/components/bolt-tooltip/src/tooltip.scss
+++ b/packages/components/bolt-tooltip/src/tooltip.scss
@@ -20,11 +20,6 @@ $bolt-tooltip-bubble-border-color: bolt-theme(background, bolt-opacity(20));
 .c-bolt-tooltip {
   display: inline-flex;
   position: relative;
-
-  // apply overflow hidden when not being interacted with to avoid no-js layout issues
-  &:not([ready]):not(:hover):not(:focus-within) {
-    overflow: hidden;
-  }
 }
 
 /**
@@ -198,9 +193,14 @@ $bolt-tooltip-bubble-border-color: bolt-theme(background, bolt-opacity(20));
   transform: scale3d(1, 1, 1) translate3d(0, 0, 0);
 }
 
-// Add the border indicator when JS is disabled
-bolt-tooltip:not([ready]) {
-  ssr-keep {
-    border-bottom: 1px dotted rgba(var(--bolt-theme-border), 0.4);
-  }
+/**
+ * Apply overflow hidden when not being interacted with to avoid no-js layout issues
+ */
+@include bolt-repeat-rule(
+  (
+    'bolt-tooltip:not([ready]):not(:hover):not(:focus-within)',
+    ':host:not([ready]):not(:hover):not(:focus-within)'
+  )
+) {
+  overflow: hidden;
 }

--- a/packages/components/bolt-tooltip/src/tooltip.scss
+++ b/packages/components/bolt-tooltip/src/tooltip.scss
@@ -266,3 +266,10 @@ $bolt-tooltip-bubble-border-color: bolt-theme(background, bolt-opacity(20));
 ) {
   transform: scale3d(1, 1, 1) translate3d(0, 0, 0);
 }
+
+// Add the border indicator when JS is disabled
+bolt-tooltip:not([ready]) {
+  ssr-keep {
+    border-bottom: 1px dotted rgba(var(--bolt-theme-border), 0.4);
+  }
+}

--- a/packages/components/bolt-tooltip/src/tooltip.twig
+++ b/packages/components/bolt-tooltip/src/tooltip.twig
@@ -17,6 +17,7 @@
   this.data.placement.value != "auto" ? base_class ~ "--" ~ this.data.placement.value,
   this.data.content.value|length > 31 ? base_class ~ "--text-wrap",
   this.data.content.value|length > 31 and this.data.content.value|length < 62 ? base_class ~ "--text-align-center",
+  "c-bolt-tooltip--dotted"
 ] %}
 
 {#


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-128

## Summary

Updated the tooltip to meet accessibility requirements

## Details

* Added a 'Esc' key event to close the tooltip
* Added functionality to highlight the tooltip trigger

## How to test

* Disable JS and check to see if the border is present
* Tab to a tooltip trigger and press "Esc" to close the flyout
