### PR TITLE
DS-42 restore schema validation twig dump

### DIFF
--- a/docs-site/.patches/faster-compile-times--add-twig-cache-support--file-system-loader.patch
+++ b/docs-site/.patches/faster-compile-times--add-twig-cache-support--file-system-loader.patch
@@ -16,7 +16,7 @@ index 1b0e00c92..5dba4d080 100644
  		$twigLoader = new \Twig_Loader_Filesystem($filesystemLoaderPaths);
 -		$instance   = new \Twig_Environment($twigLoader, array("debug" => $twigDebug));
 +		$instance   = new \Twig_Environment($twigLoader, array(
-+			"debug" => false,
++			"debug" => $twigDebug,
 +			"cache" => $twigCache,
 +			"auto_reload" => true,
 +		));

--- a/docs-site/.patches/faster-compile-times--add-twig-cache-support--pattern-loader.patch
+++ b/docs-site/.patches/faster-compile-times--add-twig-cache-support--pattern-loader.patch
@@ -16,7 +16,7 @@ index 4fa55da73..e0de95c28 100644
  		$twigLoader = new \Twig_Loader_Chain($loaders);
 -		$instance   = new \Twig_Environment($twigLoader, array("debug" => $twigDebug, "autoescape" => $twigAutoescape));
 +		$instance   = new \Twig_Environment($twigLoader, array(
-+			"debug" => false,
++			"debug" => $twigDebug,
 +			"autoescape" => $twigAutoescape,
 +			"cache" => $twigCache,
 +			"auto_reload" => true,

--- a/docs-site/.patches/faster-compile-times--add-twig-cache-support--string-loader.patch
+++ b/docs-site/.patches/faster-compile-times--add-twig-cache-support--string-loader.patch
@@ -16,7 +16,7 @@ index 4526c2ce7..87a76068e 100644
  		$twigLoader = new \Twig_Loader_Chain($loaders);
 -		$instance   = new \Twig_Environment($twigLoader, array("debug" => $twigDebug));
 +		$instance   = new \Twig_Environment($twigLoader, array(
-+			"debug" => false,
++			"debug" => $twigDebug,
 +			"cache" => $twigCache,
 +			"auto_reload" => true,
 +		));

--- a/docs-site/config/config.yml
+++ b/docs-site/config/config.yml
@@ -54,7 +54,7 @@ twigExtensions:
   - '\Bolt\TwigExtensions\BoltCore'
   - '\Bolt\TwigExtensions\BoltCoreCompat'
   - '\Bolt\TwigExtensions\BoltExtras'
-twigDebug: false
+twigDebug: true
 twigCache: cache/twig
 twigAutoescape: false
 twigDefaultDateFormat: ''

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/headline/25-headline-icon-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/headline/25-headline-icon-variations.twig
@@ -46,7 +46,7 @@
     text: "What we do at Pega is brilliant!",
     icon: {
       name: "energy",
-      color: "blue"
+      color: "navy",
     }
   } only %}
 </bolt-stack>

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/icon/10-icon-size-variation.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/icon/10-icon-size-variation.twig
@@ -1,6 +1,7 @@
-{% set exampleSizes = ["small", "medium", "large", "xlarge"] %}
+{% set schema = bolt.data.components["@bolt-components-icon"].schema %}
+{% set sizes = schema.properties.size.enum %}
 
-{% for size in exampleSizes %}
+{% for size in sizes %}
   {% include "@bolt-components-icon/icon.twig" with {
     name: "add-open",
     size: size
@@ -9,7 +10,7 @@
 
 <hr>
 
-{% for size in exampleSizes %}
+{% for size in sizes %}
   {% include "@bolt-components-icon/icon.twig" with {
     name: "add-open",
     background: "circle",

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/35-d8-events/05-event-detail.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/35-d8-events/05-event-detail.twig
@@ -249,7 +249,7 @@
                   "icon": {
                     "position": "before",
                     "name": "linkedin-solid",
-                    "color": "blue",
+                    "color": "navy",
                     "size": "medium"
                   }
                 } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/35-d8-events/10-event-form-example.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/35-d8-events/10-event-form-example.twig
@@ -32,7 +32,7 @@
               "icon": {
                 "position": "before",
                 "name": "linkedin-solid",
-                "color": "blue",
+                "color": "navy",
                 "size": "medium"
               }
             } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/02-molecules/cards/_vertical-card.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/02-molecules/cards/_vertical-card.twig
@@ -8,7 +8,6 @@
   gradientEnd: gradientEnd,
   cardIcon: cardIcon,
   cardSubtitle: cardSubtitle,
-  horizontal: horizontal,
   cardTitle: cardTitle,
   cardMetaItems: cardMetaItems,
   cardDescription: cardDescription,
@@ -21,7 +20,7 @@
       gradientMiddle: gradientMiddle,
       gradientEnd: gradientEnd,
       cardIcon: cardIcon,
-      horizontal: horizontal,
+      horizontal: false,
     } only %}
     <div class="t-bolt-dark u-bolt-padding-medium u-bolt-border-radius-small">
       {% grid "o-bolt-grid--flex o-bolt-grid--matrix o-bolt-grid--xsmall u-bolt-negative-margin-top-small u-bolt-negative-margin-right-small" %}

--- a/packages/components/bolt-background/background.schema.js
+++ b/packages/components/bolt-background/background.schema.js
@@ -4,7 +4,6 @@ module.exports = {
   description:
     'A content container that delivers important messages to the user.',
   type: 'object',
-  required: ['content'],
   properties: {
     attributes: {
       type: 'object',

--- a/packages/components/bolt-card-replacement/src/card-replacement-actions/_card-replacement-action.twig
+++ b/packages/components/bolt-card-replacement/src/card-replacement-actions/_card-replacement-action.twig
@@ -11,9 +11,12 @@
           icon: {
             name: external == false or external == null ? "chevron-right" : "external-link",
           },
-          size: spacing,
           attributes: attributes|default({})
         } %}
+
+        {% if spacing is not empty %}
+          {% set button_props = button_props|merge({ size: spacing }) %}
+        {% endif %}
 
         {% if url is not empty %}
           {% set button_props = button_props|merge({ url: url }) %}

--- a/packages/components/bolt-card-replacement/src/card-replacement-body/_card-replacement-body.twig
+++ b/packages/components/bolt-card-replacement/src/card-replacement-body/_card-replacement-body.twig
@@ -1,9 +1,5 @@
 {% set schema = bolt.data.components["@bolt-components-card-replacement"].schema %}
 
-{% if enable_json_schema_validation %}
-  {{ validate_data_schema(schema, _self) | raw }}
-{% endif %}
-
 {% set attributes = create_attribute(body.attributes|default({})) %}
 {% set inner_attributes = create_attribute({}) %}
 {% set card_replacement_body_content = body.content %}

--- a/packages/components/bolt-chip-list/__tests__/__snapshots__/chip-list.js.snap
+++ b/packages/components/bolt-chip-list/__tests__/__snapshots__/chip-list.js.snap
@@ -676,6 +676,7 @@ exports[`<bolt-chip-list> Component collapsible 2`] = `
                     <ssr-keep for="bolt-chip"
                               class="c-bolt-chip__text"
                     >
+                      Show more
                     </ssr-keep>
                     <ssr-keep for="bolt-chip"
                               class="c-bolt-chip__icon"
@@ -725,6 +726,7 @@ exports[`<bolt-chip-list> Component collapsible 2`] = `
                     <ssr-keep for="bolt-chip"
                               class="c-bolt-chip__text"
                     >
+                      Show less
                     </ssr-keep>
                     <ssr-keep for="bolt-chip"
                               class="c-bolt-chip__icon"
@@ -1262,6 +1264,7 @@ exports[`<bolt-chip-list> Component truncate 2`] = `
                     <ssr-keep for="bolt-chip"
                               class="c-bolt-chip__text"
                     >
+                      Show more
                     </ssr-keep>
                     <ssr-keep for="bolt-chip"
                               class="c-bolt-chip__icon"

--- a/packages/components/bolt-chip-list/src/_chip-list-macros.twig
+++ b/packages/components/bolt-chip-list/src/_chip-list-macros.twig
@@ -1,6 +1,7 @@
-{% macro truncateTrigger(iconName, size, inputId) %}
+{% macro truncateTrigger(iconName, size, inputId, text) %}
   <label class="c-bolt-chip-list__label" for="{{ inputId }}">
     {% include "@bolt-components-chip/chip.twig" with {
+      text: text,
       size: size,
       icon: {
         name: iconName

--- a/packages/components/bolt-chip-list/src/chip-list.twig
+++ b/packages/components/bolt-chip-list/src/chip-list.twig
@@ -64,7 +64,7 @@
 {% if willTruncate %}
   {% set list = list|merge([
     {
-      content: macros.truncateTrigger("more", size, inputId),
+      content: macros.truncateTrigger("more", size, inputId, "Show more"|t),
       attributes: {
         "truncate-trigger": "",
         "truncate-trigger-expand": ""
@@ -75,7 +75,7 @@
   {% if collapsible %}
     {% set list = list|merge([
       {
-        content: macros.truncateTrigger("chevron-left", size, inputId),
+        content: macros.truncateTrigger("chevron-left", size, inputId, "Show less"|t),
         attributes: {
           "truncate-trigger": "",
           "truncate-trigger-collapse": ""

--- a/packages/components/bolt-headline/src/_typography.twig
+++ b/packages/components/bolt-headline/src/_typography.twig
@@ -107,11 +107,13 @@
   {% endif %}
   {%- if url -%}
     {% set linkVars = {
-      target: target,
       text: text,
       url: url,
       isHeadline: (type != "text")
     } %}
+    {% if target %}
+      {% set linkVars = linkVars | merge({ target: target }) %}
+    {% endif %}
     {% if icon %}
       {% set linkVars = linkVars | merge({ icon: icon }) %}
     {% endif %}

--- a/packages/components/bolt-icon/icon.schema.json
+++ b/packages/components/bolt-icon/icon.schema.json
@@ -175,6 +175,7 @@
       "type": "string",
       "description": "Icon size.",
       "enum": [
+        "xsmall",
         "small",
         "medium",
         "large",

--- a/packages/components/bolt-share/src/share.twig
+++ b/packages/components/bolt-share/src/share.twig
@@ -79,7 +79,7 @@
     {% set icon_before %}
       {% include '@bolt-components-icon/icon.twig' with {
         name: source_icon,
-        size: size == 'medium' ? 'small',
+        size: 'small',
       } only %}
     {% endset %}
     {% set source_menu_items %}
@@ -156,7 +156,7 @@
       <span class="c-bolt-menu-item__icon-before" aria-hidden="true">
         {% include '@bolt-components-icon/icon.twig' with {
           name: 'asset-link',
-          size: size == 'medium' ? 'small',
+          size: 'small',
         } only %}
       </span>
       {{ trigger_text }}
@@ -167,7 +167,7 @@
       <span class="c-bolt-menu-item__icon-before u-bolt-opacity-0" aria-hidden="true">
         {% include '@bolt-components-icon/icon.twig' with {
           name: 'asset-link',
-          size: size == 'medium' ? 'small',
+          size: 'small',
         } only %}
       </span>
       {{ transition_text }}
@@ -178,7 +178,7 @@
       <span class="c-bolt-menu-item__icon-before" aria-hidden="true">
         {% include '@bolt-components-icon/icon.twig' with {
           name: 'check',
-          size: size == 'medium' ? 'small',
+          size: 'small',
         } only %}
       </span>
       {{ confirmation_text }}

--- a/packages/elements/bolt-button/button.schema.js
+++ b/packages/elements/bolt-button/button.schema.js
@@ -10,21 +10,21 @@ module.exports = {
         'A Drupal-style attributes object with extra attributes to append to this component.',
     },
     content: {
-      type: 'object',
+      type: 'any',
       description: 'Content of the button.',
     },
     icon_before: {
-      type: 'object',
+      type: 'any',
       description:
         'Append an icon before the button content. Icon component is recommended. However, &lt;img&gt; elements are also acceptable.',
     },
     icon_after: {
-      type: 'object',
+      type: 'any',
       description:
         'Append an icon after the button content. Icon component is recommended. However, &lt;img&gt; elements are also acceptable.',
     },
     icon_only: {
-      type: 'object',
+      type: 'any',
       description:
         'Append an icon to the button content and visually hide the text content. This prop trumps icon_before and icon_after.',
     },

--- a/packages/elements/bolt-text-link/text-link.schema.js
+++ b/packages/elements/bolt-text-link/text-link.schema.js
@@ -10,16 +10,16 @@ module.exports = {
         'A Drupal-style attributes object with extra attributes to append to this component.',
     },
     content: {
-      type: 'object',
+      type: 'any',
       description: 'Content of the text link.',
     },
     icon_before: {
-      type: 'object',
+      type: 'any',
       description:
         'Append an icon before the text. Icon component is recommended. However, &lt;img&gt; elements are also acceptable.',
     },
     icon_after: {
-      type: 'object',
+      type: 'any',
       description:
         'Append an icon after the text. Icon component is recommended. However, &lt;img&gt; elements are also acceptable.',
     },


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-42

## Summary

Restores both schema validation and twig dump function in Pattern Lab.  Also fixes numerous schema violations.

## Details

#1802 disabled twig debugging in the name of performance.  That broke several useful things, including schema validation and the ability to use the twig [dump](https://twig.symfony.com/doc/2.x/functions/dump.html) function.

This PR does the following:
1. Updates the pattern lab patches to allow twig debugging to be enabled
2. Enables twig debugging by default in docs-site/config/config.yml
3. Fixes all the schema errors that have been added in while schema validation was broken

The only downside is that Item 2 decreases performance somewhat.  I found my re-compile times to be about 10 seconds before these changes and about 15 seconds after them.  I think that's worth it to be able to catch your bugs immediately and use the twig debug function, but we could potentially turn it off conditionally (e.g. maybe only enable it on Travis?).  As it stands, developers could also manually update that line locally to disable twig debugging while working locally.  I'm open to suggestions on this.

## How to test

#### Confirm that schema validation and twig dump are working
- Checkout this branch locally and run `yarn setup`
- Add an intentional schema violation in pattern lab, such as:
```
{% include "@bolt-components-button/button.twig" with {
  text: 'foo',    
  size: 'not a valid size',
} only %}
```
- Run `yarn start`.  Building should fail and you'll get an error message about your schema validation in the cli.
- Remove the schema validation and run `yarn start` again and wait for PL to load.
- Add the schema validation back again after PL has loaded.  Confirm that there is again a schema validation error in the cli.  - Confirm that removing the schema validation results in a successful build without the need to restart
- Add the snippet `{{ dump('hello world') }}` to any twig file in pattern lab (e.g. 05-button.twig).  Confirm that it outputs `string(2) "hi"` to the page where this twig file is rendered.  You can also test dumping objects, arrays, etc.

#### Review all code changes for sanity/logic
Most of the commits in this PR fix problems in the schema.  Each one is small, so the ideal thing to do is look at each one and confirm that the fix makes sense.  You can also check the corresponding page in pattern lab to make sure things look as expected. 
