### PR TITLE
DS-258 fix typos and bad code in Stack component

### DIFF
--- a/packages/components/bolt-stack/src/stack.scss
+++ b/packages/components/bolt-stack/src/stack.scss
@@ -15,11 +15,16 @@
 @each $size in $bolt-spacing-multiplier-system {
   $size-name: nth($size, 1);
 
-  bolt-stack:not(:last-child)[spacing='#{$size-name}'] {
+  @include bolt-repeat-rule(
+    (
+      'bolt-stack:not(:last-child)[spacing=#{$size-name}]',
+      ':host:not(:last-child)[spacing=#{$size-name}]'
+    )
+  ) {
     margin-bottom: var(--bolt-spacing-y-#{$size-name});
   }
 }
 
-bolt-stack[spacing='none'] {
+@include bolt-repeat-rule(('bolt-stack[spacing=none]', ':host[spacing=none]')) {
   margin-bottom: 0;
 }

--- a/packages/components/bolt-stack/src/stack.twig
+++ b/packages/components/bolt-stack/src/stack.twig
@@ -1,7 +1,7 @@
-{% set schema = bolt.data.components["@bolt-components-stack"].schema %}
+{% set schema = bolt.data.components['@bolt-components-stack'].schema %}
 
 {% if enable_json_schema_validation %}
-  {{ validate_data_schema(schema, _self) | raw }}
+  {{ validate_data_schema(schema, _self)|raw }}
 {% endif %}
 
 {# Variables #}
@@ -9,9 +9,7 @@
 {% set inner_attributes = create_attribute({}) %}
 
 {% set classes = [
-  "c-bolt-stack",
-  this.data.spacing.value ? "c-bolt-example--spacing-" ~ this.data.spacing.value : "",
-  this.data.borderless.value ? "c-bolt-example--borderless" : "",
+  'c-bolt-stack',
 ] %}
 
 {#
@@ -23,16 +21,16 @@
 {% set inner_classes = classes %}
 
 {% for class in this.props.class %}
-  {% if class starts with "is-" or class starts with "has-" %}
+  {% if class starts with 'is-' or class starts with 'has-' %}
     {% set inner_classes = inner_classes|merge([class]) %}
-  {% elseif class starts with "c-bolt-" == false %}
+  {% elseif class starts with 'c-bolt-' == false %}
     {% set outer_classes = outer_classes|merge([class]) %}
   {% endif %}
 {% endfor %}
 
 <bolt-stack
   {% if outer_classes %} class="{{ outer_classes|join(' ') }}" {% endif %}
-  {{ this.props|without("content")|without("class") }}
+  {{ this.props|without('content')|without('class') }}
 >
   <ssr-keep for="bolt-stack" {{ inner_attributes.addClass(inner_classes) }}>
     {{ content }}

--- a/packages/components/bolt-stack/stack.schema.js
+++ b/packages/components/bolt-stack/stack.schema.js
@@ -7,7 +7,7 @@ module.exports = {
       title: 'Attributes (Twig-only)',
       type: 'object',
       description:
-        'A Drupal attributes object. Used to apply with extra HTML attributes to the outer &lt;bolt-stack&gt; tag.',
+        'A Drupal attributes object. Applies extra HTML attributes to the outer &lt;bolt-stack&gt; tag.',
     },
     spacing: {
       type: 'string',
@@ -18,20 +18,6 @@ module.exports = {
     content: {
       type: ['string', 'array', 'object'],
       description: 'Content of the stack.',
-    },
-    no_shadow: {
-      title: 'Disable Shadow DOM (Twig-only)',
-      description:
-        'Manually disables the component from rendering to the Shadow DOM in a Twig template. Useful for testing cross browser functionality / rendering behavior. By default this is handled globally based on browser support.',
-      hidden: true,
-      type: 'boolean',
-    },
-    'no-shadow': {
-      title: 'Disable Shadow DOM (Web Component-only)',
-      description:
-        'Manually disables the web component from rendering to the Shadow DOM. Useful for testing cross browser functionality / rendering behavior. By default this is handled globally based on browser support.',
-      hidden: true,
-      type: 'boolean',
     },
   },
 };


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-258

## Summary

Cleaned up code in the Stack component.

## Details

1. Fixed typos in schema and remove the no-shadow props.
2. Removed unrelated code in twig.
3. Convert to using repeat-rule mixin for styling custom elements.

## How to test

There is no existing visual bugs, just bad code. Run the branch locally and check the Stack docs. Make sure it's still working the same way.