### PR TITLE
DS-275 Make the background component absolute positioned

### DIFF
--- a/packages/components/bolt-background/src/background.scss
+++ b/packages/components/bolt-background/src/background.scss
@@ -43,20 +43,24 @@ $bolt-bg-shape-offset-side-large: $bolt-bg-shape-offset-bottom-large * 1.2;
 }
 
 bolt-background {
-  flex-grow: 1;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 0;
+  pointer-events: none;
+  user-select: none;
 }
 
 .c-bolt-background {
   position: absolute;
-  top: 0;
-  right: 0;
   width: 100%;
   height: 100%;
   overflow: hidden;
 }
 
 .c-bolt-background__item {
-  display: block;
   display: flex;
   position: absolute;
   width: 100%;


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-275

## Summary

Fixes a bug where the background component does not fill up its parent container.

## Details

Moved the absolute position CSS rules to the outer most container which is `<bolt-background>`.

## How to test

Run the branch locally and check the background docs.

Create some dummy code to test the background component inside a CSS grid:

```
.container {
  display: grid;
  grid-template-columns: repeat(3, 1fr);
  position: relative;
  width: 500px;
  height: 500px;
}

<div class="container">
  <!-- use the background component and set an image here -->
  <p>Some text here.</p>
</div>
```