### PR TITLE
DS-421: passing custom attributes to the band

### DIFF
--- a/packages/components/bolt-hero/hero.schema.js
+++ b/packages/components/bolt-hero/hero.schema.js
@@ -62,5 +62,10 @@ module.exports = {
         'Reverses the order on larger screens (desktop) so the image comes first (left column) and the content comes second (right column).',
       default: false,
     },
+    attributes: {
+      type: 'object',
+      description:
+        'A Drupal attributes object. Applies extra HTML attributes to the parent element.',
+    },
   },
 };

--- a/packages/components/bolt-hero/hero.twig
+++ b/packages/components/bolt-hero/hero.twig
@@ -6,6 +6,11 @@
 
 {% set this = init(schema) %}
 
+{% set band_attributes = create_attribute({}) %}
+{% if attributes %}
+  {% set band_attributes = band_attributes|merge(attributes) %}
+{% endif %}
+
 {% set imageValign = this.data["image_valign"].value %}
 {% set imageAlign = this.data["image_align"].value %}
 
@@ -104,5 +109,6 @@
   background: {
     overlay: "disabled",
     contentItems: background_content
-  }
+  },
+  attributes: band_attributes
 } only %}

--- a/packages/components/bolt-hero/hero.twig
+++ b/packages/components/bolt-hero/hero.twig
@@ -6,10 +6,7 @@
 
 {% set this = init(schema) %}
 
-{% set band_attributes = create_attribute({}) %}
-{% if attributes %}
-  {% set band_attributes = band_attributes|merge(attributes) %}
-{% endif %}
+{% set attributes = create_attribute(attributes|default({})) %}
 
 {% set imageValign = this.data["image_valign"].value %}
 {% set imageAlign = this.data["image_align"].value %}
@@ -110,5 +107,5 @@
     overlay: "disabled",
     contentItems: background_content
   },
-  attributes: band_attributes
+  attributes: attributes
 } only %}


### PR DESCRIPTION
## Jira

[https://pegadigitalit.atlassian.net/browse/DS-421](https://pegadigitalit.atlassian.net/browse/DS-421)

## Summary

Creating custom attribute list and passing them to the band include.

## Details

As in summary. The explanation why this change is needed is in the ticket in Job Summary.

## How to test

As far as Drupal projects are concerned
- add Hero component to the content page
- try to pass something as an attribute e.g. from within the hook `pega_bolt_hero_paragraph_view`, it should be added to the band markup

### Visual changes

There should be no visual changes as long as nothing is passed.
