### PR TITLE
DS-393 fix theme colors for modals

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/modal/20-modal-theme-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/modal/20-modal-theme-variations.twig
@@ -1,4 +1,4 @@
-{% set schema = bolt.data.components["@bolt-components-modal"].schema %}
+{% set schema = bolt.data.components['@bolt-components-modal'].schema %}
 
 <bolt-text>The modal container's coloring theme can be adjusted by the <code>theme</code> prop. The default is set to <code>xlight</code>.</bolt-text>
 
@@ -10,21 +10,27 @@
       {% for theme in schema.properties.theme.enum %}
         <tr>
           <th>
-            {% include "@bolt-components-button/button.twig" with {
+            {% set text = 'This is a modal set to ' ~ theme ~ ' theme.' %}
+            {% if theme == 'none' %}
+              {% set modal_content = '<mark>' ~ text ~ '</mark>' %}
+            {% else %}
+              {% set modal_content = text %}
+            {% endif %}
+            {% include '@bolt-components-button/button.twig' with {
               text: theme|capitalize,
-              size: "small",
-              width: "full",
+              size: 'small',
+              width: 'full',
               attributes: {
-                onclick: "this.nextElementSibling.show()",
+                onclick: 'this.nextElementSibling.show()',
               }
             } only %}
-            {% include "@bolt-components-modal/modal.twig" with {
-              content: "<mark>This is a modal set to " ~ theme ~ " theme.</mark>",
+            {% include '@bolt-components-modal/modal.twig' with {
+              content: modal_content,
               theme: theme,
             } only %}
           </th>
           <td>
-            {% if theme == "none" %}
+            {% if theme == 'none' %}
               This makes the modal container transparent.
             {% else %}
               This sets the {{ theme }} theme on the modal container.

--- a/packages/components/bolt-card-replacement/src/card-replacement/card-replacement.scss
+++ b/packages/components/bolt-card-replacement/src/card-replacement/card-replacement.scss
@@ -4,7 +4,7 @@
 
 @import '@bolt/core-v3.x';
 @import '../_card-replacement-settings-and-tools.scss';
-@import '@bolt/global/styles/06-themes/_themes.all.scss'; // @todo: remove this once bolt-theme() function is completely remove.
+@import '@bolt/global/styles/06-themes/_themes.all.scss'; // @todo: remove this once bolt-theme() function is completely deprecated and removed.
 @import '@bolt/global/styles/00-vars/_vars-mode.scss';
 
 // Custom element

--- a/packages/components/bolt-card-replacement/src/card-replacement/card-replacement.scss
+++ b/packages/components/bolt-card-replacement/src/card-replacement/card-replacement.scss
@@ -4,7 +4,8 @@
 
 @import '@bolt/core-v3.x';
 @import '../_card-replacement-settings-and-tools.scss';
-@import '@bolt/global/styles/06-themes/_themes.all.scss';
+@import '@bolt/global/styles/06-themes/_themes.all.scss'; // @todo: remove this once bolt-theme() function is completely remove.
+@import '@bolt/global/styles/00-vars/_vars-mode.scss';
 
 // Custom element
 @include bolt-custom-element('bolt-card-replacement', block, medium);

--- a/packages/components/bolt-modal/src/modal.scss
+++ b/packages/components/bolt-modal/src/modal.scss
@@ -1,5 +1,5 @@
 @import '@bolt/core-v3.x';
-@import '@bolt/global/styles/06-themes/_themes.all.scss'; // @todo: remove this once bolt-theme() function is completely remove.
+@import '@bolt/global/styles/06-themes/_themes.all.scss'; // @todo: remove this once bolt-theme() function is completely deprecated and removed.
 @import '@bolt/global/styles/00-vars/_vars-mode.scss';
 
 /* ------------------------------------ *\

--- a/packages/components/bolt-modal/src/modal.scss
+++ b/packages/components/bolt-modal/src/modal.scss
@@ -1,5 +1,6 @@
 @import '@bolt/core-v3.x';
-@import '@bolt/global/styles/06-themes/_themes.all.scss';
+@import '@bolt/global/styles/06-themes/_themes.all.scss'; // @todo: remove this once bolt-theme() function is completely remove.
+@import '@bolt/global/styles/00-vars/_vars-mode.scss';
 
 /* ------------------------------------ *\
    Modal

--- a/packages/global/styles/00-vars/_vars-mode.scss
+++ b/packages/global/styles/00-vars/_vars-mode.scss
@@ -7,9 +7,7 @@
 :root,
 [data-bolt-mode='light'],
 .t-bolt-light,
-.t-bolt-xlight,
-bolt-card-replacement[theme='light'],
-bolt-card-replacement[theme='xlight'] {
+.t-bolt-xlight {
   --m-bolt-neutral: var(--bolt-color-gray);
   --m-bolt-text: var(--bolt-color-black);
   --m-bolt-bg: var(--bolt-color-white);
@@ -30,9 +28,7 @@ bolt-card-replacement[theme='xlight'] {
 [data-bolt-mode='dark'],
 .t-bolt-dark,
 .t-bolt-xdark,
-.t-bolt-xxdark,
-bolt-card-replacement[theme='dark'],
-bolt-card-replacement[theme='xdark'] {
+.t-bolt-xxdark {
   --m-bolt-neutral: var(--bolt-color-gray);
   --m-bolt-text: var(--bolt-color-white);
   --m-bolt-bg: var(--bolt-color-navy);


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-393

## Summary

Fixes an issue where theme colors are not displaying correctly in modals.

## Details

1. Added the new mode css vars to modal.scss so they are loaded inside the shadow dom as well.
2. Updated the same method in card.scss.

## How to test

Run the branch locally and view the card and modal theme docs. Make sure colors are displaying as expected.