### PR TITLE
Fix: secondary color variable

### DIFF
--- a/packages/global/styles/00-vars/_vars-mode.scss
+++ b/packages/global/styles/00-vars/_vars-mode.scss
@@ -17,7 +17,7 @@ bolt-card-replacement[theme='xlight'] {
   --m-bolt-link: var(--bolt-color-navy-light);
   --m-bolt-primary: var(--bolt-color-navy-light);
   --m-bolt-text-on-primary: var(--m-bolt-bg);
-  --m-bolt-secondary: var(--m-bolt-bg);
+  --m-bolt-secondary: var(--bolt-color-white);
   --m-bolt-text-on-secondary: var(--m-bolt-headline);
   --m-bolt-tertiary: hsla(220.4, 80%, 15%, 0.15);
   --m-bolt-text-on-tertiary: var(--m-bolt-headline);
@@ -40,7 +40,7 @@ bolt-card-replacement[theme='xdark'] {
   --m-bolt-link: var(--bolt-color-white);
   --m-bolt-primary: var(--bolt-color-yellow);
   --m-bolt-text-on-primary: var(--bolt-color-black);
-  --m-bolt-secondary: var(--m-bolt-headline);
+  --m-bolt-secondary: var(--bolt-color-white);
   --m-bolt-text-on-secondary: var(--m-bolt-bg);
   --m-bolt-tertiary: hsla(0, 0%, 100%, 0.15);
   --m-bolt-text-on-tertiary: var(--m-bolt-headline);


### PR DESCRIPTION
## Jira

N/A

## Summary

Fixes a bug where the secondary color variable is not rendering white in all themes.

## How to test

Run the branch locally and check secondary buttons on Button docs or other demo pages. Make sure the background color of the secondary buttons is white.