### PR TITLE
DS-300 Fix Slotify empty component bug

### DIFF
--- a/packages/base-element/src/Slotify.js
+++ b/packages/base-element/src/Slotify.js
@@ -26,18 +26,24 @@ export class Slotify extends LitElement {
 
   // Save a reference to the pseudoSlot content before lit-element renders
   saveSlots() {
-    Array.from(this.childNodes).forEach(child => {
-      const slot = this.assignSlotToContent(child);
+    const childNodes = Array.from(this.childNodes);
 
-      // Prevent dupes when `saveSlots` is run multiple times
-      if (this.slotMap.get(slot)?.includes(child)) return;
+    if (childNodes.length) {
+      childNodes.forEach(child => {
+        const slot = this.assignSlotToContent(child);
+        // Prevent dupes when `saveSlots` is run multiple times
+        if (this.slotMap.get(slot)?.includes(child)) return;
 
-      if (!child.textContent || child.textContent.trim().length > 0) {
-        this.addChildToSlotMap(slot, child);
-      } else if (slot && child instanceof HTMLElement) {
-        this.addChildToSlotMap(slot, child);
-      }
-    });
+        if (!child.textContent || child.textContent.trim().length > 0) {
+          this.addChildToSlotMap(slot, child);
+        } else if (slot && child instanceof HTMLElement) {
+          this.addChildToSlotMap(slot, child);
+        }
+      });
+    } else {
+      // Always add at least a default slot to the slotMap. Otherwise, content added after the initial render will not appear.
+      this.addChildToSlotMap('default', '');
+    }
   }
 
   update(changedProperties) {


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-300

## Summary

If a component is initially empty (i.e. no text or elements inside), content added later never appears. This PR updates `Slotify` to handle this case, which happens on Academy in the `pega_modal` module.

## Details

`Slotify` does a one-time setup where it loops through the child nodes of a component and assigns them all to various slots. If there are no child nodes, no slots are created and when content is later added there is no slot for the content to appear in. The fix ensures that at least a default slot is always added to the `slotMap` so that when content is added it will display if it's supposed to (i.e. only if the component template says to render the default slot)

On Academy, the `pega_modal` module appends an empty `<bolt-modal>` to the page, then adds content to it based on an AJAX request, and then shows the modal. This worked fine before the renderer update, but now it shows an empty modal. This should address the underlying issue with the new renderer.

## How to test

1. On master, open a Modal demo page in PL and delete any Bolt elements on the page. Then add this JS via the console and verify it displays an empty modal (the bug).
```
const modal = document.createElement('bolt-modal');
document.body.append(modal);
modal.innerHTML = 'test';
modal.show();
```

2. Repeat on this bugfix branch and verify the modal displays "test".

3. Do a spot check of other components. This is a relatively safe change, but it does touch every component as it edits the renderer. So, verify there are no other regressions.