### PR TITLE
DS-388 Allow `download` attribute to be added to inner `<a>`

### DIFF
--- a/packages/components/bolt-button/__tests__/__snapshots__/button.js.snap
+++ b/packages/components/bolt-button/__tests__/__snapshots__/button.js.snap
@@ -135,6 +135,24 @@ exports[`button Button type: submit 1`] = `
 </bolt-button>
 `;
 
+exports[`button Button will add \`download\` attribute to inner anchor element 1`] = `
+<bolt-button download="download.pdf"
+             url="download.pdf"
+>
+  <a href="download.pdf"
+     target="_self"
+     download="download.pdf"
+     class="c-bolt-button c-bolt-button--medium c-bolt-button--primary c-bolt-button--border-radius-regular c-bolt-button--center"
+  >
+    <ssr-keep for="bolt-button"
+              class="c-bolt-button__item"
+    >
+      Button with download link
+    </ssr-keep>
+  </a>
+</bolt-button>
+`;
+
 exports[`button Button with "disabled" adds attr to <a> 1`] = `
 <bolt-button url="http://pega.com"
              disabled

--- a/packages/components/bolt-button/__tests__/button.js
+++ b/packages/components/bolt-button/__tests__/button.js
@@ -138,6 +138,18 @@ describe('button', () => {
     expect(results.html).toMatchSnapshot();
   });
 
+  test('Button will add `download` attribute to inner anchor element', async () => {
+    const results = await render('@bolt-components-button/button.twig', {
+      text: 'Button with download link',
+      url: 'download.pdf',
+      attributes: {
+        download: 'download.pdf',
+      },
+    });
+    expect(results.ok).toBe(true);
+    expect(results.html).toMatchSnapshot();
+  });
+
   test('Button with inner classes via Drupal Attributes', async () => {
     const results = await render('@bolt-components-button/button.twig', {
       text: 'Button with inner classes',

--- a/packages/components/bolt-button/src/button.twig
+++ b/packages/components/bolt-button/src/button.twig
@@ -49,6 +49,9 @@
   {% if this.data.target.value %}
     {% set inner_attributes = inner_attributes.setAttribute('target', this.data.target.value) %}
   {% endif %}
+  {% if this.data.download.value %}
+    {% set inner_attributes = inner_attributes.setAttribute('download', this.data.download.value) %}
+  {% endif %}
 {% else %}
   {% set _tag = 'button' %}
 


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-388

## Summary

Allow `download` attribute to be added to the inner `<a>` of `<bolt-button>` and download a resource without opening in a new tab.

## Details

Initially I thought the solution would be to allow arbitrary attributes to be added to to the inner element, but this is too risky as many attributes are already used on `<bolt-button>` in the wild, and suddenly applying them all to the inner element is a potential breaking change.  Instead, simply check for the `download` attribute and add it to the `<a>` like we do for `target`.

Note: only applies if Button has `url`.

## How to test
- Tests are passing
- Review files changed
- Run locally and paste this example into PL:
```
{% include "@bolt-components-button/button.twig" with {
  text: "This is a button",
  url: "http://pega.com",
  attributes: {
    download: "file.pdf"
  }
} only %}
```