### PR TITLE
Hotfix/Revert adding build-tools to missing pkgs whitelist

### DIFF
--- a/packages/build-tools/utils/manifest.get-pkg-info.js
+++ b/packages/build-tools/utils/manifest.get-pkg-info.js
@@ -10,7 +10,6 @@ let config; // cached Bolt config
 
 // don't automatically include these Bolt packages as extra (undeclared) dependencies
 const missingBoltPkgsWhitelist = [
-  '@bolt/build-tools',
   '@bolt/core',
   '@bolt/core-v3.x',
   '@bolt/polyfills',


### PR DESCRIPTION
## Summary

Revert changes made in #2068 that may be causing `regeneratorRuntime is not defined` error downstream.