### PR TITLE
Fix failing autolink test

### DIFF
--- a/packages/analytics/autolink/__tests__/autolink.test.js
+++ b/packages/analytics/autolink/__tests__/autolink.test.js
@@ -49,7 +49,7 @@ describe('analytics autolinker', () => {
     await page.evaluate(() => {
       const btn = document.createElement('bolt-button');
       btn.textContent = 'External URL - Shadow DOM Test';
-      btn.setAttribute('url', 'https://www.brightcove.com');
+      btn.setAttribute('url', 'https://www.boltdesignsystem.com');
       document.body.appendChild(btn);
     });
 
@@ -73,7 +73,7 @@ describe('analytics autolinker', () => {
 
     await page.evaluate(() => {
       const btn = document.querySelector('bolt-button');
-      btn.setAttribute('url', 'https://www.brightcove.com');
+      btn.setAttribute('url', 'https://www.boltdesignsystem.com');
       btn.setAttribute('color', 'secondary');
       return document.body.innerHTML;
     });
@@ -82,7 +82,7 @@ describe('analytics autolinker', () => {
     const currentUrl = await page.url();
 
     expect(currentUrl).toContain('_ga');
-    expect(currentUrl).toContain('brightcove.com');
+    expect(currentUrl).toContain('boltdesignsystem.com');
   }, 5000);
 
   test('autolinker updates the URLs of a <bolt-button> with an external url + rendering to the Shadow DOM', async function() {

--- a/packages/analytics/autolink/__tests__/fixtures/test-analytics-config.data.js
+++ b/packages/analytics/autolink/__tests__/fixtures/test-analytics-config.data.js
@@ -1,6 +1,6 @@
 window.bolt = window.bolt || {};
 window.bolt.autolink = {
-  domains: ['google.com', 'brightcove.com'],
+  domains: ['google.com', 'boltdesignsystem.com'],
 };
 
 // or an inline script


### PR DESCRIPTION
## Jira

n/a

## Summary

Fix failing autolink test.

## Details

Autolink tests are failing on all branches due to a new Brightcove redirect.

In these tests, we click on a link, go to a new URL, and check if the URL includes the expected query param. Where we use `brightcove.com`, that query param is stripped out when `brightcove.com` redirects to `brightcove.com/en`. To fix, I changed the test URL to `boltdesignsystem.com`.

## How to test

- Review files changed
- Tests are passing