### PR TITLE
Hotfix: Filter out `style` prop from button WC

### DIFF
--- a/packages/components/bolt-button/src/button.js
+++ b/packages/components/bolt-button/src/button.js
@@ -13,6 +13,9 @@ import schema from '../button.schema.js';
 
 let cx = classNames.bind(styles);
 
+// Note: must use `delete` or outputs empty `style` attr on bolt-button WC
+delete schema.properties.style;
+
 @customElement('bolt-button')
 @convertInitialTags(['button', 'a'])
 class BoltButton extends BoltActionElement {


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-311

## Summary

Remove `style` prop from Button web component. It is Twig-only.

## Details

If `style` gets set as a prop, it overwrites the native `style` tag and can throw JS errors.