### PR TITLE
DS-268: Update copy-to-clipboard WC to latest renderer

### DIFF
--- a/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.standalone.js
+++ b/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.standalone.js
@@ -1,26 +1,32 @@
 import { html, customElement, BoltElement, unsafeCSS } from '@bolt/element';
 import ClipboardJS from 'clipboard';
-import classNames from 'classnames/bind';
-import styles from './copy-to-clipboard.scss';
-import schema from '../copy-to-clipboard.schema';
 
-let cx = classNames.bind(styles);
+/**
+ * 1. This web component does not currently use props or the shadow dom, so these lines of code are not required.
+ *    Uncomment if we later decide to rebuild this as a full-featured web component.
+ */
+
+// import classNames from 'classnames/bind'; /* [1] */
+// import styles from './copy-to-clipboard.scss'; /* [1] */
+// import schema from '../copy-to-clipboard.schema'; /* [1] */
+
+// let cx = classNames.bind(styles); /* [1] */
 
 @customElement('bolt-copy-to-clipboard')
 class BoltCopyToClipboard extends BoltElement {
-  static schema = schema;
+  // static schema = schema; /* [1] */
 
-  static get properties() {
-    return {
-      ...this.props,
-    };
-  }
+  // static get properties() {
+  //   return {
+  //     ...this.props,
+  //   };
+  // } /* [1] */
 
   static useShadow = false;
 
-  static get styles() {
-    return [unsafeCSS(styles)];
-  }
+  // static get styles() {
+  //   return [unsafeCSS(styles)];
+  // } /* [1] */
 
   connectedCallback() {
     super.connectedCallback && super.connectedCallback();

--- a/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.standalone.js
+++ b/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.standalone.js
@@ -1,16 +1,27 @@
-import { html, customElement } from '@bolt/element';
+import { html, customElement, BoltElement, unsafeCSS } from '@bolt/element';
 import ClipboardJS from 'clipboard';
-import { withLitHtml } from '@bolt/core-v3.x/renderers/renderer-lit-html';
+import classNames from 'classnames/bind';
+import styles from './copy-to-clipboard.scss';
+import schema from '../copy-to-clipboard.schema';
+
+let cx = classNames.bind(styles);
 
 @customElement('bolt-copy-to-clipboard')
-class BoltCopyToClipboard extends withLitHtml {
-  constructor(self) {
-    self = super(self);
-    self.useShadow = false;
-    return self;
+class BoltCopyToClipboard extends BoltElement {
+  static schema = schema;
+
+  static get properties() {
+    return {
+      ...this.props,
+    };
   }
 
-  connecting() {
+  static get styles() {
+    return [unsafeCSS(styles)];
+  }
+
+  connectedCallback() {
+    super.connectedCallback && super.connectedCallback();
     this.copyTrigger = this.querySelector('[data-clipboard-text]');
     this.parentElem = this.querySelector('.js-bolt-copy-to-clipboard');
 
@@ -35,13 +46,14 @@ class BoltCopyToClipboard extends withLitHtml {
     });
   }
 
-  disconnecting() {
+  disconnectedCallback() {
+    super.disconnectedCallback && super.disconnectedCallback();
     this.clipboardInstance.destroy();
   }
 
   render() {
     return html`
-      ${this.slot('default')}
+      ${this.slotify('default')}
     `;
   }
 }

--- a/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.standalone.js
+++ b/packages/components/bolt-copy-to-clipboard/src/copy-to-clipboard.standalone.js
@@ -16,6 +16,8 @@ class BoltCopyToClipboard extends BoltElement {
     };
   }
 
+  static useShadow = false;
+
   static get styles() {
     return [unsafeCSS(styles)];
   }


### PR DESCRIPTION
## Jira

[https://pegadigitalit.atlassian.net/browse/DS-268](https://pegadigitalit.atlassian.net/browse/DS-268)

## Summary

Update copy-to-clipboard to the latest renderer standards. 

## Details

Update copy-to-clipboard to the latest renderer standards. 

## How to test

To test the conversion:

- Review changes
- Test copy-to-clipboard demos