### PR TITLE
WWW-606: Create PW Replay view and facets

### DIFF
--- a/packages/components/bolt-teaser/src/teaser.scss
+++ b/packages/components/bolt-teaser/src/teaser.scss
@@ -208,7 +208,6 @@
     --bolt-type-line-height-small
   ); // Height and line-height must match to limit to 3 lines of text.
   hyphens: auto;
-  word-break: break-all;
 
   &:after {
     content: '\2026';


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/WWW-606

## Summary

Removed the word break from the Teaser description text

## Details

This fix prevents words from being broken (without hyphens) in the hover description text. This came up on testing of WWW-606.

## How to test

Review the /pattern-lab/?p=components-teaser-text-options page and check how the hover description text breaks to a new line and hyphenates
 

