### PR TITLE
Fix: remove bolt-button[type] browser defaults

### DIFF
--- a/packages/components/bolt-button/src/button.scss
+++ b/packages/components/bolt-button/src/button.scss
@@ -5,6 +5,7 @@
 // Dev Notes
 // 1. [Morse] This mixin outputs a separate ruleset for each selector to prevent IE from failing on unrecognized selectors like `:host`. It is not a substitute for comma-separated selectors.
 // 2. [Morse] Bolt-link delegates focus to inner element.
+// 3. [Mai] These selectors and rules must be separated to override browser defaults.
 
 @import '@bolt/core-v3.x';
 @import './button-settings-and-tools';
@@ -15,8 +16,11 @@
 @include bolt-repeat-rule(('bolt-button', ':host(bolt-button)')) {
   // [1]
   display: inline-flex;
-  appearance: none;
   outline: none; // [2]
+}
+
+@include bolt-repeat-rule(('bolt-button[type]', ':host(bolt-button[type])')) {
+  @include bolt-button-native-styles-reset;
 }
 
 .c-bolt-button {


### PR DESCRIPTION
## Summary

Fixes a bug when `bolt-button[type]` is rendering browser default button styles.

## Details

1. Changed the CSS to specifically target `bolt-button[type]`.
2. We need to avoid using existing HTML attribute name as prop name. This is a prime example of unexpected behaviors.

## How to test

Run the branch locally and find a bolt-button, add `type="submit"` and see if it produces browser default button styles in Safari. Also check the typeahead docs, make sure the search icon button does not look like a browser default button.