### PR TITLE
Hotfix/WWW-546 Fix JS error in MJ editor (v2.30.3)

### DIFF
--- a/packages/base-element/src/lib/decorators/json-schema-props.js
+++ b/packages/base-element/src/lib/decorators/json-schema-props.js
@@ -39,7 +39,13 @@ const jsonSchemaPropsDecorator = clazz => {
           .includes('deprecated');
 
         // these schema props are never used by Web Components, only by Twig
-        const twigOnlyProps = ['attributes', 'content', 'items', 'children'];
+        const twigOnlyProps = [
+          'attributes',
+          'content',
+          'items',
+          'children',
+          'style',
+        ];
         const isTwigOnly = twigOnlyProps.includes(key.toLowerCase());
 
         // skip deprecated and Twig-only props

--- a/packages/components/bolt-button/src/button.js
+++ b/packages/components/bolt-button/src/button.js
@@ -13,9 +13,6 @@ import schema from '../button.schema.js';
 
 let cx = classNames.bind(styles);
 
-// Note: must use `delete` or outputs empty `style` attr on bolt-button WC
-delete schema.properties.style;
-
 @customElement('bolt-button')
 @convertInitialTags(['button', 'a'])
 class BoltButton extends BoltActionElement {


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/WWW-446

## Summary

Fix JS error that breaks Microjourneys editor.

## Details

In a [previous PR](https://github.com/boltdesignsystem/bolt/pull/2081) I removed the `style` property from the Button component schema via the `delete` operator. Using `delete` appears to delete it everywhere, even in the Editor, where the schema is imported separately. The editor needs the `style` prop to exist in order to [remap it](https://github.com/boltdesignsystem/bolt/blob/master/packages/experimental/editor/src/setup-bolt.js#L364) onto the `color` prop. When it's missing, it throws an error and breaks the editor.

To fix this bug and [the original](https://pegadigitalit.atlassian.net/browse/DS-311), I'm keeping `style` in the schema, but filtering it out at the renderer level, as this is a prop that we never want to add to our web components. Actually, If I don't filter it out at the renderer-level and wait to remove it at the compnent-level (without `delete`) the renderer puts an empty `style` tag on our web component, and that throws a new Grape JS error. So, fixing this in the renderer is the only way to go. The only other component that has a `style` prop is Headline and it's Twig-only.

## How to test

- Run this branch locally and verify editor works as expected: `/pattern-lab/patterns/60-experiments-editor/index.html`
- On this same page, open the console.
  - Run `customElements.get('bolt-button').schema.properties` and verify that `style` _is_ in the schema.
  - Run `customElements.get('bolt-button').properties` and verify `style` _is not_ in the component properties.
- Verify there are no button regressions