### PR TITLE
Hotfix/v2.30.1

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/popover/00-popover-auto-open.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/popover/00-popover-auto-open.twig
@@ -1,4 +1,3 @@
-{# Setting variables for demo purposes #}
 {% set schema = bolt.data.components["@bolt-components-popover"].schema %}
 {% set link %}
   {% include "@bolt-components-link/link.twig" with {
@@ -10,8 +9,6 @@
   This is the content of the popover with a {{ link }}.
 {% endset %}
 
-<bolt-text headline>Content theme</bolt-text>
-<bolt-text>Adjust the Bolt color theme of the content by using the <bolt-code-snippet display="inline" lang="html">theme</bolt-code-snippet> prop.</bolt-text>
 <bolt-list display="inline" spacing="medium">
   {% for theme in schema.properties.theme.enum %}
     <bolt-list-item>
@@ -21,13 +18,15 @@
           size: "small",
         } only %}
       {% endset %}
-      {# Start component specific code #}
       {% include "@bolt-components-popover/popover.twig" with {
         trigger: trigger,
         content: content,
-        theme: theme
+        theme: theme,
+        uuid: "theme-demo-#{theme}-#{loop.index}",
+        attributes: {
+          "no-shadow": true,
+        }
       } only %}
-      {# End component specific code #}
     </bolt-list-item>
   {% endfor %}
 </bolt-list>

--- a/packages/components/bolt-button/src/button.scss
+++ b/packages/components/bolt-button/src/button.scss
@@ -5,6 +5,7 @@
 // Dev Notes
 // 1. [Morse] This mixin outputs a separate ruleset for each selector to prevent IE from failing on unrecognized selectors like `:host`. It is not a substitute for comma-separated selectors.
 // 2. [Morse] Bolt-link delegates focus to inner element.
+// 3. [Mai] These selectors and rules must be separated to override browser defaults.
 
 @import '@bolt/core-v3.x';
 @import './button-settings-and-tools';
@@ -15,8 +16,11 @@
 @include bolt-repeat-rule(('bolt-button', ':host(bolt-button)')) {
   // [1]
   display: inline-flex;
-  appearance: none;
   outline: none; // [2]
+}
+
+@include bolt-repeat-rule(('bolt-button[type]', ':host(bolt-button[type])')) {
+  @include bolt-button-native-styles-reset;
 }
 
 .c-bolt-button {

--- a/packages/components/bolt-popover/__tests__/popover.e2e.js
+++ b/packages/components/bolt-popover/__tests__/popover.e2e.js
@@ -10,7 +10,7 @@ module.exports = {
 
     browser
       .url(
-        `${testingUrl}/pattern-lab/patterns/40-components-popover-25-popover-theme-variations/40-components-popover-25-popover-theme-variations.html#js-bolt-popover-theme-demo-xdark-5`,
+        `${testingUrl}/pattern-lab/patterns/999-tests-popover-00-popover-auto-open/999-tests-popover-00-popover-auto-open.html#js-bolt-popover-theme-demo-xdark-5`,
       )
       .waitForElementVisible('bolt-popover[uuid="theme-demo-xdark-5"]', 1000)
       .pause(1000)
@@ -31,7 +31,7 @@ module.exports = {
 
     browser
       .url(
-        `${testingUrl}/pattern-lab/patterns/40-components-popover-25-popover-theme-variations/40-components-popover-25-popover-theme-variations.html#js-bolt-popover-trigger-theme-demo-xdark-5`,
+        `${testingUrl}/pattern-lab/patterns/999-tests-popover-00-popover-auto-open/999-tests-popover-00-popover-auto-open.html#js-bolt-popover-trigger-theme-demo-xdark-5`,
       )
       .waitForElementVisible('bolt-popover[uuid="theme-demo-xdark-5"]', 1000)
       .pause(1000)
@@ -50,7 +50,7 @@ module.exports = {
 
     browser
       .url(
-        `${testingUrl}/pattern-lab/patterns/40-components-popover-25-popover-theme-variations/40-components-popover-25-popover-theme-variations.html?foo=bar#js-bolt-popover-theme-demo-xdark-5`,
+        `${testingUrl}/pattern-lab/patterns/999-tests-popover-00-popover-auto-open/999-tests-popover-00-popover-auto-open.html?foo=bar#js-bolt-popover-theme-demo-xdark-5`,
       )
       .waitForElementVisible('bolt-popover[uuid="theme-demo-xdark-5"]', 1000)
       .pause(1000)

--- a/packages/components/bolt-popover/src/popover.scss
+++ b/packages/components/bolt-popover/src/popover.scss
@@ -2,7 +2,7 @@
    Popover
 \* ------------------------------------ */
 @import '@bolt/core-v3.x';
-@import '@bolt/global/styles/06-themes/_themes.all.scss';
+@import '@bolt/global/styles/00-vars/_vars-mode.scss';
 
 // Dev Notes
 // 1. Any instance of bolt-popover:not([ready]) in this file is used to create NoJS fallback styles.


### PR DESCRIPTION
## Summary

- Fixes Popover bubble background "theme": https://github.com/boltdesignsystem/bolt/pull/2073
- Fixes Typeahead button style in Safari: https://github.com/boltdesignsystem/bolt/pull/2074