### PR TITLE
DS-245: Links to external sites in Teaser headlines not opening in new tab

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/10-teaser-variation.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/10-teaser-variation.twig
@@ -2,7 +2,7 @@
   content: "Body text. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Proin vel ante a orci tempus eleifend ut et magna. Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
   headlines: [
     {
-      text: "This is a headline."
+      text: "This is a headline"
     }
   ],
   eyebrow: {

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/15-teaser-linked.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/15-teaser-linked.twig
@@ -1,0 +1,10 @@
+{% include "@bolt-components-teaser/teaser.twig" with {
+  headlines: [
+    {
+      text: "This is a linked headline.",
+      url: "https://pega.com/",
+      target: "_blank",
+    }
+  ],
+  content: "This demo is to test linking and setting a target in the Teaser's Headline. Eiusmod officia tempor amet esse aliquip ad fugiat officia aliqua reprehenderit esse dolore consectetur laboris.",
+} %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/15-teaser-with headline-link.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/15-teaser-with headline-link.twig
@@ -1,7 +1,7 @@
 {% include "@bolt-components-teaser/teaser.twig" with {
   headlines: [
     {
-      text: "This headline is a link.",
+      text: "This headline is a link",
       url: "https://pega.com/",
       target: "_blank",
     }

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/15-teaser-with headline-link.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/15-teaser-with headline-link.twig
@@ -1,7 +1,7 @@
 {% include "@bolt-components-teaser/teaser.twig" with {
   headlines: [
     {
-      text: "This is a linked headline.",
+      text: "This headline is a link.",
       url: "https://pega.com/",
       target: "_blank",
     }

--- a/packages/components/bolt-headline/headline.schema.js
+++ b/packages/components/bolt-headline/headline.schema.js
@@ -1,3 +1,6 @@
+const elementSchemas = require('@bolt/element/element.schemas');
+const { url, target } = elementSchemas.boltActionElement.properties;
+
 module.exports = {
   $schema: 'http://json-schema.org/draft-04/schema#',
   title: 'Headline',
@@ -52,21 +55,13 @@ module.exports = {
         'Automatically shrink the font size used in the `xxxlarge` headline size when 60 or more characters are used.',
       default: true,
     },
-    target: {
-      type: 'string',
-      description: '',
-      default: '_self',
-      enum: ['_blank', '_self'],
-    },
+    target,
     transform: {
       type: 'string',
       description: 'Text transformation.',
       enum: ['uppercase', 'lowercase', 'capitalize'],
     },
-    url: {
-      type: 'string',
-      description: 'If provided, turns headline into a link to given url.',
-    },
+    url,
     icon: {
       description:
         "Bolt icon. Accepts either 1) an icon name as a string 2) an icon object as expected by `@bolt-components-icon` or 3) the string 'none' to explicitly remove default icons",

--- a/packages/components/bolt-headline/headline.schema.js
+++ b/packages/components/bolt-headline/headline.schema.js
@@ -52,6 +52,12 @@ module.exports = {
         'Automatically shrink the font size used in the `xxxlarge` headline size when 60 or more characters are used.',
       default: true,
     },
+    target: {
+      type: 'string',
+      description: '',
+      default: '_self',
+      enum: ['_blank', '_self'],
+    },
     transform: {
       type: 'string',
       description: 'Text transformation.',

--- a/packages/components/bolt-headline/src/_typography.twig
+++ b/packages/components/bolt-headline/src/_typography.twig
@@ -107,6 +107,7 @@
   {% endif %}
   {%- if url -%}
     {% set linkVars = {
+      target: target,
       text: text,
       url: url,
       isHeadline: (type != "text")


### PR DESCRIPTION
## Jira

[https://pegadigitalit.atlassian.net/browse/DS-245](https://pegadigitalit.atlassian.net/browse/DS-245)

## Summary

Allow links in the headline of bolt-teaser to use the target attribute.

## Details

Allowed a new target attribute on bolt-teaser be passed into bolt-headline, and ultimately set a target on bolt-link to allow for opening links in a new tab.

## How to test

There's a demo in bolt-teaser.

## Release notes

Add target option to bolt-teaser.