### PR TITLE
DS-434: Fix tooltip alignment

### DIFF
--- a/packages/components/bolt-tooltip/src/tooltip.scss
+++ b/packages/components/bolt-tooltip/src/tooltip.scss
@@ -10,8 +10,7 @@
  */
 //  Note: this does not actually render to the Shadow DOM so :host rule not required
 bolt-tooltip {
-  // 'inline-flex' required for proper tooltip placement on buttons
-  display: inline-flex;
+  display: inline;
 
   &:not([ready]) [slot='content'] {
     display: none;
@@ -19,8 +18,6 @@ bolt-tooltip {
 
   // Plain text trigger gets underlined
   &[dotted] {
-    // if dotted (or inline text-only) use inline or spaces will collapse when you use inline elements like `<em>`
-    display: inline;
     cursor: help;
     border-bottom: 1px dotted var(--m-bolt-neutral);
   }


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-434

## Summary

Make tooltip display `inline` not `inline-flex` to fix alignment when next to other inline elements.

## Details

Tooltip was changed to `inline-flex` as part of the conversion to Tippy.js. It's not actually needed anymore, and tooltip can be set to always  display `inline` to avoid vertical alignment issues.

## How to test

@mikemai2awesome copy these changes into your Tech doc template to test.