### PR TITLE
Fix Twig conditions in Page Header and Listing Teaser

### DIFF
--- a/packages/components/bolt-listing-teaser/src/listing-teaser.twig
+++ b/packages/components/bolt-listing-teaser/src/listing-teaser.twig
@@ -47,7 +47,7 @@
           {% endfor %}
         </ul>
       {% endif %}
-      {% if this.data.more_info %}
+      {% if this.data.more_info.value %}
         <div class="c-bolt-listing-teaser__flag-content__item">
           {% set _icon_chevron_right %}
             {% include '@bolt-components-icon/icon.twig' with {
@@ -64,7 +64,7 @@
           } only %}
         </div>
       {% endif %}
-      {% if this.data.warning %}
+      {% if this.data.warning.value %}
         <div class="c-bolt-listing-teaser__flag-content__item">
           {% set _icon_warning %}
             {% include '@bolt-components-icon/icon.twig' with {

--- a/packages/components/bolt-page-header/src/page-header.twig
+++ b/packages/components/bolt-page-header/src/page-header.twig
@@ -12,8 +12,8 @@
 
 {% set classes = [
   'c-bolt-page-header',
-  this.data.static ? 'c-bolt-page-header--static',
-  this.data.theme ? 't-bolt-' ~ this.data.theme.value,
+  this.data.static.value ? 'c-bolt-page-header--static',
+  this.data.theme.value ? 't-bolt-' ~ this.data.theme.value,
 ] %}
 
 {# Setting the desktop breakpoint to work with JS. See page-header.js #}


### PR DESCRIPTION
## Summary

Fixes a few instances of Twig conditions missing `.value` in Page Header and Listing Teaser.

## How to test

Run the branch locally. Check the following:

### Page Header

Make sure the `static` prop works as intended, the `c-bolt-page-header--static` should not be generated unless the prop value is `true`.

### Listing Teaser

Make sure the `more_info` and `warning` prop work as intended. This wasn't broken, we are just adding `.value` to stay consistent.