### PR TITLE
DS-278 add page padding css vars

### DIFF
--- a/packages/global/styles/00-vars/_vars-page-width-and-spacing.scss
+++ b/packages/global/styles/00-vars/_vars-page-width-and-spacing.scss
@@ -1,0 +1,18 @@
+/* ------------------------------------ *\
+   Page Padding
+
+   Note: the padding alone will create a max-width for the content, there's no need for a wrapper element when using these vars.
+\* ------------------------------------ */
+:root {
+  --bolt-page-padding-x: #{$bolt-wrapper-padding};
+
+  @include bolt-mq(medium) {
+    --bolt-page-padding-x: #{$bolt-wrapper-padding-at-medium-bp};
+  }
+
+  @include bolt-mq(xxlarge) {
+    --bolt-page-padding-x: calc(
+      (100vw - #{bolt-breakpoint(xxlarge)}) / 2 + #{$bolt-wrapper-padding} * 2
+    );
+  }
+}

--- a/packages/global/styles/index.scss
+++ b/packages/global/styles/index.scss
@@ -3,8 +3,9 @@
 @import '00-vars/_vars-color';
 @import '00-vars/_vars-spacing';
 @import '00-vars/_vars-typography';
-@import '00-vars/_vars-mode';
 @import '00-vars/_vars-interactive-states';
+@import '00-vars/_vars-mode';
+@import '00-vars/_vars-page-width-and-spacing';
 @import '00-vars/_vars-transition';
 @import '00-vars/_vars-info-density'; /* Info density config must come after all other global vars */
 @import '00-vars/_vars-japanese'; /* Japanese config must come last to override everything else */


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-278

## Summary

Adds page padding CSS vars to global styles.

## Details

1. Responsive CSS vars are created to handle page padding and page max-width.
2. The method of using a wrapper element is no longer needed. Instead, setting padding using these vars will achieve the same effects.

## How to test

Run the branch locally. Create a dummy element and test out the CSS vars, make sure it works as expected.

```css
.test {
  @include bolt-full-bleed;
  padding-right: var(--bolt-page-padding-x);
  padding-left: var(--bolt-page-padding-x);
  background: red;
}
```