### PR TITLE
DS-383: Carousel slides_per_group=1 changes click behavior

### DIFF
--- a/packages/components/bolt-carousel/src/carousel.js
+++ b/packages/components/bolt-carousel/src/carousel.js
@@ -328,7 +328,6 @@ class BoltCarousel extends BoltElement {
       centerInsufficientSlides: false,
       watchSlidesProgress: true,
       watchSlidesVisibility: true,
-      slideToClickedSlide: true,
       threshold: 3,
       centeredSlides: this.slideAlign === 'center' ? true : false,
       effect: this.fade ? 'fade' : 'slide',


### PR DESCRIPTION
## Jira

[https://pegadigitalit.atlassian.net/browse/DS-383](https://pegadigitalit.atlassian.net/browse/DS-383)

## Summary

Resolve click behavior inconsistency in carousel. 

## Details

Remove swiper setting `slideToClickedSlide` to resolve click behavior inconsistency in carousel. 

## How to test

Add a demo with `slides_per_group` set to `1` and verify that clicking on the last slide does not advance the carousel. 
