### PR TITLE
WWW-421: Do not show remaining video time in accordion or tabs

### DIFF
--- a/packages/components/bolt-video/src/video.scss
+++ b/packages/components/bolt-video/src/video.scss
@@ -196,6 +196,11 @@ bolt-accordion-item,
 bolt-tab-panel {
   @include bolt-mq($from: medium) {
     .video-js.vjs-layout-tiny:not(.vjs-fullscreen) {
+      // Remaining time should never be shown.  Other controls that shouldn't be forced to show, but sometimes do show--
+      // such as the subs-caps button-- are typically hidden with an !important declaration when they should be hidden.
+      // This seems to be the exception.
+      //
+      // .vjs-remaining-time,
       .vjs-audio-button,
       .vjs-captions-button,
       .vjs-chapters-button,
@@ -205,7 +210,6 @@ bolt-tab-panel {
       .vjs-mute-control,
       .vjs-playback-rate,
       .vjs-progress-control,
-      .vjs-remaining-time,
       .vjs-subs-caps-button,
       .vjs-subtitles-button,
       .vjs-time-divider,


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/WWW-421

## Summary

Fixes a bug where time remaining shows on videos that are placed within tabs or accordion

## Details

![Screen Shot 2020-12-03 at 2 17 26 PM](https://user-images.githubusercontent.com/677668/101077190-7c20cb80-3572-11eb-9a09-d5428e9fc097.png)

## How to test

This _should_ be testable in Bolt on the [tabs content](https://boltdesignsystem.com/pattern-lab/?p=components-tabs-content) and [accordion content](https://boltdesignsystem.com/pattern-lab/?p=components-accordion-content-variations) pages, but it's not.  For some reason, videos in those scenarios get the `vjs-layout-medium` class instead of the `vjs-layout-tiny` class that happens on pega.com production, and for which this CSS was originally written.  Maybe there's a race condition of some sort?  @colbytcook and I are stumped 🤷 .

Edit: it appears that videos inconsistently get either `vjs-layout-medium` or `vjs-layout-tiny`.  It's likely some race condition (FYI @danielamorse), but that isn't a problem for this PR, which only cares about the scenario where videos load with `vjs-layout-tiny` class.