### PR TITLE
DS-276 Remove -0.5px top/bottom margins from full bleed mixin

### DIFF
--- a/packages/core-v3.x/styles/02-tools/tools-full-bleed/_tools-full-bleed.scss
+++ b/packages/core-v3.x/styles/02-tools/tools-full-bleed/_tools-full-bleed.scss
@@ -9,10 +9,8 @@
   position: relative;
   right: 50%;
   left: 50%;
-  width: 100%; //fallback if vw not supported.
+  width: 100%; // Fallback if vw not supported.
   width: 100vw;
-  margin-top: -0.5px; //-0.5px is currently needed to patch a rendering bug in Firefox (when combined with layers being hardware accelerated)
   margin-right: -50vw;
-  margin-bottom: -0.5px; //-0.5px is currently needed to patch a rendering bug in Firefox (when combined with layers being hardware accelerated)
   margin-left: -50vw;
 }


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-276

## Summary

Fixes a bug where the full bleed mixin is creating negative margins top and bottom, causing a visual bug between bands.

## Details

Removed the negative margin top and bottom. Checked in Firefox and everything is working as expected (because there was an old comment about Firefox).

## How to test

Run the branch locally and check the Pages section.

Create a dummy page with 2 bands:

1. Top band: full bleed, dark theme
2. Bottom band: full bleed, light theme, and spacing none. Nest another band inside, set it to not full bleed and light theme

Check the line where the top and bottom bands meet, the line should be perfectly straight.