### PR TITLE
Fix play icon

### DIFF
--- a/packages/components/bolt-video/src/_videojs-enhancements.scss
+++ b/packages/components/bolt-video/src/_videojs-enhancements.scss
@@ -66,39 +66,35 @@ $bolt-video-js-button-shadow-level-hover: 'level-40';
         * Temporary Microsoft Edge .v~40 work around due to lack of 'clip-path' support
         */
       @include bolt-ms-edge-42-only {
-        font-size: 40%;
-        background-color: transparent;
+        left: 60%;
+        width: 43%;
 
-        @include bolt-mq(xsmall) {
-          font-size: 50%;
-        }
-
-        @include bolt-mq(small) {
-          font-size: 60%;
-        }
-
-        @include bolt-mq(medium) {
-          font-size: 70%;
-        }
-
-        @include bolt-mq(large) {
-          font-size: 80%;
-        }
-
-        @include bolt-mq(xlarge) {
-          font-size: 90%;
-        }
-
-        @include bolt-mq(xxlarge) {
-          font-size: 100%;
+        &:before,
+        &:after {
+          content: '';
+          display: block;
+          position: absolute;
+          top: 50%;
+          transform: translateY(-50%);
+          width: calc(100% + 4px);
+          height: calc(100% + 4px);
+          font-family: var(--bolt-type-font-family-body);
         }
 
         &:before {
-          position: absolute;
-          top: -33%;
-          left: -50%;
-          width: 100%;
-          height: 100%;
+          background: linear-gradient(
+                          -30deg,
+                          $bolt-video-js-button-background-color 48%,
+                          transparent 50%
+          );
+        }
+
+        &:after {
+          background: linear-gradient(
+                          -150deg,
+                          $bolt-video-js-button-background-color 48%,
+                          transparent 50%
+          );
         }
       }
     }


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/WWW-384

## Summary

Create Edge ~v.42 specific CSS to handle the video player "play" icon

## Details

The previous fix was based on media queries and it works when we have a video with the same dimensions as the page but if we have video as a part of the page fix was not working correctly. This will work in that case now.

### Previous fix:
![image](https://user-images.githubusercontent.com/16049049/100351765-4452da80-2fec-11eb-8b50-918d7c00204e.png)
![image](https://user-images.githubusercontent.com/16049049/100351772-46b53480-2fec-11eb-9752-152c92c2fda6.png)

### Correct fix:
![image](https://user-images.githubusercontent.com/16049049/100351791-4cab1580-2fec-11eb-9d38-9659cdf835d2.png)
![image](https://user-images.githubusercontent.com/16049049/100351801-50d73300-2fec-11eb-98ff-1d0d66d15087.png)

## How to test

View "/pattern-lab/?p=components-video" and "/pattern-lab/?p=components-card-replacement-with-video" in Edge v.18 Browserstack (this browser also doesn't support clip-path)
Check it on different screen sizes.

