### PR TITLE
Hotfix/DS-238 Build updates

### DIFF
--- a/packages/base-element/index.js
+++ b/packages/base-element/index.js
@@ -1,3 +1,5 @@
+// Must include Custom Element polyfills for Edge < 79, no longer auto-added via Bolt webpack config
+import '@bolt/polyfills';
 export { BoltElement } from './src/BoltElement';
 export { BoltActionElement } from './src/BoltActionElement';
 export { Slotify } from './src/Slotify';

--- a/packages/base-lazy-queue/index.mjs
+++ b/packages/base-lazy-queue/index.mjs
@@ -1,3 +1,5 @@
+// Must include Custom Element polyfills for Edge < 79, no longer auto-added via Bolt webpack config
+import '@bolt/polyfills';
 import {
   lazyDefinitions,
   lazyDefinitionObserver,

--- a/packages/base-lazy-queue/package.json
+++ b/packages/base-lazy-queue/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "module": "index.mjs",
   "dependencies": {
+    "@bolt/polyfills": "^3.0.0",
     "idlize": "^0.1.1"
   },
   "publishConfig": {

--- a/packages/build-tools/create-webpack-config.js
+++ b/packages/build-tools/create-webpack-config.js
@@ -67,10 +67,7 @@ async function createWebpackConfig(buildConfig) {
     const globalEntryName = 'bolt-global';
 
     if (components.global) {
-      entry[globalEntryName] = [
-        '@bolt/polyfills',
-        '@bolt/core-v3.x/styles/main.scss',
-      ];
+      entry[globalEntryName] = ['@bolt/core-v3.x/styles/main.scss'];
 
       entry['brightcove'] = ['@bolt/components-video/brightcove.scss'];
 

--- a/packages/build-tools/create-webpack-config.js
+++ b/packages/build-tools/create-webpack-config.js
@@ -69,7 +69,9 @@ async function createWebpackConfig(buildConfig) {
     if (components.global) {
       entry[globalEntryName] = ['@bolt/core-v3.x/styles/main.scss'];
 
-      entry['brightcove'] = ['@bolt/components-video/brightcove.scss'];
+      if (config.env !== 'drupal') {
+        entry['brightcove'] = ['@bolt/components-video/brightcove.scss'];
+      }
 
       components.global.forEach(component => {
         if (component.assets.style) {


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-238

## Summary

Update Bolt build tools and dependencies to work with `pega_bolt_theme` build.

## Details

- Polyfills are not getting bundled in `pega_bolt_theme`, and we couldn't easily figure out why. So, simply include the polyfills where they are needed (lazyqueue and element). Remove polyfills from the Bolt webpack config.
- Update function that gets `boltrc.js` file to be asynchronous as `pega_bolt_theme`'s `boltrc.js` runs several tasks and returns asynchronously.
- Skip brightcove entry in 'drupal' environment. Otherwise throws error `Can't resolve '@bolt/components-video/brightcove.scss' in '/var/www/docroot/themes/custom/pega_bolt_theme'`. This file is only needed in Bolt mono repo so skip in Drupal.

> Note: before we officially release any of this we need to merge `master` into the `v3.0` branch. Resolving conflicts with master will be tedious so let's wait and do it just once at the end.

## How to test

Review code. Tests are passing.