### PR TITLE
DS-178 Fix Blockquote quotes in Safari

### DIFF
--- a/packages/components/bolt-blockquote/src/blockquote.js
+++ b/packages/components/bolt-blockquote/src/blockquote.js
@@ -31,40 +31,6 @@ class BoltBlockquote extends BoltElement {
     };
   }
 
-  firstUpdated() {
-    super.firstUpdated && super.firstUpdated();
-
-    // @todo: I've added this.useShadow here to exclude IE.
-    // In IE-only this mutation callback causes multiple re-renders
-    // and causes component to disappear.
-    if (window.MutationObserver && this.useShadow && !this.observer) {
-      // Re-generate slots + re-render when mutations are observed
-      const mutationCallback = (mutationsList, observer) => {
-        this.saveSlots();
-        this.requestUpdate();
-      };
-
-      // Create an observer instance linked to the callback function
-      this.observer = new MutationObserver(mutationCallback);
-
-      // Start observing the target node for configured mutations
-      this.observer.observe(this, {
-        attributes: false,
-        childList: true,
-        subtree: true,
-      });
-    }
-  }
-
-  disconnectedCallback() {
-    super.disconnected && super.disconnected();
-
-    // remove MutationObserver if supported + exists
-    if (window.MutationObserver && this.observer) {
-      this.observer.disconnect();
-    }
-  }
-
   getAlignItemsOption(prop) {
     switch (prop) {
       case 'right':
@@ -89,31 +55,6 @@ class BoltBlockquote extends BoltElement {
     }
   }
 
-  // automatically adds classes for the first and last slotted item (in the default slot) to help with tricky ::slotted selectors
-  addClassesToSlottedChildren() {
-    if (!this.slotMap?.get('default')) return;
-
-    const defaultSlot = [];
-
-    this.slotMap.get('default').forEach(item => {
-      if (item.tagName) {
-        item.classList.remove('is-first-child');
-        item.classList.remove('is-last-child'); // clean up existing classes
-        defaultSlot.push(item);
-      }
-    });
-
-    if (defaultSlot.length) {
-      defaultSlot[0].classList.add('is-first-child');
-
-      if (defaultSlot.length === 1) {
-        defaultSlot[0].classList.add('is-last-child');
-      } else {
-        defaultSlot[defaultSlot.length - 1].classList.add('is-last-child');
-      }
-    }
-  }
-
   render() {
     const classes = cx('c-bolt-blockquote', {
       [`c-bolt-blockquote--align-items-${this.getAlignItemsOption(
@@ -124,7 +65,6 @@ class BoltBlockquote extends BoltElement {
       )}`]: this.getBorderOption(this.border),
       [`c-bolt-blockquote--indented`]: this.indent,
       [`c-bolt-blockquote--full`]: this.fullBleed,
-      [`c-bolt-blockquote--no-quotes`]: this.noQuotes,
     });
 
     const textClasses = cx(
@@ -136,23 +76,10 @@ class BoltBlockquote extends BoltElement {
       AuthorImage(this),
       AuthorName(this),
       AuthorTitle(this),
-    ].filter(el => el);
-
-    this.addClassesToSlottedChildren();
+    ].filter((el) => el);
 
     return html`
-      <blockquote
-        class="${classes}"
-        lang="${ifDefined(
-          this.lang
-            ? this.lang
-            : this.closest('[lang]')
-            ? this.closest('[lang]')
-                .getAttribute('lang')
-                .toLowerCase()
-            : undefined,
-        )}"
-      >
+      <blockquote class="${classes}">
         ${this.slotMap.get('logo')
           ? html`
               <div class="${cx('c-bolt-blockquote__logo')}">
@@ -167,7 +94,7 @@ class BoltBlockquote extends BoltElement {
           ? html`
               <footer class="${cx('c-bolt-blockquote__footer')}">
                 ${footerItems.map(
-                  footerItem => html`
+                  (footerItem) => html`
                     <div class="${cx('c-bolt-blockquote__footer-item')}">
                       ${footerItem}
                     </div>

--- a/packages/components/bolt-blockquote/src/blockquote.scss
+++ b/packages/components/bolt-blockquote/src/blockquote.scss
@@ -10,18 +10,34 @@ $bolt-blockquote-image-border-color: rgba(bolt-color(gray), 0.2);
 $bolt-blockquote-image-size: 4rem;
 
 @mixin bolt-lang-specific-quotes($type: 'open') {
-  content: map-get-deep($bolt-quotation-marks, 'en', $type);
-
-  [lang='de'] & {
-    content: map-get-deep($bolt-quotation-marks, 'de', $type);
+  $quote-selector: 'p:not([slot]):first-of-type:before';
+  @if ($type == 'close') {
+    $quote-selector: 'p:not([slot]):last-of-type:after';
   }
 
-  [lang='fr'] & {
-    content: map-get-deep($bolt-quotation-marks, 'fr', $type);
+  #{$quote-selector} {
+    content: map-get-deep($bolt-quotation-marks, 'en', $type);
   }
 
-  [lang='ja'] & {
-    content: map-get-deep($bolt-quotation-marks, 'ja', $type);
+  @at-root [lang='de'] &,
+    &[lang='de'] {
+    #{$quote-selector} {
+      content: map-get-deep($bolt-quotation-marks, 'de', $type);
+    }
+  }
+
+  @at-root [lang='fr'] &,
+    &[lang='fr'] {
+    #{$quote-selector} {
+      content: map-get-deep($bolt-quotation-marks, 'fr', $type);
+    }
+  }
+
+  @at-root [lang='ja'] &,
+    &[lang='ja'] {
+    #{$quote-selector} {
+      content: map-get-deep($bolt-quotation-marks, 'ja', $type);
+    }
   }
 }
 
@@ -79,41 +95,60 @@ $bolt-blockquote-image-size: 4rem;
       font-weight: var(--bolt-type-font-weight-#{$weight});
     }
   }
+}
 
-  p:not([slot]):first-child:before,
-  p:not([slot]):last-child:after {
+// Quotes
+bolt-blockquote {
+  @include bolt-lang-specific-quotes('open');
+  @include bolt-lang-specific-quotes('close');
+
+  p:not([slot]):first-of-type:before,
+  p:not([slot]):last-of-type:after {
     font-family: 'Georgia', serif; // TODO: Replace with Noto Serif when it is added.
   }
 
-  p:not([slot]):first-child:before {
-    @include bolt-lang-specific-quotes('open');
+  // Prop-specific styles
+  // Note: Ordinarily we would use classes not attribute selectors, but we must use attribute selectors here
+  // because Safari does not support ::slotted + pseudo-selectors, like this: `::slotted(p):before { }`.
+
+  // "left" is default alignment
+  &,
+  &[align-items='left'] {
+    p:not([slot]):first-of-type:before {
+      position: absolute;
+      transform: translate3d(-110%, 0, 0);
+    }
   }
 
-  p:not([slot]):last-child:after {
-    @include bolt-lang-specific-quotes('close');
+  &[align-items='center'] {
+    p:not([slot]):first-of-type:before {
+      padding: 0 2px;
+    }
   }
 
-  ::slotted(p:first-child),
-  ::slotted(p.is-first-child),
-  ::slotted(p:last-child),
-  ::slotted(p.is-last-child) {
+  &[align-items='right'] {
+    p:not([slot]):first-of-type:before {
+      padding: 0 2px;
+    }
+
+    p:not([slot]):last-of-type:after {
+      position: absolute;
+      transform: translate3d(10%, 0, 0);
+    }
+  }
+
+  &[no-quotes] {
+    p:not([slot]):before,
+    p:not([slot]):after {
+      display: none;
+    }
+  }
+
+  // Just in case user puts <p> in 'author' or 'cite' slot
+  [slot] p {
     &:before,
     &:after {
-      font-family: 'Georgia', serif; // TODO: Replace with Noto Serif when it is added.
-    }
-  }
-
-  ::slotted(p:first-child),
-  ::slotted(p.is-first-child) {
-    &:before {
-      @include bolt-lang-specific-quotes('open');
-    }
-  }
-
-  ::slotted(p:last-child),
-  ::slotted(p.is-last-child) {
-    &:after {
-      @include bolt-lang-specific-quotes('close');
+      display: none;
     }
   }
 }
@@ -275,80 +310,5 @@ $bolt-blockquote-image-size: 4rem;
 
   &.c-bolt-blockquote--align-items-end {
     margin-left: 0;
-  }
-}
-
-// Perfecting the hanging quotation mark's position in all browsers.
-.c-bolt-blockquote--align-items-start {
-  .c-bolt-blockquote__quote {
-    p:first-child:before {
-      position: absolute;
-      transform: translate3d(-110%, 0, 0);
-    }
-
-    ::slotted(p:first-child),
-    ::slotted(p.is-first-child) {
-      &:before {
-        position: absolute;
-        transform: translate3d(-110%, 0, 0);
-      }
-    }
-  }
-}
-
-.c-bolt-blockquote--align-items-center {
-  .c-bolt-blockquote__quote {
-    p:first-child:before {
-      padding: 0 2px;
-    }
-
-    ::slotted(p:first-child),
-    ::slotted(p.is-first-child) {
-      &:before {
-        padding: 0 2px;
-      }
-    }
-  }
-}
-
-.c-bolt-blockquote--align-items-end {
-  .c-bolt-blockquote__quote {
-    p:first-child:before {
-      padding: 0 2px;
-    }
-
-    ::slotted(p:first-child),
-    ::slotted(p.is-first-child) {
-      &:before {
-        padding: 0 2px;
-      }
-    }
-
-    p:last-child:after {
-      position: absolute;
-      transform: translate3d(10%, 0, 0);
-    }
-
-    ::slotted(p:last-child),
-    ::slotted(p.is-last-child) {
-      &:after {
-        position: absolute;
-        transform: translate3d(10%, 0, 0);
-      }
-    }
-  }
-}
-
-.c-bolt-blockquote--no-quotes {
-  .c-bolt-blockquote__quote {
-    p:before,
-    p:after {
-      display: none;
-    }
-
-    ::slotted(p):before,
-    ::slotted(p):after {
-      display: none;
-    }
   }
 }

--- a/packages/components/bolt-blockquote/src/blockquote.twig
+++ b/packages/components/bolt-blockquote/src/blockquote.twig
@@ -26,8 +26,7 @@
   this.data.align_items.value in align_items_options|keys ? base_class ~ "--align-items-" ~ align_items_options[this.data.align_items.value],
   this.data.border.value == 'none' ? base_class ~ "--borderless" : base_class ~ "--bordered-" ~ this.data.border.value,
   this.data.indent.value ? base_class ~ "--indented" : "",
-  this.data.full_bleed.value ? base_class ~ "--full" : "",
-  this.data.no_quotes.value ? base_class ~ "--no-quotes" : ""
+  this.data.full_bleed.value ? base_class ~ "--full" : ""
 ] %}
 
 {% set text_classes = [


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-178

## Summary

Fixes quotes in Safari which were previously not showing.

## Details

Safari doesn't support the CSS selector we were using to add quotation marks. That selector is `::slotted()` combined with a pseudo-selector, example: `::slotted(p):before { }`. I couldn't find any Safari docs specifically saying this isn't supported, but it's what I found after testing. It supports chaining `::slotted()` with other selectors, just no pseudo-selectors.

Given that limitation of Safari, I had to refactor the CSS to use attribute selectors not classes in order to target the blockquote `<p>` tags. In the end this actually reduced a lot of complexity in the CSS _and_ in the JS.

I switch to use `first-of-type` rather than `.is-first-child` classes and eliminated some unnecessary JS in the process.

I also had to refactor the language-specific quotes so that it worked when the `[lang]` attribute was on the blockquote itself _or_ somewhere up the tree.

## How to test
- Review code changes
- Review all [Blockquote demos](https://bugfix-ds-178-blockquote-quotes-in-safari.boltdesignsystem.com/pattern-lab/?p=viewall-components-blockquote) in Safari