### PR TITLE
DS-253 Fix invisible Accordion content

### DIFF
--- a/packages/components/bolt-band/src/band.js
+++ b/packages/components/bolt-band/src/band.js
@@ -17,7 +17,8 @@ class BoltBand extends BoltElement {
   }
 
   firstUpdated() {
-    // super.connectedCallback && super.connectedCallback();
+    super.firstUpdated && super.firstUpdated();
+
     this.state = {
       ready: false,
     };


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-253

## Summary

Fix a bug where accordion content is invisible on initial load, occurs intermittently when you put an accordion inside and band and use deep linking.

## Details

When you put an Accordion in a Band, sometimes Accordion renders first, sometimes Band, because our components load asynchronously. When the Accordion loads first _and_ you are deep linking to an accordion section, Accordion starts to open the deep linked section and the CSS animation gets interrupted by the parent Band rendering. Handorgel, the accordion library we use, waits for the `transitionend` event to make the content visible. When Band interrupts the animation, this event never fires and we get this bug.

The fix is really just a workaround. It waits for the closest band to finish rendering before starting to open the initial Accordion section. I think this workaround is appropriate given that Band will be downgraded from a WC in the near future.

Note: this fix required a separate but related fix to the Band WC. It was not calling `super.firstUpdated()` so the Band's `ready` event was not firing.

## How to test

1. On master, copy this code into PL:
```
<bolt-text>
  Deep link to an accordion item by adding a query string to the URL with "selected-accordion-item" as the name and the item ID as the value. For example: <bolt-link url="?selected-accordion-item=item-3">?selected-accordion-item=item-3</bolt-link>.
</bolt-text>

{% set accordion %}
  {% include "@bolt-components-accordion/accordion.twig" with {
    items: [
      {
        trigger: "Accordion item 1",
        content: "This is the accordion content.",
        id: "item-1",
      },
      {
        trigger: "Accordion item 2",
        content: "This is the accordion content.",
        id: "item-2",
      },
      {
        trigger: "Accordion item 3",
        content: "This is the accordion content.",
        id: "item-3",
      }
    ]
  } only %}
{% endset %}

{% include "@bolt-components-band/band.twig" with {
  content: accordion
} only %}
```

2. Go to that page and click the "deep link" or just append the query string `?selected-accordion-item=item-3`. Be sure to open the page in a new window, not in PL iframe. Verify you can reproduce the bug. The deep linked section should open but the content is invisible.

3. Checkout this feature branch and repeat the steps above. Verify it is fixed.