### PR TITLE
Fixed a Brightcove CSS error for the new player

### DIFF
--- a/packages/components/bolt-video/brightcove/_video.scss
+++ b/packages/components/bolt-video/brightcove/_video.scss
@@ -446,7 +446,7 @@ $base-video-meta-transition: $bolt-transition;
     }
   }
 
-  .vjs-controls-disabled {
+  &.vjs-controls-disabled {
     pointer-events: none;
 
     .video-meta__item--title,
@@ -456,9 +456,9 @@ $base-video-meta-transition: $bolt-transition;
   }
 
   // Force control icons to be visible at smaller layout sizes, commented out names are shown here to indicate which ones are hidden.
-  .vjs-layout-tiny,
-  .vjs-layout-x-small,
-  .vjs-layout-small {
+  &.vjs-layout-tiny,
+  &.vjs-layout-x-small,
+  &.vjs-layout-small {
     &:not(.vjs-fullscreen) {
       /* .vjs-time-divider, */
       /* .vjs-duration, */


### PR DESCRIPTION
## Summary

Fixed a CSS error in the new Brightcove Player

## Details

Fixed a CSS error in the Brightcove CSS in order to get the icons to display correctly on small screens


