### PR TITLE
DS-323: deprecate auto slides per view. set max slides to 4.

### DIFF
--- a/packages/components/bolt-carousel/carousel.schema.js
+++ b/packages/components/bolt-carousel/carousel.schema.js
@@ -19,9 +19,10 @@ module.exports = {
     },
     slides_per_view: {
       type: 'string',
-      description: 'Controls the number of slides to be shown at once.',
+      description:
+        'Controls the number of slides to be shown at once. Note: the value auto is deprecated, please be explicit.',
       default: '1',
-      enum: ['auto', '1', '2', '3'],
+      enum: ['1', '2', '3', '4'],
     },
     slides_per_group: {
       type: 'string',
@@ -33,9 +34,9 @@ module.exports = {
       type: 'integer',
       description:
         'Limits the maximum number of slides that can display at any screen size. Combine this with the <code>slidesPerView</code> option to get the benefits of automatically adjusting the number of slides displayed at different screen sizes while putting a max limit of how many slides display at once.',
-      default: 3,
+      default: 4,
       minimum: 1,
-      maximum: 3,
+      maximum: 4,
       hidden: true,
     },
     space_between: {

--- a/packages/components/bolt-carousel/src/carousel.twig
+++ b/packages/components/bolt-carousel/src/carousel.twig
@@ -1,5 +1,10 @@
 {% set schema = bolt.data.components["@bolt-components-carousel"].schema %}
 
+{# slides_per_view 'auto' is deprecated.  Only numbers are supported #}
+{% if slides_per_view == "auto" %}
+  {% set slides_per_view = 3 %}
+{% endif %}
+
 {% if slides_per_view == 1 %}
   {% set slides_per_view = "1" %}
 {% elseif slides_per_view == 2 %}
@@ -8,8 +13,6 @@
   {% set slides_per_view = "3" %}
 {% elseif slides_per_view == 4 %}
   {% set slides_per_view = "4" %}
-{% elseif slides_per_view == "auto" %}
-  {% set slides_per_view = "auto" %}
 {% else %}
   {% set slides_per_view = "1" %}
 {% endif %}


### PR DESCRIPTION
## Jira

[https://pegadigitalit.atlassian.net/browse/DS-323](https://pegadigitalit.atlassian.net/browse/DS-323)

## Summary

Allow users to have 4 slides per view.

## Details

Change schema to allow 4 slides per view and a max sliders per view of 4. Deprecate auto from slides per view to avoid further confusion.

## How to test

Check out carousel demos

## Release notes

`auto` has been deprecated from the carousel `slides_per_group` prop.  Use an integer (1, 2, 3, 4) for `slides_per_group` instead.  Note that the number of items shown will be always automatically reduced as necessary at smaller breakpoints.
