### PR TITLE
WWW-467 Create PegaWorld navigation with Page Header component

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/page-header/-example-pegaworld.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/page-header/-example-pegaworld.twig
@@ -1,0 +1,260 @@
+{# Icons #}
+{% set icon_user %}
+  {% include '@bolt-components-icon/icon.twig' with {
+    name: 'user',
+  } only %}
+{% endset %}
+{% set icon_global %}
+  {% include '@bolt-components-icon/icon.twig' with {
+    name: 'global',
+  } only %}
+{% endset %}
+{% set icon_menu %}
+  {% include '@bolt-components-icon/icon.twig' with {
+    name: 'menu',
+  } only %}
+{% endset %}
+
+{# Site nav #}
+{% set site_nav_lv1_list_items = [
+  {
+    link: {
+      content: 'Explore event',
+      attributes: {
+        href: 'https://pega.com',
+      }
+    },
+  },
+  {
+    link: {
+      content: 'iNsiders',
+      attributes: {
+        href: 'https://pega.com',
+      }
+    },
+  },
+  {
+    link: {
+      content: 'FAQ',
+      attributes: {
+        href: 'https://pega.com',
+      }
+    },
+  },
+] %}
+
+{% set site_nav_lv1_ul_content = [] %}
+{% for list_item in site_nav_lv1_list_items %}
+  {% set site_nav_lv1_li %}
+    {% include '@bolt-components-page-header/page-header-nav-li.twig' with list_item only %}
+  {% endset %}
+  {% set site_nav_lv1_ul_content = site_nav_lv1_ul_content|merge([site_nav_lv1_li]) %}
+{% endfor %}
+
+{% set site_nav %}
+  {% include '@bolt-components-page-header/page-header-nav-ul.twig' with {
+    content: site_nav_lv1_ul_content|join,
+    category: 'site',
+  } only %}
+{% endset %}
+
+{# User nav #}
+{% set user_nav_lv1_ul_content %}
+  {% include '@bolt-components-page-header/page-header-nav-li.twig' with {
+    link: {
+      content: 'Log in',
+      attributes: {
+        href: 'https://pega.com/',
+      },
+    },
+  } only %}
+  {% include '@bolt-components-page-header/page-header-nav-li.twig' with {
+    link: {
+      content: 'Sign up',
+      attributes: {
+        href: 'https://pega.com/',
+      },
+    },
+  } only %}
+{% endset %}
+
+{% set user_nav %}
+  {% include '@bolt-components-page-header/page-header-nav-ul.twig' with {
+    content: user_nav_lv1_ul_content,
+    category: 'user',
+  } only %}
+{% endset %}
+
+{# Related sites nav #}
+{% set more_pega_sites_nav_lv3_ul_content %}
+  {% include '@bolt-components-page-header/page-header-nav-li.twig' with {
+    link: {
+      content: 'PegaWorld',
+      attributes: {
+        href: 'https://pega.com/',
+      },
+    },
+  } only %}
+  {% include '@bolt-components-page-header/page-header-nav-li.twig' with {
+    link: {
+      content: 'Product Design',
+      attributes: {
+        href: 'https://pega.com/',
+      },
+    },
+  } only %}
+  {% include '@bolt-components-page-header/page-header-nav-li.twig' with {
+    link: {
+      content: 'Partners',
+      attributes: {
+        href: 'https://pega.com/',
+      },
+    },
+  } only %}
+  {% include '@bolt-components-page-header/page-header-nav-li.twig' with {
+    link: {
+      content: 'Consulting',
+      attributes: {
+        href: 'https://pega.com/',
+      },
+    },
+  } only %}
+  {% include '@bolt-components-page-header/page-header-nav-li.twig' with {
+    link: {
+      content: 'Blog',
+      attributes: {
+        href: 'https://pega.com/',
+      },
+    },
+  } only %}
+  {% include '@bolt-components-page-header/page-header-nav-li.twig' with {
+    link: {
+      content: 'Careers',
+      attributes: {
+        href: 'https://pega.com/',
+      },
+    },
+  } only %}
+  {% include '@bolt-components-page-header/page-header-nav-li.twig' with {
+    link: {
+      content: 'My Pega',
+      attributes: {
+        href: 'https://pega.com/',
+      },
+    },
+  } only %}
+{% endset %}
+
+{% set more_pega_sites_nav_lv3 %}
+  {% include '@bolt-components-page-header/page-header-nav-ul.twig' with {
+    content: more_pega_sites_nav_lv3_ul_content,
+  } only %}
+{% endset %}
+
+{% set pega_sites_nav_lv2_ul_content %}
+  {% include '@bolt-components-page-header/page-header-nav-li.twig' with {
+    link: {
+      content: 'Training',
+      attributes: {
+        href: 'https://pega.com/',
+      },
+    },
+  } only %}
+  {% include '@bolt-components-page-header/page-header-nav-li.twig' with {
+    link: {
+      content: 'Support',
+      attributes: {
+        href: 'https://pega.com/',
+      },
+    },
+  } only %}
+  {% include '@bolt-components-page-header/page-header-nav-li.twig' with {
+    link: {
+      content: 'Knowledgebase',
+      attributes: {
+        href: 'https://pega.com/',
+      },
+    },
+  } only %}
+  {% include '@bolt-components-page-header/page-header-nav-li.twig' with {
+    link: {
+      content: icon_menu ~ 'More Pega Sites',
+    },
+    children: more_pega_sites_nav_lv3,
+    popover: true,
+  } only %}
+{% endset %}
+
+{% set pega_sites_nav_lv2 %}
+  {% include '@bolt-components-page-header/page-header-nav-ul.twig' with {
+    content: pega_sites_nav_lv2_ul_content,
+  } only %}
+{% endset %}
+
+{% set related_sites_nav_lv1_ul_content %}
+  {% include '@bolt-components-page-header/page-header-nav-li.twig' with {
+    link: {
+      content: 'Pega Sites',
+    },
+    children: pega_sites_nav_lv2,
+  } only %}
+{% endset %}
+
+{% set related_sites_nav %}
+  {% include '@bolt-components-page-header/page-header-nav-ul.twig' with {
+    content: related_sites_nav_lv1_ul_content,
+    category: 'related-sites',
+  } only %}
+{% endset %}
+
+{# Put all the navs together #}
+{% set primary_nav %}
+  {% set primary_nav_content %}
+    {{ user_nav }}
+    {{ site_nav }}
+    {{ related_sites_nav }}
+  {% endset %}
+
+  {% include '@bolt-components-page-header/page-header-primary-nav.twig' with {
+    content: primary_nav_content,
+  } only %}
+{% endset %}
+
+{# Page Header #}
+{% set page_header_content %}
+  {{ primary_nav }}
+{% endset %}
+
+{% set subheadline %}
+  PegaWorld <strong class="u-bolt-color-teal">iN</strong>spire<br>
+  Virtual event<br>
+  May 4, 2021
+{% endset %}
+
+{% set cta %}
+  {% include '@bolt-elements-button/button.twig' with {
+    content: 'Register free',
+    display: 'block',
+    size: 'small',
+    attributes: {
+      href: 'https://pega.com',
+    }
+  } only %}
+{% endset %}
+
+{% include '@bolt-components-page-header/page-header.twig' with {
+  logo: {
+    image_src: '/images/logos/pega-logo.svg',
+    label: 'Pega Saleshub',
+    attributes: {
+      href: 'https://pega.com',
+    }
+  },
+  content: page_header_content,
+  subheadline: subheadline,
+  cta: cta,
+  theme: 'dark',
+  attributes: {
+    style: '--c-bolt-page-header-desktop-spacing-y: var(--bolt-spacing-y-medium);',
+  },
+} only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/page-header/-example-pegaworld.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/page-header/-example-pegaworld.twig
@@ -245,7 +245,7 @@
 {% include '@bolt-components-page-header/page-header.twig' with {
   logo: {
     image_src: '/images/logos/pega-logo.svg',
-    label: 'Pega Saleshub',
+    label: 'PegaWolrd',
     attributes: {
       href: 'https://pega.com',
     }

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/page-header/05-page-header.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/page-header/05-page-header.twig
@@ -67,7 +67,7 @@
   cta: cta_button,
   static: true,
   attributes: {
-    style: '--c-bolt-page-header-logo-max-width: 150px',
+    style: '--c-bolt-page-header-logo-max-width: 150px', // Only use the CSS vars on edge cases
   },
 } only %}
 
@@ -84,7 +84,9 @@
 // Nav ul template (pass to primary nav template's content prop)
 {% include '@bolt-components-page-header/page-header-nav-ul.twig' with {
   content: content,
-  category: category,
+  category: category, // ['site', 'related-sites', 'user']
+  popover_position: popover_position, // ['edge-start', 'edge-end']
+  wrap_site_nav_items: false, // This allows top level desktop site nav items to wrap
 } only %}
 
 // Nav li template (pass to nav ul template's content prop)
@@ -96,7 +98,11 @@
     },
   },
   children: children,
-  current: true,
+  content: content, // This overrides link and children
+  full_width: false, // This is for "view all" links
+  popover: false, // This is for utility nav
+  selected: false, // This is for language select
+  current: true, // This is for marking a top level desktop site nav item as the current page
 } only %}
 {% endverbatim %}
 {% endset %}

--- a/packages/components/bolt-page-header/page-header.schema.js
+++ b/packages/components/bolt-page-header/page-header.schema.js
@@ -44,6 +44,11 @@ module.exports = {
       description:
         'Set the main call-to-action. Button element is expected here.',
     },
+    theme: {
+      type: 'string',
+      description: 'Set the color theme of the page header.',
+      enum: ['xlight', 'light', 'dark', 'xdark'],
+    },
     static: {
       type: 'boolean',
       description: 'Set the page header to be static instead of sticky.',

--- a/packages/components/bolt-page-header/src/_page-header-desktop.scss
+++ b/packages/components/bolt-page-header/src/_page-header-desktop.scss
@@ -293,12 +293,14 @@
           content: '';
           opacity: 0;
           position: absolute;
-          top: -4px;
+          top: 50%;
           left: 0;
-          transform: translateY(3px);
+          transform: translate3d(0, -50%, 0);
           z-index: 0;
           width: 100%;
-          height: calc(#{$bolt-page-header-click-target-size} + 4px);
+          height: calc(
+            #{$bolt-page-header-desktop-spacing-y} * 2 + #{$bolt-page-header-click-target-size}
+          );
           background: linear-gradient(
             transparent 0%,
             transparent calc(100% - 3px),
@@ -316,7 +318,6 @@
 
           &:after {
             opacity: 1;
-            transform: none;
           }
         }
       }
@@ -463,13 +464,6 @@
         transition-delay: $bolt-transition-timing;
         max-height: calc(100vh - var(--bolt-page-header-height));
       }
-
-      &:hover > .c-bolt-page-header__nav-link[aria-expanded] {
-        &:after {
-          opacity: 1;
-          transform: none;
-        }
-      }
     }
   }
 
@@ -488,6 +482,16 @@
           }
         }
       }
+    }
+  }
+
+  // Subheadline
+  .c-bolt-page-header__subheadline {
+    order: 1;
+
+    & ~ .c-bolt-page-header__nav {
+      margin-right: 0;
+      margin-left: auto;
     }
   }
 

--- a/packages/components/bolt-page-header/src/_page-header-mobile.scss
+++ b/packages/components/bolt-page-header/src/_page-header-mobile.scss
@@ -18,7 +18,7 @@
 
   // Toolbar
   .c-bolt-page-header__toolbar {
-    margin-left: auto;
+    justify-content: flex-end;
   }
 
   .c-bolt-page-header__action-trigger {
@@ -48,7 +48,6 @@
     left: 0;
     transform: translate3d(100%, 0, 0);
     overflow: hidden;
-    padding-bottom: $bolt-page-header-click-target-size;
     border-top-color: $bolt-border-color;
     border-top-style: $bolt-border-style;
     border-top-width: $bolt-border-width;
@@ -68,6 +67,7 @@
     flex-direction: column;
     width: 100%;
     height: 100%;
+    padding-bottom: $bolt-page-header-click-target-size;
   }
 
   .c-bolt-page-header__nav-list {
@@ -301,6 +301,11 @@
 
   .c-bolt-page-header__nav-link--heading {
     display: none;
+  }
+
+  // Subheadline
+  .c-bolt-page-header__subheadline {
+    margin-right: auto;
   }
 
   // Main CTA

--- a/packages/components/bolt-page-header/src/_page-header-settings-and-tools.scss
+++ b/packages/components/bolt-page-header/src/_page-header-settings-and-tools.scss
@@ -145,7 +145,8 @@ $bolt-page-header-mobile-expanded-content-spacing-x: calc(
 
 @mixin bolt-page-header-nav-background {
   background: linear-gradient(
-    var(--bolt-color-gray-light),
-    var(--bolt-color-gray-xlight)
+    rgba(bolt-color(gray), 0.1),
+    rgba(bolt-color(gray), 0.2)
   );
+  background-color: var(--m-bolt-bg);
 }

--- a/packages/components/bolt-page-header/src/page-header.scss
+++ b/packages/components/bolt-page-header/src/page-header.scss
@@ -210,6 +210,17 @@
   }
 }
 
+// Subheadline
+.c-bolt-page-header__subheadline {
+  font-size: var(--bolt-type-font-size-xxsmall);
+  font-weight: var(--bolt-type-font-weight-semibold);
+  line-height: calc(
+    var(--bolt-type-line-height-xxsmall) *
+      var(--bolt-type-line-height-multiplier-tight)
+  );
+  white-space: nowrap;
+}
+
 // Main CTA
 .c-bolt-page-header__cta {
   @include bolt-button-native-styles-reset;

--- a/packages/components/bolt-page-header/src/page-header.twig
+++ b/packages/components/bolt-page-header/src/page-header.twig
@@ -43,7 +43,9 @@
       {% endif %}
     </div>
   </div>
-  <div class="c-bolt-page-header__secondary">
-    {{ secondary_content }}
-  </div>
+  {% if secondary_content %}
+    <div class="c-bolt-page-header__secondary">
+      {{ secondary_content }}
+    </div>
+  {% endif %}
 </header>

--- a/packages/components/bolt-page-header/src/page-header.twig
+++ b/packages/components/bolt-page-header/src/page-header.twig
@@ -13,6 +13,7 @@
 {% set classes = [
   'c-bolt-page-header',
   static ? 'c-bolt-page-header--static',
+  theme ? 't-bolt-' ~ theme,
 ] %}
 
 {# Setting the desktop breakpoint to work with JS. See page-header.js #}
@@ -29,6 +30,11 @@
       </{{ logo_tag }}>
     {% endif %}
     <div class="c-bolt-page-header__toolbar">
+      {% if subheadline %}
+        <div class="c-bolt-page-header__subheadline">
+          {{ subheadline }}
+        </div>
+      {% endif %}
       {{ content }}
       {% if cta %}
         <div class="c-bolt-page-header__cta">

--- a/packages/components/bolt-page-header/src/page-header.twig
+++ b/packages/components/bolt-page-header/src/page-header.twig
@@ -12,8 +12,8 @@
 
 {% set classes = [
   'c-bolt-page-header',
-  static ? 'c-bolt-page-header--static',
-  theme ? 't-bolt-' ~ theme,
+  this.data.static ? 'c-bolt-page-header--static',
+  this.data.theme ? 't-bolt-' ~ this.data.theme.value,
 ] %}
 
 {# Setting the desktop breakpoint to work with JS. See page-header.js #}
@@ -25,7 +25,7 @@
     {% if logo %}
       <{{ logo_tag }} {{ logo_attributes.addClass('c-bolt-page-header__logo')|without('aria-label') }} aria-label="{{ logo.label|t }}">
         <span class="c-bolt-page-header__logo__img" aria-hidden="true">
-          <img src="{{ logo.image_src }}">
+          <img src="{{ logo.image_src }}" alt="">
         </span>
       </{{ logo_tag }}>
     {% endif %}


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/WWW-467

## Summary

Adds an example of PegaWorld navigation under Page Header component docs.

## Details

1. `theme` prop is added to Page Header to handle various color themes.
2. `subheadline` prop is added to Page Header to handle additional text next to the logo.
3. When there is a subheadline, desktop main nav items are pushed to the right side as seen in the PegaWorld navigation.
4. Updated CSS to make sure all color themes are working correctly.

## How to test

Run the branch locally and check the PegaWorld example under Page Header.