### PR TITLE
Fixed a active state color bug on the quick tabs

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/index.scss
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/index.scss
@@ -110,7 +110,7 @@ $www-quick-filters-button-shadow-offset: var(--bolt-spacing-y-medium);
   }
 
   &:checked + .e-bolt-button {
-    color: var(--m-bolt-link);
+    color: var(--m-bolt-text-on-secondary);
     box-shadow: 0 0 0 1px var(--bolt-color-navy-light);
     background-image: linear-gradient(
       rgba(bolt-color(gray, light), 0.2),
@@ -144,7 +144,7 @@ $www-quick-filters-button-shadow-offset: var(--bolt-spacing-y-medium);
   }
 
   &:checked:focus + .e-bolt-button {
-    color: var(--m-bolt-link);
+    color: var(--m-bolt-text-on-secondary);
     box-shadow: none;
   }
 }

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/index.scss
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/index.scss
@@ -130,8 +130,8 @@ $www-quick-filters-button-shadow-offset: var(--bolt-spacing-y-medium);
         rotate(45deg);
       width: 0.5em;
       height: 0.75em;
-      border-right: 2px solid var(--m-bolt-headline);
-      border-bottom: 2px solid var(--m-bolt-headline);
+      border-right: 2px solid var(--m-bolt-text-on-secondary);
+      border-bottom: 2px solid var(--m-bolt-text-on-secondary);
       border-radius: 0;
       box-shadow: none;
     }


### PR DESCRIPTION
## Summary

Quick filter colors now correctly display in dark themes

## Details

Changed the CSS color vars to be match the secondary text color value

## How to test

Navigate to "/pattern-lab/?p=pages-boc-gallery-phase2", change the containing ".c-bolt-band" to a dark theme and click on one of the quick filters, the text will no longer display as white on a white background

### Visual changes

The Quick Filters (Best of Content) labels will now correctly display when this component is rendered in a dark theme
