### PR TITLE
WWW-467 Header tweaks

### DIFF
--- a/packages/components/bolt-page-header/page-header.schema.js
+++ b/packages/components/bolt-page-header/page-header.schema.js
@@ -39,6 +39,10 @@ module.exports = {
         },
       },
     },
+    subheadline: {
+      type: 'any',
+      description: 'Text or other content to display next to the logo.',
+    },
     cta: {
       type: 'object',
       description:

--- a/packages/components/bolt-page-header/src/page-header.twig
+++ b/packages/components/bolt-page-header/src/page-header.twig
@@ -23,7 +23,7 @@
 <header {{ attributes.addClass(classes)|without('data-bolt-page-header-desktop-bp') }} data-bolt-page-header-desktop-bp="{{ breakpoint }}">
   <div class="c-bolt-page-header__primary">
     {% if logo %}
-      <{{ logo_tag }} {{ logo_attributes.addClass('c-bolt-page-header__logo')|without('aria-label') }} aria-label="{{ logo.label|t }}">
+      <{{ logo_tag }} {{ logo_attributes.addClass('c-bolt-page-header__logo')|without('aria-label') }} aria-label="{{ logo.label }}">
         <span class="c-bolt-page-header__logo__img" aria-hidden="true">
           <img src="{{ logo.image_src }}" alt="">
         </span>


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/WWW-467

## Summary

Fixes a minor header translation bug and adds missing docs

## Details

- The `|t` filter should only be used on actual translatable strings of text, not variables.  It won't work if you use in on a variable (e.g. `{{ logo.label|t }}`), and will actually prevent translating the original string.  The correct way to handle this is to print the variable as-is (`{{ logo.label }}`) and translate the string that gets passed in (e.g. `logo: { label: 'Home'|t }`)
- Adds missing schema entry for `subheadline`
 
## How to test

N/A really, unless you want to test translation in Drupal.  Read more here if you don't believe me: https://www.drupal.org/docs/8/api/translation-api/overview#s-variables-in-user-interface-text
