### PR TITLE
[DO NOT MERGE] Video Modal Hotfix

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/modal/45-modal-usage-video.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/modal/45-modal-usage-video.twig
@@ -25,10 +25,11 @@
   {% set modal_content_1 %}
     {% set video %}
       <video-js
-        data-account="1900410236"
-        data-player="O3FkeBiaDz"
+        data-modal-account="1900410236"
+        data-modal-player="O3FkeBiaDz"
         data-embed="default"
-        data-video-id="4892122320001"
+        data-modal-video-id="4892122320001"
+        data-video-modal
         controls
         data-media-title
         data-media-duration
@@ -79,7 +80,7 @@
   // Show modal on video toggle, pause on modal hide
   const modal2 = document.querySelector('.js-bolt-modal-456');
   const video2 = document.querySelector('.js-modal-video-456');
-\
+
   video2.addEventListener('playing', function() {
     videojs.getPlayer(video2).show();
   });
@@ -95,10 +96,11 @@
   {% set modal_content_2 %}
     {% set video %}
       <video-js
-        data-account="1900410236"
-        data-player="O3FkeBiaDz"
+        data-modal-account="1900410236"
+        data-modal-player="O3FkeBiaDz"
         data-embed="default"
-        data-video-id="4892122320001"
+        data-modal-video-id="4892122320001"
+        data-video-modal
         data-media-title
         data-media-duration
         controls

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/25-teaser-type-and-time.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/25-teaser-type-and-time.twig
@@ -15,10 +15,11 @@
   {% set modal_content %}
     {% set video %}
       <video-js
-        data-account='1900410236'
-        data-player='O3FkeBiaDz'
+        data-modal-account='1900410236'
+        data-modal-player='O3FkeBiaDz'
         data-embed='default'
-        data-video-id='4892122320001'
+        data-modal-video-id='4892122320001'
+        data-video-modal
         controls
         data-media-title
         data-media-duration

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-gallery.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-gallery.twig
@@ -6,10 +6,11 @@
   {% set modal_content %}
     {% set video %}
       <video-js
-        data-account='1900410236'
-        data-player='O3FkeBiaDz'
+        data-modal-account='1900410236'
+        data-modal-player='O3FkeBiaDz'
+        data-modal-video-id='4892122320001'
+        data-video-modal
         data-embed='default'
-        data-video-id='4892122320001'
         controls
         data-media-title
         data-media-duration

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-homepage.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-homepage.twig
@@ -3,10 +3,11 @@
 {% set modal_content %}
   {% set video %}
     <video-js
-      data-account='1900410236'
-      data-player='O3FkeBiaDz'
+      data-modal-account='1900410236'
+      data-modal-player='O3FkeBiaDz'
       data-embed='default'
-      data-video-id='4892122320001'
+      data-modal-video-id='4892122320001'
+      data-video-modal
       controls
       data-media-title
       data-media-duration

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-customers.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-customers.twig
@@ -6,10 +6,11 @@
   {% set modal_content %}
     {% set video %}
       <video-js
-        data-account='1900410236'
-        data-player='O3FkeBiaDz'
+        data-modal-account='1900410236'
+        data-modal-player='O3FkeBiaDz'
         data-embed='default'
-        data-video-id='4892122320001'
+        data-modal-video-id='4892122320001'
+        data-video-modal
         controls
         data-media-title
         data-media-duration

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-pegaworld.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-pegaworld.twig
@@ -6,10 +6,11 @@
   {% set modal_content %}
     {% set video %}
       <video-js
-        data-account='1900410236'
-        data-player='O3FkeBiaDz'
+        data-modal-account='1900410236'
+        data-modal-player='O3FkeBiaDz'
         data-embed='default'
-        data-video-id='4892122320001'
+        data-modal-video-id='4892122320001'
+        data-video-modal
         controls
         data-media-title
         data-media-duration

--- a/docs-site/src/pages/pattern-lab/_patterns/60-experiments/editor/20-editor-modal.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/60-experiments/editor/20-editor-modal.twig
@@ -23,10 +23,11 @@
 {% set video_content %}
   {% set video %}
     <video-js
-      data-account="1900410236"
-      data-player="O3FkeBiaDz"
+      data-modal-account="1900410236"
+      data-modal-player="O3FkeBiaDz"
       data-embed="default"
-      data-video-id="3861325118001"
+      data-modal-video-id="3861325118001"
+      data-video-modal
       controls
       class="c-base-video"></video-js>
   {% endset %}

--- a/packages/website-ui/styleguidekit-twig-default/views/partials/general-footer.twig
+++ b/packages/website-ui/styleguidekit-twig-default/views/partials/general-footer.twig
@@ -28,10 +28,10 @@
       }
     })
   }
-  
-  players.forEach(function(player) {
-    var thisPlayer = videojs.getPlayer(player.id);
+
+  var videoInit = (thisPlayer) => {
     thisPlayer.on('error', function(err) {
+      this.errorReporting(this, err, this.ga().sendbeacon);
       // OPTIONS
       // data-custom-error-message (optional) [string]: Pass in a acustom message to be displayed on errors
       this.customError(this.getAttribute('data-custom-error-message'))
@@ -104,7 +104,50 @@
       if (this.el_.hasAttribute('data-autoplay-on-viewport') ? true : false) {
         this.autoplayOnViewport();
       }
-      // this.chaptering();
     })
+    thisPlayer.on('firstplay', function(player){
+      // NOTE: Safari does not immediately load the closed captioning menu on load, need to first wait until 'firstplay' event + 1/2 second wait time to avoid race conditions
+      window.setTimeout(function(){
+        this.closeCaptioning();
+      }.bind(this), 500);
+    })
+  };
+
+  players.forEach(function(player) {
+    // [data-video-modal] prevents the video from being loaded on page load
+    if(!player.hasAttribute('data-video-modal')){
+      // Initialize the Brigthcove video functionality
+      videoInit(videojs.getPlayer(player.id))
+    } else {
+      // Find all videos that have the 'data-video-modal' data attribute
+      const videoModals = document.querySelectorAll('[data-video-modal]');
+      videoModals.forEach(video => {
+        let myPlayer;
+        // Find the closest bolt-modal for each of the modal videos
+        const modal = video.closest('bolt-modal');
+        if(modal){
+          // Target the modal's 'modal:show' event (as defined in "packages/components/bolt-modal/src/modal.js")
+          modal.addEventListener('modal:show', (e) => {
+            if(!video.classList.contains('vjs-player-info')){
+              // Using the temporary data attribute ("data-modal..." attributes), create the Brightcove atttributes required for init
+              video.setAttribute('data-account', video.dataset.modalAccount);
+              video.setAttribute('data-player', video.dataset.modalPlayer);
+              video.setAttribute('data-video-id', video.dataset.modalVideoId);
+              // Initialize the Brightcove video
+              myPlayer = bc(video);
+              // Pass in the initialized video into the Pega custom videoInit function 
+              videoInit(myPlayer); 
+            }
+            // Play the video automatically
+            myPlayer.play();
+          });
+          // Target the modal's 'modal:hide' event (as defined in "packages/components/bolt-modal/src/modal.js")
+          modal.addEventListener('modal:hide', (e) => {
+            // Pause the video automatically
+            myPlayer.pause();
+          });
+        }
+      });
+    }
   });
 </script>


### PR DESCRIPTION
## Summary

Reworked the modal video behavior to have the videos load when a modal is opened

## Details

- Created a conditional that will load a video immediately if it does not have a 'data-video-modal' attribute on the video (so inline videos will immediately initialize)
- Created a function to handle all the Pega specific initialization (initialize plugins...)
- Added functionality that will initialize and autoplay the video when the "modal:show" event fires
- Added functionality that will pause the video on the "modal:hide" event

## How to test

- Pull down the branch
- Make sure the video are being initialized on the AFTER modal open on "/pattern-lab/?p=pages-boc-gallery-phase2" (Observe that you see the video ID listed in the Network/XHR panel after the modal is opened)
- Do a cursory check on other video modal pages

