### PR TITLE
WWW-277: Allow video captions button to show

### DIFF
--- a/packages/components/bolt-video/src/_videojs-enhancements.scss
+++ b/packages/components/bolt-video/src/_videojs-enhancements.scss
@@ -3,7 +3,6 @@
 // Dev Notes
 // 1. [Mai] Because these styles are overrides, they need to be repeated.
 // 2. [Mai] Input font-size needs to be 16px to prevent zooming.
-// 3. [Mai] Hide close captions button.
 // 4. [Mai] Flexbox messes up IE layout, this prevents IE from loading display: flex.
 // 5. Required so videos with intrinsic ratio (used in the <bolt-ratio> object) properly fill the space available in IE 11.
 // 6. [Denton] Hide the title when sharing to minimize the chances that you'll see a scrollbar, which is undesirable.  The description field will take its place.
@@ -409,8 +408,4 @@ $bolt-video-js-button-shadow-level-hover: 'level-40';
       }
     }
   }
-}
-
-.vjs-subs-caps-button {
-  display: none; // [3]
 }


### PR DESCRIPTION


## Jira

https://pegadigitalit.atlassian.net/browse/WWW-277

## Summary

Allows closed caption button to display, but only on videos that have stored captions.

## Details

From all my testing, the CC button only shows if there is actually a stored caption available for the video.  I'm not sure why it was ever a problem before-- fingers crossed that it was just a bug on the bc side that's since been fixed.

## How to test

Confirm that all videos that don't have stored closed caption files (as of now, all of them) don't show the CC button.

![Screen Shot 2020-10-23 at 4 27 54 PM](https://user-images.githubusercontent.com/677668/97051189-bc8d3280-154c-11eb-8ba8-bfb3e1bd7fdf.png)

