### PR TITLE
DS-89 Remove font-loading code

### DIFF
--- a/packages/core-v3.x/styles/01-settings/settings-font-family/_settings-font-family.scss
+++ b/packages/core-v3.x/styles/01-settings/settings-font-family/_settings-font-family.scss
@@ -55,22 +55,18 @@ $bolt-font-families: (
     body: (
       fallback-font: $bolt-font-family--sans-fallback,
       custom-font: $bolt-font-family--sans,
-      loaded-class: $bolt-fonts--loaded-class,
     ),
     bodySubset: (
       fallback-font: $bolt-font-family--sans-fallback,
       custom-font: $bolt-font-family--sans-subset,
-      loaded-class: $bolt-fonts--subset-loaded-class,
     ),
     heading: (
       fallback-font: $bolt-font-family--sans-fallback,
       custom-font: $bolt-font-family--sans,
-      loaded-class: $bolt-fonts--loaded-class,
     ),
     code: (
       fallback-font: $bolt-font-family--mono-fallback,
       custom-font: $bolt-font-family--mono,
-      loaded-class: $bolt-fonts--loaded-class,
     ),
   ),
 ) !default;

--- a/packages/core-v3.x/styles/01-settings/settings-global/_settings-global.scss
+++ b/packages/core-v3.x/styles/01-settings/settings-global/_settings-global.scss
@@ -19,12 +19,6 @@ $bolt-base-font-size--min: 15px !default;
 /// Global Default Max Base Font Size
 $bolt-base-font-size--max: 18px !default;
 
-// Async font loading classes.
-/// Async Default font subset loaded class.
-$bolt-fonts--subset-loaded-class: 'js-fonts-subset-loaded' !default;
-/// Async Default font loaded class.
-$bolt-fonts--loaded-class: 'js-fonts-loaded' !default;
-
 // Border
 /// Bolt border width
 $bolt-border-width: 1px !default;

--- a/packages/servers/testing-server/index.js
+++ b/packages/servers/testing-server/index.js
@@ -16,7 +16,7 @@ getConfig().then(async boltConfig => {
 
   app.use((req, res) => {
     res.send(
-      `<html class="js-fonts-loaded">
+      `<html>
         <head>
           <title>Test</title>
           <link rel="stylesheet" href="/build/bolt-global.css" />


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-89

## Summary

Remove remaining code related to old JS font-loading approach.

## Details

Removes `js-fonts-loaded` class in SCSS and testing server HTML. We no longer use this class for anything. It was removed [as part of `3.0`](https://github.com/boltdesignsystem/bolt/commit/142e8730b712ddfc7959e9d2222323b9c6dd8d47#diff-eecf057daf323883b3a840cf8fdbdc64afba36274164320b02bf3aa972f4605fL19-L22).  No usage downstream except for [Bolt Emulsify POC](https://gitlab.com/search?group_id=5804310&repository_ref=&scope=blobs&search=loaded-class%2A&snippets=false).

## How to test

- Review code changes
- Verify no regressions to fonts