### PR TITLE
DS-303 Fix init() bugs

### DIFF
--- a/packages/components/bolt-trigger/__tests__/__snapshots__/trigger.js.snap
+++ b/packages/components/bolt-trigger/__tests__/__snapshots__/trigger.js.snap
@@ -40,6 +40,20 @@ exports[`trigger Trigger with "no_outline" 1`] = `
 </bolt-trigger>
 `;
 
+exports[`trigger Trigger with "target" attribute renders same value on <bolt-trigger> and inner <a> 1`] = `
+<bolt-trigger target="_blank"
+              url="http://pega.com"
+>
+  <a href="http://pega.com"
+     target="_blank"
+     class="c-bolt-trigger c-bolt-trigger--display-inline c-bolt-trigger--cursor-pointer"
+     is="shadow-root"
+  >
+    Hello World
+  </a>
+</bolt-trigger>
+`;
+
 exports[`trigger Trigger with "type" adds attr to <button> 1`] = `
 <bolt-trigger type="submit"
               disabled

--- a/packages/components/bolt-trigger/__tests__/trigger.js
+++ b/packages/components/bolt-trigger/__tests__/trigger.js
@@ -52,6 +52,20 @@ describe('trigger', () => {
     expect(results.html).toMatchSnapshot();
   });
 
+  // This is a test of the `init()` function, @see packages/twig-integration/twig-extensions-shared/src/TwigFunctions.php
+  // It verifies `this.props` and `this.data` match. Previously, an attribute would be reflected in `this.props` but not `this.data`.
+  test('Trigger with "target" attribute renders same value on <bolt-trigger> and inner <a>', async () => {
+    const results = await render('@bolt-components-trigger/trigger.twig', {
+      content: 'Hello World',
+      url: 'http://pega.com',
+      attributes: {
+        target: '_blank',
+      },
+    });
+    expect(results.ok).toBe(true);
+    expect(results.html).toMatchSnapshot();
+  });
+
   test('Trigger with "disabled" adds attr to <button>', async () => {
     const results = await render('@bolt-components-trigger/trigger.twig', {
       content: 'Hello World',

--- a/packages/twig-integration/twig-extensions-shared/src/Utils.php
+++ b/packages/twig-integration/twig-extensions-shared/src/Utils.php
@@ -251,9 +251,17 @@ class Utils {
             $convertedPropName = $isData ? self::convertToSnakeCase($propName, $caseType) : self::convertToKebabCase($propName, $caseType);
             $props[$convertedPropName] = $items[$propName];
           }
+          elseif (isset($items["attributes"][$propName])) {
+
+            // No value for this prop was found in $items, but one was defined via attributes.
+            if ($isData) {
+              $convertedPropName = self::convertToSnakeCase($propName, $caseType);
+              $props[$convertedPropName] = $items["attributes"][$propName];
+            }
+          }
           elseif (isset($propSchema["default"])) {
 
-            // No value for this prop was found in $items, but a default is defined in the schema.
+            // No value for this prop was found in $items or attributes, but a default is defined in the schema.
             if ($isData) {
               $convertedPropName = self::convertToSnakeCase($propName, $caseType);
               $props[$convertedPropName] = $propSchema["default"];

--- a/packages/twig-integration/twig-extensions-shared/src/Utils.php
+++ b/packages/twig-integration/twig-extensions-shared/src/Utils.php
@@ -241,8 +241,11 @@ class Utils {
     if (!empty($schema["properties"])) {
       foreach ($schema["properties"] as $propName => $propSchema) {
 
-        // Check the prop "type" in the schema and omit it if it is (or might be) an "array" or "object".
-        if (isset($propSchema["type"]) && self::isAllowedSchemaType($propSchema["type"])) {
+        // Check if prop is deprecated based on "title" field
+        $isDeprecated = isset($propSchema["title"]) && strpos(strtolower($propSchema["title"]), 'deprecated') !== false;
+
+        // Check the prop "type" in the schema and omit it if it is (or might be) an "array" or "object". Omit deprecated props.
+        if (isset($propSchema["type"]) && self::isAllowedSchemaType($propSchema["type"]) && !$isDeprecated) {
           $caseType = self::getCaseType($propName);
 
           if (isset($items[$propName])) {


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-303

## Summary

Fix an `init()` bug where `this.props` and `this.data` values do not match when a prop like `target` is passed via `attributes` object. Also, omit deprecated props from the object returned by `init()`.

## Details

**Include matching attributes in `this.data`**
On the Button component, when you pass `attributes: { target: "_blank" }` (something I assume we support because there is a Jest test for it), that `target` value is added to `<bolt-button>`, but the default value, `_self`, is added to the inner `<a>`. This is because attributes that match a component prop are added to `this.props` but not `this.data`, and we use `this.data` to determine what value the `<a>` gets. This PR updates `init()` to include matching attributes in `this.data`.

**Omit deprecated props**
Make sure deprecated props are not returned in `init()` object. This ensures they are not added to the custom-element. All deprecated props should be converted before `init()` is called. This came up on Button where both `hierarchy` and `style` were being output on the `<bolt-button>` element. Rather than filter out each deprecated prop in the component, let's filter them out in `init()`.

I'm making a separate PR for these fixes since they affect all components. I wanted it to be reviewed and tested separately.

## How to test

- Tests are passing
- No regressions to existing components. Pay especially close attention to `BoltActionElements` like Button, Link, Trigger.