### PR TITLE
DS 327 Fix page header background color and static position

### DIFF
--- a/packages/components/bolt-page-header/src/_page-header-desktop.scss
+++ b/packages/components/bolt-page-header/src/_page-header-desktop.scss
@@ -13,10 +13,10 @@
     padding-bottom: $bolt-page-header-desktop-padding-bottom;
     padding-left: var(--bolt-page-padding-x);
     background: linear-gradient(
-      var(--bolt-color-gray-xlight) 0%,
-      var(--bolt-color-gray-xlight) $bolt-page-header-desktop-util-nav-height,
-      var(--bolt-color-white) $bolt-page-header-desktop-util-nav-height,
-      var(--bolt-color-white) 100%
+      rgba(bolt-color(gray), 0.1) 0%,
+      rgba(bolt-color(gray), 0.1) $bolt-page-header-desktop-util-nav-height,
+      var(--m-bolt-bg) $bolt-page-header-desktop-util-nav-height,
+      var(--m-bolt-bg) 100%
     );
     grid-template-columns:
       minmax(82px, var(--c-bolt-page-header-logo-max-width, auto))

--- a/packages/components/bolt-page-header/src/page-header.scss
+++ b/packages/components/bolt-page-header/src/page-header.scss
@@ -46,7 +46,7 @@
 }
 
 .c-bolt-page-header--static {
-  position: static;
+  position: relative;
 }
 
 .c-bolt-page-header__primary,
@@ -95,6 +95,7 @@
     height: 100%;
     object-fit: contain;
     object-position: left center;
+    filter: var(--m-bolt-img-filter);
   }
 }
 


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-327

## Summary

1. Fixes a bug where the Page Header does not work with color themes.
2. Fixes a bug where the static prop of the Page Header is not working expected (other sticky elements overlaps the Page Header). 

## Details

1. Converted the CSS to use mode specific color vars.
2. Fixed the static version to use `position: relative` instead to maintain the correct stacking context.

## How to test

Run the branch locally and do the following us:

1. Add a theme class (eg. `.t-bolt-dark`) to the page header. Make sure it works with all themes.
2. Create a page that has a static page header and a sticky subnav. Make sure the sticky subnav does not overlap the page header's dropdown links.