### PR TITLE
DS-295 remove xsmall icon size

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/03-organisms/collections/dashboard/_dashboard-band--my-missions.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/03-organisms/collections/dashboard/_dashboard-band--my-missions.twig
@@ -8,7 +8,6 @@
     icon: {
       name: "chevron-down",
       position: "after",
-      size: "xsmall"
     }
   } only %}
 {% endset %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/03-organisms/collections/search/_search-results--results-list.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/03-organisms/collections/search/_search-results--results-list.twig
@@ -6,7 +6,6 @@
     icon: {
       name: "chevron-down",
       position: "after",
-      size: "xsmall"
     }
   } only %}
 {% endset %}

--- a/packages/components/bolt-icon/icon.schema.json
+++ b/packages/components/bolt-icon/icon.schema.json
@@ -175,7 +175,6 @@
       "type": "string",
       "description": "Icon size.",
       "enum": [
-        "xsmall",
         "small",
         "medium",
         "large",

--- a/packages/components/bolt-icon/icon.schema.json
+++ b/packages/components/bolt-icon/icon.schema.json
@@ -165,21 +165,12 @@
       "type": "string",
       "description": "Customizes the background that's displayed behind the SVG icon itself. Choosing any option other than `none` will automatically add a bit of space around the SVG so the background has the necessary space. Note, this option is now available to icons of all sizes!",
       "default": "none",
-      "enum": [
-        "none",
-        "circle",
-        "square"
-      ]
+      "enum": ["none", "circle", "square"]
     },
     "size": {
       "type": "string",
-      "description": "Icon size.",
-      "enum": [
-        "small",
-        "medium",
-        "large",
-        "xlarge"
-      ]
+      "description": "Controls the size of the icon. Each size is set to a specific pixel value: 16px, 24px, 32px, and 38px. However, this prop is optional. When no size is specified, the icon is expected to act as an inline icon, which will grow or shrink depending on the font-size of its parent container.",
+      "enum": ["small", "medium", "large", "xlarge"]
     },
     "color": {
       "type": "string",


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-295

## Summary

Removes `xsmall` size from Icon component that was added by mistake.

## Details

1. Removed `xsmall` from icon schema.
2. Removed `size` prop value from 2 Academy pages where it's not needed at all.

## How to test

Run the branch locally and check the the 2 Academy pages: Dashboard and Dashboard (My Missions). Make sure the chevron down icon for the decision hub version dropdown is matching the text's font size.