### PR TITLE
WWW-384: Fix responsiveness on Edge 42/44 

### DIFF
--- a/packages/components/bolt-video/src/_videojs-enhancements.scss
+++ b/packages/components/bolt-video/src/_videojs-enhancements.scss
@@ -95,9 +95,8 @@ $bolt-video-js-button-shadow-level-hover: 'level-40';
 
         &:before {
           position: absolute;
-          top: 0;
-          left: 0;
-          transform: translate(-65%, -30%);
+          top: -33%;
+          left: -50%;
           width: 100%;
           height: 100%;
         }

--- a/packages/components/bolt-video/src/_videojs-enhancements.scss
+++ b/packages/components/bolt-video/src/_videojs-enhancements.scss
@@ -66,9 +66,6 @@ $bolt-video-js-button-shadow-level-hover: 'level-40';
         * Temporary Microsoft Edge .v~40 work around due to lack of 'clip-path' support
         */
       @include bolt-ms-edge-42-only {
-        top: 40%;
-        left: 40%;
-        transform: translate(-50%, -50%);
         font-size: 40%;
         background-color: transparent;
 
@@ -86,6 +83,23 @@ $bolt-video-js-button-shadow-level-hover: 'level-40';
 
         @include bolt-mq(large) {
           font-size: 80%;
+        }
+
+        @include bolt-mq(xlarge) {
+          font-size: 90%;
+        }
+
+        @include bolt-mq(xxlarge) {
+          font-size: 100%;
+        }
+
+        &:before {
+          position: absolute;
+          top: 0;
+          left: 0;
+          transform: translate(-65%, -30%);
+          width: 100%;
+          height: 100%;
         }
       }
     }


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/WWW-384

## Summary

Create Edge ~v.42 specific CSS to handle the video player "play" icon

## Details

Make play icon responsive

## How to test

View "/pattern-lab/?p=components-video" in Edge v.18 Browserstack (this browser also doesn't support clip-path)
Check it on different screen sizes.
