### PR TITLE
DS-426 Fix Tabs overflow menu bug

### DIFF
--- a/packages/components/bolt-tabs/src/tabs.js
+++ b/packages/components/bolt-tabs/src/tabs.js
@@ -404,7 +404,14 @@ class BoltTabs extends withContext(BoltElement) {
     this.priorityDropdown = this.renderRoot.querySelector(
       '.c-bolt-tabs__dropdown',
     );
-    customElements.whenDefined('bolt-trigger').then(() => {
+    customElements.whenDefined('bolt-trigger').then(async () => {
+      const tabLabels = this.renderRoot.querySelectorAll('.c-bolt-tabs__label');
+
+      // Tab Labels are bolt-trigger elements. Wait for them to be ready or _resizeMenu() will miscalculate widths.
+      await Promise.all(
+        [...tabLabels].map(async el => await el.updateComplete),
+      );
+
       this._resizeMenu();
     });
 


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-426

## Summary

Fix the a bug where the Tabs overflow menu does not display on load.

## Details

On initial page load the Tabs overflow menu should display if Tab Labels overflow the container. It appears this broke around `v2.30.0`, probably when we upgraded the Bolt Trigger renderer.

On load, the JS that calculates the width of each Tab Label was returning `0` because the Tab Labels, which are web components, were not yet ready. I added a `Promise` that waits for the Tab Labels to finish rendering before proceeding to the overflow menu step.

## How to test

- To reproduce the bug, go to [current Tabs demo](https://boltdesignsystem.com/pattern-lab/patterns/40-components-tabs-05-tabs/40-components-tabs-05-tabs.html).
- Shrink the browser width until the overflow menu kicks in. Then, reload the page.
- You should see that the Tab Labels overflow the container and there is no overflow menu. If you resize, it fixes itself.
- Repeat on [the feature branch](https://bugfix-ds-426-tabs-overflow-menu.boltdesignsystem.com/pattern-lab/patterns/40-components-tabs-05-tabs/40-components-tabs-05-tabs.html) and you will see the overflow menu on load, as expected.