### PR TITLE
Unable to tap/select first step in microjourneys experiences on mobile

### DIFF
--- a/packages/experimental/micro-journeys/src/interactive-pathway.js
+++ b/packages/experimental/micro-journeys/src/interactive-pathway.js
@@ -60,7 +60,7 @@ class BoltInteractivePathway extends withLitContext {
     self.addEventListener('bolt-interactive-step:change-active-step', event => {
       const steps = self.getSteps();
       const stepId = steps.findIndex(step => step.el === event.target);
-      if (stepId > 0) {
+      if (stepId >= 0) {
         self.setActiveStep(stepId);
       } else {
         console.warn('uh oh! could not find active step', { event, steps });


### PR DESCRIPTION
## Jira

WWW-446 - Unable to tap/select first step in microjourneys experiences on mobile

## Summary

Unable to tap/select first step in microjourneys experiences on mobile

## Details

(Explain the changes in enough detail fo reviewers to understand.  Raise any questions for reviewers to consider.)

## How to test

* Open any microjourney experience on mobile.
* Switch to any step (but not first)
* Try to switch back to first step