### PR TITLE
DS-456: Overwrite, do not merge, `this.defaultProps`

### DIFF
--- a/packages/base-element/src/lib/decorators/json-schema-props.js
+++ b/packages/base-element/src/lib/decorators/json-schema-props.js
@@ -23,7 +23,7 @@ const jsonSchemaPropsDecorator = clazz => {
 
     // uses the static schema data passed to to generate default property data
     static get props() {
-      this.defaultProps = this.defaultProps || {};
+      this.defaultProps = {};
 
       if (!this.schema) {
         return {};


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-456

## Summary

Fixes bug where two components that both extend `BoltActionElement` can overwrite each other's default prop values.

## Details
In v3.5.0 we converted `BoltActionElement` to use [the `this.props` getter](https://github.com/boltdesignsystem/bolt/pull/2132/files#diff-a64f2ffab2e85d31369c13ddf85e88b3031f3e4f5ede41751fde038c34ec47e7R13). This led to a bug where the default props of `BoltChip`, say, are applied to `BoltActionElement`. Then, when `BoltButton` extends `BoltActionElement` it inherits `BoltChip`'s default values.

To fix this, I am now always [resetting `defaultProps`](https://github.com/boltdesignsystem/bolt/blob/f445c23ebfd7e2d606523df22d4c4f475711264f/packages/base-element/src/lib/decorators/json-schema-props.js#L26), rather than inheriting it. The parent Class defaults are still applied, but the child props are no longer stored on the parent Class.

Admittedly, I'm still not 100% sure why [`this`](https://github.com/boltdesignsystem/bolt/blob/f445c23ebfd7e2d606523df22d4c4f475711264f/packages/base-element/src/lib/decorators/json-schema-props.js#L26) would ever refer to the parent not the child Class, but I had no luck troubleshooting that. I suspect it has something to do with how we're using decorators combined with Class inheritance. I'm not sure if inheriting `defaultProps` was ever necessary. What I can say is that resetting `defaultProps` each time fixes the bug and everywhere we extend `BoltActionElements` appears to work as expected.

## How to test

- To reproduce the bug go to [BOC demo on v3.5.3 staging link](https://v3-5-3.boltdesignsystem.com/pattern-lab/patterns/50-pages-65-best-of-content--10-boc-gallery-phase0/50-pages-65-best-of-content--10-boc-gallery-phase0.html
)
- Run the following into the console:
```
const btn = document.createElement('bolt-button');
btn.innerHTML = "Test button";
document.body.append(btn);
```
- You will see a button at the bottom of the page at size "small", the wrong default size.
- To see the fix, go to the [feature staging link](https://hotfix-ds-456-default-props.boltdesignsystem.com/pattern-lab/patterns/50-pages-65-best-of-content--10-boc-gallery-phase0/50-pages-65-best-of-content--10-boc-gallery-phase0.html) and repeat the above steps.
- You will see a button at "medium" size, the correct default size.
- You can run `customElements.get('bolt-button').defaultProps` in the console to see the actual default values.
- Review Button, Card Replacement Link, Chip, Link, and Trigger components for regressions. These components also extend `BoltActionElement`.