### PR TITLE
DS-297 Update background twig to latest conventions

### DIFF
--- a/packages/components/bolt-background/src/background-item.twig
+++ b/packages/components/bolt-background/src/background-item.twig
@@ -1,31 +1,33 @@
 {% set schema = bolt.data.components["@bolt-components-background"].schema %}
 
-{% set baseClass = "c-bolt-background" %}
-{% set itemAttributes = item.pattern ~ "Attributes" %}
+{# Variables #}
+{% set this = init(schema) %}
+{% set item_attributes = item.pattern ~ "Attributes" %}
 
 {# Image expects "ratio" to be passed as string, Video expects boolean #}
 {# todo: in v3.0 remove reference to Video, no longer supported #}
-{% set ratioValue = item.pattern == "image" ? "none" : false %}
+{% set ratio_value = item.pattern == "image" ? "none" : false %}
 
 {% if item.pattern and item.pattern != "image" %}
   {% set item = item | merge({
-    (itemAttributes): {
+    (item_attributes): {
       class: ["c-bolt-background__#{item.pattern}"]
     }
   }) %}
 {% endif %}
 
+
 {# todo: in v3.0 nix the pattern_template pattern? #}
 {% if item.pattern %}
-  <div class="{{ "#{baseClass}__item" }}">
+  <div class="{{ "c-bolt-background__item" }}">
     {% include pattern_template(item.pattern) with item | merge({
-      ratio: ratioValue,
+      ratio: ratio_value,
       lazyload: item.lazyload ?? true,
       cover: item.cover ?? true
     }) only %}
   </div>
 {% elseif (item is iterable) %}
-  <div class="{{ "#{baseClass}__item" }}">
+  <div class="{{ "c-bolt-background__item" }}">
     {{ item }}
   </div>
 {% else %}

--- a/packages/components/bolt-background/src/background-overlay.twig
+++ b/packages/components/bolt-background/src/background-overlay.twig
@@ -1,23 +1,19 @@
 {% set schema = bolt.data.components["@bolt-components-background"].schema %}
 
-{% set baseClass = "c-bolt-background" %}
+{# Variables #}
+{% set this = init(schema) %}
 {% set attributes = create_attribute({}) %}
-{% set overlay = overlay in schema.properties.overlay.enum ? overlay : schema.properties.overlay.default %}
-{% set opacity = opacity in schema.properties.opacity.enum ? opacity : opacity in schema.properties.opacity.default %}
-{% set fill = fill in schema.properties.fill.enum ? fill : schema.properties.fill.default %}
-{% set fillColor = fillColor in schema.properties.fillColor.enum ? fillColor : schema.properties.fillColor.default %}
 
-{% if focalPoint and focalPoint.horizontal == "left" and fill == "gradient" %}
-  {% set fill = "gradient-reversed" %}
-{% endif %}
+{% set is_reversed = focalPoint and focalPoint.horizontal == "left" and this.data.fill.value == "gradient" %}
+{% set fill_value = is_reversed ? "gradient-reversed" : this.data.fill.value %}
 
 {% set classes = [
-  baseClass ~ "__overlay",
-  baseClass ~ "__overlay--" ~ opacity ~ "-opacity",
-  baseClass ~ "__overlay--" ~ fill ~ "-fill",
-  baseClass ~ "__overlay-fill-color--" ~ fillColor
+  "c-bolt-background__overlay",
+  "c-bolt-background__overlay--" ~ this.data.opacity.value ~ "-opacity",
+  "c-bolt-background__overlay--" ~ fill_value ~ "-fill",
+  "c-bolt-background__overlay-fill-color--" ~ this.data.fill_color.value
 ] %}
 
-{% if overlay == 'enabled' %}
+{% if this.data.overlay.value == 'enabled' %}
   <div {{ attributes.addClass(classes) }} ></div>
 {% endif %}

--- a/packages/components/bolt-background/src/background-shapes-wrapper.twig
+++ b/packages/components/bolt-background/src/background-shapes-wrapper.twig
@@ -1,15 +1,14 @@
 {% set schema = bolt.data.components["@bolt-components-background"].schema %}
 
-{% set baseClass = "c-bolt-background" %}
+{# Variables #}
+{% set this = init(schema) %}
 {% set attributes = create_attribute({}) %}
-{% set shapeGroup =  shapeGroup in schema.properties.shapeGroup.enum ? shapeGroup : schema.properties.shapeGroup.default %}
-{% set shapeAlignment = shapeAlignment in schema.properties.shapeAlignment.enum ? shapeAlignment : schema.properties.shapeAlignment.default %}
 
-{% set shapeClasses = [
-  baseClass ~ "__shapes",
-  baseClass ~ "__shapes--" ~ shapeAlignment
+{% set classes = [
+  "c-bolt-background__shapes",
+  this.data.shape_alignment.value ? "c-bolt-background__shapes--" ~ this.data.shape_alignment.value : "",
 ] %}
 
-<div {{ attributes.addClass(shapeClasses) }}>
-  {% include "@bolt/background-shapes.twig" with { "shapeGroup": shapeGroup } only %}
+<div {{ attributes.addClass(classes) }}>
+  {% include "@bolt/background-shapes.twig" with { "shapeGroup": this.data.shape_group.value } only %}
 </div>

--- a/packages/components/bolt-background/src/background.scss
+++ b/packages/components/bolt-background/src/background.scss
@@ -76,7 +76,7 @@ bolt-background {
   animation: a-bolt-zoom-in-out 45s ease-in-out infinite both;
 }
 
-// todo: remove in v3.0, video background in deprecated
+// todo: remove in v3.0, video background is deprecated
 .c-bolt-background__video {
   top: 0;
   right: 0;

--- a/packages/components/bolt-background/src/background.twig
+++ b/packages/components/bolt-background/src/background.twig
@@ -4,26 +4,28 @@
   {{ validate_data_schema(schema, _self) | raw }}
 {% endif %}
 
+{# Variables #}
+{% set this = init(schema) %}
 {% set attributes = create_attribute(attributes|default({})) %}
-{% set baseClass = "c-bolt-background" %}
-{% set shapeGroup =  shapeGroup in schema.properties.shapeGroup.enum ? shapeGroup : schema.properties.shapeGroup.default %}
-{% set overlay = overlay in schema.properties.overlay.enum ? overlay : schema.properties.overlay.default %}
 
 <bolt-background bolt-component>
-  <div {{ attributes.addClass([baseClass]) }}>
+  <div {{ attributes.addClass(['c-bolt-background']) }}>
     {% if contentItems %}
       {% for item in contentItems %}
-        {% include "@bolt-components-background/background-item.twig" %}
+        {% if item %}
+          {% include "@bolt-components-background/background-item.twig" %}
+        {% endif %}
       {% endfor %}
     {% endif %}
 
-    {% if overlay == "enabled" or shapeGroup != 'none'  %}
-      <div class="{{ "#{baseClass}__item" }}">
-        {% if overlay == "enabled" %}
+    {% if this.data.overlay.value == "enabled" or this.data.shape_group.value != 'none'  %}
+      <div class="{{ "c-bolt-background__item" }}">
+        {# @todo `overlay` should be Boolean #}
+        {% if this.data.overlay.value == "enabled" %}
           {% include "@bolt-components-background/background-overlay.twig" %}
         {% endif %}
 
-        {% if shapeGroup != 'none' %}
+        {% if this.data.shape_group.value != 'none' %}
           {% include "@bolt-components-background/background-shapes-wrapper.twig" %}
         {% endif %}
       </div>


### PR DESCRIPTION
## Jira

[https://pegadigitalit.atlassian.net/browse/DS-297](https://pegadigitalit.atlassian.net/browse/DS-297)

## Summary

update background twig conventions

## Details

background still used the old validation so this updates background validation to use `{% set this = init(schema) %}`. also used this time to remove `base_class` variable and update as many other twig standards as I could manage.

## How to test

- test unexpected props and classes.
- visually test demos against master.