### PR TITLE
DS-450 Fix stacking order of Teaser view count in FF

### DIFF
--- a/packages/components/bolt-teaser/src/teaser.scss
+++ b/packages/components/bolt-teaser/src/teaser.scss
@@ -248,7 +248,7 @@
 }
 
 .c-bolt-teaser__description,
-.c-bolt-teaser__actions {
+.c-bolt-teaser__actions-and-views {
   margin-bottom: var(--bolt-spacing-y-small);
 }
 
@@ -268,11 +268,10 @@
   order: 1;
 }
 
-.c-bolt-teaser__actions {
+.c-bolt-teaser__actions-and-views {
   display: flex;
   align-items: center;
   order: 0;
-  z-index: 1; // Must use z-index to fix stacking order in FF. `position: relative` does not seem to work in FF when combined with `order: 0`.
 
   @at-root .c-bolt-teaser--horizontal #{&} {
     order: 2;
@@ -301,6 +300,7 @@
   display: flex;
   flex-wrap: nowrap;
   position: relative;
+  z-index: 1; // Must use z-index to fix stacking order in FF.
   margin: 0 0 0 auto;
   padding: 0;
   font-size: var(--bolt-type-font-size-xsmall);

--- a/packages/components/bolt-teaser/src/teaser.twig
+++ b/packages/components/bolt-teaser/src/teaser.twig
@@ -96,7 +96,7 @@
     {% endif %}
 
     {% if status.views or like or share %}
-      <div class="c-bolt-teaser__actions">
+      <div class="c-bolt-teaser__actions-and-views">
         {% if status.views %}
           <div class="c-bolt-teaser__views">
             {% include '@bolt-components-icon/icon.twig' with {


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-450

## Summary

Fixes an issue where the teaser view count has a higher stacking order than the teaser headline link.

## Details

1. Limited the z-index usage to only the like and share buttons
2. Renamed a container element to be less confusing

## How to test

Run the branch locally and test this page: http://localhost:3000/pattern-lab/?p=components-teaser-status-and-actions, make sure the like and share still work as expected and view count is not blocking the headline link, in Firefox, Safari, Chrome, and Edge. Also test the same thing in Best of Content phase 2 gallery page.