### PR TITLE
Release 3.6.0

### DIFF
--- a/auto-release.js
+++ b/auto-release.js
@@ -39,7 +39,10 @@ async function init() {
   if (isFullRelease) {
     const version =
       (await shell
-        .exec(`auto version --from v${currentVersion}`, { silent: true })
+        .exec(`auto version --from v${currentVersion}`, {
+          silent: true,
+          maxBuffer: 1024 * 500,
+        })
         .stdout.trim()) || 'minor';
 
     try {


### PR DESCRIPTION
## Summary

Attempt to fix auto-deploy script and cut next minor release.

## Details

The last release failed. I believe this command, run by `auto`, exceeds the max buffer length:
`git log -n 9007199254740991 --pretty="@begin@\t%H\t%an\t%ae\t%B@end@" v3.5.4..HEAD --name-status`

See https://travis-ci.com/github/boltdesignsystem/bolt/jobs/503811542#L738

There were an unusually high number of commits and changed files in this release and it's possible we hit an upper limit for the first time.

This PR increases `maxBuffer` [option](https://github.com/shelljs/shelljs#execcommand--options--callback) when we run the `auto` command.

## How to test
Merge and watch Travis 🍿