### PR TITLE
DS-315 Fix icon schema formatting

### DIFF
--- a/packages/build-tools/tasks/icon-tasks.js
+++ b/packages/build-tools/tasks/icon-tasks.js
@@ -8,6 +8,7 @@ const chalk = require('chalk');
 const { getConfig } = require('@bolt/build-utils/config-store');
 const log = require('@bolt/build-utils/log');
 const iconGenerator = require('@bolt/build-utils/icon-generator');
+const prettier = require('prettier');
 
 let initialBuild = true;
 
@@ -75,8 +76,13 @@ async function generateSchemaFile(icons) {
   const schema = await fs.readJson(iconComponentSchema);
   schema.properties.name.anyOf[0].enum = names;
 
+  const formattedSchema = prettier.format(JSON.stringify(schema), {
+    parser: 'json',
+  });
+
   // update bolt-icon schema with newest icons from svgs folder
-  await fs.writeJson(iconComponentSchema, schema, { spaces: 2 });
+  await fs.writeFile(iconComponentSchema, formattedSchema);
+
   // generate `icons.bolt.json` file with newest icons array
   await fs.writeFile(
     path.join(config.dataDir, 'icons.bolt.json'),

--- a/packages/components/bolt-icon/icon.schema.json
+++ b/packages/components/bolt-icon/icon.schema.json
@@ -155,10 +155,7 @@
             "youtube-solid"
           ]
         },
-        {
-          "type": "string",
-          "pattern": "^custom-[a-z-]*$"
-        }
+        { "type": "string", "pattern": "^custom-[a-z-]*$" }
       ]
     },
     "background": {


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-315

## Summary

Fix Icon schema formatting conflicts.

## Details

When you run `yarn start` the Icon schema file is automatically updated with icon svgs found in the filesystem. The schema file was previously formatted with node's `writeJson()` formatting options. These are a bit different than our Prettier settings. This PR updates the icon task to use Prettier to format the schema.

## How to test

- Checkout master and run `yarn start`. You should see a modified Icon schema file.
- Checkout this feature branch and repeat. There shouldn't be any modified file afterwards.