### PR TITLE
Hotfix: WWW-696 Fix Drupal escaping markup when using 'set' in Share component

### DIFF
--- a/packages/components/bolt-share/src/share.twig
+++ b/packages/components/bolt-share/src/share.twig
@@ -40,7 +40,8 @@
 {% endset %}
 {% set inline_items = inline_items|merge([inline_label]) %}
 
-{% set menu_items = [] %}
+{# After initial set, you must use {% set/endset %} to modify menu_items. Otherwise, Drupal may render content as raw HTML. @see https://www.drupal.org/project/drupal/issues/2994673 #}
+{% set menu_items = '' %}
 
 {% for source in sources %}
   {% set source_name = source.name %}
@@ -93,7 +94,10 @@
         }
       } only %}
     {% endset %}
-    {% set menu_items = menu_items|merge([source_menu_items]) %}
+    {% set menu_items %}
+      {{ menu_items }}
+      {{ source_menu_items }}
+    {% endset %}
   {% endif %}
 {% endfor %}
 
@@ -195,7 +199,10 @@
       }
     } only %}
   {% endset %}
-  {% set menu_items = menu_items|merge([menu_copy_to_clipboard_include]) %}
+  {% set menu_items %}
+    {{ menu_items }}
+    {{ menu_copy_to_clipboard_include }}
+  {% endset %}
 {% endif %}
 
 {# Share component's custom element wrapper. #}
@@ -223,7 +230,7 @@
     {% elseif display == 'menu' %}
       {% include '@bolt-components-menu/menu.twig' with {
         title: text,
-        content: menu_items|join,
+        content: menu_items,
         spacing: size,
       } only %}
     {% endif %}


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/WWW-696?focusedCommentId=26785

## Summary

https://github.com/boltdesignsystem/bolt/pull/2173