### PR TITLE
Hotfix/DS-238 yarn lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1090,6 +1090,16 @@
     node-fetch "^2.1.2"
     sleep-promise "^8.0.1"
 
+"@bolt/testing-utils@^2.8.0-beta.4":
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/@bolt/testing-utils/-/testing-utils-2.19.0.tgz#dfeebc1fb5624dba937f3d56f835e40e7fcff3bc"
+  integrity sha512-FtERN5zdDK9h54gFOiPfXc2rcoE1qQwt9AdatxGZoa6sJweclHdgEEcYDrSRmNTjyJGD5m3PLFpFKWgfm9YtfQ==
+  dependencies:
+    execa "^1.0.0"
+    find-pkg "^2.0.0"
+    fs-extra "^8.1.0"
+    globby "^9.2.0"
+
 "@ckeditor/ckeditor5-build-classic@^12.1.0":
   version "12.4.0"
   resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-build-classic/-/ckeditor5-build-classic-12.4.0.tgz#d5eefb00424d6c559f826d8509ba6ce7e1ce12b9"


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-238

## Summary

Update `yarn.lock` to fix auto-release step on Travis.