### PR TITLE
[DO NOT MERGE] DS-419: Fix support for Edge 18/44

### DIFF
--- a/packages/configs/browserslist-config/index.js
+++ b/packages/configs/browserslist-config/index.js
@@ -4,4 +4,5 @@ module.exports = [
   'last 2 iOS versions',
   'last 2 Edge versions',
   'Firefox ESR',
+  'Edge 18',
 ];


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-419

## Summary

Fix JS error in Edge 18 that says `Expected '('`.

## Details

I believe this error is thrown because Edge 18 doesn't know how to handle [`...rest` syntax](https://stackoverflow.com/questions/53628191/edge-script1028-expected-identifier-string-or-number). This feature was presumably transpiled automatically before upgrading Babel because this bug does not appear below Bolt `3.2.0` when Babel was upgraded.

Explicitly adding `Edge 18` to our browserslist-config fixes the bug in Edge 18 on Browserstack.

## How to test

- Reviewed deployed site (tbd) in Edge 18 in Browserstack.
- Look at a few demos and verify there is no `Expected '('` error or any other major JS errors.
- @colbytcook please take a look on your real Windows machine with Edge 42/44 if possible to verify the same.