### PR TITLE
DS-294: update action-block twig conventions

### DIFF
--- a/packages/components/bolt-action-blocks/__tests__/__snapshots__/action-blocks.js.snap
+++ b/packages/components/bolt-action-blocks/__tests__/__snapshots__/action-blocks.js.snap
@@ -1,10 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<bolt-action-blocks> Component Basic usage 1`] = `
-<bolt-action-blocks spacing="medium"
-                    valign="start"
-                    max-items-per-row="6"
->
+<bolt-action-blocks>
   <ul class="c-bolt-action-blocks c-bolt-action-blocks--spacing-medium c-bolt-action-blocks--valign-start c-bolt-action-blocks--item-max-6">
     <li class="c-bolt-action-blocks__item">
       <bolt-action-block>
@@ -122,10 +119,7 @@ exports[`<bolt-action-blocks> Component Basic usage 1`] = `
 `;
 
 exports[`<bolt-action-blocks> Component Border in between each block: false 1`] = `
-<bolt-action-blocks spacing="medium"
-                    valign="start"
-                    max-items-per-row="6"
->
+<bolt-action-blocks>
   <ul class="c-bolt-action-blocks c-bolt-action-blocks--spacing-medium c-bolt-action-blocks--valign-start c-bolt-action-blocks--item-max-6">
     <li class="c-bolt-action-blocks__item">
       <bolt-action-block>
@@ -243,11 +237,7 @@ exports[`<bolt-action-blocks> Component Border in between each block: false 1`] 
 `;
 
 exports[`<bolt-action-blocks> Component Border in between each block: true 1`] = `
-<bolt-action-blocks spacing="medium"
-                    valign="start"
-                    max-items-per-row="6"
-                    borderless
->
+<bolt-action-blocks borderless>
   <ul class="c-bolt-action-blocks c-bolt-action-blocks--spacing-medium c-bolt-action-blocks--valign-start c-bolt-action-blocks--item-max-6 c-bolt-action-blocks--borderless">
     <li class="c-bolt-action-blocks__item">
       <bolt-action-block>
@@ -365,9 +355,8 @@ exports[`<bolt-action-blocks> Component Border in between each block: true 1`] =
 `;
 
 exports[`<bolt-action-blocks> Component Deprecated props still render as expected 1`] = `
-<bolt-action-blocks spacing="medium"
+<bolt-action-blocks max-items-per-row="2"
                     valign="center"
-                    max-items-per-row="2"
                     borderless
 >
   <ul class="c-bolt-action-blocks c-bolt-action-blocks--spacing-medium c-bolt-action-blocks--valign-center c-bolt-action-blocks--item-max-2 c-bolt-action-blocks--borderless">
@@ -529,10 +518,7 @@ exports[`<bolt-action-blocks> Component Subcomponent renders as expected 1`] = `
 `;
 
 exports[`<bolt-action-blocks> Component Vertical alignment of each block's content: center 1`] = `
-<bolt-action-blocks spacing="medium"
-                    valign="center"
-                    max-items-per-row="6"
->
+<bolt-action-blocks valign="center">
   <ul class="c-bolt-action-blocks c-bolt-action-blocks--spacing-medium c-bolt-action-blocks--valign-center c-bolt-action-blocks--item-max-6">
     <li class="c-bolt-action-blocks__item">
       <bolt-action-block>
@@ -650,10 +636,7 @@ exports[`<bolt-action-blocks> Component Vertical alignment of each block's conte
 `;
 
 exports[`<bolt-action-blocks> Component Vertical alignment of each block's content: end 1`] = `
-<bolt-action-blocks spacing="medium"
-                    valign="end"
-                    max-items-per-row="6"
->
+<bolt-action-blocks valign="end">
   <ul class="c-bolt-action-blocks c-bolt-action-blocks--spacing-medium c-bolt-action-blocks--valign-end c-bolt-action-blocks--item-max-6">
     <li class="c-bolt-action-blocks__item">
       <bolt-action-block>
@@ -771,10 +754,7 @@ exports[`<bolt-action-blocks> Component Vertical alignment of each block's conte
 `;
 
 exports[`<bolt-action-blocks> Component Vertical alignment of each block's content: medium 1`] = `
-<bolt-action-blocks spacing="medium"
-                    valign="start"
-                    max-items-per-row="6"
->
+<bolt-action-blocks spacing="medium">
   <ul class="c-bolt-action-blocks c-bolt-action-blocks--spacing-medium c-bolt-action-blocks--valign-start c-bolt-action-blocks--item-max-6">
     <li class="c-bolt-action-blocks__item">
       <bolt-action-block>
@@ -892,10 +872,7 @@ exports[`<bolt-action-blocks> Component Vertical alignment of each block's conte
 `;
 
 exports[`<bolt-action-blocks> Component Vertical alignment of each block's content: small 1`] = `
-<bolt-action-blocks spacing="small"
-                    valign="start"
-                    max-items-per-row="6"
->
+<bolt-action-blocks spacing="small">
   <ul class="c-bolt-action-blocks c-bolt-action-blocks--spacing-small c-bolt-action-blocks--valign-start c-bolt-action-blocks--item-max-6">
     <li class="c-bolt-action-blocks__item">
       <bolt-action-block>
@@ -1013,10 +990,7 @@ exports[`<bolt-action-blocks> Component Vertical alignment of each block's conte
 `;
 
 exports[`<bolt-action-blocks> Component Vertical alignment of each block's content: start 1`] = `
-<bolt-action-blocks spacing="medium"
-                    valign="start"
-                    max-items-per-row="6"
->
+<bolt-action-blocks valign="start">
   <ul class="c-bolt-action-blocks c-bolt-action-blocks--spacing-medium c-bolt-action-blocks--valign-start c-bolt-action-blocks--item-max-6">
     <li class="c-bolt-action-blocks__item">
       <bolt-action-block>
@@ -1134,10 +1108,7 @@ exports[`<bolt-action-blocks> Component Vertical alignment of each block's conte
 `;
 
 exports[`<bolt-action-blocks> Component Vertical alignment of each block's content: xsmall 1`] = `
-<bolt-action-blocks spacing="xsmall"
-                    valign="start"
-                    max-items-per-row="6"
->
+<bolt-action-blocks spacing="xsmall">
   <ul class="c-bolt-action-blocks c-bolt-action-blocks--spacing-xsmall c-bolt-action-blocks--valign-start c-bolt-action-blocks--item-max-6">
     <li class="c-bolt-action-blocks__item">
       <bolt-action-block>

--- a/packages/components/bolt-action-blocks/action-blocks.schema.js
+++ b/packages/components/bolt-action-blocks/action-blocks.schema.js
@@ -49,6 +49,14 @@ module.exports = {
       description: 'Removes the border in between each action block.',
       default: false,
     },
+    content: {
+      type: ['string', 'array', 'object'],
+      description: 'Free form content to populate the action blocks',
+    },
+    children: {
+      title: 'DEPRECATED',
+      description: 'Use content prop instead.',
+    },
     items: {
       type: 'array',
       description: 'Content items to populate the action blocks.',

--- a/packages/components/bolt-action-blocks/src/action-blocks.twig
+++ b/packages/components/bolt-action-blocks/src/action-blocks.twig
@@ -32,7 +32,6 @@
 
 {# Variables #}
 {% set this = init(schema) %}
-{% set attributes = create_attribute(attributes|default({})) %}
 {% set inner_attributes = create_attribute({}) %}
 
 {# Array of classes based on the defined + default props #}
@@ -60,7 +59,6 @@
   {% endif %}
 {% endfor %}
 
-{# Example component's custom element wrapper #}
 <bolt-action-blocks
   {% if outer_classes %} class="{{ outer_classes|join(' ') }}" {% endif %}
   {{ this.props|without("content")|without("class") }}

--- a/packages/components/bolt-action-blocks/src/action-blocks.twig
+++ b/packages/components/bolt-action-blocks/src/action-blocks.twig
@@ -30,6 +30,11 @@
   {% set items = contentItems %}
 {% endif %}
 
+{# DEPRECATED.  `children` has been renamed to `content` #}
+{% if children %}
+  {% set content = children %}
+{% endif %}
+
 {# Variables #}
 {% set this = init(schema) %}
 {% set inner_attributes = create_attribute({}) %}
@@ -64,9 +69,8 @@
   {{ this.props|without("items")|without("class") }}
 >
   <ul {{ inner_attributes.addClass(inner_classes) }}>
-    {# `children` is not in the schema but is in use on WWW, @see 'featured-partners-row.twig'. Cannot safely remove until removed there. #}
-    {% if children %}
-      {{ children }}
+    {% if content %}
+      {{ content }}
     {% else %}
       {% for item in items %}
         <li class="c-bolt-action-blocks__item">

--- a/packages/components/bolt-action-blocks/src/action-blocks.twig
+++ b/packages/components/bolt-action-blocks/src/action-blocks.twig
@@ -38,9 +38,9 @@
 {# Array of classes based on the defined + default props #}
 {% set classes = [
   "c-bolt-action-blocks",
-  this.data.spacing.value != "none" ? "c-bolt-action-blocks--spacing-" ~ this.data.spacing.value : "",
-  this.data.valign.value != "none" ? "c-bolt-action-blocks--valign-" ~ this.data.valign.value : "",
-  this.data.max_items_per_row.value != "none" ? "c-bolt-action-blocks--item-max-" ~ this.data.max_items_per_row.value : "",
+  this.data.spacing.value ? "c-bolt-action-blocks--spacing-" ~ this.data.spacing.value : "",
+  this.data.valign.value ? "c-bolt-action-blocks--valign-" ~ this.data.valign.value : "",
+  this.data.max_items_per_row.value ? "c-bolt-action-blocks--item-max-" ~ this.data.max_items_per_row.value : "",
   this.data.borderless.value ? "c-bolt-action-blocks--borderless" : "",
 ] %}
 

--- a/packages/components/bolt-action-blocks/src/action-blocks.twig
+++ b/packages/components/bolt-action-blocks/src/action-blocks.twig
@@ -5,7 +5,7 @@
 {% endif %}
 
 {# Variables #}
-{% set base_class = "c-bolt-action-blocks" %}
+{% set this = init(schema) %}
 {% set attributes = create_attribute(attributes|default({})) %}
 {% set inner_attributes = create_attribute({}) %}
 
@@ -35,24 +35,13 @@
   {% set items = contentItems %}
 {% endif %}
 
-{# Set up checks to validate that the component's prop values are allowed, based on the component's schema #}
-{% set spacing_options = schema.properties.spacing.enum %}
-{% set valign_options = schema.properties.valign.enum %}
-{% set max_items_per_row_options = schema.properties.max_items_per_row.enum %}
-
-{# Check that the component's current prop values are valid. if not, default to the schema default #}
-{% set spacing = spacing in spacing_options ? spacing : schema.properties.spacing.default %}
-{% set valign = valign in valign_options ? valign : schema.properties.valign.default %}
-{% set max_items_per_row = max_items_per_row in max_items_per_row_options ? max_items_per_row : schema.properties.max_items_per_row.default %}
-{% set borderless = borderless is sameas(true) or borderless is sameas(false) ? borderless : schema.properties.borderless.default %}
-
 {# Array of classes based on the defined + default props #}
 {% set classes = [
-  base_class,
-  spacing in spacing_options ? "#{base_class}--spacing-#{spacing}" : "",
-  valign in valign_options ? "#{base_class}--valign-#{valign}" : "",
-  max_items_per_row in max_items_per_row_options ? "#{base_class}--item-max-#{max_items_per_row}" : "",
-  borderless ? "#{base_class}--borderless" : "",
+  "c-bolt-action-blocks",
+  this.data.spacing.value != "none" ? "c-bolt-action-blocks--spacing-" ~ this.data.spacing.value : "",
+  this.data.valign.value != "none" ? "c-bolt-action-blocks--valign-" ~ this.data.valign.value : "",
+  this.data.max_items_per_row.value != "none" ? "c-bolt-action-blocks--item-max-" ~ this.data.max_items_per_row.value : "",
+  this.data.borderless.value ? "c-bolt-action-blocks--borderless" : "",
 ] %}
 
 {#
@@ -63,7 +52,7 @@
 {% set outer_classes = [] %}
 {% set inner_classes = classes %}
 
-{% for class in attributes["class"] %}
+{% for class in this.props.class %}
   {% if class starts with "is-" or class starts with "has-" %}
     {% set inner_classes = inner_classes|merge([class]) %}
   {% elseif class starts with "c-bolt-" == false %}
@@ -73,19 +62,15 @@
 
 {# Example component's custom element wrapper #}
 <bolt-action-blocks
-  {% if spacing %} spacing="{{ spacing }}" {% endif %}
-  {% if valign %} valign="{{ valign }}" {% endif %}
-  {% if max_items_per_row %} max-items-per-row="{{ max_items_per_row }}" {% endif %}
-  {% if borderless %} borderless {% endif %}
   {% if outer_classes %} class="{{ outer_classes|join(' ') }}" {% endif %}
-  {{ attributes | without("class") }}
+  {{ this.props|without("content")|without("class") }}
 >
   <ul {{ inner_attributes.addClass(inner_classes) }}>
     {% if children %}
       {{ children }}
     {% else %}
       {% for item in items %}
-        <li class="{{ "#{base_class}__item" }}">
+        <li class="c-bolt-action-blocks__item">
           {% include "@bolt-components-action-blocks/action-block.twig" with item only %}
         </li>
       {% endfor %}

--- a/packages/components/bolt-action-blocks/src/action-blocks.twig
+++ b/packages/components/bolt-action-blocks/src/action-blocks.twig
@@ -62,6 +62,11 @@
 
 {# Example component's custom element wrapper #}
 <bolt-action-blocks
+  {% if this.data.spacing.value %} spacing="{{ this.data.spacing.value }}" {% endif %}
+  {% if this.data.valign.value %} valign="{{ this.data.valign.value }}" {% endif %}
+  {% if this.data.max_items_per_row.value %} max-items-per-row="{{ this.data.max_items_per_row.value }}" {% endif %}
+  {% if this.data.borderless.value %} borderless {% endif %}
+
   {% if outer_classes %} class="{{ outer_classes|join(' ') }}" {% endif %}
   {{ this.props|without("content")|without("class") }}
 >

--- a/packages/components/bolt-action-blocks/src/action-blocks.twig
+++ b/packages/components/bolt-action-blocks/src/action-blocks.twig
@@ -4,11 +4,6 @@
   {{ validate_data_schema(schema, _self) | raw }}
 {% endif %}
 
-{# Variables #}
-{% set this = init(schema) %}
-{% set attributes = create_attribute(attributes|default({})) %}
-{% set inner_attributes = create_attribute({}) %}
-
 {# DEPRECATED: maxItemsPerRow has been renamed to max_items_per_row #}
 {% if maxItemsPerRow %}
   {% set max_items_per_row = maxItemsPerRow %}
@@ -34,6 +29,11 @@
 {% if contentItems %}
   {% set items = contentItems %}
 {% endif %}
+
+{# Variables #}
+{% set this = init(schema) %}
+{% set attributes = create_attribute(attributes|default({})) %}
+{% set inner_attributes = create_attribute({}) %}
 
 {# Array of classes based on the defined + default props #}
 {% set classes = [
@@ -62,11 +62,6 @@
 
 {# Example component's custom element wrapper #}
 <bolt-action-blocks
-  {% if this.data.spacing.value %} spacing="{{ this.data.spacing.value }}" {% endif %}
-  {% if this.data.valign.value %} valign="{{ this.data.valign.value }}" {% endif %}
-  {% if this.data.max_items_per_row.value %} max-items-per-row="{{ this.data.max_items_per_row.value }}" {% endif %}
-  {% if this.data.borderless.value %} borderless {% endif %}
-
   {% if outer_classes %} class="{{ outer_classes|join(' ') }}" {% endif %}
   {{ this.props|without("content")|without("class") }}
 >

--- a/packages/components/bolt-action-blocks/src/action-blocks.twig
+++ b/packages/components/bolt-action-blocks/src/action-blocks.twig
@@ -64,6 +64,7 @@
   {{ this.props|without("items")|without("class") }}
 >
   <ul {{ inner_attributes.addClass(inner_classes) }}>
+    {# `children` is not in the schema but is in use on WWW, @see 'featured-partners-row.twig'. Cannot safely remove until removed there. #}
     {% if children %}
       {{ children }}
     {% else %}

--- a/packages/components/bolt-action-blocks/src/action-blocks.twig
+++ b/packages/components/bolt-action-blocks/src/action-blocks.twig
@@ -61,7 +61,7 @@
 
 <bolt-action-blocks
   {% if outer_classes %} class="{{ outer_classes|join(' ') }}" {% endif %}
-  {{ this.props|without("content")|without("class") }}
+  {{ this.props|without("items")|without("class") }}
 >
   <ul {{ inner_attributes.addClass(inner_classes) }}>
     {% if children %}


### PR DESCRIPTION
## Jira

[https://pegadigitalit.atlassian.net/browse/DS-294](https://pegadigitalit.atlassian.net/browse/DS-294)

## Summary

update action-block twig conventions

## Details

action-block still used the old validation so this updates action-block validation to use `{% set this = init(schema) %}`. also used this time to remove `base_class` variable.

## How to test

- test unexpected props and classes.
- visual test demos against master.

## Release notes

Deprecated Action Blocks `children` prop. Use `content` instead.
