### PR TITLE
DS-449: Fix stacking order in FF

### DIFF
--- a/packages/components/bolt-teaser/src/teaser.scss
+++ b/packages/components/bolt-teaser/src/teaser.scss
@@ -272,6 +272,7 @@
   display: flex;
   align-items: center;
   order: 0;
+  z-index: 1; // Must use z-index to fix stacking order in FF. `position: relative` does not seem to work in FF when combined with `order: 0`.
 
   @at-root .c-bolt-teaser--horizontal #{&} {
     order: 2;


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-449

## Summary

Fix stacking order of like/share buttons in Teaser.

## Details

In FF you cannot click on like/share buttons inside the Teaser, [see example](https://boltdesignsystem.com/pattern-lab/patterns/50-pages-65-best-of-content--25-boc-listing-pegaworld-phase1/50-pages-65-best-of-content--25-boc-listing-pegaworld-phase1.html).

In every other browser the stack order works differently and like/share are still hoverable/clickable. In FF it seems that because we set the "actions" container to `order: 0` it lowers the stack order and they're covered up by the headline link. If I remove the `order` rule it fixes itself in FF. So, without any alternative, I added `z-index: 1`. Sorry @mikemai2awesome. Let me know if you have a better idea.

## How to test

- View [this page](https://boltdesignsystem.com/pattern-lab/patterns/50-pages-65-best-of-content--25-boc-listing-pegaworld-phase1/50-pages-65-best-of-content--25-boc-listing-pegaworld-phase1.html) in FF and verify you cannot interact with like/share buttons.
- Checkout feature branch and view [this page](http://localhost:3000/pattern-lab/patterns/50-pages-65-best-of-content--25-boc-listing-pegaworld-phase1/50-pages-65-best-of-content--25-boc-listing-pegaworld-phase1.html) locally and verify you _can_ interact with like/share buttons.