### PR TITLE
DS-321 Update Slotify to handle only whitespace as content

### DIFF
--- a/packages/base-element/src/Slotify.js
+++ b/packages/base-element/src/Slotify.js
@@ -25,6 +25,7 @@ export class Slotify extends LitElement {
   }
 
   // Save a reference to the pseudoSlot content before lit-element renders
+  // 1. Always add at least a default slot to the slotMap. Otherwise, content added after the initial render will not appear.
   saveSlots() {
     const childNodes = Array.from(this.childNodes);
 
@@ -38,11 +39,12 @@ export class Slotify extends LitElement {
           this.addChildToSlotMap(slot, child);
         } else if (slot && child instanceof HTMLElement) {
           this.addChildToSlotMap(slot, child);
+        } else {
+          this.addChildToSlotMap('default', ''); // [1]
         }
       });
     } else {
-      // Always add at least a default slot to the slotMap. Otherwise, content added after the initial render will not appear.
-      this.addChildToSlotMap('default', '');
+      this.addChildToSlotMap('default', ''); // [1]
     }
   }
 

--- a/packages/components/bolt-accordion/__tests__/__snapshots__/accordion.js.snap
+++ b/packages/components/bolt-accordion/__tests__/__snapshots__/accordion.js.snap
@@ -17,6 +17,7 @@ exports[`<bolt-accordion> Component Default <bolt-accordion> w/o Shadow DOM rend
     
         
     <!---->
+    <!---->
     <bolt-accordion-item
       no-shadow=""
       style=""
@@ -155,12 +156,15 @@ exports[`<bolt-accordion> Component Default <bolt-accordion> w/o Shadow DOM rend
             
           
             <!---->
+            <!---->
+            <!---->
             <div
               class="is-first-child is-last-child"
               style=""
             >
               Lorem ipsum dolor sit, amet consectetur adipisicing elit.
             </div>
+            <!---->
             <!---->
             
         
@@ -177,6 +181,7 @@ exports[`<bolt-accordion> Component Default <bolt-accordion> w/o Shadow DOM rend
     
       <!---->
     </bolt-accordion-item>
+    <!---->
     <!---->
     <bolt-accordion-item
       no-shadow=""
@@ -316,12 +321,15 @@ exports[`<bolt-accordion> Component Default <bolt-accordion> w/o Shadow DOM rend
             
           
             <!---->
+            <!---->
+            <!---->
             <div
               class="is-first-child is-last-child"
               style=""
             >
               Lorem ipsum dolor sit, amet consectetur adipisicing elit.
             </div>
+            <!---->
             <!---->
             
         
@@ -338,6 +346,7 @@ exports[`<bolt-accordion> Component Default <bolt-accordion> w/o Shadow DOM rend
     
       <!---->
     </bolt-accordion-item>
+    <!---->
     <!---->
     <bolt-accordion-item
       no-shadow=""
@@ -477,12 +486,15 @@ exports[`<bolt-accordion> Component Default <bolt-accordion> w/o Shadow DOM rend
             
           
             <!---->
+            <!---->
+            <!---->
             <div
               class="is-first-child is-last-child"
               style=""
             >
               Lorem ipsum dolor sit, amet consectetur adipisicing elit.
             </div>
+            <!---->
             <!---->
             
         
@@ -499,6 +511,7 @@ exports[`<bolt-accordion> Component Default <bolt-accordion> w/o Shadow DOM rend
     
       <!---->
     </bolt-accordion-item>
+    <!---->
     <!---->
     
       

--- a/packages/components/bolt-button/__tests__/__snapshots__/button.js.snap
+++ b/packages/components/bolt-button/__tests__/__snapshots__/button.js.snap
@@ -571,6 +571,8 @@ exports[`button correctly render and retains extra HTML attributes 1`] = `
     >
       <!---->
       <!---->
+      <!---->
+      <!---->
       Button w/ Data Attribute
       <!---->
       <!---->
@@ -611,6 +613,8 @@ exports[`button correctly render and retains extra HTML attributes 2`] = `
       class="c-bolt-button__item"
       style=""
     >
+      <!---->
+      <!---->
       <!---->
       <!---->
       Button w/ Data Attribute
@@ -658,6 +662,8 @@ exports[`button initial HTML attributes in conflict w/ custom element props will
     >
       <!---->
       <!---->
+      <!---->
+      <!---->
       Button w/ Href Not Matching Prop
       <!---->
       <!---->
@@ -701,6 +707,8 @@ exports[`button initial HTML attributes in conflict w/ custom element props will
       class="c-bolt-button__item"
       style=""
     >
+      <!---->
+      <!---->
       <!---->
       <!---->
       Button w/ Href Not Matching Prop

--- a/packages/components/bolt-modal/__tests__/__snapshots__/modal.js.snap
+++ b/packages/components/bolt-modal/__tests__/__snapshots__/modal.js.snap
@@ -148,6 +148,8 @@ exports[`<bolt-modal> Component Long content usage <bolt-modal> w/o Shadow DOM r
             
                 
             <!---->
+            <!---->
+            <!---->
             <div
               class="is-first-child"
               style=""
@@ -155,12 +157,15 @@ exports[`<bolt-modal> Component Long content usage <bolt-modal> w/o Shadow DOM r
               This is very long content.
             </div>
             <!---->
+            <!---->
             <bolt-image
               alt="Placeholder"
               class="is-last-child"
               src="/fixtures/1200x2500.jpg"
               style=""
             />
+            <!---->
+            <!---->
             <!---->
             
               
@@ -416,12 +421,16 @@ exports[`<bolt-modal> Component Simple usage <bolt-modal> w/o Shadow DOM renders
             
                 
             <!---->
+            <!---->
+            <!---->
             <div
               class="is-first-child is-last-child"
               style=""
             >
               Default slot.
             </div>
+            <!---->
+            <!---->
             <!---->
             
               


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-321

## Summary

If a component initially contains only whitespace, content added later never appears. This PR updates Slotify to handle this case, which happens on [Collaboration center](https://pegadigitalit.atlassian.net/browse/CC-416).

## Details

Add some conditional logic to handle the case where there _are_ child nodes, but they contain only whitespace. Ensures a `<slot>` is added when that is true, as is the case when you use the Modal Twig template and pass `content: ''` - Twig adds line breaks.

## How to test

- To reproduce the bug, go to [modal demo on `2.30.2` site](https://v2-30-2.boltdesignsystem.com/pattern-lab/patterns/40-components-modal-05-modal/40-components-modal-05-modal.html) or do the same on `master` locally.
- Via Chrome dev tools delete the `<bolt-modal>` elements on the page.
- Enter the following via console:
```
const modal = document.createElement('bolt-modal');
modal.innerHTML = ' ';
document.body.append(modal);
```
- Then (important you do this is two steps not one):
```
modal.innerHTML = 'test';
modal.show();
```
- Verify the modal opens up, is empty and does not contain "test" text content.
- Then, checkout this feature branch and repeat locally to verify the content is properly added.
- Spot check other components to be sure there are no regressions to other web components.