### PR TITLE
WWW-694: PW Replay facets :On IOS mobile upon trying to apply the filter the save option is not in the viewport. Upon scrolling able to see the same

### DIFF
--- a/packages/components/bolt-modal/src/modal.js
+++ b/packages/components/bolt-modal/src/modal.js
@@ -135,6 +135,8 @@ class BoltModal extends BoltElement {
 
     this._noBodyScroll && this._setScrollbar();
 
+    document.body.classList.add('u-bolt-overflow-hidden');
+
     // @todo: re-evaluate if the trigger element used needs to have it's tabindex messed with
     // this.querySelector('[slot="trigger"]').setAttribute('tabindex', '-1');
 
@@ -169,6 +171,8 @@ class BoltModal extends BoltElement {
     this.ready = false;
 
     this.dispatchEvent(new CustomEvent('modal:hide', this._toggleEventOptions));
+
+    document.body.classList.remove('u-bolt-overflow-hidden');
 
     this.transitionDuration = getTransitionDuration(
       this.renderRoot.querySelector('.c-bolt-modal'),


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/WWW-694

## Summary

Added a class to prevent the page from being scrollable when a modal is opened

## Details

Tested in the following browser/devices

- Edge (latest)
- Chrome (latest)
- FF (latest)
- Safari (latest)
- Safari iOS (latest)
- Android 9, 10, 11

## How to test

Pull down the branch
Test examples of the modal in Patternlab

### Visual changes

A modal will no longer allow the page to scroll behind it and will be 100% the hight of the viewport
