### PR TITLE
WWW-467: Remove separate hard-coded classes on desktop heading links

### DIFF
--- a/packages/components/bolt-page-header/src/page-header-nav-li.twig
+++ b/packages/components/bolt-page-header/src/page-header-nav-li.twig
@@ -23,6 +23,11 @@
   current ? 'is-current',
 ] %}
 
+{% set link_classes = [
+  'c-bolt-page-header__nav-link',
+  link.desktop_heading ? 'c-bolt-page-header__nav-link--heading',
+] %}
+
 {# Template #}
 <li {{ attributes.addClass(classes) }}>
   {% if content and not link %}
@@ -33,7 +38,7 @@
     {% if link and children %}
       {# Visible desktop heading #}
       {% if link.desktop_heading %}
-        <{{ link_tag }} {{ link_attributes }} class="c-bolt-page-header__nav-link c-bolt-page-header__nav-link--heading">
+        <{{ link_tag }} {{ link_attributes.addClass(link_classes) }}>
           <strong class="c-bolt-page-header__nav-link__content">
             {{ link.content }}
           </strong>
@@ -55,10 +60,6 @@
       {{ children }}
     {% else %}
       {# Simple link without children #}
-      {% set link_classes = [
-        'c-bolt-page-header__nav-link',
-        link.desktop_heading ? 'c-bolt-page-header__nav-link--heading'
-      ] %}
       <{{ link_tag }} {{ link_attributes.addClass(link_classes) }} {% if selected and not current %}aria-current="true"{% endif %}>
         <span class="c-bolt-page-header__nav-link__content">
           {{ link.content }}

--- a/packages/components/bolt-page-header/src/page-header-nav-li.twig
+++ b/packages/components/bolt-page-header/src/page-header-nav-li.twig
@@ -46,11 +46,7 @@
       {% endif %}
 
       {# Trigger and content for nested children #}
-      {% set children_link_classes = [
-        'js-bolt-page-header-trigger',
-        'c-bolt-page-header__nav-link',
-      ] %}
-      <button type="button" aria-expanded="false" {{ link_attributes.addClass(children_link_classes)|without('href')|without('target')|without('type')|without('aria-expanded') }}>
+      <button type="button" aria-expanded="false" class="c-bolt-page-header__nav-link js-bolt-page-header-trigger">
         <span class="c-bolt-page-header__nav-link__nested-indicator c-bolt-page-header__nav-link__nested-indicator--collapse" aria-hidden="true"></span>
         <span class="c-bolt-page-header__nav-link__content">
           {{ link.content }}
@@ -60,7 +56,7 @@
       {{ children }}
     {% else %}
       {# Simple link without children #}
-      <{{ link_tag }} {{ link_attributes.addClass(link_classes) }} {% if selected and not current %}aria-current="true"{% endif %}>
+      <{{ link_tag }} {{ link_attributes.addClass(link_classes)|without('aria-current') }} {% if selected and not current %}aria-current="true"{% endif %}>
         <span class="c-bolt-page-header__nav-link__content">
           {{ link.content }}
         </span>


### PR DESCRIPTION
## Jira

Related to https://pegadigitalit.atlassian.net/browse/WWW-467, though that doesn't describe the bug

## Summary

Fixes attributes in page header links.

## Details

The bug this fixes is that custom classes cannot be passed in `link.attributes` without breaking the two existing hard-coded CSS classes, `c-bolt-page-header__nav-link` and `c-bolt-page-header__nav-link--heading`.

Whenever they're used, `Attributes` should be expected to potentially contain all HTML attributes.  Use `addClass()` to add additional classes, or `|without()` if you wish to print some attributes separately.

## How to test

### Confirm the bug

- On master, create a page header link that adds a custom class using link.attributes 
```
{% include '@bolt-components-page-header/page-header-nav-li.twig' with {
  link: {
    content: 'Foo',
    desktop_heading: true,
    attributes: {
      class: 'bar',
      href: 'http://pega.com',
    },
    children: 'foo'
  }
} only %}
```
- Confirm that the `c-bolt-page-header__nav-link` and `c-bolt-page-header__nav-link--heading` classes do not appear on the link.

### Confirm the fix
- Checkout this branch and repeat the above.  The `c-bolt-page-header__nav-link` and `c-bolt-page-header__nav-link--heading` classes should not be removed.
