### PR TITLE
DS-306 fix desktop primary nav full width item

### DIFF
--- a/packages/components/bolt-page-header/src/_page-header-desktop.scss
+++ b/packages/components/bolt-page-header/src/_page-header-desktop.scss
@@ -324,8 +324,8 @@
 
     > .c-bolt-page-header__nav-list-item.has-children {
       > .c-bolt-page-header__nav-list {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+        display: flex;
+        flex-wrap: wrap;
         visibility: hidden;
         opacity: 0;
         position: absolute;
@@ -356,15 +356,17 @@
           transform $bolt-transition;
 
         > .c-bolt-page-header__nav-list-item {
+          flex: 1 0 calc(100% / 5);
           margin-bottom: var(--bolt-spacing-y-medium);
           padding-right: var(--bolt-spacing-x-medium);
           padding-left: var(--bolt-spacing-x-medium);
-          border-right-color: $bolt-border-color;
-          border-right-style: $bolt-border-style;
-          border-right-width: $bolt-border-width;
+          border-left-color: $bolt-border-color;
+          border-left-style: $bolt-border-style;
+          border-left-width: $bolt-border-width;
 
-          &:last-of-type {
-            border-right-width: 0;
+          &:first-of-type,
+          &:nth-child(6n + 6) {
+            border-left-width: 0;
           }
 
           .c-bolt-page-header__nav-link--heading {

--- a/packages/components/bolt-page-header/src/_page-header-desktop.scss
+++ b/packages/components/bolt-page-header/src/_page-header-desktop.scss
@@ -356,7 +356,7 @@
           transform $bolt-transition;
 
         > .c-bolt-page-header__nav-list-item {
-          flex: 1 0 calc(100% / 5);
+          flex: 1 1 20%;
           margin-bottom: var(--bolt-spacing-y-medium);
           padding-right: var(--bolt-spacing-x-medium);
           padding-left: var(--bolt-spacing-x-medium);


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-306

## Summary

Fixes a bug where the page header's primary nav full width nested item is not taking up full width.

## Details

Rewrote some CSS for a flex method that can easily allow an item to be full width.

## How to test

Run the branch locally and view the Academy demo under the Page Header component docs. On desktop, hover over the first item in the primary nav, check the dropdown activated by hovering, make sure the "View all products" link is taking up full width.

![Screen Shot 2021-01-14 at 3 59 59 PM](https://user-images.githubusercontent.com/3027663/104648742-95448e00-5681-11eb-89c1-577988eb7109.png)
