### PR TITLE
DS-399 Replace theme-tools, upgrade notifier

### DIFF
--- a/packages/build-tools/plugins/sass-export-data/index.js
+++ b/packages/build-tools/plugins/sass-export-data/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const core = require('@theme-tools/core');
+const merge = require('merge');
 const fs = require('fs-extra');
 const path = require('path');
 const jsondiff = require('jsondiffpatch');
@@ -8,7 +8,7 @@ const defaultConfig = require('./config.default');
 const getValue = require('./lib/get-value');
 
 module.exports = userConfig => {
-  const config = core.utils.merge({}, defaultConfig, userConfig);
+  const config = merge.recursive({}, defaultConfig, userConfig);
   const args = '($file, $value, $options:())';
 
   const sassFunctions = {};

--- a/packages/build-tools/plugins/sass-export-data/package.json
+++ b/packages/build-tools/plugins/sass-export-data/package.json
@@ -16,11 +16,11 @@
     "test:compile": "rm -rf tests/basics/dest/ && mkdir tests/basics/dest/ && node-sass --functions tests/basics/function.js tests/basics/scss/style.scss tests/basics/dest/style.css"
   },
   "dependencies": {
-    "@theme-tools/core": "^1.0.0",
     "chai": "^4.2.0",
     "chai-fs": "^2.0.0",
     "fs-extra": "^7.0.1",
     "jsondiffpatch": "^0.3.11",
+    "merge": "^1.2.1",
     "mocha": "^6.1.4",
     "node-sass": "^4.12.0"
   },

--- a/packages/build-tools/utils/package.json
+++ b/packages/build-tools/utils/package.json
@@ -25,7 +25,7 @@
     "json-schema-ref-parser": "^7.1.3",
     "jsonschema": "^1.2.4",
     "node-cache": "^4.2.0",
-    "node-notifier": "^5.4.0",
+    "node-notifier": "^9.0.0",
     "ora": "^3.4.0",
     "portfinder": "^1.0.20",
     "pretty-ms": "^5.0.0",


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-399

## Summary

Fix security vulnerabilities with `js-yaml` and `node-notfier`.

## Details

Replace `@theme-tools` with `merge`, which is the library `@theme-tools` uses under the hood, minus the security vulnerabilities. Upgrade `node-notifier`, a library used for outputing messages to the console. Seems pretty straight forward, no major API changes.

## How to test

- Review files changed
- Build is passing
- Runs locally