### PR TITLE
Hotfix 3.4.4

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/35-teaser-text-options.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/35-teaser-text-options.twig
@@ -5,7 +5,6 @@
 {% set notes %}
 <bolt-ol>
   <bolt-li>When setting the <bolt-code-snippet display="inline">headline</bolt-code-snippet> and <bolt-code-snippet display="inline">subheadline</bolt-code-snippet> please be sure to set the proper HTML tag to ensure SEO and accessibility best practices.</bolt-li>
-  <bolt-li>The <bolt-code-snippet display="inline">description</bolt-code-snippet> has the <bolt-code-snippet display="inline">show_on_hover</bolt-code-snippet> boolean prop. When it is set to true, the description appears as an overlay above the signifier.</bolt-li>
   <bolt-li>The traditional eyebrow/headline/subheadline lockup is best used in responsive layout.</bolt-li>
 </bolt-ol>
 {% endset %}
@@ -39,8 +38,7 @@
           size: 'xlarge',
         },
         description: {
-          content: 'This is the description. Aliqua voluptate amet do laborum culpa tempor consectetur culpa consectetur ea. Ea officia quis do enim.',
-          show_on_hover: true,
+          content: 'This is the description.',
         },
       } only %}
     </div>
@@ -65,8 +63,7 @@
     size: 'xlarge',
   },
   description: {
-    content: 'This is the description. Aliqua voluptate amet do laborum culpa tempor consectetur culpa consectetur ea. Ea officia quis do enim. Duis dolore labore cillum excepteur aute veniam dolore consectetur est sint exercitation sit. Dolor eiusmod officia laborum tempor. Enim eiusmod Lorem laboris aliqua dolore.',
-    show_on_hover: true,
+    content: 'This is the description.',
   },
   ...
 } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/40-teaser-description-on-hover.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/40-teaser-description-on-hover.twig
@@ -1,0 +1,74 @@
+{% set description %}
+  The teaser description has the <bolt-code-snippet display="inline">show_on_hover</bolt-code-snippet> boolean prop. When it is set to true, the description appears as an overlay above the signifier and it is truncated at 80 characters.
+{% endset %}
+
+{% set demo %}
+  {% set wide_image %}
+    {% include '@bolt-components-image/image.twig' with {
+      src: '/images/placeholders/signifier-pdf.jpg',
+      alt: 'Alt text.',
+    } only %}
+  {% endset %}
+  <div class="o-bolt-grid o-bolt-grid--flex o-bolt-grid--matrix">
+    <div class="o-bolt-grid__cell u-bolt-width-12/12 u-bolt-width-6/12@small u-bolt-width-4/12@medium">
+      {% include '@bolt-components-teaser/teaser.twig' with {
+        layout: 'vertical',
+        type: 'pdf',
+        time: '7 pages',
+        signifier: wide_image,
+        headline: {
+          text: 'This teaser shows a short description on hover',
+          tag: 'h3',
+          size: 'large',
+          link_attributes: {
+            href: 'https://pega.com',
+          },
+        },
+        description: {
+          content: 'Short description',
+          show_on_hover: true,
+        },
+      } only %}
+    </div>
+    <div class="o-bolt-grid__cell u-bolt-width-12/12 u-bolt-width-6/12@small u-bolt-width-4/12@medium">
+      {% include '@bolt-components-teaser/teaser.twig' with {
+        layout: 'vertical',
+        type: 'pdf',
+        time: '7 pages',
+        signifier: wide_image,
+        headline: {
+          text: 'This teaser shows a long description on hover',
+          tag: 'h3',
+          size: 'large',
+          link_attributes: {
+            href: 'https://pega.com',
+          },
+        },
+        description: {
+          content: 'Long description. Chicken bacon doner pancetta pork corned beef, swine jowl burgdoggen pastrami buffalo beef ribs shankle. Turducken pork porchetta shankle, salami short ribs corned beef. Short ribs turkey burgdoggen, fatback jerky chuck landjaeger corned beef pork t-bone jowl hamburger brisket strip steak. Tenderloin cow bacon cupim t-bone short ribs swine biltong beef ribs capicola sausage beef.',
+          show_on_hover: true,
+        },
+      } only %}
+    </div>
+  </div>
+{% endset %}
+
+{% set twig_markup %}
+{% verbatim %}
+{% include '@bolt-components-teaser/teaser.twig' with {
+  description: {
+    content: 'This is the description',
+    show_on_hover: true,
+  },
+  ...
+} only %}
+{% endverbatim %}
+{% endset %}
+
+{% include '@utils/pattern-doc-page.twig' with {
+  title: 'Show Description on Hover',
+  description: description,
+  notes: notes,
+  demo: demo,
+  twig_markup: twig_markup,
+} only %}

--- a/packages/components/bolt-share/src/share.twig
+++ b/packages/components/bolt-share/src/share.twig
@@ -40,7 +40,8 @@
 {% endset %}
 {% set inline_items = inline_items|merge([inline_label]) %}
 
-{% set menu_items = [] %}
+{# After initial set, you must use {% set/endset %} to modify menu_items. Otherwise, Drupal may render content as raw HTML. @see https://www.drupal.org/project/drupal/issues/2994673 #}
+{% set menu_items = '' %}
 
 {% for source in sources %}
   {% set source_name = source.name %}
@@ -93,7 +94,10 @@
         }
       } only %}
     {% endset %}
-    {% set menu_items = menu_items|merge([source_menu_items]) %}
+    {% set menu_items %}
+      {{ menu_items }}
+      {{ source_menu_items }}
+    {% endset %}
   {% endif %}
 {% endfor %}
 
@@ -195,7 +199,10 @@
       }
     } only %}
   {% endset %}
-  {% set menu_items = menu_items|merge([menu_copy_to_clipboard_include]) %}
+  {% set menu_items %}
+    {{ menu_items }}
+    {{ menu_copy_to_clipboard_include }}
+  {% endset %}
 {% endif %}
 
 {# Share component's custom element wrapper. #}
@@ -223,7 +230,7 @@
     {% elseif display == 'menu' %}
       {% include '@bolt-components-menu/menu.twig' with {
         title: text,
-        content: menu_items|join,
+        content: menu_items,
         spacing: size,
       } only %}
     {% endif %}

--- a/packages/components/bolt-tabs/index.js
+++ b/packages/components/bolt-tabs/index.js
@@ -1,5 +1,5 @@
 import { lazyQueue } from '@bolt/lazy-queue';
 
 lazyQueue(['bolt-tabs'], async () => {
-  await import(/*  webpackChunkName: 'bolt-tas' */ './main');
+  await import(/*  webpackChunkName: 'bolt-tabs' */ './main');
 });

--- a/packages/components/bolt-teaser/__tests__/__snapshots__/teaser.js.snap
+++ b/packages/components/bolt-teaser/__tests__/__snapshots__/teaser.js.snap
@@ -37,7 +37,7 @@ exports[`Twig usage adds class via Drupal Attributes 1`] = `
         Featured
       </p>
     </div>
-    <div class="c-bolt-teaser__actions">
+    <div class="c-bolt-teaser__actions-and-views">
       <div class="c-bolt-teaser__views">
         <bolt-icon name="eye"
                    aria-hidden="true"
@@ -171,7 +171,7 @@ exports[`Twig usage basic usage 1`] = `
         Featured
       </p>
     </div>
-    <div class="c-bolt-teaser__actions">
+    <div class="c-bolt-teaser__actions-and-views">
       <div class="c-bolt-teaser__views">
         <bolt-icon name="eye"
                    aria-hidden="true"

--- a/packages/components/bolt-teaser/src/teaser.scss
+++ b/packages/components/bolt-teaser/src/teaser.scss
@@ -185,7 +185,7 @@
   width: 100%;
   height: 100%;
   overflow: hidden;
-  padding: var(--bolt-spacing-y-medium) var(--bolt-spacing-x-large);
+  padding: var(--bolt-spacing-y-medium) 0;
   color: var(--bolt-color-white);
   background-color: black;
   place-items: center;
@@ -197,7 +197,11 @@
 }
 
 .c-bolt-teaser__signifier-description-text {
+  display: grid; // Grid and place-items required to center shorter descriptions
+  place-items: center;
   position: relative;
+  width: 197px; // Setting a width is the only way to make the ellipsis work in 99% of use cases, without complex JS counting lines and characters.
+  max-width: 100%;
   height: calc(
     var(--bolt-type-line-height-small) * 3em
   ); // Height and line-height must match to limit to 3 lines of text.
@@ -210,13 +214,11 @@
   hyphens: auto;
   word-break: normal;
 
-  &:after {
-    content: '\2026';
-    position: absolute;
-    right: 0;
-    bottom: 0;
-    padding-left: 1em;
-    background: linear-gradient(to right, rgba(black, 0), black 50%);
+  &--line-clamp {
+    // https://css-tricks.com/almanac/properties/l/line-clamp/
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
   }
 }
 

--- a/packages/components/bolt-teaser/src/teaser.scss
+++ b/packages/components/bolt-teaser/src/teaser.scss
@@ -248,7 +248,7 @@
 }
 
 .c-bolt-teaser__description,
-.c-bolt-teaser__actions {
+.c-bolt-teaser__actions-and-views {
   margin-bottom: var(--bolt-spacing-y-small);
 }
 
@@ -268,11 +268,10 @@
   order: 1;
 }
 
-.c-bolt-teaser__actions {
+.c-bolt-teaser__actions-and-views {
   display: flex;
   align-items: center;
   order: 0;
-  z-index: 1; // Must use z-index to fix stacking order in FF. `position: relative` does not seem to work in FF when combined with `order: 0`.
 
   @at-root .c-bolt-teaser--horizontal #{&} {
     order: 2;
@@ -301,6 +300,7 @@
   display: flex;
   flex-wrap: nowrap;
   position: relative;
+  z-index: 1; // Must use z-index to fix stacking order in FF.
   margin: 0 0 0 auto;
   padding: 0;
   font-size: var(--bolt-type-font-size-xsmall);

--- a/packages/components/bolt-teaser/src/teaser.scss
+++ b/packages/components/bolt-teaser/src/teaser.scss
@@ -270,6 +270,7 @@
   display: flex;
   align-items: center;
   order: 0;
+  z-index: 1; // Must use z-index to fix stacking order in FF. `position: relative` does not seem to work in FF when combined with `order: 0`.
 
   @at-root .c-bolt-teaser--horizontal #{&} {
     order: 2;

--- a/packages/components/bolt-teaser/src/teaser.twig
+++ b/packages/components/bolt-teaser/src/teaser.twig
@@ -96,7 +96,7 @@
     {% endif %}
 
     {% if status.views or like or share %}
-      <div class="c-bolt-teaser__actions">
+      <div class="c-bolt-teaser__actions-and-views">
         {% if status.views %}
           <div class="c-bolt-teaser__views">
             {% include '@bolt-components-icon/icon.twig' with {

--- a/packages/components/bolt-teaser/src/teaser.twig
+++ b/packages/components/bolt-teaser/src/teaser.twig
@@ -34,8 +34,8 @@
 
       {% if description.content and description.show_on_hover %}
         <div class="c-bolt-teaser__signifier-description" aria-hidden="true">
-          <div class="c-bolt-teaser__signifier-description-text">
-            {{ description.content }}
+          <div class="c-bolt-teaser__signifier-description-text {% if description.content|length >= 80 %}c-bolt-teaser__signifier-description-text--line-clamp{% endif %}">
+            {{ description.content }}{% if description.content|length < 80 %}&hellip;{% endif %}
           </div>
         </div>
       {% endif %}

--- a/packages/components/bolt-teaser/src/teaser.twig
+++ b/packages/components/bolt-teaser/src/teaser.twig
@@ -35,7 +35,7 @@
       {% if description.content and description.show_on_hover %}
         <div class="c-bolt-teaser__signifier-description" aria-hidden="true">
           <div class="c-bolt-teaser__signifier-description-text {% if description.content|length >= 80 %}c-bolt-teaser__signifier-description-text--line-clamp{% endif %}">
-            {{ description.content }}
+            {{ description.content }}{% if description.content|length < 80 %}&hellip;{% endif %}
           </div>
         </div>
       {% endif %}

--- a/packages/components/bolt-teaser/src/teaser.twig
+++ b/packages/components/bolt-teaser/src/teaser.twig
@@ -35,7 +35,7 @@
       {% if description.content and description.show_on_hover %}
         <div class="c-bolt-teaser__signifier-description" aria-hidden="true">
           <div class="c-bolt-teaser__signifier-description-text {% if description.content|length >= 80 %}c-bolt-teaser__signifier-description-text--line-clamp{% endif %}">
-            {{ description.content }}{% if description.content|length < 80 %}&hellip;{% endif %}
+            {{ description.content }}
           </div>
         </div>
       {% endif %}


### PR DESCRIPTION
## Jira

n/a

## Summary
Cherry-pick changes from:
- https://github.com/boltdesignsystem/bolt/pull/2161
- https://github.com/boltdesignsystem/bolt/pull/2152
- https://github.com/boltdesignsystem/bolt/pull/2164
- https://github.com/boltdesignsystem/bolt/pull/2176

## Reviewers Notes
This is an overview of the the files that were changes and the important changes that will be needed

### v3.5.2 Twig Changes (Share) [/pull/2176]
- packages/components/bolt-share/src/share.twig

### v3.5.1 Twig/CSS Changes (Teaser Like/Share) [/pull/2164]
- packages/components/bolt-share/src/share.twig (_Line 99_)
- packages/components/bolt-teaser/src/teaser.scss

### v3.5.0 Twig Changes (Ellipsis) [/pull/2152]
- packages/components/bolt-teaser/src/teaser.twig  (_Line 37_)
- packages/components/bolt-teaser/src/teaser.scss

### Patternlab Docs/Bolt specific Twig/Test Changes (you can ignore these)
- docs-site/src/pages/pattern-lab/\_patterns/40-components/teaser/35-teaser-text-options.twig
- docs-site/src/pages/pattern-lab/\_patterns/40-components/teaser/40-teaser-description-on-hover.twig
- packages/components/bolt-teaser/**tests**/**snapshots**/teaser.js.snap
- packages/components/bolt-tabs/index.js