### PR TITLE
ACD-365: Update Academy dashboard

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/02-molecules/cards/_vertical-card.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/02-molecules/cards/_vertical-card.twig
@@ -49,7 +49,7 @@
   {% endblock %}
 
   {% block body %}
-    <div class="u-bolt-overflow-hidden">
+    <div>
       {% grid "o-bolt-grid--flex o-bolt-grid--matrix o-bolt-grid--small" %}
         {% cell "u-bolt-width-12/12" %}
           {% if cardMetaItems %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/03-organisms/collections/dashboard/_dashboard-band--my-missions.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/03-organisms/collections/dashboard/_dashboard-band--my-missions.twig
@@ -1,5 +1,33 @@
 {% import "@bolt-academy/_macros.twig" as macros %}
 
+{% set trigger %}
+  {% include "@bolt-components-button/button.twig" with {
+    text: "Pega Customer Decision Hub 8.5",
+    size: "xsmall",
+    style: "tertiary",
+    icon: {
+      name: "chevron-down",
+      position: "after",
+      size: "xsmall"
+    }
+  } only %}
+{% endset %}
+
+{% set popoverContent %}
+  {% include "@bolt-components-menu/menu.twig" with {
+    items: [
+      {
+        content: "Pega Customer Decision Hub 8.1",
+        url: "https://pega.com"
+      },
+      {
+        content: "Pega Customer Decision Hub 8.3",
+        url: "https://pega.com"
+      },
+    ]
+  } only %}
+{% endset %}
+
 {% set cardContentItems = [
     {
       cardUrl: "#!",
@@ -8,22 +36,29 @@
       cardMetaItems: [
         macros.include("@bolt-components-headline/text.twig", {
           size: "small",
-          weight: "bold",
-          text: "#{bolt.faker.numberBetween(2,10)} Modules",
+          text: "1 Module",
+          weight: "semibold"
         }, false),
         macros.include("@bolt-components-headline/text.twig", {
           size: "small",
-          weight: "bold",
-          text: "1 Challenge",
-        }, false),
-        macros.include("@bolt-components-headline/text.twig", {
-          size: "small",
-          weight: "bold",
-          text: "25% complete",
+          text: "10 mins",
+          weight: "semibold",
           attributes: {
-            class: ["u-bolt-color-orange"]
-          }
-        }, false)
+            class: "stats-item",
+          },
+        }, false),
+        macros.include("@bolt-components-popover/popover.twig", {
+          trigger: trigger,
+          content: popoverContent,
+          spacing: "none",
+          boundary: "bolt-card-replacement",
+          placement: "top-start",
+          fallbackPlacements: [
+            "top",
+            "top-end"
+          ],
+          theme: "light"
+        }, false),
       ],
       cardGradient: "pink",
       cardIcon: "launchpad",
@@ -129,22 +164,29 @@
       cardMetaItems: [
         macros.include("@bolt-components-headline/text.twig", {
           size: "small",
-          weight: "bold",
-          text: "#{bolt.faker.numberBetween(2,10)} Modules",
+          text: "1 Module",
+          weight: "semibold"
         }, false),
         macros.include("@bolt-components-headline/text.twig", {
           size: "small",
-          weight: "bold",
-          text: "1 Challenge",
-        }, false),
-        macros.include("@bolt-components-headline/text.twig", {
-          size: "small",
-          weight: "bold",
-          text: "25% complete",
+          text: "10 mins",
+          weight: "semibold",
           attributes: {
-            class: ["u-bolt-color-orange"]
-          }
-        }, false)
+            class: "stats-item",
+          },
+        }, false),
+        macros.include("@bolt-components-popover/popover.twig", {
+          trigger: trigger,
+          content: popoverContent,
+          spacing: "none",
+          boundary: "bolt-card-replacement",
+          placement: "top-start",
+          fallbackPlacements: [
+            "top",
+            "top-end"
+          ],
+          theme: "light"
+        }, false),
       ],
       cardGradient: "pink",
       cardIcon: "launchpad",


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/ACD-365

## Summary

Update Academy dashboard template to include Popover, remove overflow "hidden" utility class.

## Details

This just keeps our PL template in sync with changes to production, so we can continue to use PL to troubleshoot front-end issues on Academy. Only affects Academy templates, which are not used directly anywhere outside of Bolt.

## How to test

Review code changes and deployed [Dashboard page](https://feature-acd-365-dashboard-popover.boltdesignsystem.com/pattern-lab/?p=pages-acd-dashboard). Dashboard should now have a popover on the first and fourth cards in the My Missions carousel.
