### PR TITLE
Docs: fix element docs typos

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/20-elements/button/20-button-with-icon.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/20-elements/button/20-button-with-icon.twig
@@ -83,7 +83,7 @@
 
 {% set html_markup %}
 {% verbatim %}
-<button type="button" class="e-bolt-button"><span class="e-bolt-button__icon-before"><img src="/images/placeholders/500x500.jpg"></span>This is a button with icons before and after<span class="e-bolt-button__icon-before"><bolt-icon name="chevron-down"></bolt-icon></span></button>
+<button type="button" class="e-bolt-button"><span class="e-bolt-button__icon-before"><img src="/images/placeholders/500x500.jpg"></span>This is a button with icons before and after<span class="e-bolt-button__icon-after"><bolt-icon name="chevron-down"></bolt-icon></span></button>
 {% endverbatim %}
 {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/20-elements/text-link/20-text-link-with-icon.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/20-elements/text-link/20-text-link-with-icon.twig
@@ -81,7 +81,7 @@
 
 {% set html_markup %}
 {% verbatim %}
-<a href="https://pega.com" class="e-bolt-text-link"><span class="e-bolt-text-link__icon-before"><img src="/images/placeholders/500x500.jpg"></span>This is a text link with icons before and after<span class="e-bolt-text-link__icon-before"><bolt-icon name="chevron-down"></bolt-icon></span></a>
+<a href="https://pega.com" class="e-bolt-text-link"><span class="e-bolt-text-link__icon-before"><img src="/images/placeholders/500x500.jpg"></span>This is a text link with icons before and after<span class="e-bolt-text-link__icon-after"><bolt-icon name="chevron-down"></bolt-icon></span></a>
 {% endverbatim %}
 {% endset %}
 


### PR DESCRIPTION
## Summary

Fixes two typos in text link and button element docs.

## Details

The html code snippet was written with the wrong class name, change from `before` to `after` properly in the docs involving text and icons.

## How to test

Run the branch locally and proofread the Text Link with Icon and Button with Icon docs.