### PR TITLE
[Docs] add elements to nav and add logic to doc template

### DIFF
--- a/docs-site/src/components/pattern-lab-utils/pattern-doc-page.twig
+++ b/docs-site/src/components/pattern-lab-utils/pattern-doc-page.twig
@@ -13,63 +13,67 @@
 
 {% set band_content %}
   <bolt-text headline tag="h2" font-size="xlarge">
-    {{ title }}
+    {{ title|default('Insert title') }}
   </bolt-text>
   <bolt-stack>
-    {{ description }}
+    {{ description|default('Insert description.') }}
   </bolt-stack>
 
   {% if notes %}
-  <bolt-banner align="start">
-    <bolt-text headline tag="h3" font-size="medium">Important Notes:</bolt-text>
-    <bolt-stack>
-      {{ notes }}
-    </bolt-stack>
-  </bolt-banner>
+    <bolt-banner align="start">
+      <bolt-text headline tag="h3" font-size="medium">Important Notes:</bolt-text>
+      <bolt-stack>
+        {{ notes }}
+      </bolt-stack>
+    </bolt-banner>
   {% endif %}
 
-  <bolt-text headline tag="h3" font-size="large">
-    Demo
-  </bolt-text>
-  <bolt-stack>
-    {% if demo_light_dark %}
-      <div class="u-bolt-padding-medium t-bolt-xlight">
-        <bolt-text headline font-size="xxsmall" text-transform="uppercase" letter-spacing="wide">Light</bolt-text>
+  {% if demo %}
+    <bolt-text headline tag="h3" font-size="large">
+      Demo
+    </bolt-text>
+    <bolt-stack>
+      {% if demo_light_dark %}
+        <div class="u-bolt-padding-medium t-bolt-xlight">
+          <bolt-text headline font-size="xxsmall" text-transform="uppercase" letter-spacing="wide">Light</bolt-text>
+          {{ demo }}
+        </div>
+        <div class="u-bolt-padding-medium t-bolt-dark">
+          <bolt-text headline font-size="xxsmall" text-transform="uppercase" letter-spacing="wide">Dark</bolt-text>
+          {{ demo }}
+        </div>
+      {% else %}
         {{ demo }}
-      </div>
-      <div class="u-bolt-padding-medium t-bolt-dark">
-        <bolt-text headline font-size="xxsmall" text-transform="uppercase" letter-spacing="wide">Dark</bolt-text>
-        {{ demo }}
-      </div>
-    {% else %}
-      {{ demo }}
-    {% endif %}
-  </bolt-stack>
+      {% endif %}
+    </bolt-stack>
+  {% endif %}
 
-  <bolt-tabs inset="off">
-    <bolt-tab-panel>
-      <div slot="label">Twig</div>
-      {% if twig_markup %}
-        {% include snippet.code_example(twig_markup) %}
-      {% else %}
-        <bolt-banner align="start" status="warning">
-          <bolt-icon name="warning" size="small" aria-hidden="true"></bolt-icon>
-          <strong>Not available in Twig. Please use plain HTML.</strong>
-        </bolt-banner>
-      {% endif %}
-    </bolt-tab-panel>
-    <bolt-tab-panel>
-      <div slot="label">HTML</div>
-      {% if html_markup %}
-        {% include snippet.code_example(html_markup) %}
-      {% else %}
-        <bolt-banner align="start" status="warning">
-          <bolt-icon name="warning" size="small" aria-hidden="true"></bolt-icon>
-          <strong>Not available in plain HTML. Please use Twig.</strong>
-        </bolt-banner>
-      {% endif %}
-    </bolt-tab-panel>
-  </bolt-tabs>
+  {% if html_markup or twig_markup %}
+    <bolt-tabs inset="off">
+      <bolt-tab-panel>
+        <div slot="label">Twig</div>
+        {% if twig_markup %}
+          {% include snippet.code_example(twig_markup) %}
+        {% else %}
+          <bolt-banner align="start" status="warning">
+            <bolt-icon name="warning" size="small" aria-hidden="true"></bolt-icon>
+            <strong>Not available in Twig. Please use plain HTML.</strong>
+          </bolt-banner>
+        {% endif %}
+      </bolt-tab-panel>
+      <bolt-tab-panel {% if html_markup and not twig_markup %}selected{% endif %}>
+        <div slot="label">HTML</div>
+        {% if html_markup %}
+          {% include snippet.code_example(html_markup) %}
+        {% else %}
+          <bolt-banner align="start" status="warning">
+            <bolt-icon name="warning" size="small" aria-hidden="true"></bolt-icon>
+            <strong>Not available in plain HTML. Please use Twig.</strong>
+          </bolt-banner>
+        {% endif %}
+      </bolt-tab-panel>
+    </bolt-tabs>
+  {% endif %}
 
   {% if warning %}
     <bolt-text headline tag="h3" font-size="large">

--- a/docs-site/src/templates/_page-header.twig
+++ b/docs-site/src/templates/_page-header.twig
@@ -16,6 +16,10 @@
         url: "/pattern-lab/?p=viewall-visual-styles-color",
       },
       {
+        text: "Elements",
+        url: "/pattern-lab/?p=viewall-elements-all",
+      },
+      {
         text: "Components",
         url: "/pattern-lab/index.html",
       },

--- a/docs-site/src/templates/_page-header.twig
+++ b/docs-site/src/templates/_page-header.twig
@@ -1,3 +1,5 @@
+{# This is used in the deprecated Docs section, not on the homepage. Refer to homepage.twig for everything on the homepage. #}
+
 {% set navbar %}
   {% include "@bolt-site/_navbar-with-version-selector.twig" with {
     theme: "light",

--- a/docs-site/src/templates/base-template.twig
+++ b/docs-site/src/templates/base-template.twig
@@ -1,3 +1,5 @@
+{# This is the main template for creating the homepage and other pages outside of the PL frame. #}
+
 {% include "@bolt-site/_site-head.twig" with {
   inline_global_data: true,
 } %}

--- a/docs-site/src/templates/default-redesign.twig
+++ b/docs-site/src/templates/default-redesign.twig
@@ -1,3 +1,5 @@
+{# This is used in the deprecated Docs section. #}
+
 {% extends "@bolt-site/base-template.twig" %}
 
 {% block site_body %}

--- a/docs-site/src/templates/default.twig
+++ b/docs-site/src/templates/default.twig
@@ -1,3 +1,5 @@
+{# This is used in the deprecated Docs section. #}
+
 {% extends "@bolt-site/base-template.twig" %}
 
 {% set urlChunks = page.url | split('/') %}

--- a/docs-site/src/templates/homepage.twig
+++ b/docs-site/src/templates/homepage.twig
@@ -28,6 +28,10 @@
               url: "/pattern-lab/?p=visual-styles-color-system",
             },
             {
+              text: "Elements",
+              url: "/pattern-lab/?p=viewall-elements-all",
+            },
+            {
               text: "Components",
               url: "/pattern-lab/",
             },

--- a/docs-site/src/templates/sassdoc.twig
+++ b/docs-site/src/templates/sassdoc.twig
@@ -1,3 +1,5 @@
+{# This is used in the deprecated Docs section. #}
+
 {% extends "@bolt-site/default.twig" %}
 
 {% block article_content %}


### PR DESCRIPTION
## Summary

Updates doc site navigation to have "Elements" and update display logic on doc template.

## Details

1. Elements link is added to main navigation on the homepage.
2. Doc template now has logic to display whether Twig or HTML code snippet based on which one is available.

## How to test

Run the branch locally and check the homepage navigation and docs using the doc template (everything under Elements).