### PR TITLE
DS-311: filter out the style prop to avoid conflict with jquery

### DIFF
--- a/packages/components/bolt-button/src/button.js
+++ b/packages/components/bolt-button/src/button.js
@@ -21,8 +21,9 @@ class BoltButton extends BoltActionElement {
   // static useShadow = false; example of manually disabling Shadow DOM w/ BoltElement
 
   static get properties() {
+    const { style, ...filteredProps } = this.props;
     return {
-      ...this.props,
+      ...filteredProps,
       color: { type: String },
       tabindex: { type: Number },
       inert: { type: Boolean }, // will eventually go hand in hand with https://github.com/WICG/inert#notes-on-the-polyfill


### PR DESCRIPTION
## Jira

[https://pegadigitalit.atlassian.net/browse/DS-311](https://pegadigitalit.atlassian.net/browse/DS-311)

## Summary

filter `style` out of the props in the JS to quickly resolve a bug.

## Details

applying a style with jquery created a conflict with the style prop in button

## How to test

Add jQuery to a page and try to add a  CSS style like so: `someBoltButton.css({ cursor: 'progress' });`
