### PR TITLE
Hotfix/DS-291 SASS loader min() error (v2.31.2)

### DIFF
--- a/packages/base-element/src/lib/decorators/json-schema-props.js
+++ b/packages/base-element/src/lib/decorators/json-schema-props.js
@@ -39,7 +39,13 @@ const jsonSchemaPropsDecorator = clazz => {
           .includes('deprecated');
 
         // these schema props are never used by Web Components, only by Twig
-        const twigOnlyProps = ['attributes', 'content', 'items', 'children'];
+        const twigOnlyProps = [
+          'attributes',
+          'content',
+          'items',
+          'children',
+          'style',
+        ];
         const isTwigOnly = twigOnlyProps.includes(key.toLowerCase());
 
         // skip deprecated and Twig-only props

--- a/packages/components/bolt-button/src/button.js
+++ b/packages/components/bolt-button/src/button.js
@@ -13,9 +13,6 @@ import schema from '../button.schema.js';
 
 let cx = classNames.bind(styles);
 
-// Note: must use `delete` or outputs empty `style` attr on bolt-button WC
-delete schema.properties.style;
-
 @customElement('bolt-button')
 @convertInitialTags(['button', 'a'])
 class BoltButton extends BoltActionElement {

--- a/packages/components/bolt-popover/src/popover.scss
+++ b/packages/components/bolt-popover/src/popover.scss
@@ -154,7 +154,10 @@ $bolt-popover-transition: $bolt-transition-timing
   white-space: nowrap;
 
   @at-root .c-bolt-popover--text-wrap & {
-    width: unquote('var(--c-bolt-popover-bubble-width, min(65vw, 250px))');
+    // Capitalize "Min" to avoid collision with SASS function named `min()`. Remove this hack once we switch to "dart-sass".
+    // @see https://css-tricks.com/when-sass-and-new-css-features-collide/#the-solution
+    /* stylelint-disable function-name-case */
+    width: var(--c-bolt-popover-bubble-width, Min(65vw, 250px));
     white-space: normal; // If the content is long (more than 31 characters), the bubble will have this specific width and text will wrap. This logic is in the JS and Twig files.
 
     @include bolt-ms-edge-42-only {


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-291

## Summary

Fix Sass loader error happening only in Pega Bolt builds.

## Details

The CSS `min()` function is not supported by LibSass, and we're tied to LibSass for now because of Pattern Lab. In order to use `min()` we need to workaround this limitation of LibSass.

We previously used the [unquote hack](https://github.com/boltdesignsystem/bolt/pull/2065/files#diff-4e38e563a47ffbc725eb1e53049eff038ead79a819d61c678b4dd3ca20b323afR157), but that hack only works for a single build. In sites that consume Bolt, compiled Bolt CSS is re-compiled using the same Sass loader and we see the error on the second build.

I'm replacing the "unquote" hack with the ["capitalize" hack](https://css-tricks.com/when-sass-and-new-css-features-collide/#the-solution). SASS is case sensitive, CSS isn't. So this works around the issue both in Bolt and in subsequent builds.

Long-term we just need to use dart-sass.

> Note: this hotfix also includes a bugfix from `2.30.1`, #2096.

## How to test

- Bolt builds without errors.
- View the Popover demo and see that the `Min()` rule is being applied: `/pattern-lab/patterns/40-components-popover-05-popover/40-components-popover-05-popover.html`

![image](https://user-images.githubusercontent.com/36336/106839796-e803db00-666c-11eb-81c7-01fdea23f122.png)