### PR TITLE
DS-488: PW Replay facets :On IOS mobile upon trying to apply the filter the save option is not in the viewport. Upon scrolling able to see the same

### DIFF
--- a/packages/components/bolt-modal/src/modal.scss
+++ b/packages/components/bolt-modal/src/modal.scss
@@ -75,12 +75,12 @@ bolt-modal:not([ready]) {
 
     .c-bolt-modal__content {
       width: 100%;
+      height: 100vh;
     }
 
     .c-bolt-modal__container {
-      display: flex;
-      flex-direction: column;
       height: 100vh;
+      height: -webkit-fill-available;
       color: var(--bolt-color-black);
       background-color: var(--bolt-color-white);
     }

--- a/packages/components/bolt-modal/src/modal.scss
+++ b/packages/components/bolt-modal/src/modal.scss
@@ -11,6 +11,9 @@
    and customizations
 \* ------------------------------------ */
 
+// Dev Notes
+// 1. Fixes iOS-specific bug where browser navigation bar covers up modal footer, @see https://css-tricks.com/css-fix-for-100vh-in-mobile-webkit/
+
 $bolt-modal-overlay-bg-color-dark: var(--bolt-color-navy-xdark);
 $bolt-modal-overlay-bg-color-light: var(--bolt-color-white);
 $bolt-modal-border-width: $bolt-border-width;
@@ -37,6 +40,7 @@ bolt-modal:not([ready]) {
   left: 0;
   width: 100%; // Use % instead of vh or modal scrollbar is hidden behind bold scrollbar in IE11
   height: 100vh;
+  height: -webkit-fill-available; // [1]
   // [Mai] reset font styles here so it doesn't inherit from parent container.
   font-family: var(--bolt-type-font-family-body);
   font-size: var(--bolt-type-font-size-medium);
@@ -76,11 +80,14 @@ bolt-modal:not([ready]) {
     .c-bolt-modal__content {
       width: 100%;
       height: 100vh;
+      height: -webkit-fill-available; // [1]
     }
 
     .c-bolt-modal__container {
+      display: flex;
+      flex-direction: column;
       height: 100vh;
-      height: -webkit-fill-available;
+      height: -webkit-fill-available; // [1]
       color: var(--bolt-color-black);
       background-color: var(--bolt-color-white);
     }


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-448

## Summary

(Enter a one-line summary of the changes in this PR. This will be included in the release notes)

## Details

Added a webkit specific workaround to fix a iOS bug that was having the bottom bar cover the bottom portion of the modal

## How to test

On iOS (I plugged my iPhone in my computer to test, but I think Browserstack would also work), navigate to "/pattern-lab/patterns/50-pages-65-best-of-content--20-boc-gallery-phase1/50-pages-65-best-of-content--20-boc-gallery-phase1.html", open the "More Filters" button and observe that the modal footer is not being covered by the bottom bar. 

### Visual changes

On iOS, the modal will now behave with the Safari bottom bar (it appears when scrolling)
