### PR TITLE
DS-447 Fix broken `renderWC` promise

### DIFF
--- a/packages/components/bolt-carousel/__tests__/__snapshots__/carousel.js.snap
+++ b/packages/components/bolt-carousel/__tests__/__snapshots__/carousel.js.snap
@@ -493,6 +493,12 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders w/ Variable (Auto) Slide
                  slot="before"
                  name="chevron-left"
       >
+        <span class="c-bolt-icon c-bolt-icon--large c-bolt-icon--chevron-left c-bolt-icon--auto">
+          <svg class="c-bolt-icon__icon c-bolt-icon__icon--large">
+            <use href="#chevron-left">
+            </use>
+          </svg>
+        </span>
       </bolt-icon>
     </bolt-button>
   </div>
@@ -512,6 +518,12 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders w/ Variable (Auto) Slide
                  slot="before"
                  name="chevron-right"
       >
+        <span class="c-bolt-icon c-bolt-icon--large c-bolt-icon--chevron-right c-bolt-icon--auto">
+          <svg class="c-bolt-icon__icon c-bolt-icon__icon--large">
+            <use href="#chevron-right">
+            </use>
+          </svg>
+        </span>
       </bolt-icon>
     </bolt-button>
   </div>
@@ -705,6 +717,12 @@ exports[`carousel Basic 7 Slide <bolt-carousel> Renders 1`] = `
                  slot="before"
                  name="chevron-left"
       >
+        <span class="c-bolt-icon c-bolt-icon--large c-bolt-icon--chevron-left c-bolt-icon--auto">
+          <svg class="c-bolt-icon__icon c-bolt-icon__icon--large">
+            <use href="#chevron-left">
+            </use>
+          </svg>
+        </span>
       </bolt-icon>
     </bolt-button>
   </div>
@@ -724,6 +742,12 @@ exports[`carousel Basic 7 Slide <bolt-carousel> Renders 1`] = `
                  slot="before"
                  name="chevron-right"
       >
+        <span class="c-bolt-icon c-bolt-icon--large c-bolt-icon--chevron-right c-bolt-icon--auto">
+          <svg class="c-bolt-icon__icon c-bolt-icon__icon--large">
+            <use href="#chevron-right">
+            </use>
+          </svg>
+        </span>
       </bolt-icon>
     </bolt-button>
   </div>


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-447

## Summary

Fix broken promise in renderWC to fix intermittent Jest snapshot failures, especially on the Carousel component.

## Details

[This promise](https://github.com/boltdesignsystem/bolt/blob/master/packages/testing/testing-helpers/index.js#L53) in renderWC does not work because `customElements` and `whenDefined` objects do not exist within the Jest page context.

Because this promise does not actually wait, the HTML returned may vary, resulting in intermittent snapshot failures. If we fix this broken promise, Jest test snapshots that use `renderWC` should return consistent results, or at least fail less often and for different reasons.

## How to test

- Review files changed
- Tests are passing