### PR TITLE
DS-418: 2.30 regression: Image modal scroll dragging overlay up

### DIFF
--- a/packages/components/bolt-modal/src/modal.scss
+++ b/packages/components/bolt-modal/src/modal.scss
@@ -135,7 +135,7 @@ bolt-modal:not([ready]) {
 .c-bolt-modal:before {
   content: '';
   opacity: 0.8;
-  position: absolute;
+  position: fixed;
   top: 0;
   right: 0;
   bottom: 0;


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-418

## Summary

Modal scroll fix

## Details

The fix prevents a scroll but from appearing when a image is taller than the viewport

## How to test

Navigate to "/pattern-lab/?p=components-modal-usage-image-and-caption" and open up the "Enlarge image and show caption" modal and scroll down. The modal overlay should not scroll up with the page.


