### PR TITLE
DS-305 Fix popover background

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/popover/00-popover-auto-open.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/popover/00-popover-auto-open.twig
@@ -1,4 +1,3 @@
-{# Setting variables for demo purposes #}
 {% set schema = bolt.data.components["@bolt-components-popover"].schema %}
 {% set link %}
   {% include "@bolt-components-link/link.twig" with {
@@ -10,8 +9,6 @@
   This is the content of the popover with a {{ link }}.
 {% endset %}
 
-<bolt-text headline>Content theme</bolt-text>
-<bolt-text>Adjust the Bolt color theme of the content by using the <bolt-code-snippet display="inline" lang="html">theme</bolt-code-snippet> prop.</bolt-text>
 <bolt-list display="inline" spacing="medium">
   {% for theme in schema.properties.theme.enum %}
     <bolt-list-item>
@@ -21,13 +18,15 @@
           size: "small",
         } only %}
       {% endset %}
-      {# Start component specific code #}
       {% include "@bolt-components-popover/popover.twig" with {
         trigger: trigger,
         content: content,
-        theme: theme
+        theme: theme,
+        uuid: "theme-demo-#{theme}-#{loop.index}",
+        attributes: {
+          "no-shadow": true,
+        }
       } only %}
-      {# End component specific code #}
     </bolt-list-item>
   {% endfor %}
 </bolt-list>

--- a/packages/components/bolt-popover/__tests__/popover.e2e.js
+++ b/packages/components/bolt-popover/__tests__/popover.e2e.js
@@ -10,7 +10,7 @@ module.exports = {
 
     browser
       .url(
-        `${testingUrl}/pattern-lab/patterns/40-components-popover-25-popover-theme-variations/40-components-popover-25-popover-theme-variations.html#js-bolt-popover-theme-demo-xdark-5`,
+        `${testingUrl}/pattern-lab/patterns/999-tests-popover-00-popover-auto-open/999-tests-popover-00-popover-auto-open.html#js-bolt-popover-theme-demo-xdark-5`,
       )
       .waitForElementVisible('bolt-popover[uuid="theme-demo-xdark-5"]', 1000)
       .pause(1000)
@@ -31,7 +31,7 @@ module.exports = {
 
     browser
       .url(
-        `${testingUrl}/pattern-lab/patterns/40-components-popover-25-popover-theme-variations/40-components-popover-25-popover-theme-variations.html#js-bolt-popover-trigger-theme-demo-xdark-5`,
+        `${testingUrl}/pattern-lab/patterns/999-tests-popover-00-popover-auto-open/999-tests-popover-00-popover-auto-open.html#js-bolt-popover-trigger-theme-demo-xdark-5`,
       )
       .waitForElementVisible('bolt-popover[uuid="theme-demo-xdark-5"]', 1000)
       .pause(1000)
@@ -50,7 +50,7 @@ module.exports = {
 
     browser
       .url(
-        `${testingUrl}/pattern-lab/patterns/40-components-popover-25-popover-theme-variations/40-components-popover-25-popover-theme-variations.html?foo=bar#js-bolt-popover-theme-demo-xdark-5`,
+        `${testingUrl}/pattern-lab/patterns/999-tests-popover-00-popover-auto-open/999-tests-popover-00-popover-auto-open.html?foo=bar#js-bolt-popover-theme-demo-xdark-5`,
       )
       .waitForElementVisible('bolt-popover[uuid="theme-demo-xdark-5"]', 1000)
       .pause(1000)

--- a/packages/components/bolt-popover/src/popover.scss
+++ b/packages/components/bolt-popover/src/popover.scss
@@ -2,7 +2,7 @@
    Popover
 \* ------------------------------------ */
 @import '@bolt/core-v3.x';
-@import '@bolt/global/styles/06-themes/_themes.all.scss';
+@import '@bolt/global/styles/00-vars/_vars-mode.scss';
 
 // Dev Notes
 // 1. Any instance of bolt-popover:not([ready]) in this file is used to create NoJS fallback styles.


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-305

## Summary

Fix popover content background color.

> Note: if this is the only item to hotfix we will merge directly into `release/2.x`. If not, we'll create a separate branch to combine our hotfixes.

## Details

When popover has a parent with a theme class, such as `t-bolt-xxdark`, that theme class overrides the "theme" set on the component itself. If you set the popover to theme "light" (`<bolt-popover theme="light">`) it will still be dark. This is because the right CSS vars aren't being included in the component's constructed stylesheet.

We missed this bug because our Popover theme demo used the `no-shadow` prop (for Nightwatch testing purposes), and so shadow dom encapsulation didn't factor in.

This PR fixes the bug and moves the `no-shadow` demo to the Tests directory to avoid confusion in the future.

## How to test

- Checkout this branch and go to: `/pattern-lab/?p=components-popover-theme-variations`
- Verify that the popover themes are working - "light" background should be light, "dark" should be dark.
- Add the class `t-bolt-xxdark` to the `<body>` of the demo and verify the popover themes still work.