### PR TITLE
Whitelist "build-tools" to prevent warning on `yarn start`

### DIFF
--- a/packages/build-tools/utils/manifest.get-pkg-info.js
+++ b/packages/build-tools/utils/manifest.get-pkg-info.js
@@ -10,6 +10,7 @@ let config; // cached Bolt config
 
 // don't automatically include these Bolt packages as extra (undeclared) dependencies
 const missingBoltPkgsWhitelist = [
+  '@bolt/build-tools',
   '@bolt/core',
   '@bolt/core-v3.x',
   '@bolt/polyfills',


### PR DESCRIPTION
## Jira

n/a

## Summary

This adds `@bolt/build-tools` to a whitelist so that we don't see the dependency warning every time we start up Bolt.

![image](https://user-images.githubusercontent.com/36336/104258095-df90f980-544c-11eb-9ed6-40c354b94f8c.png)

## Details

Warning is thrown because Micro Journeys adds `@bolt/build-tools` as a dependency. We should try [removing that dependency](https://github.com/boltdesignsystem/bolt/pull/1993) but that requires time to test. For now this just adds `@bolt/build-tools` to a whitelist with other core components, like `@bolt/core-v3.x`.

## How to test

Run `yarn start`. You should see no warning and everything else continues to work as expected.