### PR TITLE
Fix lock-solid.svg to work with dark theme

### DIFF
--- a/packages/components/bolt-icons/src/svgs/utility/lock-solid.svg
+++ b/packages/components/bolt-icons/src/svgs/utility/lock-solid.svg
@@ -1,6 +1,1 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" width="24" height="24" viewBox="0 0 24.00 24.00" enable-background="new 0 0 24.00 24.00" xml:space="preserve">
-  <path d="M18.4,10h-0.6l0-3c0-3.3-2.7-5.9-5.9-5.9S5.9,3.7,5.9,6.9l0,3H5.6c-1.1,0-2,0.9-2,2v9c0,1.1,0.9,2,2,2l12.7,0
-	c1.1,0,2-0.9,2-2v-9C20.4,10.9,19.5,10,18.4,10z M8,10l0-3c0-2.1,1.7-3.8,3.8-3.8c2.1,0,3.8,1.7,3.8,3.8l0,3L8,10z"/>
-</svg>
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve"><path fill="#1F2555" d="M18.4,10h-0.6V7c0-3.3-2.7-5.9-5.9-5.9c-3.2,0-6,2.6-6,5.8v3H5.6c-1.1,0-2,0.9-2,2v9c0,1.1,0.9,2,2,2h12.7	c1.1,0,2-0.9,2-2v-9C20.4,10.9,19.5,10,18.4,10z M15.6,10H8V7c0-2.1,1.7-3.8,3.8-3.8c2.1,0,3.8,1.7,3.8,3.8V10z"/></svg>

--- a/packages/components/bolt-teaser/__tests__/__snapshots__/teaser.js.snap
+++ b/packages/components/bolt-teaser/__tests__/__snapshots__/teaser.js.snap
@@ -126,10 +126,11 @@ exports[`Twig usage basic usage 1`] = `
         <span class="c-bolt-icon c-bolt-icon--lock-solid">
           <svg class="c-bolt-icon__icon"
                xmlns="http://www.w3.org/2000/svg"
-               baseprofile="full"
                viewbox="0 0 24 24"
           >
-            <path d="M18.4 10h-.6V7c0-3.3-2.7-5.9-5.9-5.9s-6 2.6-6 5.8v3h-.3a2 2 0 00-2 2v9c0 1.1.9 2 2 2h12.7a2 2 0 002-2v-9c.1-1-.8-1.9-1.9-1.9zM8 10V7a3.8 3.8 0 117.6 0v3H8z">
+            <path fill="var(--bolt-theme-icon, currentColor)"
+                  d="M18.4 10h-.6V7a6 6 0 00-5.9-5.9 6 6 0 00-6 5.8v3h-.3a2 2 0 00-2 2v9c0 1.1.9 2 2 2h12.7a2 2 0 002-2v-9c.1-1-.8-1.9-1.9-1.9zm-2.8 0H8V7a3.8 3.8 0 117.6 0v3z"
+            >
             </path>
           </svg>
         </span>


### PR DESCRIPTION
## Jira

N/A

## Summary

Fix the rendering issue with lock-solid.svg icon on dark theme

## Details

Add to svg file `fill="1F2555"` attribute.

## How to test

Check if the icon on a dark theme is rendered in white color.

### Visual changes

Icon before

![image](https://user-images.githubusercontent.com/16049049/115039823-16a1fb80-9ed1-11eb-8ba0-0134b60d6581.png)

Icon after:

![image](https://user-images.githubusercontent.com/16049049/115039713-fc681d80-9ed0-11eb-8610-759d7f29fafa.png)
