### PR TITLE
DS-316: make alt prop persistent

### DIFF
--- a/packages/components/bolt-blockquote/__tests__/__snapshots__/blockquote.js.snap
+++ b/packages/components/bolt-blockquote/__tests__/__snapshots__/blockquote.js.snap
@@ -513,6 +513,7 @@ exports[`<bolt-blockquote> component advanced <bolt-blockquote> usage 1`] = `
                       style="padding-bottom: calc((33 / 124) * 100%); --aspect-ratio: 3.7575757575758;"
             >
               <img class="c-bolt-image__image c-bolt-image__lazyload c-bolt-image__lazyload--fade js-lazyload"
+                   alt
                    data-srcset="/fixtures/paypal.svg"
                    data-sizes="auto"
                    srcset="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
@@ -520,6 +521,7 @@ exports[`<bolt-blockquote> component advanced <bolt-blockquote> usage 1`] = `
               >
               <noscript>
                 <img class="c-bolt-image__image"
+                     alt
                      src="/fixtures/paypal.svg"
                      srcset="/fixtures/paypal.svg"
                 >
@@ -556,10 +558,12 @@ exports[`<bolt-blockquote> component advanced <bolt-blockquote> usage 1`] = `
                           style="padding-bottom: calc((1 / 1) * 100%); --aspect-ratio: 1;"
                 >
                   <img class="c-bolt-image__image-placeholder"
+                       alt
                        sizes="auto"
                        src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
                   >
                   <img class="c-bolt-image__image"
+                       alt
                        srcset="/fixtures/author-50.jpg 50w, /fixtures/author-100.jpg 100w, /fixtures/author-200.jpg 200w, /fixtures/author-320.jpg 320w, /fixtures/author-480.jpg 480w, /fixtures/author.jpg 500w"
                        sizes="auto"
                        src="/fixtures/author.jpg"

--- a/packages/components/bolt-device-viewer/__tests__/__snapshots__/device-viewer.js.snap
+++ b/packages/components/bolt-device-viewer/__tests__/__snapshots__/device-viewer.js.snap
@@ -34,9 +34,11 @@ exports[`<bolt-device-viewer> Component basic usage 1`] = `
                     style="padding-bottom: calc((667 / 375) * 100%); --aspect-ratio: 0.56221889055472;"
           >
             <img class="c-bolt-image__image-placeholder"
+                 alt
                  src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
             >
             <img class="c-bolt-image__image c-bolt-image__lazyload c-bolt-image__lazyload--fade c-bolt-image__lazyload--blur js-lazyload"
+                 alt
                  data-srcset="/fixtures/device-screenshot--phone-50.jpg 50w, /fixtures/device-screenshot--phone-100.jpg 100w, /fixtures/device-screenshot--phone-200.jpg 200w, /fixtures/device-screenshot--phone-320.jpg 320w, /fixtures/device-screenshot--phone-480.jpg 480w, /fixtures/device-screenshot--phone-640.jpg 640w, /fixtures/device-screenshot--phone-800.jpg 800w, /fixtures/device-screenshot--phone-1024.jpg 1024w, /fixtures/device-screenshot--phone-1366.jpg 1366w, /fixtures/device-screenshot--phone-1536.jpg 1536w, /fixtures/device-screenshot--phone-1920.jpg 1920w, /fixtures/device-screenshot--phone-2560.jpg 2560w, /fixtures/device-screenshot--phone-2880.jpg 2880w, /fixtures/device-screenshot--phone.jpg 3000w"
                  data-sizes="auto"
                  srcset="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
@@ -44,6 +46,7 @@ exports[`<bolt-device-viewer> Component basic usage 1`] = `
             >
             <noscript>
               <img class="c-bolt-image__image"
+                   alt
                    src="/fixtures/device-screenshot--phone.jpg"
                    srcset="/fixtures/device-screenshot--phone-50.jpg 50w, /fixtures/device-screenshot--phone-100.jpg 100w, /fixtures/device-screenshot--phone-200.jpg 200w, /fixtures/device-screenshot--phone-320.jpg 320w, /fixtures/device-screenshot--phone-480.jpg 480w, /fixtures/device-screenshot--phone-640.jpg 640w, /fixtures/device-screenshot--phone-800.jpg 800w, /fixtures/device-screenshot--phone-1024.jpg 1024w, /fixtures/device-screenshot--phone-1366.jpg 1366w, /fixtures/device-screenshot--phone-1536.jpg 1536w, /fixtures/device-screenshot--phone-1920.jpg 1920w, /fixtures/device-screenshot--phone-2560.jpg 2560w, /fixtures/device-screenshot--phone-2880.jpg 2880w, /fixtures/device-screenshot--phone.jpg 3000w"
               >
@@ -310,10 +313,12 @@ exports[`<bolt-device-viewer> Component usage with magnification 1`] = `
                       style="padding-bottom: calc((683 / 512) * 100%); --aspect-ratio: 0.74963396778917;"
             >
               <img class="c-bolt-image__image-placeholder"
+                   alt
                    data-zoom="/fixtures/device-screenshot--tablet-portrait.jpg"
                    src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
               >
               <img class="c-bolt-image__image c-bolt-image__lazyload c-bolt-image__lazyload--fade c-bolt-image__lazyload--blur js-lazyload"
+                   alt
                    data-srcset="/fixtures/device-screenshot--tablet-portrait-50.jpg 50w, /fixtures/device-screenshot--tablet-portrait-100.jpg 100w, /fixtures/device-screenshot--tablet-portrait-200.jpg 200w, /fixtures/device-screenshot--tablet-portrait-320.jpg 320w, /fixtures/device-screenshot--tablet-portrait-480.jpg 480w, /fixtures/device-screenshot--tablet-portrait-640.jpg 640w, /fixtures/device-screenshot--tablet-portrait-800.jpg 800w, /fixtures/device-screenshot--tablet-portrait-1024.jpg 1024w, /fixtures/device-screenshot--tablet-portrait-1366.jpg 1366w, /fixtures/device-screenshot--tablet-portrait-1536.jpg 1536w, /fixtures/device-screenshot--tablet-portrait-1920.jpg 1920w, /fixtures/device-screenshot--tablet-portrait.jpg 2048w"
                    data-sizes="auto"
                    srcset="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
@@ -322,6 +327,7 @@ exports[`<bolt-device-viewer> Component usage with magnification 1`] = `
               >
               <noscript>
                 <img class="c-bolt-image__image"
+                     alt
                      src="/fixtures/device-screenshot--tablet-portrait.jpg"
                      srcset="/fixtures/device-screenshot--tablet-portrait-50.jpg 50w, /fixtures/device-screenshot--tablet-portrait-100.jpg 100w, /fixtures/device-screenshot--tablet-portrait-200.jpg 200w, /fixtures/device-screenshot--tablet-portrait-320.jpg 320w, /fixtures/device-screenshot--tablet-portrait-480.jpg 480w, /fixtures/device-screenshot--tablet-portrait-640.jpg 640w, /fixtures/device-screenshot--tablet-portrait-800.jpg 800w, /fixtures/device-screenshot--tablet-portrait-1024.jpg 1024w, /fixtures/device-screenshot--tablet-portrait-1366.jpg 1366w, /fixtures/device-screenshot--tablet-portrait-1536.jpg 1536w, /fixtures/device-screenshot--tablet-portrait-1920.jpg 1920w, /fixtures/device-screenshot--tablet-portrait.jpg 2048w"
                 >

--- a/packages/components/bolt-figure/__tests__/__snapshots__/figure.js.snap
+++ b/packages/components/bolt-figure/__tests__/__snapshots__/figure.js.snap
@@ -153,10 +153,12 @@ exports[`figure figure with deprecated "image" prop still renders 1`] = `
                       style="padding-bottom: calc((638 / 1151) * 100%); --aspect-ratio: 1.8040752351097;"
             >
               <img class="c-bolt-image__image-placeholder"
+                   alt
                    sizes="auto"
                    src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
               >
               <img class="c-bolt-image__image"
+                   alt
                    srcset="/fixtures/landscape-16x9-mountains-50.jpg 50w, /fixtures/landscape-16x9-mountains-100.jpg 100w, /fixtures/landscape-16x9-mountains-200.jpg 200w, /fixtures/landscape-16x9-mountains-320.jpg 320w, /fixtures/landscape-16x9-mountains-480.jpg 480w, /fixtures/landscape-16x9-mountains-640.jpg 640w, /fixtures/landscape-16x9-mountains-800.jpg 800w, /fixtures/landscape-16x9-mountains-1024.jpg 1024w, /fixtures/landscape-16x9-mountains.jpg 1151w"
                    sizes="auto"
                    src="/fixtures/landscape-16x9-mountains.jpg"
@@ -381,10 +383,12 @@ exports[`figure figure with image 1`] = `
                       style="padding-bottom: calc((638 / 1151) * 100%); --aspect-ratio: 1.8040752351097;"
             >
               <img class="c-bolt-image__image-placeholder"
+                   alt
                    sizes="auto"
                    src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
               >
               <img class="c-bolt-image__image"
+                   alt
                    srcset="/fixtures/landscape-16x9-mountains-50.jpg 50w, /fixtures/landscape-16x9-mountains-100.jpg 100w, /fixtures/landscape-16x9-mountains-200.jpg 200w, /fixtures/landscape-16x9-mountains-320.jpg 320w, /fixtures/landscape-16x9-mountains-480.jpg 480w, /fixtures/landscape-16x9-mountains-640.jpg 640w, /fixtures/landscape-16x9-mountains-800.jpg 800w, /fixtures/landscape-16x9-mountains-1024.jpg 1024w, /fixtures/landscape-16x9-mountains.jpg 1151w"
                    sizes="auto"
                    src="/fixtures/landscape-16x9-mountains.jpg"

--- a/packages/components/bolt-image/__tests__/__snapshots__/image.js.snap
+++ b/packages/components/bolt-image/__tests__/__snapshots__/image.js.snap
@@ -1,5 +1,79 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<bolt-image> Component <bolt-image> should always render alt attribute on <img> tags 1`] = `
+<bolt-image src="/fixtures/1200x660.jpg"
+            srcset="/fixtures/1200x660-50.jpg 50w, /fixtures/1200x660-100.jpg 100w, /fixtures/1200x660-200.jpg 200w, /fixtures/1200x660-320.jpg 320w, /fixtures/1200x660-480.jpg 480w, /fixtures/1200x660-640.jpg 640w, /fixtures/1200x660-800.jpg 800w, /fixtures/1200x660-1024.jpg 1024w, /fixtures/1200x660.jpg 1200w"
+            sizes="auto"
+            ratio="1200/660"
+            placeholder-color="hsl(233, 33%, 97%)"
+            placeholder-image="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+            style="background-color: hsl(233, 33%, 97%);"
+>
+  <bolt-ratio ratio="20/11">
+    <ssr-keep for="bolt-ratio"
+              class="c-bolt-ratio"
+              style="padding-bottom: calc((11 / 20) * 100%); --aspect-ratio: 1.8181818181818;"
+    >
+      <img class="c-bolt-image__image-placeholder"
+           alt
+           src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+      >
+      <img class="c-bolt-image__image c-bolt-image__lazyload c-bolt-image__lazyload--fade c-bolt-image__lazyload--blur js-lazyload"
+           alt
+           data-srcset="/fixtures/1200x660-50.jpg 50w, /fixtures/1200x660-100.jpg 100w, /fixtures/1200x660-200.jpg 200w, /fixtures/1200x660-320.jpg 320w, /fixtures/1200x660-480.jpg 480w, /fixtures/1200x660-640.jpg 640w, /fixtures/1200x660-800.jpg 800w, /fixtures/1200x660-1024.jpg 1024w, /fixtures/1200x660.jpg 1200w"
+           data-sizes="auto"
+           srcset="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+           src="/fixtures/1200x660.jpg"
+      >
+      <noscript>
+        <img class="c-bolt-image__image"
+             alt
+             src="/fixtures/1200x660.jpg"
+             srcset="/fixtures/1200x660-50.jpg 50w, /fixtures/1200x660-100.jpg 100w, /fixtures/1200x660-200.jpg 200w, /fixtures/1200x660-320.jpg 320w, /fixtures/1200x660-480.jpg 480w, /fixtures/1200x660-640.jpg 640w, /fixtures/1200x660-800.jpg 800w, /fixtures/1200x660-1024.jpg 1024w, /fixtures/1200x660.jpg 1200w"
+        >
+      </noscript>
+    </ssr-keep>
+  </bolt-ratio>
+</bolt-image>
+`;
+
+exports[`<bolt-image> Component <bolt-image> should always render alt attribute on <img> tags 2`] = `
+<bolt-image src="/fixtures/1200x660.jpg"
+            srcset="/fixtures/1200x660-50.jpg 50w, /fixtures/1200x660-100.jpg 100w, /fixtures/1200x660-200.jpg 200w, /fixtures/1200x660-320.jpg 320w, /fixtures/1200x660-480.jpg 480w, /fixtures/1200x660-640.jpg 640w, /fixtures/1200x660-800.jpg 800w, /fixtures/1200x660-1024.jpg 1024w, /fixtures/1200x660.jpg 1200w"
+            sizes="auto"
+            ratio="1200/660"
+            placeholder-color="hsl(233, 33%, 97%)"
+            placeholder-image="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+            style="background-color: hsl(233, 33%, 97%);"
+>
+  <bolt-ratio ratio="20/11">
+    <ssr-keep for="bolt-ratio"
+              class="c-bolt-ratio"
+              style="padding-bottom: calc((11 / 20) * 100%); --aspect-ratio: 1.8181818181818;"
+    >
+      <img class="c-bolt-image__image-placeholder"
+           alt
+           src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+      >
+      <img class="c-bolt-image__image c-bolt-image__lazyload c-bolt-image__lazyload--fade c-bolt-image__lazyload--blur js-lazyload"
+           alt
+           data-srcset="/fixtures/1200x660-50.jpg 50w, /fixtures/1200x660-100.jpg 100w, /fixtures/1200x660-200.jpg 200w, /fixtures/1200x660-320.jpg 320w, /fixtures/1200x660-480.jpg 480w, /fixtures/1200x660-640.jpg 640w, /fixtures/1200x660-800.jpg 800w, /fixtures/1200x660-1024.jpg 1024w, /fixtures/1200x660.jpg 1200w"
+           data-sizes="auto"
+           srcset="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+           src="/fixtures/1200x660.jpg"
+      >
+      <noscript>
+        <img class="c-bolt-image__image"
+             alt
+             src="/fixtures/1200x660.jpg"
+             srcset="/fixtures/1200x660-50.jpg 50w, /fixtures/1200x660-100.jpg 100w, /fixtures/1200x660-200.jpg 200w, /fixtures/1200x660-320.jpg 320w, /fixtures/1200x660-480.jpg 480w, /fixtures/1200x660-640.jpg 640w, /fixtures/1200x660-800.jpg 800w, /fixtures/1200x660-1024.jpg 1024w, /fixtures/1200x660.jpg 1200w"
+        >
+      </noscript>
+    </ssr-keep>
+  </bolt-ratio>
+</bolt-image>
+`;
+
 exports[`<bolt-image> Component <bolt-image> with max-width and additional style attribute renders as expected 1`] = `
 <bolt-image src="/fixtures/1200x660.jpg"
             srcset="/fixtures/1200x660-50.jpg 50w, /fixtures/1200x660-100.jpg 100w, /fixtures/1200x660-200.jpg 200w, /fixtures/1200x660-320.jpg 320w, /fixtures/1200x660-480.jpg 480w, /fixtures/1200x660-640.jpg 640w, /fixtures/1200x660-800.jpg 800w, /fixtures/1200x660-1024.jpg 1024w, /fixtures/1200x660.jpg 1200w"

--- a/packages/components/bolt-image/__tests__/image.js
+++ b/packages/components/bolt-image/__tests__/image.js
@@ -62,4 +62,18 @@ describe('<bolt-image> Component', () => {
     expect(results.ok).toBe(true);
     expect(results.html).toMatchSnapshot();
   });
+  test('<bolt-image> should always render alt attribute on <img> tags', async () => {
+    const result1 = await render('@bolt-components-image/image.twig', {
+      src: '/fixtures/1200x660.jpg',
+      alt: '',
+    });
+    expect(result1.ok).toBe(true);
+    expect(result1.html).toMatchSnapshot();
+
+    const result2 = await render('@bolt-components-image/image.twig', {
+      src: '/fixtures/1200x660.jpg',
+    });
+    expect(result2.ok).toBe(true);
+    expect(result2.html).toMatchSnapshot();
+  });
 });

--- a/packages/components/bolt-image/src/image.js
+++ b/packages/components/bolt-image/src/image.js
@@ -218,7 +218,7 @@ class BoltImage extends BoltElement {
           <img
             class="${classes}"
             src="${ifDefined(this.src ? this.src : fallbackSrc)}"
-            alt="${ifDefined(this.alt ? this.alt : undefined)}"
+            alt="${ifDefined(this.alt ? this.alt : '')}"
             srcset="${ifDefined(
               !lazyload
                 ? this.srcset || this.src || undefined
@@ -267,7 +267,7 @@ class BoltImage extends BoltElement {
               },
             )}"
             src="${this.placeholderImage}"
-            alt="${ifDefined(this.alt ? this.alt : undefined)}"
+            alt="${ifDefined(this.alt ? this.alt : '')}"
           />
         `;
       }
@@ -284,7 +284,7 @@ class BoltImage extends BoltElement {
                 'c-bolt-image--cover': this.cover,
               })}"
               src="${this.src}"
-              alt="${ifDefined(this.alt ? this.alt : undefined)}"
+              alt="${ifDefined(this.alt ? this.alt : '')}"
               srcset="${ifDefined(
                 !lazyload ? this.srcset || this.src : undefined,
               )}"

--- a/packages/components/bolt-image/src/image.js
+++ b/packages/components/bolt-image/src/image.js
@@ -218,7 +218,7 @@ class BoltImage extends BoltElement {
           <img
             class="${classes}"
             src="${ifDefined(this.src ? this.src : fallbackSrc)}"
-            alt="${ifDefined(this.alt ? this.alt : '')}"
+            alt="${this.alt || ''}"
             srcset="${ifDefined(
               !lazyload
                 ? this.srcset || this.src || undefined
@@ -267,7 +267,7 @@ class BoltImage extends BoltElement {
               },
             )}"
             src="${this.placeholderImage}"
-            alt="${ifDefined(this.alt ? this.alt : '')}"
+            alt="${this.alt || ''}"
           />
         `;
       }
@@ -284,7 +284,7 @@ class BoltImage extends BoltElement {
                 'c-bolt-image--cover': this.cover,
               })}"
               src="${this.src}"
-              alt="${ifDefined(this.alt ? this.alt : '')}"
+              alt="${this.alt || ''}"
               srcset="${ifDefined(
                 !lazyload ? this.srcset || this.src : undefined,
               )}"

--- a/packages/components/bolt-image/src/image.twig
+++ b/packages/components/bolt-image/src/image.twig
@@ -135,7 +135,8 @@
   {% if valign %}valign="{{ valign }}"{% endif %}
   {% if align %}align="{{ align }}"{% endif %}
   {% if srcset %}srcset="{{ srcset }}"{% endif %}
-  {% if alt %}alt="{{ alt }}"{% endif %}
+  {# {% if alt %}alt="{{ alt }}"{% endif %} #}
+  alt="{{ alt ? alt : '' }}"
   {% if max_width %}max-width="{{ max_width }}"{% endif %}
   {% if sizes %}sizes="{{ sizes }}"{% endif %}
   {% if ratio_string %}ratio="{{ ratio_string }}"{% elseif not use_ratio %}ratio="none"{% elseif can_use_ratio %}ratio="{{ width * 1 }}/{{ height * 1 }}"{% endif %}

--- a/packages/components/bolt-image/src/image.twig
+++ b/packages/components/bolt-image/src/image.twig
@@ -21,9 +21,6 @@
   {% set srcset = image_data_bolt.srcset %}
 {% endif %}
 
-{# Set alt to null if missing, prevents empty alt tags #}
-{% set alt = alt ? alt : null %}
-
 {# Temp: prefix "ph" to preserve original value for web component, better pattern in the works #}
 {% set ph_color = placeholder_color|default(image_data_bolt.color|default(schema.properties.placeholder_color.default)) %}
 {# Note: image-specific base64 data is only generated in production mode, default data is used for local development #}
@@ -82,7 +79,7 @@
 ] %}
 
 {% set image_attributes = create_attribute(imageAttributes | default({})).addClass(image_classes, lazyload_classes)
-  .setAttribute('alt', alt)
+  .setAttribute('alt', alt ? alt : "")
   .setAttribute( (lazyload ? "data-" : null) ~ "srcset", srcset ? srcset : null)
   .setAttribute( (lazyload ? "data-" : null) ~ "sizes", sizes)
   .setAttribute('srcset', lazyload ? schema.properties.placeholder_image.default : srcset)
@@ -95,7 +92,7 @@
 {% endif %}
 
 {% set image_fallback_attributes = create_attribute({}).addClass(image_classes)
-  .setAttribute('alt', alt)
+  .setAttribute('alt', alt ? alt : "")
   .setAttribute('src', src)
   .setAttribute(srcset ? "srcset" : "", srcset ? srcset : null)
 %}
@@ -135,8 +132,7 @@
   {% if valign %}valign="{{ valign }}"{% endif %}
   {% if align %}align="{{ align }}"{% endif %}
   {% if srcset %}srcset="{{ srcset }}"{% endif %}
-  {# {% if alt %}alt="{{ alt }}"{% endif %} #}
-  alt="{{ alt ? alt : '' }}"
+  {% if alt %}alt="{{ alt }}"{% endif %}
   {% if max_width %}max-width="{{ max_width }}"{% endif %}
   {% if sizes %}sizes="{{ sizes }}"{% endif %}
   {% if ratio_string %}ratio="{{ ratio_string }}"{% elseif not use_ratio %}ratio="none"{% elseif can_use_ratio %}ratio="{{ width * 1 }}/{{ height * 1 }}"{% endif %}

--- a/packages/components/bolt-logo/__tests__/__snapshots__/logo.js.snap
+++ b/packages/components/bolt-logo/__tests__/__snapshots__/logo.js.snap
@@ -16,6 +16,7 @@ exports[`logo Basic usage 1`] = `
                 style="padding-bottom: calc((33 / 124) * 100%); --aspect-ratio: 3.7575757575758;"
       >
         <img class="c-bolt-image__image"
+             alt
              srcset="/fixtures/logo-paypal.svg"
              sizes="auto"
              src="/fixtures/logo-paypal.svg"
@@ -69,6 +70,7 @@ exports[`logo Logo with invert set to "true" renders properly 1`] = `
                 style="padding-bottom: calc((33 / 124) * 100%); --aspect-ratio: 3.7575757575758;"
       >
         <img class="c-bolt-image__image"
+             alt
              srcset="/fixtures/logo-paypal.svg"
              sizes="auto"
              src="/fixtures/logo-paypal.svg"


### PR DESCRIPTION
## Jira

[https://pegadigitalit.atlassian.net/browse/DS-316](https://pegadigitalit.atlassian.net/browse/DS-316)

## Summary

make alt prop persistent

## Details

we want an alt prop show even if its blank, edited the conditionals to make alt prop persistent

## How to test

remove the alt prop from a twig include in the demos and verify that there is still an alt listed in the element props. 
