### PR TITLE
DS-452: Rename Waypoint "target"

### DIFF
--- a/packages/components/bolt-toc/src/_toc-item.js
+++ b/packages/components/bolt-toc/src/_toc-item.js
@@ -59,7 +59,7 @@ class BoltTocItem extends withContext(BoltElement) {
     super.connectedCallback && super.connectedCallback();
 
     if (this.url && this.url.indexOf('#') === 0) {
-      this.target = document.querySelector(this.url);
+      this.waypointElement = document.querySelector(this.url);
     }
   }
 
@@ -73,7 +73,7 @@ class BoltTocItem extends withContext(BoltElement) {
 
   handleClick(event) {
     try {
-      if (this.target) {
+      if (this.waypointElement) {
         event.preventDefault();
         let scrollOpts = scrollOptions;
 
@@ -91,7 +91,11 @@ class BoltTocItem extends withContext(BoltElement) {
         // @todo We need a solution for multiple stacked fixed/sticky elements. Also see `onPositionChange()` in toc.js.
         delete scrollOpts.header;
 
-        smoothScroll.animateScroll(this.target, this.shadowLink, scrollOpts);
+        smoothScroll.animateScroll(
+          this.waypointElement,
+          this.shadowLink,
+          scrollOpts,
+        );
       }
     } catch (err) {
       console.log(err);

--- a/packages/components/bolt-toc/src/toc.js
+++ b/packages/components/bolt-toc/src/toc.js
@@ -67,10 +67,10 @@ class BoltToc extends withContext(BoltElement) {
     const data = [];
 
     this.items.forEach(item => {
-      if (item.target) {
+      if (item.waypointElement) {
         data.push({
           trigger: item,
-          target: item.target,
+          element: item.waypointElement,
         });
       }
     });
@@ -84,8 +84,10 @@ class BoltToc extends withContext(BoltElement) {
     }
   }
 
-  getItemByTarget(target, shift = 0) {
-    const match = this.waypointData.find(item => item.target === target);
+  getItemByElement(element, shift = 0) {
+    const match = this.waypointData.find(
+      item => item.waypointElement === element,
+    );
     const index = this.waypointData.indexOf(match) + shift;
 
     if (index !== -1) {
@@ -100,7 +102,7 @@ class BoltToc extends withContext(BoltElement) {
     }
   }
 
-  onPositionChange({ target, currentPosition }) {
+  onPositionChange({ element, currentPosition }) {
     this.setStickyOffset();
 
     // If `activeItem` is undefined (could be first load), use the first item
@@ -108,7 +110,7 @@ class BoltToc extends withContext(BoltElement) {
     // the most visible section
     if (!this.activeItem) {
       if (currentPosition === 'below') {
-        let item = this.getItemByTarget(target, -1);
+        let item = this.getItemByElement(element, -1);
         if (item) {
           this.activeItem = item.trigger;
         }

--- a/packages/core-v3.x/utils/waypoint/index.js
+++ b/packages/core-v3.x/utils/waypoint/index.js
@@ -8,8 +8,8 @@ export class Waypoint {
     this.options = {
       /**
        * `items` is an array of objects. Each object contains two keys:
-       *   - `target` is the element monitored as it scrolls in and out of the boundary area.
-       *   - `trigger` is the link or actionable element associated with this target (optional).
+       *   - `element` is the element monitored as it scrolls in and out of the boundary area.
+       *   - `trigger` is the link or actionable element associated with this element (optional).
        */
       items: [],
 
@@ -114,9 +114,9 @@ export class Waypoint {
   checkWaypoint(item) {
     if (this.scrolling) return;
 
-    const { trigger, target, position } = item;
+    const { trigger, element, position } = item;
     const bounds = getBounds(
-      target,
+      element,
       window,
       this.options.topOffset,
       this.options.bottomOffset,
@@ -135,7 +135,7 @@ export class Waypoint {
 
     const callbackArg = {
       trigger,
-      target,
+      element,
       currentPosition,
       previousPosition,
       waypointTop: bounds.waypointTop,


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-452

## Summary

Rename Waypoint `target` top avoid conflict with target prop

## Details

Waypoint adds data to "target" elements. This PR changes the name of that data from `target` to `waypointElement` to avoid conflict with elements that may have a `target` prop already.

## How to test
- Review code changes
- Checkout feature branch and verify TOC component works as expected