### PR TITLE
Fix `min-indent` error

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,9 +137,7 @@
     "typescript": "^3.5.3"
   },
   "devDependencies": {
-    "stylelint": "^13.12.0",
-    "stylelint-order": "^3.0.1",
-    "stylelint-scss": "^3.9.2"
+    "stylelint": "^13.12.0"
   },
   "optionalDependencies": {
     "prettier": ">= 1.13.0"

--- a/packages/configs/stylelint-config/package.json
+++ b/packages/configs/stylelint-config/package.json
@@ -15,6 +15,7 @@
   "author": "Salem Ghoweri",
   "main": "index.js",
   "dependencies": {
+    "min-indent": "^1.0.1",
     "stylelint": "^12.0.0",
     "stylelint-declaration-strict-value": "^1.1.7",
     "stylelint-declaration-use-variable": "^1.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13496,9 +13496,10 @@ min-document@^2.19.0:
   dependencies:
     dom-walk "^0.1.0"
 
-min-indent@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.0.tgz#cfc45c37e9ec0d8f0a0ec3dd4ef7f7c3abe39256"
+min-indent@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
+  integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
 mini-css-extract-plugin@^0.9.0:
   version "0.9.0"
@@ -14600,12 +14601,6 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
 onetime@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
-
-onetime@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
-  dependencies:
-    mimic-fn "^1.0.0"
 
 onetime@^5.1.0:
   version "5.1.0"
@@ -18970,7 +18965,7 @@ stylelint-declaration-use-variable@^1.7.2:
   dependencies:
     stylelint "11.1.1"
 
-stylelint-order@^3.0.1, stylelint-order@^3.1.1:
+stylelint-order@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/stylelint-order/-/stylelint-order-3.1.1.tgz#ba9ea6844d1482f97f31204e7c9605c7b792c294"
   dependencies:
@@ -18978,7 +18973,7 @@ stylelint-order@^3.0.1, stylelint-order@^3.1.1:
     postcss "^7.0.17"
     postcss-sorting "^5.0.1"
 
-stylelint-scss@^3.13.0, stylelint-scss@^3.9.2:
+stylelint-scss@^3.13.0:
   version "3.13.0"
   resolved "https://registry.yarnpkg.com/stylelint-scss/-/stylelint-scss-3.13.0.tgz#875c76e61d95333c4f0ae737a310be6f1d27d780"
   dependencies:


### PR DESCRIPTION
## Jira

n/a

## Summary

Fix missing `min-indent` error.

## Details

`min-indent` package was removed from yarn.lock recently. I don't think it was related to any of our changes, just a change to one of our dependencies. Perhaps there is an undeclared dependency in one of our dependencies? I fix this by adding `min-indent` to our `stylelint-config` package.

In the process of debugging I also found dupe stylelint dependencies at different versions. I removed the older versions.

## How to test
- Review changed files
- This branch builds on Travis