### PR TITLE
Fix: tabs show more button active color

### DIFF
--- a/packages/components/bolt-tabs/src/tabs.scss
+++ b/packages/components/bolt-tabs/src/tabs.scss
@@ -495,8 +495,6 @@ bolt-tabs:not([ready]) {
 
   &.is-active,
   &:active {
-    background-color: var(--m-bolt-tertiary);
-
     &:before {
       opacity: 0.1;
     }

--- a/packages/core-v3.x/styles/01-settings/settings-global/_settings-global.scss
+++ b/packages/core-v3.x/styles/01-settings/settings-global/_settings-global.scss
@@ -31,7 +31,7 @@ $bolt-border-width: 1px !default;
 /// Bolt border style
 $bolt-border-style: solid !default;
 /// Bolt border color
-$bolt-border-color: var(m-bolt-border) !default;
+$bolt-border-color: var(--m-bolt-border) !default;
 /// Bolt border radius
 $bolt-border-radius: 3px !default;
 


### PR DESCRIPTION
## Summary

Fixes a color regression on tabs' show more button's active state caused by the color variable conversion.

## Details

Removed a line of CSS that caused the double background color.

## How to test

Run the branch locally and check Tabs doc page. Make the browser narrow and click on the more button of truncated tabs. Make sure it's background color is the same as the hover state's background color.