### PR TITLE
DS-277 Replace divs with spans in tooltip

### DIFF
--- a/packages/components/bolt-tooltip/__tests__/__snapshots__/tooltip.js.snap
+++ b/packages/components/bolt-tooltip/__tests__/__snapshots__/tooltip.js.snap
@@ -2,22 +2,22 @@
 
 exports[`<bolt-tooltip> Component Advanced usage: adding tooltip to button 1`] = `
 <bolt-tooltip uuid="12345">
-  <div class="c-bolt-tooltip c-bolt-tooltip--top   c-bolt-tooltip--dotted">
-    <div role="button"
-         tabindex="0"
-         aria-describedby="js-bolt-tooltip-12345"
-         aria-controls="js-bolt-tooltip-12345"
+  <span class="c-bolt-tooltip c-bolt-tooltip--top   c-bolt-tooltip--dotted">
+    <span role="button"
+          tabindex="0"
+          aria-describedby="js-bolt-tooltip-12345"
+          aria-controls="js-bolt-tooltip-12345"
     >
       <ssr-keep for="bolt-tooltip">
         <bolt-button>
           Download
         </bolt-button>
       </ssr-keep>
-    </div>
-    <div id="js-bolt-tooltip-12345"
-         class="c-bolt-tooltip__content"
-         role="tooltip"
-         aria-hidden="true"
+    </span>
+    <span id="js-bolt-tooltip-12345"
+          class="c-bolt-tooltip__content"
+          role="tooltip"
+          aria-hidden="true"
     >
       <span class="c-bolt-tooltip__bubble">
         <ssr-keep for="bolt-tooltip">
@@ -26,27 +26,27 @@ exports[`<bolt-tooltip> Component Advanced usage: adding tooltip to button 1`] =
           </span>
         </ssr-keep>
       </span>
-    </div>
-  </div>
+    </span>
+  </span>
 </bolt-tooltip>
 `;
 
 exports[`<bolt-tooltip> Component Basic usage 1`] = `
 <bolt-tooltip uuid="12345">
-  <div class="c-bolt-tooltip c-bolt-tooltip--top c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
-    <div role="button"
-         tabindex="0"
-         aria-describedby="js-bolt-tooltip-12345"
-         aria-controls="js-bolt-tooltip-12345"
+  <span class="c-bolt-tooltip c-bolt-tooltip--top c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
+    <span role="button"
+          tabindex="0"
+          aria-describedby="js-bolt-tooltip-12345"
+          aria-controls="js-bolt-tooltip-12345"
     >
       <ssr-keep for="bolt-tooltip">
         CRM
       </ssr-keep>
-    </div>
-    <div id="js-bolt-tooltip-12345"
-         class="c-bolt-tooltip__content"
-         role="tooltip"
-         aria-hidden="true"
+    </span>
+    <span id="js-bolt-tooltip-12345"
+          class="c-bolt-tooltip__content"
+          role="tooltip"
+          aria-hidden="true"
     >
       <span class="c-bolt-tooltip__bubble">
         <ssr-keep for="bolt-tooltip">
@@ -55,8 +55,8 @@ exports[`<bolt-tooltip> Component Basic usage 1`] = `
           </span>
         </ssr-keep>
       </span>
-    </div>
-  </div>
+    </span>
+  </span>
 </bolt-tooltip>
 `;
 
@@ -64,20 +64,20 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: auto 1`] = `
 <bolt-tooltip placement="auto"
               uuid="12345"
 >
-  <div class="c-bolt-tooltip  c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
-    <div role="button"
-         tabindex="0"
-         aria-describedby="js-bolt-tooltip-12345"
-         aria-controls="js-bolt-tooltip-12345"
+  <span class="c-bolt-tooltip  c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
+    <span role="button"
+          tabindex="0"
+          aria-describedby="js-bolt-tooltip-12345"
+          aria-controls="js-bolt-tooltip-12345"
     >
       <ssr-keep for="bolt-tooltip">
         CRM
       </ssr-keep>
-    </div>
-    <div id="js-bolt-tooltip-12345"
-         class="c-bolt-tooltip__content"
-         role="tooltip"
-         aria-hidden="true"
+    </span>
+    <span id="js-bolt-tooltip-12345"
+          class="c-bolt-tooltip__content"
+          role="tooltip"
+          aria-hidden="true"
     >
       <span class="c-bolt-tooltip__bubble">
         <ssr-keep for="bolt-tooltip">
@@ -86,8 +86,8 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: auto 1`] = `
           </span>
         </ssr-keep>
       </span>
-    </div>
-  </div>
+    </span>
+  </span>
 </bolt-tooltip>
 `;
 
@@ -95,20 +95,20 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: bottom 1`] = 
 <bolt-tooltip placement="bottom"
               uuid="12345"
 >
-  <div class="c-bolt-tooltip c-bolt-tooltip--bottom c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
-    <div role="button"
-         tabindex="0"
-         aria-describedby="js-bolt-tooltip-12345"
-         aria-controls="js-bolt-tooltip-12345"
+  <span class="c-bolt-tooltip c-bolt-tooltip--bottom c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
+    <span role="button"
+          tabindex="0"
+          aria-describedby="js-bolt-tooltip-12345"
+          aria-controls="js-bolt-tooltip-12345"
     >
       <ssr-keep for="bolt-tooltip">
         CRM
       </ssr-keep>
-    </div>
-    <div id="js-bolt-tooltip-12345"
-         class="c-bolt-tooltip__content"
-         role="tooltip"
-         aria-hidden="true"
+    </span>
+    <span id="js-bolt-tooltip-12345"
+          class="c-bolt-tooltip__content"
+          role="tooltip"
+          aria-hidden="true"
     >
       <span class="c-bolt-tooltip__bubble">
         <ssr-keep for="bolt-tooltip">
@@ -117,8 +117,8 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: bottom 1`] = 
           </span>
         </ssr-keep>
       </span>
-    </div>
-  </div>
+    </span>
+  </span>
 </bolt-tooltip>
 `;
 
@@ -126,20 +126,20 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: bottom-end 1`
 <bolt-tooltip placement="bottom-end"
               uuid="12345"
 >
-  <div class="c-bolt-tooltip c-bolt-tooltip--bottom-end c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
-    <div role="button"
-         tabindex="0"
-         aria-describedby="js-bolt-tooltip-12345"
-         aria-controls="js-bolt-tooltip-12345"
+  <span class="c-bolt-tooltip c-bolt-tooltip--bottom-end c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
+    <span role="button"
+          tabindex="0"
+          aria-describedby="js-bolt-tooltip-12345"
+          aria-controls="js-bolt-tooltip-12345"
     >
       <ssr-keep for="bolt-tooltip">
         CRM
       </ssr-keep>
-    </div>
-    <div id="js-bolt-tooltip-12345"
-         class="c-bolt-tooltip__content"
-         role="tooltip"
-         aria-hidden="true"
+    </span>
+    <span id="js-bolt-tooltip-12345"
+          class="c-bolt-tooltip__content"
+          role="tooltip"
+          aria-hidden="true"
     >
       <span class="c-bolt-tooltip__bubble">
         <ssr-keep for="bolt-tooltip">
@@ -148,8 +148,8 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: bottom-end 1`
           </span>
         </ssr-keep>
       </span>
-    </div>
-  </div>
+    </span>
+  </span>
 </bolt-tooltip>
 `;
 
@@ -157,20 +157,20 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: bottom-start 
 <bolt-tooltip placement="bottom-start"
               uuid="12345"
 >
-  <div class="c-bolt-tooltip c-bolt-tooltip--bottom-start c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
-    <div role="button"
-         tabindex="0"
-         aria-describedby="js-bolt-tooltip-12345"
-         aria-controls="js-bolt-tooltip-12345"
+  <span class="c-bolt-tooltip c-bolt-tooltip--bottom-start c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
+    <span role="button"
+          tabindex="0"
+          aria-describedby="js-bolt-tooltip-12345"
+          aria-controls="js-bolt-tooltip-12345"
     >
       <ssr-keep for="bolt-tooltip">
         CRM
       </ssr-keep>
-    </div>
-    <div id="js-bolt-tooltip-12345"
-         class="c-bolt-tooltip__content"
-         role="tooltip"
-         aria-hidden="true"
+    </span>
+    <span id="js-bolt-tooltip-12345"
+          class="c-bolt-tooltip__content"
+          role="tooltip"
+          aria-hidden="true"
     >
       <span class="c-bolt-tooltip__bubble">
         <ssr-keep for="bolt-tooltip">
@@ -179,8 +179,8 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: bottom-start 
           </span>
         </ssr-keep>
       </span>
-    </div>
-  </div>
+    </span>
+  </span>
 </bolt-tooltip>
 `;
 
@@ -188,20 +188,20 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: left 1`] = `
 <bolt-tooltip placement="left"
               uuid="12345"
 >
-  <div class="c-bolt-tooltip c-bolt-tooltip--left c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
-    <div role="button"
-         tabindex="0"
-         aria-describedby="js-bolt-tooltip-12345"
-         aria-controls="js-bolt-tooltip-12345"
+  <span class="c-bolt-tooltip c-bolt-tooltip--left c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
+    <span role="button"
+          tabindex="0"
+          aria-describedby="js-bolt-tooltip-12345"
+          aria-controls="js-bolt-tooltip-12345"
     >
       <ssr-keep for="bolt-tooltip">
         CRM
       </ssr-keep>
-    </div>
-    <div id="js-bolt-tooltip-12345"
-         class="c-bolt-tooltip__content"
-         role="tooltip"
-         aria-hidden="true"
+    </span>
+    <span id="js-bolt-tooltip-12345"
+          class="c-bolt-tooltip__content"
+          role="tooltip"
+          aria-hidden="true"
     >
       <span class="c-bolt-tooltip__bubble">
         <ssr-keep for="bolt-tooltip">
@@ -210,8 +210,8 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: left 1`] = `
           </span>
         </ssr-keep>
       </span>
-    </div>
-  </div>
+    </span>
+  </span>
 </bolt-tooltip>
 `;
 
@@ -219,20 +219,20 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: left-end 1`] 
 <bolt-tooltip placement="left-end"
               uuid="12345"
 >
-  <div class="c-bolt-tooltip c-bolt-tooltip--left-end c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
-    <div role="button"
-         tabindex="0"
-         aria-describedby="js-bolt-tooltip-12345"
-         aria-controls="js-bolt-tooltip-12345"
+  <span class="c-bolt-tooltip c-bolt-tooltip--left-end c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
+    <span role="button"
+          tabindex="0"
+          aria-describedby="js-bolt-tooltip-12345"
+          aria-controls="js-bolt-tooltip-12345"
     >
       <ssr-keep for="bolt-tooltip">
         CRM
       </ssr-keep>
-    </div>
-    <div id="js-bolt-tooltip-12345"
-         class="c-bolt-tooltip__content"
-         role="tooltip"
-         aria-hidden="true"
+    </span>
+    <span id="js-bolt-tooltip-12345"
+          class="c-bolt-tooltip__content"
+          role="tooltip"
+          aria-hidden="true"
     >
       <span class="c-bolt-tooltip__bubble">
         <ssr-keep for="bolt-tooltip">
@@ -241,8 +241,8 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: left-end 1`] 
           </span>
         </ssr-keep>
       </span>
-    </div>
-  </div>
+    </span>
+  </span>
 </bolt-tooltip>
 `;
 
@@ -250,20 +250,20 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: left-start 1`
 <bolt-tooltip placement="left-start"
               uuid="12345"
 >
-  <div class="c-bolt-tooltip c-bolt-tooltip--left-start c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
-    <div role="button"
-         tabindex="0"
-         aria-describedby="js-bolt-tooltip-12345"
-         aria-controls="js-bolt-tooltip-12345"
+  <span class="c-bolt-tooltip c-bolt-tooltip--left-start c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
+    <span role="button"
+          tabindex="0"
+          aria-describedby="js-bolt-tooltip-12345"
+          aria-controls="js-bolt-tooltip-12345"
     >
       <ssr-keep for="bolt-tooltip">
         CRM
       </ssr-keep>
-    </div>
-    <div id="js-bolt-tooltip-12345"
-         class="c-bolt-tooltip__content"
-         role="tooltip"
-         aria-hidden="true"
+    </span>
+    <span id="js-bolt-tooltip-12345"
+          class="c-bolt-tooltip__content"
+          role="tooltip"
+          aria-hidden="true"
     >
       <span class="c-bolt-tooltip__bubble">
         <ssr-keep for="bolt-tooltip">
@@ -272,8 +272,8 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: left-start 1`
           </span>
         </ssr-keep>
       </span>
-    </div>
-  </div>
+    </span>
+  </span>
 </bolt-tooltip>
 `;
 
@@ -281,20 +281,20 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: right 1`] = `
 <bolt-tooltip placement="right"
               uuid="12345"
 >
-  <div class="c-bolt-tooltip c-bolt-tooltip--right c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
-    <div role="button"
-         tabindex="0"
-         aria-describedby="js-bolt-tooltip-12345"
-         aria-controls="js-bolt-tooltip-12345"
+  <span class="c-bolt-tooltip c-bolt-tooltip--right c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
+    <span role="button"
+          tabindex="0"
+          aria-describedby="js-bolt-tooltip-12345"
+          aria-controls="js-bolt-tooltip-12345"
     >
       <ssr-keep for="bolt-tooltip">
         CRM
       </ssr-keep>
-    </div>
-    <div id="js-bolt-tooltip-12345"
-         class="c-bolt-tooltip__content"
-         role="tooltip"
-         aria-hidden="true"
+    </span>
+    <span id="js-bolt-tooltip-12345"
+          class="c-bolt-tooltip__content"
+          role="tooltip"
+          aria-hidden="true"
     >
       <span class="c-bolt-tooltip__bubble">
         <ssr-keep for="bolt-tooltip">
@@ -303,8 +303,8 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: right 1`] = `
           </span>
         </ssr-keep>
       </span>
-    </div>
-  </div>
+    </span>
+  </span>
 </bolt-tooltip>
 `;
 
@@ -312,20 +312,20 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: right-end 1`]
 <bolt-tooltip placement="right-end"
               uuid="12345"
 >
-  <div class="c-bolt-tooltip c-bolt-tooltip--right-end c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
-    <div role="button"
-         tabindex="0"
-         aria-describedby="js-bolt-tooltip-12345"
-         aria-controls="js-bolt-tooltip-12345"
+  <span class="c-bolt-tooltip c-bolt-tooltip--right-end c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
+    <span role="button"
+          tabindex="0"
+          aria-describedby="js-bolt-tooltip-12345"
+          aria-controls="js-bolt-tooltip-12345"
     >
       <ssr-keep for="bolt-tooltip">
         CRM
       </ssr-keep>
-    </div>
-    <div id="js-bolt-tooltip-12345"
-         class="c-bolt-tooltip__content"
-         role="tooltip"
-         aria-hidden="true"
+    </span>
+    <span id="js-bolt-tooltip-12345"
+          class="c-bolt-tooltip__content"
+          role="tooltip"
+          aria-hidden="true"
     >
       <span class="c-bolt-tooltip__bubble">
         <ssr-keep for="bolt-tooltip">
@@ -334,8 +334,8 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: right-end 1`]
           </span>
         </ssr-keep>
       </span>
-    </div>
-  </div>
+    </span>
+  </span>
 </bolt-tooltip>
 `;
 
@@ -343,20 +343,20 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: right-start 1
 <bolt-tooltip placement="right-start"
               uuid="12345"
 >
-  <div class="c-bolt-tooltip c-bolt-tooltip--right-start c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
-    <div role="button"
-         tabindex="0"
-         aria-describedby="js-bolt-tooltip-12345"
-         aria-controls="js-bolt-tooltip-12345"
+  <span class="c-bolt-tooltip c-bolt-tooltip--right-start c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
+    <span role="button"
+          tabindex="0"
+          aria-describedby="js-bolt-tooltip-12345"
+          aria-controls="js-bolt-tooltip-12345"
     >
       <ssr-keep for="bolt-tooltip">
         CRM
       </ssr-keep>
-    </div>
-    <div id="js-bolt-tooltip-12345"
-         class="c-bolt-tooltip__content"
-         role="tooltip"
-         aria-hidden="true"
+    </span>
+    <span id="js-bolt-tooltip-12345"
+          class="c-bolt-tooltip__content"
+          role="tooltip"
+          aria-hidden="true"
     >
       <span class="c-bolt-tooltip__bubble">
         <ssr-keep for="bolt-tooltip">
@@ -365,8 +365,8 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: right-start 1
           </span>
         </ssr-keep>
       </span>
-    </div>
-  </div>
+    </span>
+  </span>
 </bolt-tooltip>
 `;
 
@@ -374,20 +374,20 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: top 1`] = `
 <bolt-tooltip placement="top"
               uuid="12345"
 >
-  <div class="c-bolt-tooltip c-bolt-tooltip--top c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
-    <div role="button"
-         tabindex="0"
-         aria-describedby="js-bolt-tooltip-12345"
-         aria-controls="js-bolt-tooltip-12345"
+  <span class="c-bolt-tooltip c-bolt-tooltip--top c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
+    <span role="button"
+          tabindex="0"
+          aria-describedby="js-bolt-tooltip-12345"
+          aria-controls="js-bolt-tooltip-12345"
     >
       <ssr-keep for="bolt-tooltip">
         CRM
       </ssr-keep>
-    </div>
-    <div id="js-bolt-tooltip-12345"
-         class="c-bolt-tooltip__content"
-         role="tooltip"
-         aria-hidden="true"
+    </span>
+    <span id="js-bolt-tooltip-12345"
+          class="c-bolt-tooltip__content"
+          role="tooltip"
+          aria-hidden="true"
     >
       <span class="c-bolt-tooltip__bubble">
         <ssr-keep for="bolt-tooltip">
@@ -396,8 +396,8 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: top 1`] = `
           </span>
         </ssr-keep>
       </span>
-    </div>
-  </div>
+    </span>
+  </span>
 </bolt-tooltip>
 `;
 
@@ -405,20 +405,20 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: top-end 1`] =
 <bolt-tooltip placement="top-end"
               uuid="12345"
 >
-  <div class="c-bolt-tooltip c-bolt-tooltip--top-end c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
-    <div role="button"
-         tabindex="0"
-         aria-describedby="js-bolt-tooltip-12345"
-         aria-controls="js-bolt-tooltip-12345"
+  <span class="c-bolt-tooltip c-bolt-tooltip--top-end c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
+    <span role="button"
+          tabindex="0"
+          aria-describedby="js-bolt-tooltip-12345"
+          aria-controls="js-bolt-tooltip-12345"
     >
       <ssr-keep for="bolt-tooltip">
         CRM
       </ssr-keep>
-    </div>
-    <div id="js-bolt-tooltip-12345"
-         class="c-bolt-tooltip__content"
-         role="tooltip"
-         aria-hidden="true"
+    </span>
+    <span id="js-bolt-tooltip-12345"
+          class="c-bolt-tooltip__content"
+          role="tooltip"
+          aria-hidden="true"
     >
       <span class="c-bolt-tooltip__bubble">
         <ssr-keep for="bolt-tooltip">
@@ -427,8 +427,8 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: top-end 1`] =
           </span>
         </ssr-keep>
       </span>
-    </div>
-  </div>
+    </span>
+  </span>
 </bolt-tooltip>
 `;
 
@@ -436,20 +436,20 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: top-start 1`]
 <bolt-tooltip placement="top-start"
               uuid="12345"
 >
-  <div class="c-bolt-tooltip c-bolt-tooltip--top-start c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
-    <div role="button"
-         tabindex="0"
-         aria-describedby="js-bolt-tooltip-12345"
-         aria-controls="js-bolt-tooltip-12345"
+  <span class="c-bolt-tooltip c-bolt-tooltip--top-start c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
+    <span role="button"
+          tabindex="0"
+          aria-describedby="js-bolt-tooltip-12345"
+          aria-controls="js-bolt-tooltip-12345"
     >
       <ssr-keep for="bolt-tooltip">
         CRM
       </ssr-keep>
-    </div>
-    <div id="js-bolt-tooltip-12345"
-         class="c-bolt-tooltip__content"
-         role="tooltip"
-         aria-hidden="true"
+    </span>
+    <span id="js-bolt-tooltip-12345"
+          class="c-bolt-tooltip__content"
+          role="tooltip"
+          aria-hidden="true"
     >
       <span class="c-bolt-tooltip__bubble">
         <ssr-keep for="bolt-tooltip">
@@ -458,27 +458,27 @@ exports[`<bolt-tooltip> Component Placement of the tooltip bubble: top-start 1`]
           </span>
         </ssr-keep>
       </span>
-    </div>
-  </div>
+    </span>
+  </span>
 </bolt-tooltip>
 `;
 
 exports[`<bolt-tooltip> Component UUID of the tooltip 1`] = `
 <bolt-tooltip uuid="custom-unique-id">
-  <div class="c-bolt-tooltip c-bolt-tooltip--top c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
-    <div role="button"
-         tabindex="0"
-         aria-describedby="js-bolt-tooltip-custom-unique-id"
-         aria-controls="js-bolt-tooltip-custom-unique-id"
+  <span class="c-bolt-tooltip c-bolt-tooltip--top c-bolt-tooltip--text-wrap c-bolt-tooltip--text-align-center c-bolt-tooltip--dotted">
+    <span role="button"
+          tabindex="0"
+          aria-describedby="js-bolt-tooltip-custom-unique-id"
+          aria-controls="js-bolt-tooltip-custom-unique-id"
     >
       <ssr-keep for="bolt-tooltip">
         CRM
       </ssr-keep>
-    </div>
-    <div id="js-bolt-tooltip-custom-unique-id"
-         class="c-bolt-tooltip__content"
-         role="tooltip"
-         aria-hidden="true"
+    </span>
+    <span id="js-bolt-tooltip-custom-unique-id"
+          class="c-bolt-tooltip__content"
+          role="tooltip"
+          aria-hidden="true"
     >
       <span class="c-bolt-tooltip__bubble">
         <ssr-keep for="bolt-tooltip">
@@ -487,7 +487,7 @@ exports[`<bolt-tooltip> Component UUID of the tooltip 1`] = `
           </span>
         </ssr-keep>
       </span>
-    </div>
-  </div>
+    </span>
+  </span>
 </bolt-tooltip>
 `;

--- a/packages/components/bolt-tooltip/src/tooltip.twig
+++ b/packages/components/bolt-tooltip/src/tooltip.twig
@@ -69,11 +69,11 @@
   {% endif %}
   uuid="{{ uuid }}"
 >
-  <div {% if inner_classes %} class="{{ inner_classes|join(' ') }}" {% endif %}>
+  <span {% if inner_classes %} class="{{ inner_classes|join(' ') }}" {% endif %}>
     {% if trigger %}
       {# Start adapter for old trigger data #}
       {% if trigger.type == "text" %}
-        <div
+        <span
           role="button"
           tabindex="0"
           aria-describedby="{{ tooltip_uuid }}"
@@ -87,9 +87,9 @@
               {{ trigger.text }}
             {% endif %}
           </ssr-keep>
-        </div>
+        </span>
       {% elseif trigger.type == "button" %}
-        <div
+        <span
           role="button"
           tabindex="0"
           aria-describedby="{{ tooltip_uuid }}"
@@ -106,12 +106,12 @@
               style: "secondary",
             } only %}
           </ssr-keep>
-        </div>
+        </span>
       {# End adapter for old trigger data #}
 
       {# Start new trigger #}
       {% else %}
-        <div
+        <span
           role="button"
           tabindex="0"
           aria-describedby="{{ tooltip_uuid }}"
@@ -120,13 +120,13 @@
           <ssr-keep for="bolt-tooltip">
             {{ trigger }}
           </ssr-keep>
-        </div>
+        </span>
       {% endif %}
       {# End new trigger #}
     {% endif %}
 
     {% if content %}
-      <div id="{{ tooltip_uuid }}" class="{{ "#{base_class}__content" }}" role="tooltip" aria-hidden="true">
+      <span id="{{ tooltip_uuid }}" class="{{ "#{base_class}__content" }}" role="tooltip" aria-hidden="true">
         <span class="{{ "#{base_class}__bubble" }}">
           <ssr-keep for="bolt-tooltip">
             <span slot="content">
@@ -134,7 +134,7 @@
             </span>
           </ssr-keep>
         </span>
-      </div>
+      </span>
     {% endif %}
-  </div>
+  </span>
 </bolt-tooltip>


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-277

## Summary

Fixes a bug where any inline tooltip does not render correctly inside a paragraph of text when JS is turned off.

## Details

Replaced all `div`s in twig template with `span`s, because `div` can not go inside `p` elements.

## How to test

Run the branch locally and check tooltip docs with JS turned off.