### PR TITLE
Upgrade chromedriver to 89 to fix Travis builds

### DIFF
--- a/packages/testing/testing-nightwatch/package.json
+++ b/packages/testing/testing-nightwatch/package.json
@@ -18,7 +18,7 @@
   "main": "nightwatch.js",
   "dependencies": {
     "@zeit/fetch-retry": "^4.0.1",
-    "chromedriver": "^89.0.0",
+    "chromedriver": "latest",
     "ci-utils": "^0.6.0",
     "geckodriver": "^1.16.2",
     "globby": "^10.0.1",

--- a/packages/testing/testing-nightwatch/package.json
+++ b/packages/testing/testing-nightwatch/package.json
@@ -18,7 +18,7 @@
   "main": "nightwatch.js",
   "dependencies": {
     "@zeit/fetch-retry": "^4.0.1",
-    "chromedriver": "^88.0.0",
+    "chromedriver": "^89.0.0",
     "ci-utils": "^0.6.0",
     "geckodriver": "^1.16.2",
     "globby": "^10.0.1",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -23,7 +23,7 @@
     "querystring": "^0.2.0"
   },
   "optionalDependencies": {
-    "chromedriver": "^88.0.0",
+    "chromedriver": "^89.0.0",
     "geckodriver": "^1.19.1"
   }
 }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -23,7 +23,7 @@
     "querystring": "^0.2.0"
   },
   "optionalDependencies": {
-    "chromedriver": "^89.0.0",
+    "chromedriver": "latest",
     "geckodriver": "^1.19.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5314,9 +5314,10 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@^88.0.0:
-  version "88.0.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-88.0.0.tgz#6833fffd516db23c811eeafa1ee1069b5a12fd2f"
+chromedriver@latest:
+  version "89.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-89.0.0.tgz#a6f27aa306400651a20dc04976fe5b2c4e65d61a"
+  integrity sha512-+DVYp3+m6tZUYTMl9fEgCZIDk9YBTcHws82nIV1JYwusu51zRITA0oeNzuPyFhuK7ageFnnKCDviH2BL5I4M0w==
   dependencies:
     "@testim/chrome-version" "^1.0.7"
     axios "^0.21.1"


### PR DESCRIPTION
## Jira

n/a

## Summary

Upgrade chromedriver to 89 to fix Travis builds.

## How to test

- Review code changes
- Already passing here: https://travis-ci.com/github/boltdesignsystem/bolt/builds/223221219