### PR TITLE
Upgrade stylelint to fix autofix bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.15",
     "@types/skatejs": "^5.0.1",
-    "stylelint": "^10.1.0",
+    "stylelint": "^13.12.0",
     "stylelint-order": "^3.0.1",
     "stylelint-scss": "^3.9.2"
   },


### PR DESCRIPTION
## Jira

n/a

## Summary

Upgrade `stylelint` to fix issues with autofix.

## Details

Older versions of `stylelint` don't seem to [handle autofix properly](https://github.com/stylelint/vscode-stylelint/issues/100#issuecomment-612113626). Upgrade so that VS Code format-on-save and `yarn fix` command respect stylelint "ignore" comments.

## How to test

- Checkout feature branch and run `yarn`.
- Add this line to a SCSS file to test:
```
  /* stylelint-disable function-name-case */
  width: var(--c-bolt-popover-bubble-width, Min(65vw, 250px));
```
- Verify that after saving the file and after running `yarn fix` the "Min" rule still has capital "M".
- Remove the stylelint-disable comment and repeat. It should change the "M" to "m".