### PR TITLE
DS-264: Add srcset support for hero component

### DIFF
--- a/packages/components/bolt-hero/hero.schema.js
+++ b/packages/components/bolt-hero/hero.schema.js
@@ -29,6 +29,11 @@ module.exports = {
       description:
         'The path to a foreground image that  displays along-side the other Hero content.',
     },
+    image_srcset: {
+      type: 'string',
+      description:
+        'A valid image srcset value with different cuts of the image for different breakpoints',
+    },
     imageAlign: {
       type: 'string',
       enum: ['left', 'center', 'right'],

--- a/packages/components/bolt-hero/hero.twig
+++ b/packages/components/bolt-hero/hero.twig
@@ -38,6 +38,7 @@
       ">
       {% include "@bolt-components-image/image.twig" with {
         src: this.data["image"].value,
+        srcset: this.data["image_srcset"].value ? this.data["image_srcset"].value : this.data["image"].value,
         max_width: this.data["image_max_width"].value,
         attributes: {
           style: "min-width: " ~ (this.data["image_min_width"].value ? this.data["image_min_width"].value : 'none') ~ ";",


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-264

## Summary

Add srcset support to an image in hero component

## Details

This PR just allows passing one additional attribute to the hero image.  We don't want to handle similar problems in the same piecemeal way; this is a quick way to unblock some performance work, and the whole pattern with the hero component is not necessarily one we'll follow in the future.

## How to test

There are no changes to pattern lab.  [This line in image.twig ](https://github.com/boltdesignsystem/bolt/blob/master/packages/components/bolt-image/src/image.twig#L20-L22) automatically fills srcset in any images within pattern lab, so you'd need to comment it out in order to test that a string value can be passed to image_srcset in the hero component, like this:

```
{% include "@bolt-components-hero/hero.twig" with {
  content: exampleContent,
  image: "/images/heros/hero-foreground--yellow.png",
  image_srcset: '/images/heros/hero-foreground--yellow.png 480w, /images/heros/hero-foreground--yellow.png 800w',
} only %}
```