### PR TITLE
DS-238: Add support for 3.x releases

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -4,7 +4,6 @@
     "name": "Bolt Bot",
     "email": "no-reply@boltdesignsystem.com",
   },
-  "baseBranch": "release/2.x",
   "plugins": [
     ["./scripts/auto-plugin.js"],
     [

--- a/.travis.yml
+++ b/.travis.yml
@@ -154,13 +154,13 @@ jobs:
 
     - stage: Auto-release
       name: 'Full Release'
-      if: (branch =~ /(release\/2.x)/)
+      if: (branch =~ /(release)/)
       before_script:
         - git config --global user.email ${GITHUB_EMAIL}
         - git config --global user.name ${GITHUB_USER}
         - git remote set-url origin "https://${GITHUB_TOKEN}@github.com/boltdesignsystem/bolt.git" > /dev/null 2>&1
         - echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-        - git checkout release/2.x
+        - git checkout ${TRAVIS_BRANCH}
       install:
         - yarn install --frozen-lockfile
         - yarn run setup:php

--- a/auto-release.js
+++ b/auto-release.js
@@ -8,8 +8,7 @@ const { normalizeUrlAlias } = require('./scripts/utils/normalize-url-alias');
 const { branchName } = require('./scripts/utils/branch-name');
 const { NOW_TOKEN } = process.env;
 
-const isFullRelease =
-  branchName === 'release-2.x' || branchName === 'release/2.x';
+const isFullRelease = branchName.startsWith('release');
 
 const lernaConfig = require('./lerna.json');
 const currentVersion = lernaConfig.version;
@@ -126,7 +125,7 @@ async function init() {
           await shell.exec(`
             git checkout master
             git pull
-            git merge release/2.x
+            git merge ${branchName}
             git push --no-verify
           `);
         }

--- a/auto-release.js
+++ b/auto-release.js
@@ -122,12 +122,16 @@ async function init() {
             );
           }
 
-          await shell.exec(`
-            git checkout master
-            git pull
-            git merge ${branchName}
-            git push --no-verify
-          `);
+          // Temporarily, only merge back to master if this is the release/2.x branch.
+          if (branchName === 'release/2.x') {
+            await shell.exec(`
+              git fetch --depth=50 origin master:master
+              git checkout master
+              git pull
+              git merge ${branchName}
+              git push --no-verify
+            `);
+          }
         }
       }
     } catch (error) {


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-238

## Summary

Removes hard-coded `release/2.x` in release scripts, allows the release script to run from any release/* branch.

## How to test

I don't know of a good way to test this outside of Travis.  A good, careful code review might be the best way to check, short of pushing to Travis and seeing if anything breaks while doing a release.