### PR TITLE
Hotfix v3.6.1

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/accordion/40-accordion-content-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/accordion/40-accordion-content-variations.twig
@@ -150,19 +150,27 @@
     sources: [
       {
         name: "facebook",
-        url: "https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse"
+        attributes: {
+          href: "https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse"
+        }
       },
       {
         name: "twitter",
-        url: "https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!"
+        attributes: {
+          href: "https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!"
+        }
       },
       {
         name: "linkedin",
-        url: "https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+        attributes: {
+          href: "https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+        }
       },
       {
         name: "email",
-        url: "mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+        attributes: {
+          href: "mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+        }
       }
     ],
     copy_to_clipboard: {

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/band/30-band-with-pinned-content.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/band/30-band-with-pinned-content.twig
@@ -49,19 +49,27 @@
     sources: [
       {
         name: "facebook",
-        url: "https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse"
+        attributes: {
+          href: "https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse"
+        }
       },
       {
         name: "twitter",
-        url: "https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!"
+        attributes: {
+          href: "https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!"
+        }
       },
       {
         name: "linkedin",
-        url: "https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+        attributes: {
+          href: "https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+        }
       },
       {
         name: "email",
-        url: "mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+        attributes: {
+          href: "mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+        }
       }
     ],
     copy_to_clipboard: {

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/listing-teaser/20-listing-teaser-status-and-action.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/listing-teaser/20-listing-teaser-status-and-action.twig
@@ -60,19 +60,27 @@
       sources: [
         {
           name: 'facebook',
-          url: 'https://www.facebook.com/sharer/sharer.php?u=https://pega.com&amp;src=sdkpreparse'
+          attributes: {
+            href: 'https://www.facebook.com/sharer/sharer.php?u=https://pega.com&amp;src=sdkpreparse'
+          }
         },
         {
           name: 'twitter',
-          url: 'https://twitter.com/intent/tweet?url=https://pega.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!'
+          attributes: {
+            href: 'https://twitter.com/intent/tweet?url=https://pega.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!'
+          }
         },
         {
           name: 'linkedin',
-          url: 'https://www.linkedin.com/shareArticle?url=https://pega.com'
+          attributes: {
+            href: 'https://www.linkedin.com/shareArticle?url=https://pega.com'
+          }
         },
         {
           name: 'email',
-          url: 'mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com'
+          attributes: {
+            href: 'mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com'
+          }
         }
       ],
       copy_to_clipboard: {
@@ -137,19 +145,27 @@
     sources: [
       {
         name: 'facebook',
-        url: 'https://www.facebook.com/sharer/sharer.php?u=https://pega.com&amp;src=sdkpreparse'
+        attributes: {
+          href: 'https://www.facebook.com/sharer/sharer.php?u=https://pega.com&amp;src=sdkpreparse'
+        }
       },
       {
         name: 'twitter',
-        url: 'https://twitter.com/intent/tweet?url=https://pega.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!'
+        attributes: {
+          href: 'https://twitter.com/intent/tweet?url=https://pega.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!'
+        }
       },
       {
         name: 'linkedin',
-        url: 'https://www.linkedin.com/shareArticle?url=https://pega.com'
+        attributes: {
+          href: 'https://www.linkedin.com/shareArticle?url=https://pega.com'
+        }
       },
       {
         name: 'email',
-        url: 'mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com'
+        attributes: {
+          href: 'mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com'
+        }
       }
     ],
     copy_to_clipboard: {

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/listing-teaser/60-listing-teaser-use-case-article-list.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/listing-teaser/60-listing-teaser-use-case-article-list.twig
@@ -23,19 +23,27 @@
       sources: [
         {
           name: 'facebook',
-          url: 'https://www.facebook.com/sharer/sharer.php?u=https://pega.com&amp;src=sdkpreparse'
+          attributes: {
+            href: 'https://www.facebook.com/sharer/sharer.php?u=https://pega.com&amp;src=sdkpreparse'
+          }
         },
         {
           name: 'twitter',
-          url: 'https://twitter.com/intent/tweet?url=https://pega.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!'
+          attributes: {
+            href: 'https://twitter.com/intent/tweet?url=https://pega.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!'
+          }
         },
         {
           name: 'linkedin',
-          url: 'https://www.linkedin.com/shareArticle?url=https://pega.com'
+          attributes: {
+            href: 'https://www.linkedin.com/shareArticle?url=https://pega.com'
+          }
         },
         {
           name: 'email',
-          url: 'mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com'
+          attributes: {
+            href: 'mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com'
+          }
         }
       ],
       copy_to_clipboard: {
@@ -147,19 +155,27 @@
     sources: [
       {
         name: 'facebook',
-        url: 'https://www.facebook.com/sharer/sharer.php?u=https://pega.com&amp;src=sdkpreparse'
+        attributes: {
+          href: 'https://www.facebook.com/sharer/sharer.php?u=https://pega.com&amp;src=sdkpreparse'
+        }
       },
       {
         name: 'twitter',
-        url: 'https://twitter.com/intent/tweet?url=https://pega.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!'
+        attributes: {
+          href: 'https://twitter.com/intent/tweet?url=https://pega.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!'
+        }
       },
       {
         name: 'linkedin',
-        url: 'https://www.linkedin.com/shareArticle?url=https://pega.com'
+        attributes: {
+          href: 'https://www.linkedin.com/shareArticle?url=https://pega.com'
+        }
       },
       {
         name: 'email',
-        url: 'mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com'
+        attributes: {
+          href: 'mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com'
+        }
       }
     ],
     copy_to_clipboard: {

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/listing-teaser/65-listing-teaser-use-case-search-result-list.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/listing-teaser/65-listing-teaser-use-case-search-result-list.twig
@@ -24,19 +24,27 @@
       sources: [
         {
           name: 'facebook',
-          url: 'https://www.facebook.com/sharer/sharer.php?u=https://pega.com&amp;src=sdkpreparse'
+          attributes: {
+            href: 'https://www.facebook.com/sharer/sharer.php?u=https://pega.com&amp;src=sdkpreparse'
+          }
         },
         {
           name: 'twitter',
-          url: 'https://twitter.com/intent/tweet?url=https://pega.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!'
+          attributes: {
+            href: 'https://twitter.com/intent/tweet?url=https://pega.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!'
+          }
         },
         {
           name: 'linkedin',
-          url: 'https://www.linkedin.com/shareArticle?url=https://pega.com'
+          attributes: {
+            href: 'https://www.linkedin.com/shareArticle?url=https://pega.com'
+          }
         },
         {
           name: 'email',
-          url: 'mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com'
+          attributes: {
+            href: 'mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com'
+          }
         }
       ],
       copy_to_clipboard: {

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/share/00-share-docs.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/share/00-share-docs.twig
@@ -3,19 +3,27 @@
   sources: [
     {
       name: 'facebook',
-      url: 'https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse'
+      attributes: {
+        href: 'https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse'
+      }
     },
     {
       name: 'twitter',
-      url: 'https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!'
+      attributes: {
+        href: 'https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!'
+      }
     },
     {
       name: 'linkedin',
-      url: 'https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com'
+      attributes: {
+        href: 'https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com'
+      }
     },
     {
       name: 'email',
-      url: 'mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com'
+      attributes: {
+        href: 'mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com'
+      }
     }
   ],
   copy_to_clipboard: {

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/share/05-share.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/share/05-share.twig
@@ -18,19 +18,27 @@
   sources: [
     {
       name: 'facebook',
-      url: 'https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse'
+      attributes: {
+        href: 'https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse'
+      }
     },
     {
       name: 'twitter',
-      url: 'https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!'
+      attributes: {
+        href:  'https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!'
+      }
     },
     {
       name: 'linkedin',
-      url: 'https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com'
+      attributes: {
+        href: 'https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com'
+      }
     },
     {
       name: 'email',
-      url: 'mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com'
+      attributes: {
+        href: 'mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com'
+      }
     }
   ],
   copy_to_clipboard: {

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/share/_share-variables.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/share/_share-variables.twig
@@ -2,19 +2,27 @@
   [
     {
       name: 'facebook',
-      url: 'https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse'
+      attributes: {
+        href: 'https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse'
+      }
     },
     {
       name: 'twitter',
-      url: 'https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!'
+      attributes: {
+        href:  'https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!'
+      }
     },
     {
       name: 'linkedin',
-      url: 'https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com'
+      attributes: {
+        href: 'https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com'
+      }
     },
     {
       name: 'email',
-      url: 'mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com'
+      attributes: {
+        href: 'mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com'
+      }
     }
   ]
 %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/30-teaser-status-and-actions.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/30-teaser-status-and-actions.twig
@@ -42,19 +42,27 @@
         sources: [
           {
             name: 'facebook',
-            url: 'https://www.facebook.com/sharer/sharer.php?u=https://pega.com&amp;src=sdkpreparse'
+            attributes: {
+              href: 'https://www.facebook.com/sharer/sharer.php?u=https://pega.com&amp;src=sdkpreparse'
+            }
           },
           {
             name: 'twitter',
-            url: 'https://twitter.com/intent/tweet?url=https://pega.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!'
+            attributes: {
+              href: 'https://twitter.com/intent/tweet?url=https://pega.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!'
+            }
           },
           {
             name: 'linkedin',
-            url: 'https://www.linkedin.com/shareArticle?url=https://pega.com'
+            attributes: {
+              href: 'https://www.linkedin.com/shareArticle?url=https://pega.com'
+            }
           },
           {
             name: 'email',
-            url: 'mailto:?&body=Sample%20Text%20--%20https%3A//pega.com'
+            attributes: {
+              href: 'mailto:?&body=Sample%20Text%20--%20https%3A//pega.com'
+            }
           }
         ],
         copy_to_clipboard: {

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/20-d8-press-and-media/00-d8-news-landing.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/20-d8-press-and-media/00-d8-news-landing.twig
@@ -80,19 +80,27 @@
       sources: [
         {
           name: "facebook",
-          url: "https://www.facebook.com/sharer/sharer.php?u=https://5abd3062df99537b79e29496--bolt-design-system.netlify.com/pattern-lab/patterns/40-components-action-blocks-05-action-blocks/40-components-action-blocks-05-action-blocks.html&amp;src=sdkpreparse"
+          attributes: {
+            href: "https://www.facebook.com/sharer/sharer.php?u=https://5abd3062df99537b79e29496--bolt-design-system.netlify.com/pattern-lab/patterns/40-components-action-blocks-05-action-blocks/40-components-action-blocks-05-action-blocks.html&amp;src=sdkpreparse"
+          }
         },
         {
           name: "twitter",
-          url: "https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!"
+          attributes: {
+            href: "https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!"
+          }
         },
         {
           name: "linkedin",
-          url: "https://www.linkedin.com/shareArticle?url=https://5abd3062df99537b79e29496--bolt-design-system.netlify.com/pattern-lab/patterns/40-components-action-blocks-05-action-blocks/40-components-action-blocks-05-action-blocks.html"
+          attributes: {
+            href: "https://www.linkedin.com/shareArticle?url=https://5abd3062df99537b79e29496--bolt-design-system.netlify.com/pattern-lab/patterns/40-components-action-blocks-05-action-blocks/40-components-action-blocks-05-action-blocks.html"
+          }
         },
         {
           name: "email",
-          url: "mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+          attributes: {
+            href: "mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+          }
         }
       ]
     } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/20-d8-press-and-media/05-d8-browse-page.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/20-d8-press-and-media/05-d8-browse-page.twig
@@ -154,19 +154,27 @@
       sources: [
         {
           name: "facebook",
-          url: "https://www.facebook.com/sharer/sharer.php?u=https://5abd3062df99537b79e29496--bolt-design-system.netlify.com/pattern-lab/patterns/40-components-action-blocks-05-action-blocks/40-components-action-blocks-05-action-blocks.html&amp;src=sdkpreparse"
+          attributes: {
+            href: "https://www.facebook.com/sharer/sharer.php?u=https://5abd3062df99537b79e29496--bolt-design-system.netlify.com/pattern-lab/patterns/40-components-action-blocks-05-action-blocks/40-components-action-blocks-05-action-blocks.html&amp;src=sdkpreparse"
+          }
         },
         {
           name: "twitter",
-          url: "https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!"
+          attributes: {
+            href: "https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!"
+          }
         },
         {
           name: "linkedin",
-          url: "https://www.linkedin.com/shareArticle?url=https://5abd3062df99537b79e29496--bolt-design-system.netlify.com/pattern-lab/patterns/40-components-action-blocks-05-action-blocks/40-components-action-blocks-05-action-blocks.html"
+          attributes: {
+            href: "https://www.linkedin.com/shareArticle?url=https://5abd3062df99537b79e29496--bolt-design-system.netlify.com/pattern-lab/patterns/40-components-action-blocks-05-action-blocks/40-components-action-blocks-05-action-blocks.html"
+          }
         },
         {
           name: "email",
-          url: "mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+          attributes: {
+            href: "mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+          }
         }
       ]
     } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/20-d8-press-and-media/20-d8-details-page-press.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/20-d8-press-and-media/20-d8-details-page-press.twig
@@ -113,19 +113,27 @@
                   sources: [
                     {
                       name: "facebook",
-                      url: "https://www.facebook.com/sharer/sharer.php?u={url}&src=sdkpreparse"
+                      attributes: {
+                        href: "https://www.facebook.com/sharer/sharer.php?u={url}&src=sdkpreparse"
+                      }
                     },
                     {
                       name: "twitter",
-                      url: "https://twitter.com/intent/tweet?url={url}&text={title}&via={via}&hashtags={hashtags}"
+                      attributes: {
+                        href: "https://twitter.com/intent/tweet?url={url}&text={title}&via={via}&hashtags={hashtags}"
+                      }
                     },
                     {
                       name: "linkedin",
-                      url: "https://www.linkedin.com/shareArticle?url={url}&title={title}"
+                      attributes: {
+                        href: "https://www.linkedin.com/shareArticle?url={url}&title={title}"
+                      }
                     },
                     {
                       name: "email",
-                      url: "mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+                      attributes: {
+                        href: "mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+                      }
                     }
                   ]
                 } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/40-d8-content-hub/00-sticky-navbar.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/40-d8-content-hub/00-sticky-navbar.twig
@@ -490,19 +490,27 @@
       sources: [
         {
           name: "facebook",
-          url: "https://www.facebook.com/sharer/sharer.php?u={url}&src=sdkpreparse"
+          attributes: {
+            href: "https://www.facebook.com/sharer/sharer.php?u={url}&src=sdkpreparse"
+          }
         },
         {
           name: "twitter",
-          url: "https://twitter.com/intent/tweet?url={url}&text={title}&via={via}&hashtags={hashtags}"
+          attributes: {
+            href: "https://twitter.com/intent/tweet?url={url}&text={title}&via={via}&hashtags={hashtags}"
+          }
         },
         {
           name: "linkedin",
-          url: "https://www.linkedin.com/shareArticle?url={url}&title={title}"
+          attributes: {
+            href: "https://www.linkedin.com/shareArticle?url={url}&title={title}"
+          }
         },
         {
           name: "email",
-          url: "mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+          attributes: {
+            href: "mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+          }
         }
       ]
     } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/45-d8-blog/05-blog-post.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/45-d8-blog/05-blog-post.twig
@@ -64,19 +64,27 @@
               sources: [
                 {
                   name: "facebook",
-                  url: "https://www.facebook.com/sharer/sharer.php?u=https://5abd3062df99537b79e29496--bolt-design-system.netlify.com/pattern-lab/patterns/40-components-action-blocks-05-action-blocks/40-components-action-blocks-05-action-blocks.html&amp;src=sdkpreparse"
+                  attributes: {
+                    href: "https://www.facebook.com/sharer/sharer.php?u=https://5abd3062df99537b79e29496--bolt-design-system.netlify.com/pattern-lab/patterns/40-components-action-blocks-05-action-blocks/40-components-action-blocks-05-action-blocks.html&amp;src=sdkpreparse"
+                  }
                 },
                 {
                   name: "twitter",
-                  url: "https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!"
+                  attributes: {
+                    href: "https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!"
+                  }
                 },
                 {
                   name: "linkedin",
-                  url: "https://www.linkedin.com/shareArticle?url=https://5abd3062df99537b79e29496--bolt-design-system.netlify.com/pattern-lab/patterns/40-components-action-blocks-05-action-blocks/40-components-action-blocks-05-action-blocks.html"
+                  attributes: {
+                    href: "https://www.linkedin.com/shareArticle?url=https://5abd3062df99537b79e29496--bolt-design-system.netlify.com/pattern-lab/patterns/40-components-action-blocks-05-action-blocks/40-components-action-blocks-05-action-blocks.html"
+                  }
                 },
                 {
                   name: "email",
-                  url: "mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+                  attributes: {
+                    href: "mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+                  }
                 }
               ],
               copy_to_clipboard: {
@@ -167,19 +175,27 @@
       sources: [
         {
           name: "facebook",
-          url: "https://www.facebook.com/sharer/sharer.php?u=https://5abd3062df99537b79e29496--bolt-design-system.netlify.com/pattern-lab/patterns/40-components-action-blocks-05-action-blocks/40-components-action-blocks-05-action-blocks.html&amp;src=sdkpreparse"
+          attributes: {
+            href: "https://www.facebook.com/sharer/sharer.php?u=https://5abd3062df99537b79e29496--bolt-design-system.netlify.com/pattern-lab/patterns/40-components-action-blocks-05-action-blocks/40-components-action-blocks-05-action-blocks.html&amp;src=sdkpreparse"
+          }
         },
         {
           name: "twitter",
-          url: "https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!"
+          attributes: {
+            href: "https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!"
+          }
         },
         {
           name: "linkedin",
-          url: "https://www.linkedin.com/shareArticle?url=https://5abd3062df99537b79e29496--bolt-design-system.netlify.com/pattern-lab/patterns/40-components-action-blocks-05-action-blocks/40-components-action-blocks-05-action-blocks.html"
+          attributes: {
+            href: "https://www.linkedin.com/shareArticle?url=https://5abd3062df99537b79e29496--bolt-design-system.netlify.com/pattern-lab/patterns/40-components-action-blocks-05-action-blocks/40-components-action-blocks-05-action-blocks.html"
+          }
         },
         {
           name: "email",
-          url: "mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+          attributes: {
+            href: "mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+          }
         }
       ],
       copy_to_clipboard: {

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-gallery.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-gallery.twig
@@ -58,19 +58,27 @@
         sources: [
           {
             name: 'facebook',
-            url: 'https://www.facebook.com/sharer/sharer.php?u=https://pega.com&amp;src=sdkpreparse'
+            attributes: {
+              href: 'https://www.facebook.com/sharer/sharer.php?u=https://pega.com&amp;src=sdkpreparse'
+            }
           },
           {
             name: 'twitter',
-            url: 'https://twitter.com/intent/tweet?url=https://pega.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!'
+            attributes: {
+              href: 'https://twitter.com/intent/tweet?url=https://pega.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!'
+            }
           },
           {
             name: 'linkedin',
-            url: 'https://www.linkedin.com/shareArticle?url=https://pega.com'
+            attributes: {
+              href: 'https://www.linkedin.com/shareArticle?url=https://pega.com'
+            }
           },
           {
             name: 'email',
-            url: 'mailto:?&body=Sample%20Text%20--%20https%3A//pega.com'
+            attributes: {
+              href: 'mailto:?&body=Sample%20Text%20--%20https%3A//pega.com'
+            }
           }
         ],
         copy_to_clipboard: {

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-homepage.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-homepage.twig
@@ -55,19 +55,27 @@
       sources: [
         {
           name: 'facebook',
-          url: 'https://www.facebook.com/sharer/sharer.php?u=https://pega.com&amp;src=sdkpreparse'
+          attributes: {
+            href: 'https://www.facebook.com/sharer/sharer.php?u=https://pega.com&amp;src=sdkpreparse'
+          }
         },
         {
           name: 'twitter',
-          url: 'https://twitter.com/intent/tweet?url=https://pega.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!'
+          attributes: {
+            href: 'https://twitter.com/intent/tweet?url=https://pega.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!'
+          }
         },
         {
           name: 'linkedin',
-          url: 'https://www.linkedin.com/shareArticle?url=https://pega.com'
+          attributes: {
+            href: 'https://www.linkedin.com/shareArticle?url=https://pega.com'
+          }
         },
         {
           name: 'email',
-          url: 'mailto:?&body=Sample%20Text%20--%20https%3A//pega.com'
+          attributes: {
+            href: 'mailto:?&body=Sample%20Text%20--%20https%3A//pega.com'
+          }
         }
       ],
       copy_to_clipboard: {

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-customers.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-customers.twig
@@ -58,19 +58,27 @@
         sources: [
           {
             name: 'facebook',
-            url: 'https://www.facebook.com/sharer/sharer.php?u=https://pega.com&amp;src=sdkpreparse'
+            attributes: {
+              href: 'https://www.facebook.com/sharer/sharer.php?u=https://pega.com&amp;src=sdkpreparse'
+            }
           },
           {
             name: 'twitter',
-            url: 'https://twitter.com/intent/tweet?url=https://pega.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!'
+            attributes: {
+              href: 'https://twitter.com/intent/tweet?url=https://pega.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!'
+            }
           },
           {
             name: 'linkedin',
-            url: 'https://www.linkedin.com/shareArticle?url=https://pega.com'
+            attributes: {
+              href: 'https://www.linkedin.com/shareArticle?url=https://pega.com'
+            }
           },
           {
             name: 'email',
-            url: 'mailto:?&body=Sample%20Text%20--%20https%3A//pega.com'
+            attributes: {
+              href: 'mailto:?&body=Sample%20Text%20--%20https%3A//pega.com'
+            }
           }
         ],
         copy_to_clipboard: {

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-pegaworld.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-pegaworld.twig
@@ -58,19 +58,27 @@
         sources: [
           {
             name: 'facebook',
-            url: 'https://www.facebook.com/sharer/sharer.php?u=https://pega.com&amp;src=sdkpreparse'
+            attributes: {
+              href: 'https://www.facebook.com/sharer/sharer.php?u=https://pega.com&amp;src=sdkpreparse'
+            }
           },
           {
             name: 'twitter',
-            url: 'https://twitter.com/intent/tweet?url=https://pega.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!'
+            attributes: {
+              href: 'https://twitter.com/intent/tweet?url=https://pega.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!'
+            }
           },
           {
             name: 'linkedin',
-            url: 'https://www.linkedin.com/shareArticle?url=https://pega.com'
+            attributes: {
+              href: 'https://www.linkedin.com/shareArticle?url=https://pega.com'
+            }
           },
           {
             name: 'email',
-            url: 'mailto:?&body=Sample%20Text%20--%20https%3A//pega.com'
+            attributes: {
+              href: 'mailto:?&body=Sample%20Text%20--%20https%3A//pega.com'
+            }
           }
         ],
         copy_to_clipboard: {

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/99999-bolt-dev-sandbox/_wip-doc-layout.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/99999-bolt-dev-sandbox/_wip-doc-layout.twig
@@ -505,19 +505,27 @@
           sources: [
             {
               name: 'facebook',
-              url: 'https://www.facebook.com/sharer/sharer.php?u=https://pega.com&amp;src=sdkpreparse'
+              attributes: {
+                href: 'https://www.facebook.com/sharer/sharer.php?u=https://pega.com&amp;src=sdkpreparse'
+              }
             },
             {
               name: 'twitter',
-              url: 'https://twitter.com/intent/tweet?url=https://pega.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!'
+              attributes: {
+                href: 'https://twitter.com/intent/tweet?url=https://pega.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!'
+              }
             },
             {
               name: 'linkedin',
-              url: 'https://www.linkedin.com/shareArticle?url=https://pega.com'
+              attributes: {
+                href: 'https://www.linkedin.com/shareArticle?url=https://pega.com'
+              }
             },
             {
               name: 'email',
-              url: 'mailto:?&body=Sample%20Text%20--%20https%3A//pega.com'
+              attributes: {
+                href: 'mailto:?&body=Sample%20Text%20--%20https%3A//pega.com'
+              }
             }
           ],
           copy_to_clipboard: {

--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/accordion/00-accordion-no-shadow.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/accordion/00-accordion-no-shadow.twig
@@ -152,19 +152,27 @@
     sources: [
       {
         name: "facebook",
-        url: "https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse"
+        attributes: {
+          href: "https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse"
+        }
       },
       {
         name: "twitter",
-        url: "https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!"
+        attributes: {
+          href: "https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!"
+        }
       },
       {
         name: "linkedin",
-        url: "https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+        attributes: {
+          href: "https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+        }
       },
       {
         name: "email",
-        url: "mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+        attributes: {
+          href: "mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+        }
       }
     ],
     copy_to_clipboard: {

--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/share/05-share.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/share/05-share.twig
@@ -1,0 +1,45 @@
+{# Test passing attributes with share sources, test url still works #}
+{% set demo_sources = [
+  {
+    name: 'facebook',
+    attributes: {
+      href: 'https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse',
+      class: 'test-class',
+      'test-attribute': 'Attribute for testing purposes'
+    }
+  },
+  {
+    name: 'twitter',
+    url: 'https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!'
+  },
+  {
+    name: 'linkedin',
+    attributes: {
+      href: 'https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com'
+    }
+  },
+  {
+    name: 'email',
+    attributes: {
+      href: 'mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com'
+    }
+  }
+] %}
+
+{% set demo_copy_to_clipboard =
+  {
+    text_to_copy: 'https://boltdesignsystem.com'
+  }
+%}
+
+{% include '@bolt-components-share/share.twig' with {
+  sources: demo_sources,
+  copy_to_clipboard: demo_copy_to_clipboard,
+} only %}
+
+{# Note: passing classes do not currently work in "menu" display #}
+{% include '@bolt-components-share/share.twig' with {
+  sources: demo_sources,
+  copy_to_clipboard: demo_copy_to_clipboard,
+  display: 'menu',
+} only %}

--- a/packages/components/bolt-menu/menu.schema.js
+++ b/packages/components/bolt-menu/menu.schema.js
@@ -29,6 +29,11 @@ module.exports = {
           'A Drupal attributes object. Applies extra HTML attributes to the outer &lt;bolt-menu&gt; tag.',
         properties: {
           ...modifiedTriggerProps,
+          attributes: {
+            type: 'object',
+            description:
+              'A Drupal-style attributes object with extra attributes to append to this component.',
+          },
           icon_before: {
             type: 'object',
             description:

--- a/packages/components/bolt-share/__tests__/__snapshots__/share.js.snap
+++ b/packages/components/bolt-share/__tests__/__snapshots__/share.js.snap
@@ -1,6 +1,548 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<bolt-share> Component basic usage 1`] = `
+exports[`Bolt Share Props align items: center 1`] = `
+<bolt-share size="medium"
+            opacity="100"
+            align="center"
+            display="inline"
+>
+  <div class="c-bolt-share c-bolt-share--opacity-100">
+    <bolt-list tag="ul"
+               display="inline"
+               spacing="small"
+               separator="none"
+               align="center"
+               valign="center"
+    >
+      <ssr-keep for="bolt-list"
+                role="list"
+                class="c-bolt-list c-bolt-list--display-inline c-bolt-list--spacing-small c-bolt-list--align-center c-bolt-list--valign-center"
+      >
+        <bolt-list-item role="presentation">
+          <ssr-keep for="bolt-list-item"
+                    role="listitem"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-center"
+          >
+            <span class="c-bolt-share__label c-bolt-share__label--medium">
+              Share this page
+            </span>
+          </ssr-keep>
+        </bolt-list-item>
+        <bolt-list-item role="presentation">
+          <ssr-keep for="bolt-list-item"
+                    role="listitem"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-center"
+          >
+            <a href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
+               class="c-bolt-share__link js-bolt-share__link--facebook"
+               target="_blank"
+            >
+              <bolt-icon name="facebook-solid"
+                         size="medium"
+                         aria-hidden="true"
+              >
+                <span class="c-bolt-icon c-bolt-icon--facebook-solid c-bolt-icon--medium">
+                  <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                       xmlns="http://www.w3.org/2000/svg"
+                       data-name="Layer 1"
+                       viewbox="0 0 32 32"
+                  >
+                    <path fill="var(--bolt-theme-icon, currentColor)"
+                          d="M26 0a6 6 0 016 6v20a6 6 0 01-6 6h-4V19.6h4.2l.6-4.8h-4.7v-3.1c0-1.4.4-2.3 2.4-2.3H27V5a33.8 33.8 0 00-3.7-.2c-3.7 0-6.2 2.3-6.2 6.4v3.6h-4.2v4.8h4.2V32H6a6 6 0 01-6-6V6a6 6 0 016-6z"
+                    >
+                    </path>
+                  </svg>
+                </span>
+              </bolt-icon>
+              <span class="c-bolt-share__link-text">
+                Share via Facebook
+              </span>
+            </a>
+          </ssr-keep>
+        </bolt-list-item>
+        <bolt-list-item role="presentation">
+          <ssr-keep for="bolt-list-item"
+                    role="listitem"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-center"
+          >
+            <a href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
+               class="c-bolt-share__link js-bolt-share__link--twitter"
+               target="_blank"
+            >
+              <bolt-icon name="twitter"
+                         size="medium"
+                         aria-hidden="true"
+              >
+                <span class="c-bolt-icon c-bolt-icon--twitter c-bolt-icon--medium">
+                  <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                       xmlns="http://www.w3.org/2000/svg"
+                       data-name="Layer 1"
+                       viewbox="0 0 32 26"
+                  >
+                    <path fill="var(--bolt-theme-icon, currentColor)"
+                          d="M32 3a14 14 0 01-3.3 3.5v.8C28.7 16 22.1 26 10.1 26A18.5 18.5 0 010 23a13.8 13.8 0 001.6.1 13.1 13.1 0 008.1-2.8 6.6 6.6 0 01-6.1-4.5 8.5 8.5 0 001.2 0 7 7 0 001.8-.1 6.6 6.6 0 01-5.3-6.5 6.5 6.5 0 003 .8 6.6 6.6 0 01-2-8.8 18.6 18.6 0 0013.5 6.9 7.4 7.4 0 01-.1-1.5A6.6 6.6 0 0122 0 6.5 6.5 0 0127 2 13 13 0 0031.1.6 6.6 6.6 0 0128.2 4a13 13 0 003.8-1z"
+                    >
+                    </path>
+                  </svg>
+                </span>
+              </bolt-icon>
+              <span class="c-bolt-share__link-text">
+                Share via Twitter
+              </span>
+            </a>
+          </ssr-keep>
+        </bolt-list-item>
+        <bolt-list-item role="presentation">
+          <ssr-keep for="bolt-list-item"
+                    role="listitem"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-center"
+          >
+            <a href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+               class="c-bolt-share__link js-bolt-share__link--linkedin"
+               target="_blank"
+            >
+              <bolt-icon name="linkedin"
+                         size="medium"
+                         aria-hidden="true"
+              >
+                <span class="c-bolt-icon c-bolt-icon--linkedin c-bolt-icon--medium">
+                  <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                       xmlns="http://www.w3.org/2000/svg"
+                       data-name="Layer 1"
+                       viewbox="0 0 32 30.6"
+                  >
+                    <path fill="var(--bolt-theme-icon, currentColor)"
+                          d="M7.3 10v20.6H.4V9.9zm.4-6.4A3.6 3.6 0 013.8 7a3.6 3.6 0 110-7.1 3.5 3.5 0 014 3.6zM32 18.8v11.8h-6.9v-11c0-2.8-1-4.7-3.4-4.7a3.8 3.8 0 00-3.6 2.5 5.1 5.1 0 00-.2 1.7v11.5h-6.8V9.9h6.8v3A6.8 6.8 0 0124 9.5c4.5 0 7.9 3 7.9 9.3z"
+                    >
+                    </path>
+                  </svg>
+                </span>
+              </bolt-icon>
+              <span class="c-bolt-share__link-text">
+                Share via LinkedIn
+              </span>
+            </a>
+          </ssr-keep>
+        </bolt-list-item>
+        <bolt-list-item role="presentation">
+          <ssr-keep for="bolt-list-item"
+                    role="listitem"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-center"
+          >
+            <a href="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+               class="c-bolt-share__link js-bolt-share__link--email"
+               target="_blank"
+            >
+              <bolt-icon name="email"
+                         size="medium"
+                         aria-hidden="true"
+              >
+                <span class="c-bolt-icon c-bolt-icon--email c-bolt-icon--medium">
+                  <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                       xmlns="http://www.w3.org/2000/svg"
+                       viewbox="0 0 24 24"
+                  >
+                    <g fill="none"
+                       fill-rule="evenodd"
+                    >
+                      <path>
+                      </path>
+                      <path fill="var(--bolt-theme-icon, currentColor)"
+                            d="M20 19H4a1 1 0 01-1-1V8l8.4 5.8.6.2c.2 0 .4 0 .6-.2L21 8V18c0 .6-.4 1-1 1zM4 5h16c.4 0 .7.2.9.6L12 11.8 3.1 5.6c.2-.4.5-.6.9-.6zm19 1a3 3 0 00-3-3H4a3 3 0 00-3 3v12a3 3 0 003 3h16a3 3 0 003-3V6z"
+                      >
+                      </path>
+                    </g>
+                  </svg>
+                </span>
+              </bolt-icon>
+              <span class="c-bolt-share__link-text">
+                Share via Email
+              </span>
+            </a>
+          </ssr-keep>
+        </bolt-list-item>
+        <bolt-list-item last
+                        role="presentation"
+        >
+          <ssr-keep for="bolt-list-item"
+                    role="listitem"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-center c-bolt-list-item--last-item"
+          >
+            <bolt-copy-to-clipboard>
+              <span class="c-bolt-copy-to-clipboard js-bolt-copy-to-clipboard">
+                <button class="c-bolt-copy-to-clipboard__trigger"
+                        data-clipboard-text="https://boltdesignsystem.com"
+                >
+                  <span class="c-bolt-share__link">
+                    <bolt-icon name="asset-link"
+                               size="medium"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--asset-link c-bolt-icon--medium">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M22.7 3.2l-1.9-2a4 4 0 00-3-1.2c-1.2 0-2.2.4-3 1.2l-2 2c-.3.3-.5.6-.5 1l.4.8c.5.5 1.3.5 1.8 0l2-2c.4-.4.8-.5 1.3-.5s1 .1 1.3.5l2 2c.3.3.5.7.5 1.2s-.2 1-.5 1.3L14.5 14c-.3.4-.8.6-1.4.6-.6 0-1 0-1.3-.4l-.8-.8-.7-.7c-.3-.3-.6-.4-1-.4a1 1 0 00-.7.4c-.3.2-.5.5-.5.8 0 .3.2.6.5 1l1.4 1.4v.3h.4a4 4 0 002.7.8c1 0 1.8-.3 2.5-.8v.1l.4-.3.1-.2 6.7-6.6c.8-.8 1.2-1.8 1.2-3a4 4 0 00-1.3-3M11.3 18.9c.3.3.4.6.4 1 0 .2-.1.5-.4.8l-2 2a4 4 0 01-3 1.3c-1.2 0-2.2-.4-3-1.2l-2-2a4.2 4.2 0 01-1.3-3 4 4 0 011.2-3L8 8a4 4 0 013-1.3A4 4 0 0114 8l1.5 1.5c.3.3.4.6.4.9 0 .3-.1.6-.4.9-.5.4-1.3.4-1.7 0l-1.6-1.6c-.7-.7-1.8-.7-2.5 0L3 16.5c-.3.3-.5.7-.5 1.2s.2 1 .5 1.3L5 21c.7.7 1.8.7 2.5 0l2-2c.2-.2.5-.4 1-.4l.8.3"
+                                  mask="url(#mask-2)"
+                            >
+                            </path>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="c-bolt-share__link-text">
+                      Copy share link
+                    </span>
+                  </span>
+                </button>
+                <span class="c-bolt-copy-to-clipboard__transition">
+                  <span class="c-bolt-share__link">
+                    <bolt-icon class="c-bolt-share__copy-animation"
+                               name="refresh"
+                               size="medium"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--refresh c-bolt-icon--medium">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path>
+                            </path>
+                            <g fill="var(--bolt-theme-icon, currentColor)"
+                               fill-rule="nonzero"
+                            >
+                              <path d="M24 4.5c0-.5-.4-1-1-1a1 1 0 00-1 1v3.7l-3-2.8a10 10 0 00-12.8-1 10 10 0 00-3.6 4.8 1 1 0 001.9.6 8 8 0 0113.2-3l2.8 2.7H17a1 1 0 00-1 1c0 .5.4 1 1 1H23.4l.3-.3.2-.4.1-.2V4.4zM20.8 14.6a1 1 0 00-1.3.6 8 8 0 01-13.1 3l-2.9-2.7H7c.6 0 1-.4 1-1s-.4-1-1-1H1a1 1 0 00-.4 0v.1l-.3.2-.2.3v6.3c0 .6.4 1 1 1 .5 0 1-.4 1-1v-3.6L5 19.6a10 10 0 0016.5-3.7c.1-.5-.2-1-.7-1.3z">
+                              </path>
+                            </g>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="u-bolt-visuallyhidden">
+                      Copying...
+                    </span>
+                  </span>
+                </span>
+                <span class="c-bolt-copy-to-clipboard__confirmation">
+                  <div class="c-bolt-share__link">
+                    <bolt-icon name="check"
+                               size="medium"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--check c-bolt-icon--medium">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path>
+                            </path>
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M19.3 6.3L9 16.6l-4.3-4.3a1 1 0 00-1.4 0 1 1 0 000 1.4l5 5a1 1 0 001.4 0l11-11c.4-.4.4-1 0-1.4a1 1 0 00-1.4 0z"
+                            >
+                            </path>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="c-bolt-share__link-text">
+                      Copied!
+                    </span>
+                  </div>
+                </span>
+              </span>
+            </bolt-copy-to-clipboard>
+          </ssr-keep>
+        </bolt-list-item>
+      </ssr-keep>
+    </bolt-list>
+  </div>
+</bolt-share>
+`;
+
+exports[`Bolt Share Props align items: end 1`] = `
+<bolt-share size="medium"
+            opacity="100"
+            align="end"
+            display="inline"
+>
+  <div class="c-bolt-share c-bolt-share--opacity-100">
+    <bolt-list tag="ul"
+               display="inline"
+               spacing="small"
+               separator="none"
+               align="end"
+               valign="center"
+    >
+      <ssr-keep for="bolt-list"
+                role="list"
+                class="c-bolt-list c-bolt-list--display-inline c-bolt-list--spacing-small c-bolt-list--align-end c-bolt-list--valign-center"
+      >
+        <bolt-list-item role="presentation">
+          <ssr-keep for="bolt-list-item"
+                    role="listitem"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-end"
+          >
+            <span class="c-bolt-share__label c-bolt-share__label--medium">
+              Share this page
+            </span>
+          </ssr-keep>
+        </bolt-list-item>
+        <bolt-list-item role="presentation">
+          <ssr-keep for="bolt-list-item"
+                    role="listitem"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-end"
+          >
+            <a href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
+               class="c-bolt-share__link js-bolt-share__link--facebook"
+               target="_blank"
+            >
+              <bolt-icon name="facebook-solid"
+                         size="medium"
+                         aria-hidden="true"
+              >
+                <span class="c-bolt-icon c-bolt-icon--facebook-solid c-bolt-icon--medium">
+                  <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                       xmlns="http://www.w3.org/2000/svg"
+                       data-name="Layer 1"
+                       viewbox="0 0 32 32"
+                  >
+                    <path fill="var(--bolt-theme-icon, currentColor)"
+                          d="M26 0a6 6 0 016 6v20a6 6 0 01-6 6h-4V19.6h4.2l.6-4.8h-4.7v-3.1c0-1.4.4-2.3 2.4-2.3H27V5a33.8 33.8 0 00-3.7-.2c-3.7 0-6.2 2.3-6.2 6.4v3.6h-4.2v4.8h4.2V32H6a6 6 0 01-6-6V6a6 6 0 016-6z"
+                    >
+                    </path>
+                  </svg>
+                </span>
+              </bolt-icon>
+              <span class="c-bolt-share__link-text">
+                Share via Facebook
+              </span>
+            </a>
+          </ssr-keep>
+        </bolt-list-item>
+        <bolt-list-item role="presentation">
+          <ssr-keep for="bolt-list-item"
+                    role="listitem"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-end"
+          >
+            <a href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
+               class="c-bolt-share__link js-bolt-share__link--twitter"
+               target="_blank"
+            >
+              <bolt-icon name="twitter"
+                         size="medium"
+                         aria-hidden="true"
+              >
+                <span class="c-bolt-icon c-bolt-icon--twitter c-bolt-icon--medium">
+                  <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                       xmlns="http://www.w3.org/2000/svg"
+                       data-name="Layer 1"
+                       viewbox="0 0 32 26"
+                  >
+                    <path fill="var(--bolt-theme-icon, currentColor)"
+                          d="M32 3a14 14 0 01-3.3 3.5v.8C28.7 16 22.1 26 10.1 26A18.5 18.5 0 010 23a13.8 13.8 0 001.6.1 13.1 13.1 0 008.1-2.8 6.6 6.6 0 01-6.1-4.5 8.5 8.5 0 001.2 0 7 7 0 001.8-.1 6.6 6.6 0 01-5.3-6.5 6.5 6.5 0 003 .8 6.6 6.6 0 01-2-8.8 18.6 18.6 0 0013.5 6.9 7.4 7.4 0 01-.1-1.5A6.6 6.6 0 0122 0 6.5 6.5 0 0127 2 13 13 0 0031.1.6 6.6 6.6 0 0128.2 4a13 13 0 003.8-1z"
+                    >
+                    </path>
+                  </svg>
+                </span>
+              </bolt-icon>
+              <span class="c-bolt-share__link-text">
+                Share via Twitter
+              </span>
+            </a>
+          </ssr-keep>
+        </bolt-list-item>
+        <bolt-list-item role="presentation">
+          <ssr-keep for="bolt-list-item"
+                    role="listitem"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-end"
+          >
+            <a href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+               class="c-bolt-share__link js-bolt-share__link--linkedin"
+               target="_blank"
+            >
+              <bolt-icon name="linkedin"
+                         size="medium"
+                         aria-hidden="true"
+              >
+                <span class="c-bolt-icon c-bolt-icon--linkedin c-bolt-icon--medium">
+                  <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                       xmlns="http://www.w3.org/2000/svg"
+                       data-name="Layer 1"
+                       viewbox="0 0 32 30.6"
+                  >
+                    <path fill="var(--bolt-theme-icon, currentColor)"
+                          d="M7.3 10v20.6H.4V9.9zm.4-6.4A3.6 3.6 0 013.8 7a3.6 3.6 0 110-7.1 3.5 3.5 0 014 3.6zM32 18.8v11.8h-6.9v-11c0-2.8-1-4.7-3.4-4.7a3.8 3.8 0 00-3.6 2.5 5.1 5.1 0 00-.2 1.7v11.5h-6.8V9.9h6.8v3A6.8 6.8 0 0124 9.5c4.5 0 7.9 3 7.9 9.3z"
+                    >
+                    </path>
+                  </svg>
+                </span>
+              </bolt-icon>
+              <span class="c-bolt-share__link-text">
+                Share via LinkedIn
+              </span>
+            </a>
+          </ssr-keep>
+        </bolt-list-item>
+        <bolt-list-item role="presentation">
+          <ssr-keep for="bolt-list-item"
+                    role="listitem"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-end"
+          >
+            <a href="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+               class="c-bolt-share__link js-bolt-share__link--email"
+               target="_blank"
+            >
+              <bolt-icon name="email"
+                         size="medium"
+                         aria-hidden="true"
+              >
+                <span class="c-bolt-icon c-bolt-icon--email c-bolt-icon--medium">
+                  <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                       xmlns="http://www.w3.org/2000/svg"
+                       viewbox="0 0 24 24"
+                  >
+                    <g fill="none"
+                       fill-rule="evenodd"
+                    >
+                      <path>
+                      </path>
+                      <path fill="var(--bolt-theme-icon, currentColor)"
+                            d="M20 19H4a1 1 0 01-1-1V8l8.4 5.8.6.2c.2 0 .4 0 .6-.2L21 8V18c0 .6-.4 1-1 1zM4 5h16c.4 0 .7.2.9.6L12 11.8 3.1 5.6c.2-.4.5-.6.9-.6zm19 1a3 3 0 00-3-3H4a3 3 0 00-3 3v12a3 3 0 003 3h16a3 3 0 003-3V6z"
+                      >
+                      </path>
+                    </g>
+                  </svg>
+                </span>
+              </bolt-icon>
+              <span class="c-bolt-share__link-text">
+                Share via Email
+              </span>
+            </a>
+          </ssr-keep>
+        </bolt-list-item>
+        <bolt-list-item last
+                        role="presentation"
+        >
+          <ssr-keep for="bolt-list-item"
+                    role="listitem"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-end c-bolt-list-item--last-item"
+          >
+            <bolt-copy-to-clipboard>
+              <span class="c-bolt-copy-to-clipboard js-bolt-copy-to-clipboard">
+                <button class="c-bolt-copy-to-clipboard__trigger"
+                        data-clipboard-text="https://boltdesignsystem.com"
+                >
+                  <span class="c-bolt-share__link">
+                    <bolt-icon name="asset-link"
+                               size="medium"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--asset-link c-bolt-icon--medium">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M22.7 3.2l-1.9-2a4 4 0 00-3-1.2c-1.2 0-2.2.4-3 1.2l-2 2c-.3.3-.5.6-.5 1l.4.8c.5.5 1.3.5 1.8 0l2-2c.4-.4.8-.5 1.3-.5s1 .1 1.3.5l2 2c.3.3.5.7.5 1.2s-.2 1-.5 1.3L14.5 14c-.3.4-.8.6-1.4.6-.6 0-1 0-1.3-.4l-.8-.8-.7-.7c-.3-.3-.6-.4-1-.4a1 1 0 00-.7.4c-.3.2-.5.5-.5.8 0 .3.2.6.5 1l1.4 1.4v.3h.4a4 4 0 002.7.8c1 0 1.8-.3 2.5-.8v.1l.4-.3.1-.2 6.7-6.6c.8-.8 1.2-1.8 1.2-3a4 4 0 00-1.3-3M11.3 18.9c.3.3.4.6.4 1 0 .2-.1.5-.4.8l-2 2a4 4 0 01-3 1.3c-1.2 0-2.2-.4-3-1.2l-2-2a4.2 4.2 0 01-1.3-3 4 4 0 011.2-3L8 8a4 4 0 013-1.3A4 4 0 0114 8l1.5 1.5c.3.3.4.6.4.9 0 .3-.1.6-.4.9-.5.4-1.3.4-1.7 0l-1.6-1.6c-.7-.7-1.8-.7-2.5 0L3 16.5c-.3.3-.5.7-.5 1.2s.2 1 .5 1.3L5 21c.7.7 1.8.7 2.5 0l2-2c.2-.2.5-.4 1-.4l.8.3"
+                                  mask="url(#mask-2)"
+                            >
+                            </path>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="c-bolt-share__link-text">
+                      Copy share link
+                    </span>
+                  </span>
+                </button>
+                <span class="c-bolt-copy-to-clipboard__transition">
+                  <span class="c-bolt-share__link">
+                    <bolt-icon class="c-bolt-share__copy-animation"
+                               name="refresh"
+                               size="medium"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--refresh c-bolt-icon--medium">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path>
+                            </path>
+                            <g fill="var(--bolt-theme-icon, currentColor)"
+                               fill-rule="nonzero"
+                            >
+                              <path d="M24 4.5c0-.5-.4-1-1-1a1 1 0 00-1 1v3.7l-3-2.8a10 10 0 00-12.8-1 10 10 0 00-3.6 4.8 1 1 0 001.9.6 8 8 0 0113.2-3l2.8 2.7H17a1 1 0 00-1 1c0 .5.4 1 1 1H23.4l.3-.3.2-.4.1-.2V4.4zM20.8 14.6a1 1 0 00-1.3.6 8 8 0 01-13.1 3l-2.9-2.7H7c.6 0 1-.4 1-1s-.4-1-1-1H1a1 1 0 00-.4 0v.1l-.3.2-.2.3v6.3c0 .6.4 1 1 1 .5 0 1-.4 1-1v-3.6L5 19.6a10 10 0 0016.5-3.7c.1-.5-.2-1-.7-1.3z">
+                              </path>
+                            </g>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="u-bolt-visuallyhidden">
+                      Copying...
+                    </span>
+                  </span>
+                </span>
+                <span class="c-bolt-copy-to-clipboard__confirmation">
+                  <div class="c-bolt-share__link">
+                    <bolt-icon name="check"
+                               size="medium"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--check c-bolt-icon--medium">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path>
+                            </path>
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M19.3 6.3L9 16.6l-4.3-4.3a1 1 0 00-1.4 0 1 1 0 000 1.4l5 5a1 1 0 001.4 0l11-11c.4-.4.4-1 0-1.4a1 1 0 00-1.4 0z"
+                            >
+                            </path>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="c-bolt-share__link-text">
+                      Copied!
+                    </span>
+                  </div>
+                </span>
+              </span>
+            </bolt-copy-to-clipboard>
+          </ssr-keep>
+        </bolt-list-item>
+      </ssr-keep>
+    </bolt-list>
+  </div>
+</bolt-share>
+`;
+
+exports[`Bolt Share Props align items: start 1`] = `
 <bolt-share size="medium"
             opacity="100"
             align="start"
@@ -33,8 +575,8 @@ exports[`<bolt-share> Component basic usage 1`] = `
                     role="listitem"
                     class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--facebook"
-               href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse"
+            <a href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
+               class="c-bolt-share__link js-bolt-share__link--facebook"
                target="_blank"
             >
               <bolt-icon name="facebook-solid"
@@ -65,8 +607,8 @@ exports[`<bolt-share> Component basic usage 1`] = `
                     role="listitem"
                     class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--twitter"
-               href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!"
+            <a href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
+               class="c-bolt-share__link js-bolt-share__link--twitter"
                target="_blank"
             >
               <bolt-icon name="twitter"
@@ -97,8 +639,8 @@ exports[`<bolt-share> Component basic usage 1`] = `
                     role="listitem"
                     class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--linkedin"
-               href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+            <a href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+               class="c-bolt-share__link js-bolt-share__link--linkedin"
                target="_blank"
             >
               <bolt-icon name="linkedin"
@@ -129,8 +671,8 @@ exports[`<bolt-share> Component basic usage 1`] = `
                     role="listitem"
                     class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--email"
-               href="mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+            <a href="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+               class="c-bolt-share__link js-bolt-share__link--email"
                target="_blank"
             >
               <bolt-icon name="email"
@@ -271,514 +813,655 @@ exports[`<bolt-share> Component basic usage 1`] = `
 </bolt-share>
 `;
 
-exports[`<bolt-share> Component share align: center 1`] = `
-<bolt-share size="medium"
-            opacity="100"
-            align="center"
-            display="inline"
->
-  <div class="c-bolt-share c-bolt-share--opacity-100">
-    <bolt-list tag="ul"
-               display="inline"
-               spacing="small"
-               separator="none"
-               align="center"
-               valign="center"
-    >
-      <ssr-keep for="bolt-list"
-                role="list"
-                class="c-bolt-list c-bolt-list--display-inline c-bolt-list--spacing-small c-bolt-list--align-center c-bolt-list--valign-center"
-      >
-        <bolt-list-item role="presentation">
-          <ssr-keep for="bolt-list-item"
-                    role="listitem"
-                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-center"
-          >
-            <span class="c-bolt-share__label c-bolt-share__label--medium">
-              Share this page
-            </span>
-          </ssr-keep>
-        </bolt-list-item>
-        <bolt-list-item role="presentation">
-          <ssr-keep for="bolt-list-item"
-                    role="listitem"
-                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-center"
-          >
-            <a class="c-bolt-share__link js-bolt-share__link--facebook"
-               href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse"
-               target="_blank"
-            >
-              <bolt-icon name="facebook-solid"
-                         size="medium"
-                         aria-hidden="true"
-              >
-                <span class="c-bolt-icon c-bolt-icon--facebook-solid c-bolt-icon--medium">
-                  <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
-                       xmlns="http://www.w3.org/2000/svg"
-                       data-name="Layer 1"
-                       viewbox="0 0 32 32"
-                  >
-                    <path fill="var(--bolt-theme-icon, currentColor)"
-                          d="M26 0a6 6 0 016 6v20a6 6 0 01-6 6h-4V19.6h4.2l.6-4.8h-4.7v-3.1c0-1.4.4-2.3 2.4-2.3H27V5a33.8 33.8 0 00-3.7-.2c-3.7 0-6.2 2.3-6.2 6.4v3.6h-4.2v4.8h4.2V32H6a6 6 0 01-6-6V6a6 6 0 016-6z"
-                    >
-                    </path>
-                  </svg>
-                </span>
-              </bolt-icon>
-              <span class="c-bolt-share__link-text">
-                Share via Facebook
-              </span>
-            </a>
-          </ssr-keep>
-        </bolt-list-item>
-        <bolt-list-item role="presentation">
-          <ssr-keep for="bolt-list-item"
-                    role="listitem"
-                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-center"
-          >
-            <a class="c-bolt-share__link js-bolt-share__link--twitter"
-               href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!"
-               target="_blank"
-            >
-              <bolt-icon name="twitter"
-                         size="medium"
-                         aria-hidden="true"
-              >
-                <span class="c-bolt-icon c-bolt-icon--twitter c-bolt-icon--medium">
-                  <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
-                       xmlns="http://www.w3.org/2000/svg"
-                       data-name="Layer 1"
-                       viewbox="0 0 32 26"
-                  >
-                    <path fill="var(--bolt-theme-icon, currentColor)"
-                          d="M32 3a14 14 0 01-3.3 3.5v.8C28.7 16 22.1 26 10.1 26A18.5 18.5 0 010 23a13.8 13.8 0 001.6.1 13.1 13.1 0 008.1-2.8 6.6 6.6 0 01-6.1-4.5 8.5 8.5 0 001.2 0 7 7 0 001.8-.1 6.6 6.6 0 01-5.3-6.5 6.5 6.5 0 003 .8 6.6 6.6 0 01-2-8.8 18.6 18.6 0 0013.5 6.9 7.4 7.4 0 01-.1-1.5A6.6 6.6 0 0122 0 6.5 6.5 0 0127 2 13 13 0 0031.1.6 6.6 6.6 0 0128.2 4a13 13 0 003.8-1z"
-                    >
-                    </path>
-                  </svg>
-                </span>
-              </bolt-icon>
-              <span class="c-bolt-share__link-text">
-                Share via Twitter
-              </span>
-            </a>
-          </ssr-keep>
-        </bolt-list-item>
-        <bolt-list-item role="presentation">
-          <ssr-keep for="bolt-list-item"
-                    role="listitem"
-                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-center"
-          >
-            <a class="c-bolt-share__link js-bolt-share__link--linkedin"
-               href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
-               target="_blank"
-            >
-              <bolt-icon name="linkedin"
-                         size="medium"
-                         aria-hidden="true"
-              >
-                <span class="c-bolt-icon c-bolt-icon--linkedin c-bolt-icon--medium">
-                  <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
-                       xmlns="http://www.w3.org/2000/svg"
-                       data-name="Layer 1"
-                       viewbox="0 0 32 30.6"
-                  >
-                    <path fill="var(--bolt-theme-icon, currentColor)"
-                          d="M7.3 10v20.6H.4V9.9zm.4-6.4A3.6 3.6 0 013.8 7a3.6 3.6 0 110-7.1 3.5 3.5 0 014 3.6zM32 18.8v11.8h-6.9v-11c0-2.8-1-4.7-3.4-4.7a3.8 3.8 0 00-3.6 2.5 5.1 5.1 0 00-.2 1.7v11.5h-6.8V9.9h6.8v3A6.8 6.8 0 0124 9.5c4.5 0 7.9 3 7.9 9.3z"
-                    >
-                    </path>
-                  </svg>
-                </span>
-              </bolt-icon>
-              <span class="c-bolt-share__link-text">
-                Share via LinkedIn
-              </span>
-            </a>
-          </ssr-keep>
-        </bolt-list-item>
-        <bolt-list-item last
-                        role="presentation"
-        >
-          <ssr-keep for="bolt-list-item"
-                    role="listitem"
-                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-center c-bolt-list-item--last-item"
-          >
-            <a class="c-bolt-share__link js-bolt-share__link--email"
-               href="mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
-               target="_blank"
-            >
-              <bolt-icon name="email"
-                         size="medium"
-                         aria-hidden="true"
-              >
-                <span class="c-bolt-icon c-bolt-icon--email c-bolt-icon--medium">
-                  <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
-                       xmlns="http://www.w3.org/2000/svg"
-                       viewbox="0 0 24 24"
-                  >
-                    <g fill="none"
-                       fill-rule="evenodd"
-                    >
-                      <path>
-                      </path>
-                      <path fill="var(--bolt-theme-icon, currentColor)"
-                            d="M20 19H4a1 1 0 01-1-1V8l8.4 5.8.6.2c.2 0 .4 0 .6-.2L21 8V18c0 .6-.4 1-1 1zM4 5h16c.4 0 .7.2.9.6L12 11.8 3.1 5.6c.2-.4.5-.6.9-.6zm19 1a3 3 0 00-3-3H4a3 3 0 00-3 3v12a3 3 0 003 3h16a3 3 0 003-3V6z"
-                      >
-                      </path>
-                    </g>
-                  </svg>
-                </span>
-              </bolt-icon>
-              <span class="c-bolt-share__link-text">
-                Share via Email
-              </span>
-            </a>
-          </ssr-keep>
-        </bolt-list-item>
-      </ssr-keep>
-    </bolt-list>
-  </div>
-</bolt-share>
-`;
-
-exports[`<bolt-share> Component share align: end 1`] = `
-<bolt-share size="medium"
-            opacity="100"
-            align="end"
-            display="inline"
->
-  <div class="c-bolt-share c-bolt-share--opacity-100">
-    <bolt-list tag="ul"
-               display="inline"
-               spacing="small"
-               separator="none"
-               align="end"
-               valign="center"
-    >
-      <ssr-keep for="bolt-list"
-                role="list"
-                class="c-bolt-list c-bolt-list--display-inline c-bolt-list--spacing-small c-bolt-list--align-end c-bolt-list--valign-center"
-      >
-        <bolt-list-item role="presentation">
-          <ssr-keep for="bolt-list-item"
-                    role="listitem"
-                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-end"
-          >
-            <span class="c-bolt-share__label c-bolt-share__label--medium">
-              Share this page
-            </span>
-          </ssr-keep>
-        </bolt-list-item>
-        <bolt-list-item role="presentation">
-          <ssr-keep for="bolt-list-item"
-                    role="listitem"
-                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-end"
-          >
-            <a class="c-bolt-share__link js-bolt-share__link--facebook"
-               href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse"
-               target="_blank"
-            >
-              <bolt-icon name="facebook-solid"
-                         size="medium"
-                         aria-hidden="true"
-              >
-                <span class="c-bolt-icon c-bolt-icon--facebook-solid c-bolt-icon--medium">
-                  <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
-                       xmlns="http://www.w3.org/2000/svg"
-                       data-name="Layer 1"
-                       viewbox="0 0 32 32"
-                  >
-                    <path fill="var(--bolt-theme-icon, currentColor)"
-                          d="M26 0a6 6 0 016 6v20a6 6 0 01-6 6h-4V19.6h4.2l.6-4.8h-4.7v-3.1c0-1.4.4-2.3 2.4-2.3H27V5a33.8 33.8 0 00-3.7-.2c-3.7 0-6.2 2.3-6.2 6.4v3.6h-4.2v4.8h4.2V32H6a6 6 0 01-6-6V6a6 6 0 016-6z"
-                    >
-                    </path>
-                  </svg>
-                </span>
-              </bolt-icon>
-              <span class="c-bolt-share__link-text">
-                Share via Facebook
-              </span>
-            </a>
-          </ssr-keep>
-        </bolt-list-item>
-        <bolt-list-item role="presentation">
-          <ssr-keep for="bolt-list-item"
-                    role="listitem"
-                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-end"
-          >
-            <a class="c-bolt-share__link js-bolt-share__link--twitter"
-               href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!"
-               target="_blank"
-            >
-              <bolt-icon name="twitter"
-                         size="medium"
-                         aria-hidden="true"
-              >
-                <span class="c-bolt-icon c-bolt-icon--twitter c-bolt-icon--medium">
-                  <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
-                       xmlns="http://www.w3.org/2000/svg"
-                       data-name="Layer 1"
-                       viewbox="0 0 32 26"
-                  >
-                    <path fill="var(--bolt-theme-icon, currentColor)"
-                          d="M32 3a14 14 0 01-3.3 3.5v.8C28.7 16 22.1 26 10.1 26A18.5 18.5 0 010 23a13.8 13.8 0 001.6.1 13.1 13.1 0 008.1-2.8 6.6 6.6 0 01-6.1-4.5 8.5 8.5 0 001.2 0 7 7 0 001.8-.1 6.6 6.6 0 01-5.3-6.5 6.5 6.5 0 003 .8 6.6 6.6 0 01-2-8.8 18.6 18.6 0 0013.5 6.9 7.4 7.4 0 01-.1-1.5A6.6 6.6 0 0122 0 6.5 6.5 0 0127 2 13 13 0 0031.1.6 6.6 6.6 0 0128.2 4a13 13 0 003.8-1z"
-                    >
-                    </path>
-                  </svg>
-                </span>
-              </bolt-icon>
-              <span class="c-bolt-share__link-text">
-                Share via Twitter
-              </span>
-            </a>
-          </ssr-keep>
-        </bolt-list-item>
-        <bolt-list-item role="presentation">
-          <ssr-keep for="bolt-list-item"
-                    role="listitem"
-                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-end"
-          >
-            <a class="c-bolt-share__link js-bolt-share__link--linkedin"
-               href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
-               target="_blank"
-            >
-              <bolt-icon name="linkedin"
-                         size="medium"
-                         aria-hidden="true"
-              >
-                <span class="c-bolt-icon c-bolt-icon--linkedin c-bolt-icon--medium">
-                  <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
-                       xmlns="http://www.w3.org/2000/svg"
-                       data-name="Layer 1"
-                       viewbox="0 0 32 30.6"
-                  >
-                    <path fill="var(--bolt-theme-icon, currentColor)"
-                          d="M7.3 10v20.6H.4V9.9zm.4-6.4A3.6 3.6 0 013.8 7a3.6 3.6 0 110-7.1 3.5 3.5 0 014 3.6zM32 18.8v11.8h-6.9v-11c0-2.8-1-4.7-3.4-4.7a3.8 3.8 0 00-3.6 2.5 5.1 5.1 0 00-.2 1.7v11.5h-6.8V9.9h6.8v3A6.8 6.8 0 0124 9.5c4.5 0 7.9 3 7.9 9.3z"
-                    >
-                    </path>
-                  </svg>
-                </span>
-              </bolt-icon>
-              <span class="c-bolt-share__link-text">
-                Share via LinkedIn
-              </span>
-            </a>
-          </ssr-keep>
-        </bolt-list-item>
-        <bolt-list-item last
-                        role="presentation"
-        >
-          <ssr-keep for="bolt-list-item"
-                    role="listitem"
-                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-end c-bolt-list-item--last-item"
-          >
-            <a class="c-bolt-share__link js-bolt-share__link--email"
-               href="mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
-               target="_blank"
-            >
-              <bolt-icon name="email"
-                         size="medium"
-                         aria-hidden="true"
-              >
-                <span class="c-bolt-icon c-bolt-icon--email c-bolt-icon--medium">
-                  <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
-                       xmlns="http://www.w3.org/2000/svg"
-                       viewbox="0 0 24 24"
-                  >
-                    <g fill="none"
-                       fill-rule="evenodd"
-                    >
-                      <path>
-                      </path>
-                      <path fill="var(--bolt-theme-icon, currentColor)"
-                            d="M20 19H4a1 1 0 01-1-1V8l8.4 5.8.6.2c.2 0 .4 0 .6-.2L21 8V18c0 .6-.4 1-1 1zM4 5h16c.4 0 .7.2.9.6L12 11.8 3.1 5.6c.2-.4.5-.6.9-.6zm19 1a3 3 0 00-3-3H4a3 3 0 00-3 3v12a3 3 0 003 3h16a3 3 0 003-3V6z"
-                      >
-                      </path>
-                    </g>
-                  </svg>
-                </span>
-              </bolt-icon>
-              <span class="c-bolt-share__link-text">
-                Share via Email
-              </span>
-            </a>
-          </ssr-keep>
-        </bolt-list-item>
-      </ssr-keep>
-    </bolt-list>
-  </div>
-</bolt-share>
-`;
-
-exports[`<bolt-share> Component share align: start 1`] = `
+exports[`Bolt Share Props display menu test 1`] = `
 <bolt-share size="medium"
             opacity="100"
             align="start"
-            display="inline"
+            display="menu"
 >
   <div class="c-bolt-share c-bolt-share--opacity-100">
-    <bolt-list tag="ul"
-               display="inline"
-               spacing="small"
-               separator="none"
-               align="start"
-               valign="center"
+    <bolt-menu spacing="medium"
+               role="menu"
     >
-      <ssr-keep for="bolt-list"
-                role="list"
-                class="c-bolt-list c-bolt-list--display-inline c-bolt-list--spacing-small c-bolt-list--align-start c-bolt-list--valign-center"
+      <div role="presentation"
+           class="c-bolt-menu c-bolt-menu--spacing-medium"
       >
-        <bolt-list-item role="presentation">
-          <ssr-keep for="bolt-list-item"
-                    role="listitem"
-                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
-          >
-            <span class="c-bolt-share__label c-bolt-share__label--medium">
-              Share this page
-            </span>
-          </ssr-keep>
-        </bolt-list-item>
-        <bolt-list-item role="presentation">
-          <ssr-keep for="bolt-list-item"
-                    role="listitem"
-                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
-          >
-            <a class="c-bolt-share__link js-bolt-share__link--facebook"
-               href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse"
-               target="_blank"
-            >
-              <bolt-icon name="facebook-solid"
-                         size="medium"
-                         aria-hidden="true"
-              >
-                <span class="c-bolt-icon c-bolt-icon--facebook-solid c-bolt-icon--medium">
-                  <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
-                       xmlns="http://www.w3.org/2000/svg"
-                       data-name="Layer 1"
-                       viewbox="0 0 32 32"
-                  >
-                    <path fill="var(--bolt-theme-icon, currentColor)"
-                          d="M26 0a6 6 0 016 6v20a6 6 0 01-6 6h-4V19.6h4.2l.6-4.8h-4.7v-3.1c0-1.4.4-2.3 2.4-2.3H27V5a33.8 33.8 0 00-3.7-.2c-3.7 0-6.2 2.3-6.2 6.4v3.6h-4.2v4.8h4.2V32H6a6 6 0 01-6-6V6a6 6 0 016-6z"
-                    >
-                    </path>
-                  </svg>
-                </span>
-              </bolt-icon>
-              <span class="c-bolt-share__link-text">
-                Share via Facebook
-              </span>
-            </a>
-          </ssr-keep>
-        </bolt-list-item>
-        <bolt-list-item role="presentation">
-          <ssr-keep for="bolt-list-item"
-                    role="listitem"
-                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
-          >
-            <a class="c-bolt-share__link js-bolt-share__link--twitter"
-               href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!"
-               target="_blank"
-            >
-              <bolt-icon name="twitter"
-                         size="medium"
-                         aria-hidden="true"
-              >
-                <span class="c-bolt-icon c-bolt-icon--twitter c-bolt-icon--medium">
-                  <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
-                       xmlns="http://www.w3.org/2000/svg"
-                       data-name="Layer 1"
-                       viewbox="0 0 32 26"
-                  >
-                    <path fill="var(--bolt-theme-icon, currentColor)"
-                          d="M32 3a14 14 0 01-3.3 3.5v.8C28.7 16 22.1 26 10.1 26A18.5 18.5 0 010 23a13.8 13.8 0 001.6.1 13.1 13.1 0 008.1-2.8 6.6 6.6 0 01-6.1-4.5 8.5 8.5 0 001.2 0 7 7 0 001.8-.1 6.6 6.6 0 01-5.3-6.5 6.5 6.5 0 003 .8 6.6 6.6 0 01-2-8.8 18.6 18.6 0 0013.5 6.9 7.4 7.4 0 01-.1-1.5A6.6 6.6 0 0122 0 6.5 6.5 0 0127 2 13 13 0 0031.1.6 6.6 6.6 0 0128.2 4a13 13 0 003.8-1z"
-                    >
-                    </path>
-                  </svg>
-                </span>
-              </bolt-icon>
-              <span class="c-bolt-share__link-text">
-                Share via Twitter
-              </span>
-            </a>
-          </ssr-keep>
-        </bolt-list-item>
-        <bolt-list-item role="presentation">
-          <ssr-keep for="bolt-list-item"
-                    role="listitem"
-                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
-          >
-            <a class="c-bolt-share__link js-bolt-share__link--linkedin"
-               href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
-               target="_blank"
-            >
-              <bolt-icon name="linkedin"
-                         size="medium"
-                         aria-hidden="true"
-              >
-                <span class="c-bolt-icon c-bolt-icon--linkedin c-bolt-icon--medium">
-                  <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
-                       xmlns="http://www.w3.org/2000/svg"
-                       data-name="Layer 1"
-                       viewbox="0 0 32 30.6"
-                  >
-                    <path fill="var(--bolt-theme-icon, currentColor)"
-                          d="M7.3 10v20.6H.4V9.9zm.4-6.4A3.6 3.6 0 013.8 7a3.6 3.6 0 110-7.1 3.5 3.5 0 014 3.6zM32 18.8v11.8h-6.9v-11c0-2.8-1-4.7-3.4-4.7a3.8 3.8 0 00-3.6 2.5 5.1 5.1 0 00-.2 1.7v11.5h-6.8V9.9h6.8v3A6.8 6.8 0 0124 9.5c4.5 0 7.9 3 7.9 9.3z"
-                    >
-                    </path>
-                  </svg>
-                </span>
-              </bolt-icon>
-              <span class="c-bolt-share__link-text">
-                Share via LinkedIn
-              </span>
-            </a>
-          </ssr-keep>
-        </bolt-list-item>
-        <bolt-list-item last
-                        role="presentation"
+        <ssr-keep for="bolt-menu"
+                  class="c-bolt-menu__title c-bolt-menu__title--spacing-medium"
         >
-          <ssr-keep for="bolt-list-item"
-                    role="listitem"
-                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start c-bolt-list-item--last-item"
+          <span slot="title">
+            Share this page
+          </span>
+        </ssr-keep>
+        <ssr-keep for="bolt-menu"
+                  role="presentation"
+        >
+          <bolt-menu-item target="_blank"
+                          url="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
+                          role="presentation"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--email"
-               href="mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
-               target="_blank"
+            <bolt-trigger class="js-bolt-share__link--facebook"
+                          target="_blank"
+                          role="menuitem"
+                          url="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
+                          display="block"
+                          no-outline
             >
-              <bolt-icon name="email"
-                         size="medium"
-                         aria-hidden="true"
+              <a href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
+                 target="_blank"
+                 class="c-bolt-trigger c-bolt-trigger--display-block c-bolt-trigger--cursor-pointer c-bolt-trigger--outline-none"
+                 is="shadow-root"
               >
-                <span class="c-bolt-icon c-bolt-icon--email c-bolt-icon--medium">
-                  <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
-                       xmlns="http://www.w3.org/2000/svg"
-                       viewbox="0 0 24 24"
+                <ssr-keep for="bolt-menu-item"
+                          role="presentation"
+                          class="c-bolt-menu-item"
+                >
+                  <replace-with-children class="c-bolt-menu-item__icon-before"
+                                         aria-hidden="true"
                   >
-                    <g fill="none"
-                       fill-rule="evenodd"
-                    >
-                      <path>
-                      </path>
-                      <path fill="var(--bolt-theme-icon, currentColor)"
-                            d="M20 19H4a1 1 0 01-1-1V8l8.4 5.8.6.2c.2 0 .4 0 .6-.2L21 8V18c0 .6-.4 1-1 1zM4 5h16c.4 0 .7.2.9.6L12 11.8 3.1 5.6c.2-.4.5-.6.9-.6zm19 1a3 3 0 00-3-3H4a3 3 0 00-3 3v12a3 3 0 003 3h16a3 3 0 003-3V6z"
+                    <span slot="icon-before">
+                      <bolt-icon name="facebook-solid"
+                                 size="small"
+                                 aria-hidden="true"
                       >
-                      </path>
-                    </g>
-                  </svg>
+                        <span class="c-bolt-icon c-bolt-icon--facebook-solid c-bolt-icon--small">
+                          <svg class="c-bolt-icon__icon c-bolt-icon__icon--small"
+                               xmlns="http://www.w3.org/2000/svg"
+                               data-name="Layer 1"
+                               viewbox="0 0 32 32"
+                          >
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M26 0a6 6 0 016 6v20a6 6 0 01-6 6h-4V19.6h4.2l.6-4.8h-4.7v-3.1c0-1.4.4-2.3 2.4-2.3H27V5a33.8 33.8 0 00-3.7-.2c-3.7 0-6.2 2.3-6.2 6.4v3.6h-4.2v4.8h4.2V32H6a6 6 0 01-6-6V6a6 6 0 016-6z"
+                            >
+                            </path>
+                          </svg>
+                        </span>
+                      </bolt-icon>
+                    </span>
+                  </replace-with-children>
+                  Share via Facebook
+                </ssr-keep>
+              </a>
+            </bolt-trigger>
+          </bolt-menu-item>
+          <bolt-menu-item target="_blank"
+                          url="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
+                          role="presentation"
+          >
+            <bolt-trigger class="js-bolt-share__link--twitter"
+                          target="_blank"
+                          role="menuitem"
+                          url="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
+                          display="block"
+                          no-outline
+            >
+              <a href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
+                 target="_blank"
+                 class="c-bolt-trigger c-bolt-trigger--display-block c-bolt-trigger--cursor-pointer c-bolt-trigger--outline-none"
+                 is="shadow-root"
+              >
+                <ssr-keep for="bolt-menu-item"
+                          role="presentation"
+                          class="c-bolt-menu-item"
+                >
+                  <replace-with-children class="c-bolt-menu-item__icon-before"
+                                         aria-hidden="true"
+                  >
+                    <span slot="icon-before">
+                      <bolt-icon name="twitter"
+                                 size="small"
+                                 aria-hidden="true"
+                      >
+                        <span class="c-bolt-icon c-bolt-icon--twitter c-bolt-icon--small">
+                          <svg class="c-bolt-icon__icon c-bolt-icon__icon--small"
+                               xmlns="http://www.w3.org/2000/svg"
+                               data-name="Layer 1"
+                               viewbox="0 0 32 26"
+                          >
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M32 3a14 14 0 01-3.3 3.5v.8C28.7 16 22.1 26 10.1 26A18.5 18.5 0 010 23a13.8 13.8 0 001.6.1 13.1 13.1 0 008.1-2.8 6.6 6.6 0 01-6.1-4.5 8.5 8.5 0 001.2 0 7 7 0 001.8-.1 6.6 6.6 0 01-5.3-6.5 6.5 6.5 0 003 .8 6.6 6.6 0 01-2-8.8 18.6 18.6 0 0013.5 6.9 7.4 7.4 0 01-.1-1.5A6.6 6.6 0 0122 0 6.5 6.5 0 0127 2 13 13 0 0031.1.6 6.6 6.6 0 0128.2 4a13 13 0 003.8-1z"
+                            >
+                            </path>
+                          </svg>
+                        </span>
+                      </bolt-icon>
+                    </span>
+                  </replace-with-children>
+                  Share via Twitter
+                </ssr-keep>
+              </a>
+            </bolt-trigger>
+          </bolt-menu-item>
+          <bolt-menu-item target="_blank"
+                          url="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+                          role="presentation"
+          >
+            <bolt-trigger class="js-bolt-share__link--linkedin"
+                          target="_blank"
+                          role="menuitem"
+                          url="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+                          display="block"
+                          no-outline
+            >
+              <a href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+                 target="_blank"
+                 class="c-bolt-trigger c-bolt-trigger--display-block c-bolt-trigger--cursor-pointer c-bolt-trigger--outline-none"
+                 is="shadow-root"
+              >
+                <ssr-keep for="bolt-menu-item"
+                          role="presentation"
+                          class="c-bolt-menu-item"
+                >
+                  <replace-with-children class="c-bolt-menu-item__icon-before"
+                                         aria-hidden="true"
+                  >
+                    <span slot="icon-before">
+                      <bolt-icon name="linkedin"
+                                 size="small"
+                                 aria-hidden="true"
+                      >
+                        <span class="c-bolt-icon c-bolt-icon--linkedin c-bolt-icon--small">
+                          <svg class="c-bolt-icon__icon c-bolt-icon__icon--small"
+                               xmlns="http://www.w3.org/2000/svg"
+                               data-name="Layer 1"
+                               viewbox="0 0 32 30.6"
+                          >
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M7.3 10v20.6H.4V9.9zm.4-6.4A3.6 3.6 0 013.8 7a3.6 3.6 0 110-7.1 3.5 3.5 0 014 3.6zM32 18.8v11.8h-6.9v-11c0-2.8-1-4.7-3.4-4.7a3.8 3.8 0 00-3.6 2.5 5.1 5.1 0 00-.2 1.7v11.5h-6.8V9.9h6.8v3A6.8 6.8 0 0124 9.5c4.5 0 7.9 3 7.9 9.3z"
+                            >
+                            </path>
+                          </svg>
+                        </span>
+                      </bolt-icon>
+                    </span>
+                  </replace-with-children>
+                  Share via LinkedIn
+                </ssr-keep>
+              </a>
+            </bolt-trigger>
+          </bolt-menu-item>
+          <bolt-menu-item target="_blank"
+                          url="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+                          role="presentation"
+          >
+            <bolt-trigger class="js-bolt-share__link--email"
+                          target="_blank"
+                          role="menuitem"
+                          url="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+                          display="block"
+                          no-outline
+            >
+              <a href="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+                 target="_blank"
+                 class="c-bolt-trigger c-bolt-trigger--display-block c-bolt-trigger--cursor-pointer c-bolt-trigger--outline-none"
+                 is="shadow-root"
+              >
+                <ssr-keep for="bolt-menu-item"
+                          role="presentation"
+                          class="c-bolt-menu-item"
+                >
+                  <replace-with-children class="c-bolt-menu-item__icon-before"
+                                         aria-hidden="true"
+                  >
+                    <span slot="icon-before">
+                      <bolt-icon name="email"
+                                 size="small"
+                                 aria-hidden="true"
+                      >
+                        <span class="c-bolt-icon c-bolt-icon--email c-bolt-icon--small">
+                          <svg class="c-bolt-icon__icon c-bolt-icon__icon--small"
+                               xmlns="http://www.w3.org/2000/svg"
+                               viewbox="0 0 24 24"
+                          >
+                            <g fill="none"
+                               fill-rule="evenodd"
+                            >
+                              <path>
+                              </path>
+                              <path fill="var(--bolt-theme-icon, currentColor)"
+                                    d="M20 19H4a1 1 0 01-1-1V8l8.4 5.8.6.2c.2 0 .4 0 .6-.2L21 8V18c0 .6-.4 1-1 1zM4 5h16c.4 0 .7.2.9.6L12 11.8 3.1 5.6c.2-.4.5-.6.9-.6zm19 1a3 3 0 00-3-3H4a3 3 0 00-3 3v12a3 3 0 003 3h16a3 3 0 003-3V6z"
+                              >
+                              </path>
+                            </g>
+                          </svg>
+                        </span>
+                      </bolt-icon>
+                    </span>
+                  </replace-with-children>
+                  Share via Email
+                </ssr-keep>
+              </a>
+            </bolt-trigger>
+          </bolt-menu-item>
+          <bolt-copy-to-clipboard role="menu-item">
+            <span class="c-bolt-copy-to-clipboard js-bolt-copy-to-clipboard">
+              <button class="c-bolt-copy-to-clipboard__trigger"
+                      data-clipboard-text="https://boltdesignsystem.com"
+              >
+                <span class="c-bolt-menu-item c-bolt-menu-item--spacing-small">
+                  <span class="c-bolt-menu-item__icon-before"
+                        aria-hidden="true"
+                  >
+                    <bolt-icon name="asset-link"
+                               size="small"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--asset-link c-bolt-icon--small">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--small"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M22.7 3.2l-1.9-2a4 4 0 00-3-1.2c-1.2 0-2.2.4-3 1.2l-2 2c-.3.3-.5.6-.5 1l.4.8c.5.5 1.3.5 1.8 0l2-2c.4-.4.8-.5 1.3-.5s1 .1 1.3.5l2 2c.3.3.5.7.5 1.2s-.2 1-.5 1.3L14.5 14c-.3.4-.8.6-1.4.6-.6 0-1 0-1.3-.4l-.8-.8-.7-.7c-.3-.3-.6-.4-1-.4a1 1 0 00-.7.4c-.3.2-.5.5-.5.8 0 .3.2.6.5 1l1.4 1.4v.3h.4a4 4 0 002.7.8c1 0 1.8-.3 2.5-.8v.1l.4-.3.1-.2 6.7-6.6c.8-.8 1.2-1.8 1.2-3a4 4 0 00-1.3-3M11.3 18.9c.3.3.4.6.4 1 0 .2-.1.5-.4.8l-2 2a4 4 0 01-3 1.3c-1.2 0-2.2-.4-3-1.2l-2-2a4.2 4.2 0 01-1.3-3 4 4 0 011.2-3L8 8a4 4 0 013-1.3A4 4 0 0114 8l1.5 1.5c.3.3.4.6.4.9 0 .3-.1.6-.4.9-.5.4-1.3.4-1.7 0l-1.6-1.6c-.7-.7-1.8-.7-2.5 0L3 16.5c-.3.3-.5.7-.5 1.2s.2 1 .5 1.3L5 21c.7.7 1.8.7 2.5 0l2-2c.2-.2.5-.4 1-.4l.8.3"
+                                  mask="url(#mask-2)"
+                            >
+                            </path>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                  </span>
+                  Copy share link
                 </span>
-              </bolt-icon>
-              <span class="c-bolt-share__link-text">
-                Share via Email
+              </button>
+              <span class="c-bolt-copy-to-clipboard__transition">
+                <span class="c-bolt-menu-item c-bolt-menu-item--spacing-small">
+                  <span class="c-bolt-menu-item__icon-before u-bolt-opacity-0"
+                        aria-hidden="true"
+                  >
+                    <bolt-icon name="asset-link"
+                               size="small"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--asset-link c-bolt-icon--small">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--small"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M22.7 3.2l-1.9-2a4 4 0 00-3-1.2c-1.2 0-2.2.4-3 1.2l-2 2c-.3.3-.5.6-.5 1l.4.8c.5.5 1.3.5 1.8 0l2-2c.4-.4.8-.5 1.3-.5s1 .1 1.3.5l2 2c.3.3.5.7.5 1.2s-.2 1-.5 1.3L14.5 14c-.3.4-.8.6-1.4.6-.6 0-1 0-1.3-.4l-.8-.8-.7-.7c-.3-.3-.6-.4-1-.4a1 1 0 00-.7.4c-.3.2-.5.5-.5.8 0 .3.2.6.5 1l1.4 1.4v.3h.4a4 4 0 002.7.8c1 0 1.8-.3 2.5-.8v.1l.4-.3.1-.2 6.7-6.6c.8-.8 1.2-1.8 1.2-3a4 4 0 00-1.3-3M11.3 18.9c.3.3.4.6.4 1 0 .2-.1.5-.4.8l-2 2a4 4 0 01-3 1.3c-1.2 0-2.2-.4-3-1.2l-2-2a4.2 4.2 0 01-1.3-3 4 4 0 011.2-3L8 8a4 4 0 013-1.3A4 4 0 0114 8l1.5 1.5c.3.3.4.6.4.9 0 .3-.1.6-.4.9-.5.4-1.3.4-1.7 0l-1.6-1.6c-.7-.7-1.8-.7-2.5 0L3 16.5c-.3.3-.5.7-.5 1.2s.2 1 .5 1.3L5 21c.7.7 1.8.7 2.5 0l2-2c.2-.2.5-.4 1-.4l.8.3"
+                                  mask="url(#mask-2)"
+                            >
+                            </path>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                  </span>
+                  Copying...
+                </span>
               </span>
-            </a>
-          </ssr-keep>
-        </bolt-list-item>
-      </ssr-keep>
-    </bolt-list>
+              <span class="c-bolt-copy-to-clipboard__confirmation">
+                <span class="c-bolt-menu-item c-bolt-menu-item--spacing-small">
+                  <span class="c-bolt-menu-item__icon-before"
+                        aria-hidden="true"
+                  >
+                    <bolt-icon name="check"
+                               size="small"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--check c-bolt-icon--small">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--small"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path>
+                            </path>
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M19.3 6.3L9 16.6l-4.3-4.3a1 1 0 00-1.4 0 1 1 0 000 1.4l5 5a1 1 0 001.4 0l11-11c.4-.4.4-1 0-1.4a1 1 0 00-1.4 0z"
+                            >
+                            </path>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                  </span>
+                  Copied!
+                </span>
+              </span>
+            </span>
+          </bolt-copy-to-clipboard>
+        </ssr-keep>
+      </div>
+    </bolt-menu>
   </div>
 </bolt-share>
 `;
 
-exports[`<bolt-share> Component share opacity: 20 1`] = `
+exports[`Bolt Share Props display menu test 2`] = `
+<bolt-share size="medium"
+            opacity="100"
+            align="start"
+            display="menu"
+>
+  <div class="c-bolt-share c-bolt-share--opacity-100">
+    <bolt-menu spacing="medium"
+               role="menu"
+    >
+      <div role="presentation"
+           class="c-bolt-menu c-bolt-menu--spacing-medium"
+      >
+        <ssr-keep for="bolt-menu"
+                  class="c-bolt-menu__title c-bolt-menu__title--spacing-medium"
+        >
+          <span slot="title">
+            Share this page
+          </span>
+        </ssr-keep>
+        <ssr-keep for="bolt-menu"
+                  role="presentation"
+        >
+          <bolt-menu-item target="_blank"
+                          url="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
+                          role="presentation"
+          >
+            <bolt-trigger class="js-bolt-share__link--facebook"
+                          target="_blank"
+                          role="menuitem"
+                          url="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
+                          display="block"
+                          no-outline
+            >
+              <a href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
+                 target="_blank"
+                 class="c-bolt-trigger c-bolt-trigger--display-block c-bolt-trigger--cursor-pointer c-bolt-trigger--outline-none"
+                 is="shadow-root"
+              >
+                <ssr-keep for="bolt-menu-item"
+                          role="presentation"
+                          class="c-bolt-menu-item"
+                >
+                  <replace-with-children class="c-bolt-menu-item__icon-before"
+                                         aria-hidden="true"
+                  >
+                    <span slot="icon-before">
+                      <bolt-icon name="facebook-solid"
+                                 size="small"
+                                 aria-hidden="true"
+                      >
+                        <span class="c-bolt-icon c-bolt-icon--facebook-solid c-bolt-icon--small">
+                          <svg class="c-bolt-icon__icon c-bolt-icon__icon--small"
+                               xmlns="http://www.w3.org/2000/svg"
+                               data-name="Layer 1"
+                               viewbox="0 0 32 32"
+                          >
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M26 0a6 6 0 016 6v20a6 6 0 01-6 6h-4V19.6h4.2l.6-4.8h-4.7v-3.1c0-1.4.4-2.3 2.4-2.3H27V5a33.8 33.8 0 00-3.7-.2c-3.7 0-6.2 2.3-6.2 6.4v3.6h-4.2v4.8h4.2V32H6a6 6 0 01-6-6V6a6 6 0 016-6z"
+                            >
+                            </path>
+                          </svg>
+                        </span>
+                      </bolt-icon>
+                    </span>
+                  </replace-with-children>
+                  Share via Facebook
+                </ssr-keep>
+              </a>
+            </bolt-trigger>
+          </bolt-menu-item>
+          <bolt-menu-item target="_blank"
+                          url="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
+                          role="presentation"
+          >
+            <bolt-trigger class="js-bolt-share__link--twitter"
+                          target="_blank"
+                          role="menuitem"
+                          url="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
+                          display="block"
+                          no-outline
+            >
+              <a href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
+                 target="_blank"
+                 class="c-bolt-trigger c-bolt-trigger--display-block c-bolt-trigger--cursor-pointer c-bolt-trigger--outline-none"
+                 is="shadow-root"
+              >
+                <ssr-keep for="bolt-menu-item"
+                          role="presentation"
+                          class="c-bolt-menu-item"
+                >
+                  <replace-with-children class="c-bolt-menu-item__icon-before"
+                                         aria-hidden="true"
+                  >
+                    <span slot="icon-before">
+                      <bolt-icon name="twitter"
+                                 size="small"
+                                 aria-hidden="true"
+                      >
+                        <span class="c-bolt-icon c-bolt-icon--twitter c-bolt-icon--small">
+                          <svg class="c-bolt-icon__icon c-bolt-icon__icon--small"
+                               xmlns="http://www.w3.org/2000/svg"
+                               data-name="Layer 1"
+                               viewbox="0 0 32 26"
+                          >
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M32 3a14 14 0 01-3.3 3.5v.8C28.7 16 22.1 26 10.1 26A18.5 18.5 0 010 23a13.8 13.8 0 001.6.1 13.1 13.1 0 008.1-2.8 6.6 6.6 0 01-6.1-4.5 8.5 8.5 0 001.2 0 7 7 0 001.8-.1 6.6 6.6 0 01-5.3-6.5 6.5 6.5 0 003 .8 6.6 6.6 0 01-2-8.8 18.6 18.6 0 0013.5 6.9 7.4 7.4 0 01-.1-1.5A6.6 6.6 0 0122 0 6.5 6.5 0 0127 2 13 13 0 0031.1.6 6.6 6.6 0 0128.2 4a13 13 0 003.8-1z"
+                            >
+                            </path>
+                          </svg>
+                        </span>
+                      </bolt-icon>
+                    </span>
+                  </replace-with-children>
+                  Share via Twitter
+                </ssr-keep>
+              </a>
+            </bolt-trigger>
+          </bolt-menu-item>
+          <bolt-menu-item target="_blank"
+                          url="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+                          role="presentation"
+          >
+            <bolt-trigger class="js-bolt-share__link--linkedin"
+                          target="_blank"
+                          role="menuitem"
+                          url="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+                          display="block"
+                          no-outline
+            >
+              <a href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+                 target="_blank"
+                 class="c-bolt-trigger c-bolt-trigger--display-block c-bolt-trigger--cursor-pointer c-bolt-trigger--outline-none"
+                 is="shadow-root"
+              >
+                <ssr-keep for="bolt-menu-item"
+                          role="presentation"
+                          class="c-bolt-menu-item"
+                >
+                  <replace-with-children class="c-bolt-menu-item__icon-before"
+                                         aria-hidden="true"
+                  >
+                    <span slot="icon-before">
+                      <bolt-icon name="linkedin"
+                                 size="small"
+                                 aria-hidden="true"
+                      >
+                        <span class="c-bolt-icon c-bolt-icon--linkedin c-bolt-icon--small">
+                          <svg class="c-bolt-icon__icon c-bolt-icon__icon--small"
+                               xmlns="http://www.w3.org/2000/svg"
+                               data-name="Layer 1"
+                               viewbox="0 0 32 30.6"
+                          >
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M7.3 10v20.6H.4V9.9zm.4-6.4A3.6 3.6 0 013.8 7a3.6 3.6 0 110-7.1 3.5 3.5 0 014 3.6zM32 18.8v11.8h-6.9v-11c0-2.8-1-4.7-3.4-4.7a3.8 3.8 0 00-3.6 2.5 5.1 5.1 0 00-.2 1.7v11.5h-6.8V9.9h6.8v3A6.8 6.8 0 0124 9.5c4.5 0 7.9 3 7.9 9.3z"
+                            >
+                            </path>
+                          </svg>
+                        </span>
+                      </bolt-icon>
+                    </span>
+                  </replace-with-children>
+                  Share via LinkedIn
+                </ssr-keep>
+              </a>
+            </bolt-trigger>
+          </bolt-menu-item>
+          <bolt-menu-item target="_blank"
+                          url="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+                          role="presentation"
+          >
+            <bolt-trigger class="js-bolt-share__link--email"
+                          target="_blank"
+                          role="menuitem"
+                          url="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+                          display="block"
+                          no-outline
+            >
+              <a href="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+                 target="_blank"
+                 class="c-bolt-trigger c-bolt-trigger--display-block c-bolt-trigger--cursor-pointer c-bolt-trigger--outline-none"
+                 is="shadow-root"
+              >
+                <ssr-keep for="bolt-menu-item"
+                          role="presentation"
+                          class="c-bolt-menu-item"
+                >
+                  <replace-with-children class="c-bolt-menu-item__icon-before"
+                                         aria-hidden="true"
+                  >
+                    <span slot="icon-before">
+                      <bolt-icon name="email"
+                                 size="small"
+                                 aria-hidden="true"
+                      >
+                        <span class="c-bolt-icon c-bolt-icon--email c-bolt-icon--small">
+                          <svg class="c-bolt-icon__icon c-bolt-icon__icon--small"
+                               xmlns="http://www.w3.org/2000/svg"
+                               viewbox="0 0 24 24"
+                          >
+                            <g fill="none"
+                               fill-rule="evenodd"
+                            >
+                              <path>
+                              </path>
+                              <path fill="var(--bolt-theme-icon, currentColor)"
+                                    d="M20 19H4a1 1 0 01-1-1V8l8.4 5.8.6.2c.2 0 .4 0 .6-.2L21 8V18c0 .6-.4 1-1 1zM4 5h16c.4 0 .7.2.9.6L12 11.8 3.1 5.6c.2-.4.5-.6.9-.6zm19 1a3 3 0 00-3-3H4a3 3 0 00-3 3v12a3 3 0 003 3h16a3 3 0 003-3V6z"
+                              >
+                              </path>
+                            </g>
+                          </svg>
+                        </span>
+                      </bolt-icon>
+                    </span>
+                  </replace-with-children>
+                  Share via Email
+                </ssr-keep>
+              </a>
+            </bolt-trigger>
+          </bolt-menu-item>
+          <bolt-copy-to-clipboard role="menu-item">
+            <span class="c-bolt-copy-to-clipboard js-bolt-copy-to-clipboard">
+              <button class="c-bolt-copy-to-clipboard__trigger"
+                      data-clipboard-text="https://boltdesignsystem.com"
+              >
+                <span class="c-bolt-menu-item c-bolt-menu-item--spacing-small">
+                  <span class="c-bolt-menu-item__icon-before"
+                        aria-hidden="true"
+                  >
+                    <bolt-icon name="asset-link"
+                               size="small"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--asset-link c-bolt-icon--small">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--small"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M22.7 3.2l-1.9-2a4 4 0 00-3-1.2c-1.2 0-2.2.4-3 1.2l-2 2c-.3.3-.5.6-.5 1l.4.8c.5.5 1.3.5 1.8 0l2-2c.4-.4.8-.5 1.3-.5s1 .1 1.3.5l2 2c.3.3.5.7.5 1.2s-.2 1-.5 1.3L14.5 14c-.3.4-.8.6-1.4.6-.6 0-1 0-1.3-.4l-.8-.8-.7-.7c-.3-.3-.6-.4-1-.4a1 1 0 00-.7.4c-.3.2-.5.5-.5.8 0 .3.2.6.5 1l1.4 1.4v.3h.4a4 4 0 002.7.8c1 0 1.8-.3 2.5-.8v.1l.4-.3.1-.2 6.7-6.6c.8-.8 1.2-1.8 1.2-3a4 4 0 00-1.3-3M11.3 18.9c.3.3.4.6.4 1 0 .2-.1.5-.4.8l-2 2a4 4 0 01-3 1.3c-1.2 0-2.2-.4-3-1.2l-2-2a4.2 4.2 0 01-1.3-3 4 4 0 011.2-3L8 8a4 4 0 013-1.3A4 4 0 0114 8l1.5 1.5c.3.3.4.6.4.9 0 .3-.1.6-.4.9-.5.4-1.3.4-1.7 0l-1.6-1.6c-.7-.7-1.8-.7-2.5 0L3 16.5c-.3.3-.5.7-.5 1.2s.2 1 .5 1.3L5 21c.7.7 1.8.7 2.5 0l2-2c.2-.2.5-.4 1-.4l.8.3"
+                                  mask="url(#mask-2)"
+                            >
+                            </path>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                  </span>
+                  Copy share link
+                </span>
+              </button>
+              <span class="c-bolt-copy-to-clipboard__transition">
+                <span class="c-bolt-menu-item c-bolt-menu-item--spacing-small">
+                  <span class="c-bolt-menu-item__icon-before u-bolt-opacity-0"
+                        aria-hidden="true"
+                  >
+                    <bolt-icon name="asset-link"
+                               size="small"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--asset-link c-bolt-icon--small">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--small"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M22.7 3.2l-1.9-2a4 4 0 00-3-1.2c-1.2 0-2.2.4-3 1.2l-2 2c-.3.3-.5.6-.5 1l.4.8c.5.5 1.3.5 1.8 0l2-2c.4-.4.8-.5 1.3-.5s1 .1 1.3.5l2 2c.3.3.5.7.5 1.2s-.2 1-.5 1.3L14.5 14c-.3.4-.8.6-1.4.6-.6 0-1 0-1.3-.4l-.8-.8-.7-.7c-.3-.3-.6-.4-1-.4a1 1 0 00-.7.4c-.3.2-.5.5-.5.8 0 .3.2.6.5 1l1.4 1.4v.3h.4a4 4 0 002.7.8c1 0 1.8-.3 2.5-.8v.1l.4-.3.1-.2 6.7-6.6c.8-.8 1.2-1.8 1.2-3a4 4 0 00-1.3-3M11.3 18.9c.3.3.4.6.4 1 0 .2-.1.5-.4.8l-2 2a4 4 0 01-3 1.3c-1.2 0-2.2-.4-3-1.2l-2-2a4.2 4.2 0 01-1.3-3 4 4 0 011.2-3L8 8a4 4 0 013-1.3A4 4 0 0114 8l1.5 1.5c.3.3.4.6.4.9 0 .3-.1.6-.4.9-.5.4-1.3.4-1.7 0l-1.6-1.6c-.7-.7-1.8-.7-2.5 0L3 16.5c-.3.3-.5.7-.5 1.2s.2 1 .5 1.3L5 21c.7.7 1.8.7 2.5 0l2-2c.2-.2.5-.4 1-.4l.8.3"
+                                  mask="url(#mask-2)"
+                            >
+                            </path>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                  </span>
+                  Copying...
+                </span>
+              </span>
+              <span class="c-bolt-copy-to-clipboard__confirmation">
+                <span class="c-bolt-menu-item c-bolt-menu-item--spacing-small">
+                  <span class="c-bolt-menu-item__icon-before"
+                        aria-hidden="true"
+                  >
+                    <bolt-icon name="check"
+                               size="small"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--check c-bolt-icon--small">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--small"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path>
+                            </path>
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M19.3 6.3L9 16.6l-4.3-4.3a1 1 0 00-1.4 0 1 1 0 000 1.4l5 5a1 1 0 001.4 0l11-11c.4-.4.4-1 0-1.4a1 1 0 00-1.4 0z"
+                            >
+                            </path>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                  </span>
+                  Copied!
+                </span>
+              </span>
+            </span>
+          </bolt-copy-to-clipboard>
+        </ssr-keep>
+      </div>
+    </bolt-menu>
+  </div>
+</bolt-share>
+`;
+
+exports[`Bolt Share Props opacity items: 20 1`] = `
 <bolt-share size="medium"
             opacity="20"
             align="start"
@@ -811,8 +1494,8 @@ exports[`<bolt-share> Component share opacity: 20 1`] = `
                     role="listitem"
                     class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--facebook"
-               href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse"
+            <a href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
+               class="c-bolt-share__link js-bolt-share__link--facebook"
                target="_blank"
             >
               <bolt-icon name="facebook-solid"
@@ -843,8 +1526,8 @@ exports[`<bolt-share> Component share opacity: 20 1`] = `
                     role="listitem"
                     class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--twitter"
-               href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!"
+            <a href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
+               class="c-bolt-share__link js-bolt-share__link--twitter"
                target="_blank"
             >
               <bolt-icon name="twitter"
@@ -875,8 +1558,8 @@ exports[`<bolt-share> Component share opacity: 20 1`] = `
                     role="listitem"
                     class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--linkedin"
-               href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+            <a href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+               class="c-bolt-share__link js-bolt-share__link--linkedin"
                target="_blank"
             >
               <bolt-icon name="linkedin"
@@ -902,15 +1585,13 @@ exports[`<bolt-share> Component share opacity: 20 1`] = `
             </a>
           </ssr-keep>
         </bolt-list-item>
-        <bolt-list-item last
-                        role="presentation"
-        >
+        <bolt-list-item role="presentation">
           <ssr-keep for="bolt-list-item"
                     role="listitem"
-                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start c-bolt-list-item--last-item"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--email"
-               href="mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+            <a href="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+               class="c-bolt-share__link js-bolt-share__link--email"
                target="_blank"
             >
               <bolt-icon name="email"
@@ -941,13 +1622,117 @@ exports[`<bolt-share> Component share opacity: 20 1`] = `
             </a>
           </ssr-keep>
         </bolt-list-item>
+        <bolt-list-item last
+                        role="presentation"
+        >
+          <ssr-keep for="bolt-list-item"
+                    role="listitem"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start c-bolt-list-item--last-item"
+          >
+            <bolt-copy-to-clipboard>
+              <span class="c-bolt-copy-to-clipboard js-bolt-copy-to-clipboard">
+                <button class="c-bolt-copy-to-clipboard__trigger"
+                        data-clipboard-text="https://boltdesignsystem.com"
+                >
+                  <span class="c-bolt-share__link">
+                    <bolt-icon name="asset-link"
+                               size="medium"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--asset-link c-bolt-icon--medium">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M22.7 3.2l-1.9-2a4 4 0 00-3-1.2c-1.2 0-2.2.4-3 1.2l-2 2c-.3.3-.5.6-.5 1l.4.8c.5.5 1.3.5 1.8 0l2-2c.4-.4.8-.5 1.3-.5s1 .1 1.3.5l2 2c.3.3.5.7.5 1.2s-.2 1-.5 1.3L14.5 14c-.3.4-.8.6-1.4.6-.6 0-1 0-1.3-.4l-.8-.8-.7-.7c-.3-.3-.6-.4-1-.4a1 1 0 00-.7.4c-.3.2-.5.5-.5.8 0 .3.2.6.5 1l1.4 1.4v.3h.4a4 4 0 002.7.8c1 0 1.8-.3 2.5-.8v.1l.4-.3.1-.2 6.7-6.6c.8-.8 1.2-1.8 1.2-3a4 4 0 00-1.3-3M11.3 18.9c.3.3.4.6.4 1 0 .2-.1.5-.4.8l-2 2a4 4 0 01-3 1.3c-1.2 0-2.2-.4-3-1.2l-2-2a4.2 4.2 0 01-1.3-3 4 4 0 011.2-3L8 8a4 4 0 013-1.3A4 4 0 0114 8l1.5 1.5c.3.3.4.6.4.9 0 .3-.1.6-.4.9-.5.4-1.3.4-1.7 0l-1.6-1.6c-.7-.7-1.8-.7-2.5 0L3 16.5c-.3.3-.5.7-.5 1.2s.2 1 .5 1.3L5 21c.7.7 1.8.7 2.5 0l2-2c.2-.2.5-.4 1-.4l.8.3"
+                                  mask="url(#mask-2)"
+                            >
+                            </path>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="c-bolt-share__link-text">
+                      Copy share link
+                    </span>
+                  </span>
+                </button>
+                <span class="c-bolt-copy-to-clipboard__transition">
+                  <span class="c-bolt-share__link">
+                    <bolt-icon class="c-bolt-share__copy-animation"
+                               name="refresh"
+                               size="medium"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--refresh c-bolt-icon--medium">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path>
+                            </path>
+                            <g fill="var(--bolt-theme-icon, currentColor)"
+                               fill-rule="nonzero"
+                            >
+                              <path d="M24 4.5c0-.5-.4-1-1-1a1 1 0 00-1 1v3.7l-3-2.8a10 10 0 00-12.8-1 10 10 0 00-3.6 4.8 1 1 0 001.9.6 8 8 0 0113.2-3l2.8 2.7H17a1 1 0 00-1 1c0 .5.4 1 1 1H23.4l.3-.3.2-.4.1-.2V4.4zM20.8 14.6a1 1 0 00-1.3.6 8 8 0 01-13.1 3l-2.9-2.7H7c.6 0 1-.4 1-1s-.4-1-1-1H1a1 1 0 00-.4 0v.1l-.3.2-.2.3v6.3c0 .6.4 1 1 1 .5 0 1-.4 1-1v-3.6L5 19.6a10 10 0 0016.5-3.7c.1-.5-.2-1-.7-1.3z">
+                              </path>
+                            </g>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="u-bolt-visuallyhidden">
+                      Copying...
+                    </span>
+                  </span>
+                </span>
+                <span class="c-bolt-copy-to-clipboard__confirmation">
+                  <div class="c-bolt-share__link">
+                    <bolt-icon name="check"
+                               size="medium"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--check c-bolt-icon--medium">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path>
+                            </path>
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M19.3 6.3L9 16.6l-4.3-4.3a1 1 0 00-1.4 0 1 1 0 000 1.4l5 5a1 1 0 001.4 0l11-11c.4-.4.4-1 0-1.4a1 1 0 00-1.4 0z"
+                            >
+                            </path>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="c-bolt-share__link-text">
+                      Copied!
+                    </span>
+                  </div>
+                </span>
+              </span>
+            </bolt-copy-to-clipboard>
+          </ssr-keep>
+        </bolt-list-item>
       </ssr-keep>
     </bolt-list>
   </div>
 </bolt-share>
 `;
 
-exports[`<bolt-share> Component share opacity: 40 1`] = `
+exports[`Bolt Share Props opacity items: 40 1`] = `
 <bolt-share size="medium"
             opacity="40"
             align="start"
@@ -980,8 +1765,8 @@ exports[`<bolt-share> Component share opacity: 40 1`] = `
                     role="listitem"
                     class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--facebook"
-               href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse"
+            <a href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
+               class="c-bolt-share__link js-bolt-share__link--facebook"
                target="_blank"
             >
               <bolt-icon name="facebook-solid"
@@ -1012,8 +1797,8 @@ exports[`<bolt-share> Component share opacity: 40 1`] = `
                     role="listitem"
                     class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--twitter"
-               href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!"
+            <a href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
+               class="c-bolt-share__link js-bolt-share__link--twitter"
                target="_blank"
             >
               <bolt-icon name="twitter"
@@ -1044,8 +1829,8 @@ exports[`<bolt-share> Component share opacity: 40 1`] = `
                     role="listitem"
                     class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--linkedin"
-               href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+            <a href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+               class="c-bolt-share__link js-bolt-share__link--linkedin"
                target="_blank"
             >
               <bolt-icon name="linkedin"
@@ -1071,15 +1856,13 @@ exports[`<bolt-share> Component share opacity: 40 1`] = `
             </a>
           </ssr-keep>
         </bolt-list-item>
-        <bolt-list-item last
-                        role="presentation"
-        >
+        <bolt-list-item role="presentation">
           <ssr-keep for="bolt-list-item"
                     role="listitem"
-                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start c-bolt-list-item--last-item"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--email"
-               href="mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+            <a href="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+               class="c-bolt-share__link js-bolt-share__link--email"
                target="_blank"
             >
               <bolt-icon name="email"
@@ -1110,13 +1893,117 @@ exports[`<bolt-share> Component share opacity: 40 1`] = `
             </a>
           </ssr-keep>
         </bolt-list-item>
+        <bolt-list-item last
+                        role="presentation"
+        >
+          <ssr-keep for="bolt-list-item"
+                    role="listitem"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start c-bolt-list-item--last-item"
+          >
+            <bolt-copy-to-clipboard>
+              <span class="c-bolt-copy-to-clipboard js-bolt-copy-to-clipboard">
+                <button class="c-bolt-copy-to-clipboard__trigger"
+                        data-clipboard-text="https://boltdesignsystem.com"
+                >
+                  <span class="c-bolt-share__link">
+                    <bolt-icon name="asset-link"
+                               size="medium"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--asset-link c-bolt-icon--medium">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M22.7 3.2l-1.9-2a4 4 0 00-3-1.2c-1.2 0-2.2.4-3 1.2l-2 2c-.3.3-.5.6-.5 1l.4.8c.5.5 1.3.5 1.8 0l2-2c.4-.4.8-.5 1.3-.5s1 .1 1.3.5l2 2c.3.3.5.7.5 1.2s-.2 1-.5 1.3L14.5 14c-.3.4-.8.6-1.4.6-.6 0-1 0-1.3-.4l-.8-.8-.7-.7c-.3-.3-.6-.4-1-.4a1 1 0 00-.7.4c-.3.2-.5.5-.5.8 0 .3.2.6.5 1l1.4 1.4v.3h.4a4 4 0 002.7.8c1 0 1.8-.3 2.5-.8v.1l.4-.3.1-.2 6.7-6.6c.8-.8 1.2-1.8 1.2-3a4 4 0 00-1.3-3M11.3 18.9c.3.3.4.6.4 1 0 .2-.1.5-.4.8l-2 2a4 4 0 01-3 1.3c-1.2 0-2.2-.4-3-1.2l-2-2a4.2 4.2 0 01-1.3-3 4 4 0 011.2-3L8 8a4 4 0 013-1.3A4 4 0 0114 8l1.5 1.5c.3.3.4.6.4.9 0 .3-.1.6-.4.9-.5.4-1.3.4-1.7 0l-1.6-1.6c-.7-.7-1.8-.7-2.5 0L3 16.5c-.3.3-.5.7-.5 1.2s.2 1 .5 1.3L5 21c.7.7 1.8.7 2.5 0l2-2c.2-.2.5-.4 1-.4l.8.3"
+                                  mask="url(#mask-2)"
+                            >
+                            </path>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="c-bolt-share__link-text">
+                      Copy share link
+                    </span>
+                  </span>
+                </button>
+                <span class="c-bolt-copy-to-clipboard__transition">
+                  <span class="c-bolt-share__link">
+                    <bolt-icon class="c-bolt-share__copy-animation"
+                               name="refresh"
+                               size="medium"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--refresh c-bolt-icon--medium">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path>
+                            </path>
+                            <g fill="var(--bolt-theme-icon, currentColor)"
+                               fill-rule="nonzero"
+                            >
+                              <path d="M24 4.5c0-.5-.4-1-1-1a1 1 0 00-1 1v3.7l-3-2.8a10 10 0 00-12.8-1 10 10 0 00-3.6 4.8 1 1 0 001.9.6 8 8 0 0113.2-3l2.8 2.7H17a1 1 0 00-1 1c0 .5.4 1 1 1H23.4l.3-.3.2-.4.1-.2V4.4zM20.8 14.6a1 1 0 00-1.3.6 8 8 0 01-13.1 3l-2.9-2.7H7c.6 0 1-.4 1-1s-.4-1-1-1H1a1 1 0 00-.4 0v.1l-.3.2-.2.3v6.3c0 .6.4 1 1 1 .5 0 1-.4 1-1v-3.6L5 19.6a10 10 0 0016.5-3.7c.1-.5-.2-1-.7-1.3z">
+                              </path>
+                            </g>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="u-bolt-visuallyhidden">
+                      Copying...
+                    </span>
+                  </span>
+                </span>
+                <span class="c-bolt-copy-to-clipboard__confirmation">
+                  <div class="c-bolt-share__link">
+                    <bolt-icon name="check"
+                               size="medium"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--check c-bolt-icon--medium">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path>
+                            </path>
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M19.3 6.3L9 16.6l-4.3-4.3a1 1 0 00-1.4 0 1 1 0 000 1.4l5 5a1 1 0 001.4 0l11-11c.4-.4.4-1 0-1.4a1 1 0 00-1.4 0z"
+                            >
+                            </path>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="c-bolt-share__link-text">
+                      Copied!
+                    </span>
+                  </div>
+                </span>
+              </span>
+            </bolt-copy-to-clipboard>
+          </ssr-keep>
+        </bolt-list-item>
       </ssr-keep>
     </bolt-list>
   </div>
 </bolt-share>
 `;
 
-exports[`<bolt-share> Component share opacity: 60 1`] = `
+exports[`Bolt Share Props opacity items: 60 1`] = `
 <bolt-share size="medium"
             opacity="60"
             align="start"
@@ -1149,8 +2036,8 @@ exports[`<bolt-share> Component share opacity: 60 1`] = `
                     role="listitem"
                     class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--facebook"
-               href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse"
+            <a href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
+               class="c-bolt-share__link js-bolt-share__link--facebook"
                target="_blank"
             >
               <bolt-icon name="facebook-solid"
@@ -1181,8 +2068,8 @@ exports[`<bolt-share> Component share opacity: 60 1`] = `
                     role="listitem"
                     class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--twitter"
-               href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!"
+            <a href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
+               class="c-bolt-share__link js-bolt-share__link--twitter"
                target="_blank"
             >
               <bolt-icon name="twitter"
@@ -1213,8 +2100,8 @@ exports[`<bolt-share> Component share opacity: 60 1`] = `
                     role="listitem"
                     class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--linkedin"
-               href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+            <a href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+               class="c-bolt-share__link js-bolt-share__link--linkedin"
                target="_blank"
             >
               <bolt-icon name="linkedin"
@@ -1240,15 +2127,13 @@ exports[`<bolt-share> Component share opacity: 60 1`] = `
             </a>
           </ssr-keep>
         </bolt-list-item>
-        <bolt-list-item last
-                        role="presentation"
-        >
+        <bolt-list-item role="presentation">
           <ssr-keep for="bolt-list-item"
                     role="listitem"
-                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start c-bolt-list-item--last-item"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--email"
-               href="mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+            <a href="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+               class="c-bolt-share__link js-bolt-share__link--email"
                target="_blank"
             >
               <bolt-icon name="email"
@@ -1279,13 +2164,117 @@ exports[`<bolt-share> Component share opacity: 60 1`] = `
             </a>
           </ssr-keep>
         </bolt-list-item>
+        <bolt-list-item last
+                        role="presentation"
+        >
+          <ssr-keep for="bolt-list-item"
+                    role="listitem"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start c-bolt-list-item--last-item"
+          >
+            <bolt-copy-to-clipboard>
+              <span class="c-bolt-copy-to-clipboard js-bolt-copy-to-clipboard">
+                <button class="c-bolt-copy-to-clipboard__trigger"
+                        data-clipboard-text="https://boltdesignsystem.com"
+                >
+                  <span class="c-bolt-share__link">
+                    <bolt-icon name="asset-link"
+                               size="medium"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--asset-link c-bolt-icon--medium">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M22.7 3.2l-1.9-2a4 4 0 00-3-1.2c-1.2 0-2.2.4-3 1.2l-2 2c-.3.3-.5.6-.5 1l.4.8c.5.5 1.3.5 1.8 0l2-2c.4-.4.8-.5 1.3-.5s1 .1 1.3.5l2 2c.3.3.5.7.5 1.2s-.2 1-.5 1.3L14.5 14c-.3.4-.8.6-1.4.6-.6 0-1 0-1.3-.4l-.8-.8-.7-.7c-.3-.3-.6-.4-1-.4a1 1 0 00-.7.4c-.3.2-.5.5-.5.8 0 .3.2.6.5 1l1.4 1.4v.3h.4a4 4 0 002.7.8c1 0 1.8-.3 2.5-.8v.1l.4-.3.1-.2 6.7-6.6c.8-.8 1.2-1.8 1.2-3a4 4 0 00-1.3-3M11.3 18.9c.3.3.4.6.4 1 0 .2-.1.5-.4.8l-2 2a4 4 0 01-3 1.3c-1.2 0-2.2-.4-3-1.2l-2-2a4.2 4.2 0 01-1.3-3 4 4 0 011.2-3L8 8a4 4 0 013-1.3A4 4 0 0114 8l1.5 1.5c.3.3.4.6.4.9 0 .3-.1.6-.4.9-.5.4-1.3.4-1.7 0l-1.6-1.6c-.7-.7-1.8-.7-2.5 0L3 16.5c-.3.3-.5.7-.5 1.2s.2 1 .5 1.3L5 21c.7.7 1.8.7 2.5 0l2-2c.2-.2.5-.4 1-.4l.8.3"
+                                  mask="url(#mask-2)"
+                            >
+                            </path>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="c-bolt-share__link-text">
+                      Copy share link
+                    </span>
+                  </span>
+                </button>
+                <span class="c-bolt-copy-to-clipboard__transition">
+                  <span class="c-bolt-share__link">
+                    <bolt-icon class="c-bolt-share__copy-animation"
+                               name="refresh"
+                               size="medium"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--refresh c-bolt-icon--medium">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path>
+                            </path>
+                            <g fill="var(--bolt-theme-icon, currentColor)"
+                               fill-rule="nonzero"
+                            >
+                              <path d="M24 4.5c0-.5-.4-1-1-1a1 1 0 00-1 1v3.7l-3-2.8a10 10 0 00-12.8-1 10 10 0 00-3.6 4.8 1 1 0 001.9.6 8 8 0 0113.2-3l2.8 2.7H17a1 1 0 00-1 1c0 .5.4 1 1 1H23.4l.3-.3.2-.4.1-.2V4.4zM20.8 14.6a1 1 0 00-1.3.6 8 8 0 01-13.1 3l-2.9-2.7H7c.6 0 1-.4 1-1s-.4-1-1-1H1a1 1 0 00-.4 0v.1l-.3.2-.2.3v6.3c0 .6.4 1 1 1 .5 0 1-.4 1-1v-3.6L5 19.6a10 10 0 0016.5-3.7c.1-.5-.2-1-.7-1.3z">
+                              </path>
+                            </g>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="u-bolt-visuallyhidden">
+                      Copying...
+                    </span>
+                  </span>
+                </span>
+                <span class="c-bolt-copy-to-clipboard__confirmation">
+                  <div class="c-bolt-share__link">
+                    <bolt-icon name="check"
+                               size="medium"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--check c-bolt-icon--medium">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path>
+                            </path>
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M19.3 6.3L9 16.6l-4.3-4.3a1 1 0 00-1.4 0 1 1 0 000 1.4l5 5a1 1 0 001.4 0l11-11c.4-.4.4-1 0-1.4a1 1 0 00-1.4 0z"
+                            >
+                            </path>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="c-bolt-share__link-text">
+                      Copied!
+                    </span>
+                  </div>
+                </span>
+              </span>
+            </bolt-copy-to-clipboard>
+          </ssr-keep>
+        </bolt-list-item>
       </ssr-keep>
     </bolt-list>
   </div>
 </bolt-share>
 `;
 
-exports[`<bolt-share> Component share opacity: 80 1`] = `
+exports[`Bolt Share Props opacity items: 80 1`] = `
 <bolt-share size="medium"
             opacity="80"
             align="start"
@@ -1318,8 +2307,8 @@ exports[`<bolt-share> Component share opacity: 80 1`] = `
                     role="listitem"
                     class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--facebook"
-               href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse"
+            <a href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
+               class="c-bolt-share__link js-bolt-share__link--facebook"
                target="_blank"
             >
               <bolt-icon name="facebook-solid"
@@ -1350,8 +2339,8 @@ exports[`<bolt-share> Component share opacity: 80 1`] = `
                     role="listitem"
                     class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--twitter"
-               href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!"
+            <a href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
+               class="c-bolt-share__link js-bolt-share__link--twitter"
                target="_blank"
             >
               <bolt-icon name="twitter"
@@ -1382,8 +2371,8 @@ exports[`<bolt-share> Component share opacity: 80 1`] = `
                     role="listitem"
                     class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--linkedin"
-               href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+            <a href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+               class="c-bolt-share__link js-bolt-share__link--linkedin"
                target="_blank"
             >
               <bolt-icon name="linkedin"
@@ -1409,15 +2398,13 @@ exports[`<bolt-share> Component share opacity: 80 1`] = `
             </a>
           </ssr-keep>
         </bolt-list-item>
-        <bolt-list-item last
-                        role="presentation"
-        >
+        <bolt-list-item role="presentation">
           <ssr-keep for="bolt-list-item"
                     role="listitem"
-                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start c-bolt-list-item--last-item"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--email"
-               href="mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+            <a href="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+               class="c-bolt-share__link js-bolt-share__link--email"
                target="_blank"
             >
               <bolt-icon name="email"
@@ -1448,13 +2435,117 @@ exports[`<bolt-share> Component share opacity: 80 1`] = `
             </a>
           </ssr-keep>
         </bolt-list-item>
+        <bolt-list-item last
+                        role="presentation"
+        >
+          <ssr-keep for="bolt-list-item"
+                    role="listitem"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start c-bolt-list-item--last-item"
+          >
+            <bolt-copy-to-clipboard>
+              <span class="c-bolt-copy-to-clipboard js-bolt-copy-to-clipboard">
+                <button class="c-bolt-copy-to-clipboard__trigger"
+                        data-clipboard-text="https://boltdesignsystem.com"
+                >
+                  <span class="c-bolt-share__link">
+                    <bolt-icon name="asset-link"
+                               size="medium"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--asset-link c-bolt-icon--medium">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M22.7 3.2l-1.9-2a4 4 0 00-3-1.2c-1.2 0-2.2.4-3 1.2l-2 2c-.3.3-.5.6-.5 1l.4.8c.5.5 1.3.5 1.8 0l2-2c.4-.4.8-.5 1.3-.5s1 .1 1.3.5l2 2c.3.3.5.7.5 1.2s-.2 1-.5 1.3L14.5 14c-.3.4-.8.6-1.4.6-.6 0-1 0-1.3-.4l-.8-.8-.7-.7c-.3-.3-.6-.4-1-.4a1 1 0 00-.7.4c-.3.2-.5.5-.5.8 0 .3.2.6.5 1l1.4 1.4v.3h.4a4 4 0 002.7.8c1 0 1.8-.3 2.5-.8v.1l.4-.3.1-.2 6.7-6.6c.8-.8 1.2-1.8 1.2-3a4 4 0 00-1.3-3M11.3 18.9c.3.3.4.6.4 1 0 .2-.1.5-.4.8l-2 2a4 4 0 01-3 1.3c-1.2 0-2.2-.4-3-1.2l-2-2a4.2 4.2 0 01-1.3-3 4 4 0 011.2-3L8 8a4 4 0 013-1.3A4 4 0 0114 8l1.5 1.5c.3.3.4.6.4.9 0 .3-.1.6-.4.9-.5.4-1.3.4-1.7 0l-1.6-1.6c-.7-.7-1.8-.7-2.5 0L3 16.5c-.3.3-.5.7-.5 1.2s.2 1 .5 1.3L5 21c.7.7 1.8.7 2.5 0l2-2c.2-.2.5-.4 1-.4l.8.3"
+                                  mask="url(#mask-2)"
+                            >
+                            </path>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="c-bolt-share__link-text">
+                      Copy share link
+                    </span>
+                  </span>
+                </button>
+                <span class="c-bolt-copy-to-clipboard__transition">
+                  <span class="c-bolt-share__link">
+                    <bolt-icon class="c-bolt-share__copy-animation"
+                               name="refresh"
+                               size="medium"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--refresh c-bolt-icon--medium">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path>
+                            </path>
+                            <g fill="var(--bolt-theme-icon, currentColor)"
+                               fill-rule="nonzero"
+                            >
+                              <path d="M24 4.5c0-.5-.4-1-1-1a1 1 0 00-1 1v3.7l-3-2.8a10 10 0 00-12.8-1 10 10 0 00-3.6 4.8 1 1 0 001.9.6 8 8 0 0113.2-3l2.8 2.7H17a1 1 0 00-1 1c0 .5.4 1 1 1H23.4l.3-.3.2-.4.1-.2V4.4zM20.8 14.6a1 1 0 00-1.3.6 8 8 0 01-13.1 3l-2.9-2.7H7c.6 0 1-.4 1-1s-.4-1-1-1H1a1 1 0 00-.4 0v.1l-.3.2-.2.3v6.3c0 .6.4 1 1 1 .5 0 1-.4 1-1v-3.6L5 19.6a10 10 0 0016.5-3.7c.1-.5-.2-1-.7-1.3z">
+                              </path>
+                            </g>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="u-bolt-visuallyhidden">
+                      Copying...
+                    </span>
+                  </span>
+                </span>
+                <span class="c-bolt-copy-to-clipboard__confirmation">
+                  <div class="c-bolt-share__link">
+                    <bolt-icon name="check"
+                               size="medium"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--check c-bolt-icon--medium">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path>
+                            </path>
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M19.3 6.3L9 16.6l-4.3-4.3a1 1 0 00-1.4 0 1 1 0 000 1.4l5 5a1 1 0 001.4 0l11-11c.4-.4.4-1 0-1.4a1 1 0 00-1.4 0z"
+                            >
+                            </path>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="c-bolt-share__link-text">
+                      Copied!
+                    </span>
+                  </div>
+                </span>
+              </span>
+            </bolt-copy-to-clipboard>
+          </ssr-keep>
+        </bolt-list-item>
       </ssr-keep>
     </bolt-list>
   </div>
 </bolt-share>
 `;
 
-exports[`<bolt-share> Component share opacity: 100 1`] = `
+exports[`Bolt Share Props opacity items: 100 1`] = `
 <bolt-share size="medium"
             opacity="100"
             align="start"
@@ -1487,8 +2578,8 @@ exports[`<bolt-share> Component share opacity: 100 1`] = `
                     role="listitem"
                     class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--facebook"
-               href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse"
+            <a href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
+               class="c-bolt-share__link js-bolt-share__link--facebook"
                target="_blank"
             >
               <bolt-icon name="facebook-solid"
@@ -1519,8 +2610,8 @@ exports[`<bolt-share> Component share opacity: 100 1`] = `
                     role="listitem"
                     class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--twitter"
-               href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!"
+            <a href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
+               class="c-bolt-share__link js-bolt-share__link--twitter"
                target="_blank"
             >
               <bolt-icon name="twitter"
@@ -1551,8 +2642,8 @@ exports[`<bolt-share> Component share opacity: 100 1`] = `
                     role="listitem"
                     class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--linkedin"
-               href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+            <a href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+               class="c-bolt-share__link js-bolt-share__link--linkedin"
                target="_blank"
             >
               <bolt-icon name="linkedin"
@@ -1578,15 +2669,13 @@ exports[`<bolt-share> Component share opacity: 100 1`] = `
             </a>
           </ssr-keep>
         </bolt-list-item>
-        <bolt-list-item last
-                        role="presentation"
-        >
+        <bolt-list-item role="presentation">
           <ssr-keep for="bolt-list-item"
                     role="listitem"
-                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start c-bolt-list-item--last-item"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--email"
-               href="mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+            <a href="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+               class="c-bolt-share__link js-bolt-share__link--email"
                target="_blank"
             >
               <bolt-icon name="email"
@@ -1617,13 +2706,117 @@ exports[`<bolt-share> Component share opacity: 100 1`] = `
             </a>
           </ssr-keep>
         </bolt-list-item>
+        <bolt-list-item last
+                        role="presentation"
+        >
+          <ssr-keep for="bolt-list-item"
+                    role="listitem"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start c-bolt-list-item--last-item"
+          >
+            <bolt-copy-to-clipboard>
+              <span class="c-bolt-copy-to-clipboard js-bolt-copy-to-clipboard">
+                <button class="c-bolt-copy-to-clipboard__trigger"
+                        data-clipboard-text="https://boltdesignsystem.com"
+                >
+                  <span class="c-bolt-share__link">
+                    <bolt-icon name="asset-link"
+                               size="medium"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--asset-link c-bolt-icon--medium">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M22.7 3.2l-1.9-2a4 4 0 00-3-1.2c-1.2 0-2.2.4-3 1.2l-2 2c-.3.3-.5.6-.5 1l.4.8c.5.5 1.3.5 1.8 0l2-2c.4-.4.8-.5 1.3-.5s1 .1 1.3.5l2 2c.3.3.5.7.5 1.2s-.2 1-.5 1.3L14.5 14c-.3.4-.8.6-1.4.6-.6 0-1 0-1.3-.4l-.8-.8-.7-.7c-.3-.3-.6-.4-1-.4a1 1 0 00-.7.4c-.3.2-.5.5-.5.8 0 .3.2.6.5 1l1.4 1.4v.3h.4a4 4 0 002.7.8c1 0 1.8-.3 2.5-.8v.1l.4-.3.1-.2 6.7-6.6c.8-.8 1.2-1.8 1.2-3a4 4 0 00-1.3-3M11.3 18.9c.3.3.4.6.4 1 0 .2-.1.5-.4.8l-2 2a4 4 0 01-3 1.3c-1.2 0-2.2-.4-3-1.2l-2-2a4.2 4.2 0 01-1.3-3 4 4 0 011.2-3L8 8a4 4 0 013-1.3A4 4 0 0114 8l1.5 1.5c.3.3.4.6.4.9 0 .3-.1.6-.4.9-.5.4-1.3.4-1.7 0l-1.6-1.6c-.7-.7-1.8-.7-2.5 0L3 16.5c-.3.3-.5.7-.5 1.2s.2 1 .5 1.3L5 21c.7.7 1.8.7 2.5 0l2-2c.2-.2.5-.4 1-.4l.8.3"
+                                  mask="url(#mask-2)"
+                            >
+                            </path>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="c-bolt-share__link-text">
+                      Copy share link
+                    </span>
+                  </span>
+                </button>
+                <span class="c-bolt-copy-to-clipboard__transition">
+                  <span class="c-bolt-share__link">
+                    <bolt-icon class="c-bolt-share__copy-animation"
+                               name="refresh"
+                               size="medium"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--refresh c-bolt-icon--medium">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path>
+                            </path>
+                            <g fill="var(--bolt-theme-icon, currentColor)"
+                               fill-rule="nonzero"
+                            >
+                              <path d="M24 4.5c0-.5-.4-1-1-1a1 1 0 00-1 1v3.7l-3-2.8a10 10 0 00-12.8-1 10 10 0 00-3.6 4.8 1 1 0 001.9.6 8 8 0 0113.2-3l2.8 2.7H17a1 1 0 00-1 1c0 .5.4 1 1 1H23.4l.3-.3.2-.4.1-.2V4.4zM20.8 14.6a1 1 0 00-1.3.6 8 8 0 01-13.1 3l-2.9-2.7H7c.6 0 1-.4 1-1s-.4-1-1-1H1a1 1 0 00-.4 0v.1l-.3.2-.2.3v6.3c0 .6.4 1 1 1 .5 0 1-.4 1-1v-3.6L5 19.6a10 10 0 0016.5-3.7c.1-.5-.2-1-.7-1.3z">
+                              </path>
+                            </g>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="u-bolt-visuallyhidden">
+                      Copying...
+                    </span>
+                  </span>
+                </span>
+                <span class="c-bolt-copy-to-clipboard__confirmation">
+                  <div class="c-bolt-share__link">
+                    <bolt-icon name="check"
+                               size="medium"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--check c-bolt-icon--medium">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path>
+                            </path>
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M19.3 6.3L9 16.6l-4.3-4.3a1 1 0 00-1.4 0 1 1 0 000 1.4l5 5a1 1 0 001.4 0l11-11c.4-.4.4-1 0-1.4a1 1 0 00-1.4 0z"
+                            >
+                            </path>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="c-bolt-share__link-text">
+                      Copied!
+                    </span>
+                  </div>
+                </span>
+              </span>
+            </bolt-copy-to-clipboard>
+          </ssr-keep>
+        </bolt-list-item>
       </ssr-keep>
     </bolt-list>
   </div>
 </bolt-share>
 `;
 
-exports[`<bolt-share> Component share size: medium 1`] = `
+exports[`Bolt Share Props size items: medium 1`] = `
 <bolt-share size="medium"
             opacity="100"
             align="start"
@@ -1656,8 +2849,8 @@ exports[`<bolt-share> Component share size: medium 1`] = `
                     role="listitem"
                     class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--facebook"
-               href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse"
+            <a href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
+               class="c-bolt-share__link js-bolt-share__link--facebook"
                target="_blank"
             >
               <bolt-icon name="facebook-solid"
@@ -1688,8 +2881,8 @@ exports[`<bolt-share> Component share size: medium 1`] = `
                     role="listitem"
                     class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--twitter"
-               href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!"
+            <a href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
+               class="c-bolt-share__link js-bolt-share__link--twitter"
                target="_blank"
             >
               <bolt-icon name="twitter"
@@ -1720,8 +2913,8 @@ exports[`<bolt-share> Component share size: medium 1`] = `
                     role="listitem"
                     class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--linkedin"
-               href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+            <a href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+               class="c-bolt-share__link js-bolt-share__link--linkedin"
                target="_blank"
             >
               <bolt-icon name="linkedin"
@@ -1747,15 +2940,13 @@ exports[`<bolt-share> Component share size: medium 1`] = `
             </a>
           </ssr-keep>
         </bolt-list-item>
-        <bolt-list-item last
-                        role="presentation"
-        >
+        <bolt-list-item role="presentation">
           <ssr-keep for="bolt-list-item"
                     role="listitem"
-                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start c-bolt-list-item--last-item"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--email"
-               href="mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+            <a href="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+               class="c-bolt-share__link js-bolt-share__link--email"
                target="_blank"
             >
               <bolt-icon name="email"
@@ -1786,13 +2977,117 @@ exports[`<bolt-share> Component share size: medium 1`] = `
             </a>
           </ssr-keep>
         </bolt-list-item>
+        <bolt-list-item last
+                        role="presentation"
+        >
+          <ssr-keep for="bolt-list-item"
+                    role="listitem"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start c-bolt-list-item--last-item"
+          >
+            <bolt-copy-to-clipboard>
+              <span class="c-bolt-copy-to-clipboard js-bolt-copy-to-clipboard">
+                <button class="c-bolt-copy-to-clipboard__trigger"
+                        data-clipboard-text="https://boltdesignsystem.com"
+                >
+                  <span class="c-bolt-share__link">
+                    <bolt-icon name="asset-link"
+                               size="medium"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--asset-link c-bolt-icon--medium">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M22.7 3.2l-1.9-2a4 4 0 00-3-1.2c-1.2 0-2.2.4-3 1.2l-2 2c-.3.3-.5.6-.5 1l.4.8c.5.5 1.3.5 1.8 0l2-2c.4-.4.8-.5 1.3-.5s1 .1 1.3.5l2 2c.3.3.5.7.5 1.2s-.2 1-.5 1.3L14.5 14c-.3.4-.8.6-1.4.6-.6 0-1 0-1.3-.4l-.8-.8-.7-.7c-.3-.3-.6-.4-1-.4a1 1 0 00-.7.4c-.3.2-.5.5-.5.8 0 .3.2.6.5 1l1.4 1.4v.3h.4a4 4 0 002.7.8c1 0 1.8-.3 2.5-.8v.1l.4-.3.1-.2 6.7-6.6c.8-.8 1.2-1.8 1.2-3a4 4 0 00-1.3-3M11.3 18.9c.3.3.4.6.4 1 0 .2-.1.5-.4.8l-2 2a4 4 0 01-3 1.3c-1.2 0-2.2-.4-3-1.2l-2-2a4.2 4.2 0 01-1.3-3 4 4 0 011.2-3L8 8a4 4 0 013-1.3A4 4 0 0114 8l1.5 1.5c.3.3.4.6.4.9 0 .3-.1.6-.4.9-.5.4-1.3.4-1.7 0l-1.6-1.6c-.7-.7-1.8-.7-2.5 0L3 16.5c-.3.3-.5.7-.5 1.2s.2 1 .5 1.3L5 21c.7.7 1.8.7 2.5 0l2-2c.2-.2.5-.4 1-.4l.8.3"
+                                  mask="url(#mask-2)"
+                            >
+                            </path>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="c-bolt-share__link-text">
+                      Copy share link
+                    </span>
+                  </span>
+                </button>
+                <span class="c-bolt-copy-to-clipboard__transition">
+                  <span class="c-bolt-share__link">
+                    <bolt-icon class="c-bolt-share__copy-animation"
+                               name="refresh"
+                               size="medium"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--refresh c-bolt-icon--medium">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path>
+                            </path>
+                            <g fill="var(--bolt-theme-icon, currentColor)"
+                               fill-rule="nonzero"
+                            >
+                              <path d="M24 4.5c0-.5-.4-1-1-1a1 1 0 00-1 1v3.7l-3-2.8a10 10 0 00-12.8-1 10 10 0 00-3.6 4.8 1 1 0 001.9.6 8 8 0 0113.2-3l2.8 2.7H17a1 1 0 00-1 1c0 .5.4 1 1 1H23.4l.3-.3.2-.4.1-.2V4.4zM20.8 14.6a1 1 0 00-1.3.6 8 8 0 01-13.1 3l-2.9-2.7H7c.6 0 1-.4 1-1s-.4-1-1-1H1a1 1 0 00-.4 0v.1l-.3.2-.2.3v6.3c0 .6.4 1 1 1 .5 0 1-.4 1-1v-3.6L5 19.6a10 10 0 0016.5-3.7c.1-.5-.2-1-.7-1.3z">
+                              </path>
+                            </g>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="u-bolt-visuallyhidden">
+                      Copying...
+                    </span>
+                  </span>
+                </span>
+                <span class="c-bolt-copy-to-clipboard__confirmation">
+                  <div class="c-bolt-share__link">
+                    <bolt-icon name="check"
+                               size="medium"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--check c-bolt-icon--medium">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path>
+                            </path>
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M19.3 6.3L9 16.6l-4.3-4.3a1 1 0 00-1.4 0 1 1 0 000 1.4l5 5a1 1 0 001.4 0l11-11c.4-.4.4-1 0-1.4a1 1 0 00-1.4 0z"
+                            >
+                            </path>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="c-bolt-share__link-text">
+                      Copied!
+                    </span>
+                  </div>
+                </span>
+              </span>
+            </bolt-copy-to-clipboard>
+          </ssr-keep>
+        </bolt-list-item>
       </ssr-keep>
     </bolt-list>
   </div>
 </bolt-share>
 `;
 
-exports[`<bolt-share> Component share size: small 1`] = `
+exports[`Bolt Share Props size items: small 1`] = `
 <bolt-share size="small"
             opacity="100"
             align="start"
@@ -1825,8 +3120,8 @@ exports[`<bolt-share> Component share size: small 1`] = `
                     role="listitem"
                     class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-xsmall c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--facebook"
-               href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse"
+            <a href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
+               class="c-bolt-share__link js-bolt-share__link--facebook"
                target="_blank"
             >
               <bolt-icon name="facebook-solid"
@@ -1857,8 +3152,8 @@ exports[`<bolt-share> Component share size: small 1`] = `
                     role="listitem"
                     class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-xsmall c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--twitter"
-               href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!"
+            <a href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
+               class="c-bolt-share__link js-bolt-share__link--twitter"
                target="_blank"
             >
               <bolt-icon name="twitter"
@@ -1889,8 +3184,8 @@ exports[`<bolt-share> Component share size: small 1`] = `
                     role="listitem"
                     class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-xsmall c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--linkedin"
-               href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+            <a href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+               class="c-bolt-share__link js-bolt-share__link--linkedin"
                target="_blank"
             >
               <bolt-icon name="linkedin"
@@ -1916,15 +3211,13 @@ exports[`<bolt-share> Component share size: small 1`] = `
             </a>
           </ssr-keep>
         </bolt-list-item>
-        <bolt-list-item last
-                        role="presentation"
-        >
+        <bolt-list-item role="presentation">
           <ssr-keep for="bolt-list-item"
                     role="listitem"
-                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-xsmall c-bolt-list-item--align-start c-bolt-list-item--last-item"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-xsmall c-bolt-list-item--align-start"
           >
-            <a class="c-bolt-share__link js-bolt-share__link--email"
-               href="mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+            <a href="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+               class="c-bolt-share__link js-bolt-share__link--email"
                target="_blank"
             >
               <bolt-icon name="email"
@@ -1953,6 +3246,652 @@ exports[`<bolt-share> Component share size: small 1`] = `
                 Share via Email
               </span>
             </a>
+          </ssr-keep>
+        </bolt-list-item>
+        <bolt-list-item last
+                        role="presentation"
+        >
+          <ssr-keep for="bolt-list-item"
+                    role="listitem"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-xsmall c-bolt-list-item--align-start c-bolt-list-item--last-item"
+          >
+            <bolt-copy-to-clipboard>
+              <span class="c-bolt-copy-to-clipboard js-bolt-copy-to-clipboard">
+                <button class="c-bolt-copy-to-clipboard__trigger"
+                        data-clipboard-text="https://boltdesignsystem.com"
+                >
+                  <span class="c-bolt-share__link">
+                    <bolt-icon name="asset-link"
+                               size="small"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--asset-link c-bolt-icon--small">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--small"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M22.7 3.2l-1.9-2a4 4 0 00-3-1.2c-1.2 0-2.2.4-3 1.2l-2 2c-.3.3-.5.6-.5 1l.4.8c.5.5 1.3.5 1.8 0l2-2c.4-.4.8-.5 1.3-.5s1 .1 1.3.5l2 2c.3.3.5.7.5 1.2s-.2 1-.5 1.3L14.5 14c-.3.4-.8.6-1.4.6-.6 0-1 0-1.3-.4l-.8-.8-.7-.7c-.3-.3-.6-.4-1-.4a1 1 0 00-.7.4c-.3.2-.5.5-.5.8 0 .3.2.6.5 1l1.4 1.4v.3h.4a4 4 0 002.7.8c1 0 1.8-.3 2.5-.8v.1l.4-.3.1-.2 6.7-6.6c.8-.8 1.2-1.8 1.2-3a4 4 0 00-1.3-3M11.3 18.9c.3.3.4.6.4 1 0 .2-.1.5-.4.8l-2 2a4 4 0 01-3 1.3c-1.2 0-2.2-.4-3-1.2l-2-2a4.2 4.2 0 01-1.3-3 4 4 0 011.2-3L8 8a4 4 0 013-1.3A4 4 0 0114 8l1.5 1.5c.3.3.4.6.4.9 0 .3-.1.6-.4.9-.5.4-1.3.4-1.7 0l-1.6-1.6c-.7-.7-1.8-.7-2.5 0L3 16.5c-.3.3-.5.7-.5 1.2s.2 1 .5 1.3L5 21c.7.7 1.8.7 2.5 0l2-2c.2-.2.5-.4 1-.4l.8.3"
+                                  mask="url(#mask-2)"
+                            >
+                            </path>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="c-bolt-share__link-text">
+                      Copy share link
+                    </span>
+                  </span>
+                </button>
+                <span class="c-bolt-copy-to-clipboard__transition">
+                  <span class="c-bolt-share__link">
+                    <bolt-icon class="c-bolt-share__copy-animation"
+                               name="refresh"
+                               size="small"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--refresh c-bolt-icon--small">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--small"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path>
+                            </path>
+                            <g fill="var(--bolt-theme-icon, currentColor)"
+                               fill-rule="nonzero"
+                            >
+                              <path d="M24 4.5c0-.5-.4-1-1-1a1 1 0 00-1 1v3.7l-3-2.8a10 10 0 00-12.8-1 10 10 0 00-3.6 4.8 1 1 0 001.9.6 8 8 0 0113.2-3l2.8 2.7H17a1 1 0 00-1 1c0 .5.4 1 1 1H23.4l.3-.3.2-.4.1-.2V4.4zM20.8 14.6a1 1 0 00-1.3.6 8 8 0 01-13.1 3l-2.9-2.7H7c.6 0 1-.4 1-1s-.4-1-1-1H1a1 1 0 00-.4 0v.1l-.3.2-.2.3v6.3c0 .6.4 1 1 1 .5 0 1-.4 1-1v-3.6L5 19.6a10 10 0 0016.5-3.7c.1-.5-.2-1-.7-1.3z">
+                              </path>
+                            </g>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="u-bolt-visuallyhidden">
+                      Copying...
+                    </span>
+                  </span>
+                </span>
+                <span class="c-bolt-copy-to-clipboard__confirmation">
+                  <div class="c-bolt-share__link">
+                    <bolt-icon name="check"
+                               size="small"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--check c-bolt-icon--small">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--small"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path>
+                            </path>
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M19.3 6.3L9 16.6l-4.3-4.3a1 1 0 00-1.4 0 1 1 0 000 1.4l5 5a1 1 0 001.4 0l11-11c.4-.4.4-1 0-1.4a1 1 0 00-1.4 0z"
+                            >
+                            </path>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="c-bolt-share__link-text">
+                      Copied!
+                    </span>
+                  </div>
+                </span>
+              </span>
+            </bolt-copy-to-clipboard>
+          </ssr-keep>
+        </bolt-list-item>
+      </ssr-keep>
+    </bolt-list>
+  </div>
+</bolt-share>
+`;
+
+exports[`Bolt Share default 1`] = `
+<bolt-share size="medium"
+            opacity="100"
+            align="start"
+            display="inline"
+>
+  <div class="c-bolt-share c-bolt-share--opacity-100">
+    <bolt-list tag="ul"
+               display="inline"
+               spacing="small"
+               separator="none"
+               align="start"
+               valign="center"
+    >
+      <ssr-keep for="bolt-list"
+                role="list"
+                class="c-bolt-list c-bolt-list--display-inline c-bolt-list--spacing-small c-bolt-list--align-start c-bolt-list--valign-center"
+      >
+        <bolt-list-item role="presentation">
+          <ssr-keep for="bolt-list-item"
+                    role="listitem"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
+          >
+            <span class="c-bolt-share__label c-bolt-share__label--medium">
+              Share this page
+            </span>
+          </ssr-keep>
+        </bolt-list-item>
+        <bolt-list-item role="presentation">
+          <ssr-keep for="bolt-list-item"
+                    role="listitem"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
+          >
+            <a href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
+               class="c-bolt-share__link js-bolt-share__link--facebook"
+               target="_blank"
+            >
+              <bolt-icon name="facebook-solid"
+                         size="medium"
+                         aria-hidden="true"
+              >
+                <span class="c-bolt-icon c-bolt-icon--facebook-solid c-bolt-icon--medium">
+                  <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                       xmlns="http://www.w3.org/2000/svg"
+                       data-name="Layer 1"
+                       viewbox="0 0 32 32"
+                  >
+                    <path fill="var(--bolt-theme-icon, currentColor)"
+                          d="M26 0a6 6 0 016 6v20a6 6 0 01-6 6h-4V19.6h4.2l.6-4.8h-4.7v-3.1c0-1.4.4-2.3 2.4-2.3H27V5a33.8 33.8 0 00-3.7-.2c-3.7 0-6.2 2.3-6.2 6.4v3.6h-4.2v4.8h4.2V32H6a6 6 0 01-6-6V6a6 6 0 016-6z"
+                    >
+                    </path>
+                  </svg>
+                </span>
+              </bolt-icon>
+              <span class="c-bolt-share__link-text">
+                Share via Facebook
+              </span>
+            </a>
+          </ssr-keep>
+        </bolt-list-item>
+        <bolt-list-item role="presentation">
+          <ssr-keep for="bolt-list-item"
+                    role="listitem"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
+          >
+            <a href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
+               class="c-bolt-share__link js-bolt-share__link--twitter"
+               target="_blank"
+            >
+              <bolt-icon name="twitter"
+                         size="medium"
+                         aria-hidden="true"
+              >
+                <span class="c-bolt-icon c-bolt-icon--twitter c-bolt-icon--medium">
+                  <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                       xmlns="http://www.w3.org/2000/svg"
+                       data-name="Layer 1"
+                       viewbox="0 0 32 26"
+                  >
+                    <path fill="var(--bolt-theme-icon, currentColor)"
+                          d="M32 3a14 14 0 01-3.3 3.5v.8C28.7 16 22.1 26 10.1 26A18.5 18.5 0 010 23a13.8 13.8 0 001.6.1 13.1 13.1 0 008.1-2.8 6.6 6.6 0 01-6.1-4.5 8.5 8.5 0 001.2 0 7 7 0 001.8-.1 6.6 6.6 0 01-5.3-6.5 6.5 6.5 0 003 .8 6.6 6.6 0 01-2-8.8 18.6 18.6 0 0013.5 6.9 7.4 7.4 0 01-.1-1.5A6.6 6.6 0 0122 0 6.5 6.5 0 0127 2 13 13 0 0031.1.6 6.6 6.6 0 0128.2 4a13 13 0 003.8-1z"
+                    >
+                    </path>
+                  </svg>
+                </span>
+              </bolt-icon>
+              <span class="c-bolt-share__link-text">
+                Share via Twitter
+              </span>
+            </a>
+          </ssr-keep>
+        </bolt-list-item>
+        <bolt-list-item role="presentation">
+          <ssr-keep for="bolt-list-item"
+                    role="listitem"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
+          >
+            <a href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+               class="c-bolt-share__link js-bolt-share__link--linkedin"
+               target="_blank"
+            >
+              <bolt-icon name="linkedin"
+                         size="medium"
+                         aria-hidden="true"
+              >
+                <span class="c-bolt-icon c-bolt-icon--linkedin c-bolt-icon--medium">
+                  <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                       xmlns="http://www.w3.org/2000/svg"
+                       data-name="Layer 1"
+                       viewbox="0 0 32 30.6"
+                  >
+                    <path fill="var(--bolt-theme-icon, currentColor)"
+                          d="M7.3 10v20.6H.4V9.9zm.4-6.4A3.6 3.6 0 013.8 7a3.6 3.6 0 110-7.1 3.5 3.5 0 014 3.6zM32 18.8v11.8h-6.9v-11c0-2.8-1-4.7-3.4-4.7a3.8 3.8 0 00-3.6 2.5 5.1 5.1 0 00-.2 1.7v11.5h-6.8V9.9h6.8v3A6.8 6.8 0 0124 9.5c4.5 0 7.9 3 7.9 9.3z"
+                    >
+                    </path>
+                  </svg>
+                </span>
+              </bolt-icon>
+              <span class="c-bolt-share__link-text">
+                Share via LinkedIn
+              </span>
+            </a>
+          </ssr-keep>
+        </bolt-list-item>
+        <bolt-list-item role="presentation">
+          <ssr-keep for="bolt-list-item"
+                    role="listitem"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
+          >
+            <a href="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+               class="c-bolt-share__link js-bolt-share__link--email"
+               target="_blank"
+            >
+              <bolt-icon name="email"
+                         size="medium"
+                         aria-hidden="true"
+              >
+                <span class="c-bolt-icon c-bolt-icon--email c-bolt-icon--medium">
+                  <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                       xmlns="http://www.w3.org/2000/svg"
+                       viewbox="0 0 24 24"
+                  >
+                    <g fill="none"
+                       fill-rule="evenodd"
+                    >
+                      <path>
+                      </path>
+                      <path fill="var(--bolt-theme-icon, currentColor)"
+                            d="M20 19H4a1 1 0 01-1-1V8l8.4 5.8.6.2c.2 0 .4 0 .6-.2L21 8V18c0 .6-.4 1-1 1zM4 5h16c.4 0 .7.2.9.6L12 11.8 3.1 5.6c.2-.4.5-.6.9-.6zm19 1a3 3 0 00-3-3H4a3 3 0 00-3 3v12a3 3 0 003 3h16a3 3 0 003-3V6z"
+                      >
+                      </path>
+                    </g>
+                  </svg>
+                </span>
+              </bolt-icon>
+              <span class="c-bolt-share__link-text">
+                Share via Email
+              </span>
+            </a>
+          </ssr-keep>
+        </bolt-list-item>
+        <bolt-list-item last
+                        role="presentation"
+        >
+          <ssr-keep for="bolt-list-item"
+                    role="listitem"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start c-bolt-list-item--last-item"
+          >
+            <bolt-copy-to-clipboard>
+              <span class="c-bolt-copy-to-clipboard js-bolt-copy-to-clipboard">
+                <button class="c-bolt-copy-to-clipboard__trigger"
+                        data-clipboard-text="https://boltdesignsystem.com"
+                >
+                  <span class="c-bolt-share__link">
+                    <bolt-icon name="asset-link"
+                               size="medium"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--asset-link c-bolt-icon--medium">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M22.7 3.2l-1.9-2a4 4 0 00-3-1.2c-1.2 0-2.2.4-3 1.2l-2 2c-.3.3-.5.6-.5 1l.4.8c.5.5 1.3.5 1.8 0l2-2c.4-.4.8-.5 1.3-.5s1 .1 1.3.5l2 2c.3.3.5.7.5 1.2s-.2 1-.5 1.3L14.5 14c-.3.4-.8.6-1.4.6-.6 0-1 0-1.3-.4l-.8-.8-.7-.7c-.3-.3-.6-.4-1-.4a1 1 0 00-.7.4c-.3.2-.5.5-.5.8 0 .3.2.6.5 1l1.4 1.4v.3h.4a4 4 0 002.7.8c1 0 1.8-.3 2.5-.8v.1l.4-.3.1-.2 6.7-6.6c.8-.8 1.2-1.8 1.2-3a4 4 0 00-1.3-3M11.3 18.9c.3.3.4.6.4 1 0 .2-.1.5-.4.8l-2 2a4 4 0 01-3 1.3c-1.2 0-2.2-.4-3-1.2l-2-2a4.2 4.2 0 01-1.3-3 4 4 0 011.2-3L8 8a4 4 0 013-1.3A4 4 0 0114 8l1.5 1.5c.3.3.4.6.4.9 0 .3-.1.6-.4.9-.5.4-1.3.4-1.7 0l-1.6-1.6c-.7-.7-1.8-.7-2.5 0L3 16.5c-.3.3-.5.7-.5 1.2s.2 1 .5 1.3L5 21c.7.7 1.8.7 2.5 0l2-2c.2-.2.5-.4 1-.4l.8.3"
+                                  mask="url(#mask-2)"
+                            >
+                            </path>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="c-bolt-share__link-text">
+                      Copy share link
+                    </span>
+                  </span>
+                </button>
+                <span class="c-bolt-copy-to-clipboard__transition">
+                  <span class="c-bolt-share__link">
+                    <bolt-icon class="c-bolt-share__copy-animation"
+                               name="refresh"
+                               size="medium"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--refresh c-bolt-icon--medium">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path>
+                            </path>
+                            <g fill="var(--bolt-theme-icon, currentColor)"
+                               fill-rule="nonzero"
+                            >
+                              <path d="M24 4.5c0-.5-.4-1-1-1a1 1 0 00-1 1v3.7l-3-2.8a10 10 0 00-12.8-1 10 10 0 00-3.6 4.8 1 1 0 001.9.6 8 8 0 0113.2-3l2.8 2.7H17a1 1 0 00-1 1c0 .5.4 1 1 1H23.4l.3-.3.2-.4.1-.2V4.4zM20.8 14.6a1 1 0 00-1.3.6 8 8 0 01-13.1 3l-2.9-2.7H7c.6 0 1-.4 1-1s-.4-1-1-1H1a1 1 0 00-.4 0v.1l-.3.2-.2.3v6.3c0 .6.4 1 1 1 .5 0 1-.4 1-1v-3.6L5 19.6a10 10 0 0016.5-3.7c.1-.5-.2-1-.7-1.3z">
+                              </path>
+                            </g>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="u-bolt-visuallyhidden">
+                      Copying...
+                    </span>
+                  </span>
+                </span>
+                <span class="c-bolt-copy-to-clipboard__confirmation">
+                  <div class="c-bolt-share__link">
+                    <bolt-icon name="check"
+                               size="medium"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--check c-bolt-icon--medium">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path>
+                            </path>
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M19.3 6.3L9 16.6l-4.3-4.3a1 1 0 00-1.4 0 1 1 0 000 1.4l5 5a1 1 0 001.4 0l11-11c.4-.4.4-1 0-1.4a1 1 0 00-1.4 0z"
+                            >
+                            </path>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="c-bolt-share__link-text">
+                      Copied!
+                    </span>
+                  </div>
+                </span>
+              </span>
+            </bolt-copy-to-clipboard>
+          </ssr-keep>
+        </bolt-list-item>
+      </ssr-keep>
+    </bolt-list>
+  </div>
+</bolt-share>
+`;
+
+exports[`Bolt Share url deprecated test 1`] = `
+<bolt-share size="medium"
+            opacity="100"
+            align="start"
+            display="inline"
+>
+  <div class="c-bolt-share c-bolt-share--opacity-100">
+    <bolt-list tag="ul"
+               display="inline"
+               spacing="small"
+               separator="none"
+               align="start"
+               valign="center"
+    >
+      <ssr-keep for="bolt-list"
+                role="list"
+                class="c-bolt-list c-bolt-list--display-inline c-bolt-list--spacing-small c-bolt-list--align-start c-bolt-list--valign-center"
+      >
+        <bolt-list-item role="presentation">
+          <ssr-keep for="bolt-list-item"
+                    role="listitem"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
+          >
+            <span class="c-bolt-share__label c-bolt-share__label--medium">
+              Share this page
+            </span>
+          </ssr-keep>
+        </bolt-list-item>
+        <bolt-list-item role="presentation">
+          <ssr-keep for="bolt-list-item"
+                    role="listitem"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
+          >
+            <a href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
+               class="c-bolt-share__link js-bolt-share__link--facebook"
+               target="_blank"
+            >
+              <bolt-icon name="facebook-solid"
+                         size="medium"
+                         aria-hidden="true"
+              >
+                <span class="c-bolt-icon c-bolt-icon--facebook-solid c-bolt-icon--medium">
+                  <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                       xmlns="http://www.w3.org/2000/svg"
+                       data-name="Layer 1"
+                       viewbox="0 0 32 32"
+                  >
+                    <path fill="var(--bolt-theme-icon, currentColor)"
+                          d="M26 0a6 6 0 016 6v20a6 6 0 01-6 6h-4V19.6h4.2l.6-4.8h-4.7v-3.1c0-1.4.4-2.3 2.4-2.3H27V5a33.8 33.8 0 00-3.7-.2c-3.7 0-6.2 2.3-6.2 6.4v3.6h-4.2v4.8h4.2V32H6a6 6 0 01-6-6V6a6 6 0 016-6z"
+                    >
+                    </path>
+                  </svg>
+                </span>
+              </bolt-icon>
+              <span class="c-bolt-share__link-text">
+                Share via Facebook
+              </span>
+            </a>
+          </ssr-keep>
+        </bolt-list-item>
+        <bolt-list-item role="presentation">
+          <ssr-keep for="bolt-list-item"
+                    role="listitem"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
+          >
+            <a href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
+               class="c-bolt-share__link js-bolt-share__link--twitter"
+               target="_blank"
+            >
+              <bolt-icon name="twitter"
+                         size="medium"
+                         aria-hidden="true"
+              >
+                <span class="c-bolt-icon c-bolt-icon--twitter c-bolt-icon--medium">
+                  <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                       xmlns="http://www.w3.org/2000/svg"
+                       data-name="Layer 1"
+                       viewbox="0 0 32 26"
+                  >
+                    <path fill="var(--bolt-theme-icon, currentColor)"
+                          d="M32 3a14 14 0 01-3.3 3.5v.8C28.7 16 22.1 26 10.1 26A18.5 18.5 0 010 23a13.8 13.8 0 001.6.1 13.1 13.1 0 008.1-2.8 6.6 6.6 0 01-6.1-4.5 8.5 8.5 0 001.2 0 7 7 0 001.8-.1 6.6 6.6 0 01-5.3-6.5 6.5 6.5 0 003 .8 6.6 6.6 0 01-2-8.8 18.6 18.6 0 0013.5 6.9 7.4 7.4 0 01-.1-1.5A6.6 6.6 0 0122 0 6.5 6.5 0 0127 2 13 13 0 0031.1.6 6.6 6.6 0 0128.2 4a13 13 0 003.8-1z"
+                    >
+                    </path>
+                  </svg>
+                </span>
+              </bolt-icon>
+              <span class="c-bolt-share__link-text">
+                Share via Twitter
+              </span>
+            </a>
+          </ssr-keep>
+        </bolt-list-item>
+        <bolt-list-item role="presentation">
+          <ssr-keep for="bolt-list-item"
+                    role="listitem"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
+          >
+            <a href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
+               class="c-bolt-share__link js-bolt-share__link--linkedin"
+               target="_blank"
+            >
+              <bolt-icon name="linkedin"
+                         size="medium"
+                         aria-hidden="true"
+              >
+                <span class="c-bolt-icon c-bolt-icon--linkedin c-bolt-icon--medium">
+                  <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                       xmlns="http://www.w3.org/2000/svg"
+                       data-name="Layer 1"
+                       viewbox="0 0 32 30.6"
+                  >
+                    <path fill="var(--bolt-theme-icon, currentColor)"
+                          d="M7.3 10v20.6H.4V9.9zm.4-6.4A3.6 3.6 0 013.8 7a3.6 3.6 0 110-7.1 3.5 3.5 0 014 3.6zM32 18.8v11.8h-6.9v-11c0-2.8-1-4.7-3.4-4.7a3.8 3.8 0 00-3.6 2.5 5.1 5.1 0 00-.2 1.7v11.5h-6.8V9.9h6.8v3A6.8 6.8 0 0124 9.5c4.5 0 7.9 3 7.9 9.3z"
+                    >
+                    </path>
+                  </svg>
+                </span>
+              </bolt-icon>
+              <span class="c-bolt-share__link-text">
+                Share via LinkedIn
+              </span>
+            </a>
+          </ssr-keep>
+        </bolt-list-item>
+        <bolt-list-item role="presentation">
+          <ssr-keep for="bolt-list-item"
+                    role="listitem"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start"
+          >
+            <a href="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
+               class="c-bolt-share__link js-bolt-share__link--email"
+               target="_blank"
+            >
+              <bolt-icon name="email"
+                         size="medium"
+                         aria-hidden="true"
+              >
+                <span class="c-bolt-icon c-bolt-icon--email c-bolt-icon--medium">
+                  <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                       xmlns="http://www.w3.org/2000/svg"
+                       viewbox="0 0 24 24"
+                  >
+                    <g fill="none"
+                       fill-rule="evenodd"
+                    >
+                      <path>
+                      </path>
+                      <path fill="var(--bolt-theme-icon, currentColor)"
+                            d="M20 19H4a1 1 0 01-1-1V8l8.4 5.8.6.2c.2 0 .4 0 .6-.2L21 8V18c0 .6-.4 1-1 1zM4 5h16c.4 0 .7.2.9.6L12 11.8 3.1 5.6c.2-.4.5-.6.9-.6zm19 1a3 3 0 00-3-3H4a3 3 0 00-3 3v12a3 3 0 003 3h16a3 3 0 003-3V6z"
+                      >
+                      </path>
+                    </g>
+                  </svg>
+                </span>
+              </bolt-icon>
+              <span class="c-bolt-share__link-text">
+                Share via Email
+              </span>
+            </a>
+          </ssr-keep>
+        </bolt-list-item>
+        <bolt-list-item last
+                        role="presentation"
+        >
+          <ssr-keep for="bolt-list-item"
+                    role="listitem"
+                    class="c-bolt-list-item c-bolt-list-item--display-inline c-bolt-list-item--spacing-small c-bolt-list-item--align-start c-bolt-list-item--last-item"
+          >
+            <bolt-copy-to-clipboard>
+              <span class="c-bolt-copy-to-clipboard js-bolt-copy-to-clipboard">
+                <button class="c-bolt-copy-to-clipboard__trigger"
+                        data-clipboard-text="https://boltdesignsystem.com"
+                >
+                  <span class="c-bolt-share__link">
+                    <bolt-icon name="asset-link"
+                               size="medium"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--asset-link c-bolt-icon--medium">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M22.7 3.2l-1.9-2a4 4 0 00-3-1.2c-1.2 0-2.2.4-3 1.2l-2 2c-.3.3-.5.6-.5 1l.4.8c.5.5 1.3.5 1.8 0l2-2c.4-.4.8-.5 1.3-.5s1 .1 1.3.5l2 2c.3.3.5.7.5 1.2s-.2 1-.5 1.3L14.5 14c-.3.4-.8.6-1.4.6-.6 0-1 0-1.3-.4l-.8-.8-.7-.7c-.3-.3-.6-.4-1-.4a1 1 0 00-.7.4c-.3.2-.5.5-.5.8 0 .3.2.6.5 1l1.4 1.4v.3h.4a4 4 0 002.7.8c1 0 1.8-.3 2.5-.8v.1l.4-.3.1-.2 6.7-6.6c.8-.8 1.2-1.8 1.2-3a4 4 0 00-1.3-3M11.3 18.9c.3.3.4.6.4 1 0 .2-.1.5-.4.8l-2 2a4 4 0 01-3 1.3c-1.2 0-2.2-.4-3-1.2l-2-2a4.2 4.2 0 01-1.3-3 4 4 0 011.2-3L8 8a4 4 0 013-1.3A4 4 0 0114 8l1.5 1.5c.3.3.4.6.4.9 0 .3-.1.6-.4.9-.5.4-1.3.4-1.7 0l-1.6-1.6c-.7-.7-1.8-.7-2.5 0L3 16.5c-.3.3-.5.7-.5 1.2s.2 1 .5 1.3L5 21c.7.7 1.8.7 2.5 0l2-2c.2-.2.5-.4 1-.4l.8.3"
+                                  mask="url(#mask-2)"
+                            >
+                            </path>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="c-bolt-share__link-text">
+                      Copy share link
+                    </span>
+                  </span>
+                </button>
+                <span class="c-bolt-copy-to-clipboard__transition">
+                  <span class="c-bolt-share__link">
+                    <bolt-icon class="c-bolt-share__copy-animation"
+                               name="refresh"
+                               size="medium"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--refresh c-bolt-icon--medium">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path>
+                            </path>
+                            <g fill="var(--bolt-theme-icon, currentColor)"
+                               fill-rule="nonzero"
+                            >
+                              <path d="M24 4.5c0-.5-.4-1-1-1a1 1 0 00-1 1v3.7l-3-2.8a10 10 0 00-12.8-1 10 10 0 00-3.6 4.8 1 1 0 001.9.6 8 8 0 0113.2-3l2.8 2.7H17a1 1 0 00-1 1c0 .5.4 1 1 1H23.4l.3-.3.2-.4.1-.2V4.4zM20.8 14.6a1 1 0 00-1.3.6 8 8 0 01-13.1 3l-2.9-2.7H7c.6 0 1-.4 1-1s-.4-1-1-1H1a1 1 0 00-.4 0v.1l-.3.2-.2.3v6.3c0 .6.4 1 1 1 .5 0 1-.4 1-1v-3.6L5 19.6a10 10 0 0016.5-3.7c.1-.5-.2-1-.7-1.3z">
+                              </path>
+                            </g>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="u-bolt-visuallyhidden">
+                      Copying...
+                    </span>
+                  </span>
+                </span>
+                <span class="c-bolt-copy-to-clipboard__confirmation">
+                  <div class="c-bolt-share__link">
+                    <bolt-icon name="check"
+                               size="medium"
+                               aria-hidden="true"
+                    >
+                      <span class="c-bolt-icon c-bolt-icon--check c-bolt-icon--medium">
+                        <svg class="c-bolt-icon__icon c-bolt-icon__icon--medium"
+                             xmlns="http://www.w3.org/2000/svg"
+                             viewbox="0 0 24 24"
+                        >
+                          <g fill="none"
+                             fill-rule="evenodd"
+                          >
+                            <path>
+                            </path>
+                            <path fill="var(--bolt-theme-icon, currentColor)"
+                                  d="M19.3 6.3L9 16.6l-4.3-4.3a1 1 0 00-1.4 0 1 1 0 000 1.4l5 5a1 1 0 001.4 0l11-11c.4-.4.4-1 0-1.4a1 1 0 00-1.4 0z"
+                            >
+                            </path>
+                          </g>
+                        </svg>
+                      </span>
+                    </bolt-icon>
+                    <span class="c-bolt-share__link-text">
+                      Copied!
+                    </span>
+                  </div>
+                </span>
+              </span>
+            </bolt-copy-to-clipboard>
           </ssr-keep>
         </bolt-list-item>
       </ssr-keep>

--- a/packages/components/bolt-share/__tests__/share.js
+++ b/packages/components/bolt-share/__tests__/share.js
@@ -1,137 +1,171 @@
 import { render, stopServer } from '../../../testing/testing-helpers';
 import schema from '../share.schema';
 const { size, opacity, align } = schema.properties;
+let page, fixtures;
 
-describe('<bolt-share> Component', () => {
-  afterAll(async () => {
-    await stopServer();
-  }, 100);
+afterAll(async () => {
+  await stopServer();
+  await page.close();
+}, 100);
 
-  test('basic usage', async () => {
-    const results = await render('@bolt-components-share/share.twig', {
-      sources: [
-        {
-          name: 'facebook',
-          url:
+beforeEach(async () => {
+  await page.evaluate(() => {
+    document.body.innerHTML = '';
+  });
+  await page.setViewport({ width: 800, height: 400 });
+});
+
+beforeAll(async () => {
+  page = await global.__BROWSER__.newPage();
+  await page.goto('http://127.0.0.1:4444/', {
+    timeout: 0,
+  });
+
+  const defaultData = {
+    sources: [
+      {
+        name: 'facebook',
+        attributes: {
+          href:
             'https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse',
         },
-        {
-          name: 'twitter',
-          url:
+      },
+      {
+        name: 'twitter',
+        attributes: {
+          href:
             'https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!',
         },
-        {
-          name: 'linkedin',
-          url:
+      },
+      {
+        name: 'linkedin',
+        attributes: {
+          href:
             'https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com',
         },
-        {
-          name: 'email',
-          url:
+      },
+      {
+        name: 'email',
+        attributes: {
+          href:
             'mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com',
         },
-      ],
-      copy_to_clipboard: {
-        text_to_copy: 'https://boltdesignsystem.com',
       },
+    ],
+    copy_to_clipboard: {
+      text_to_copy: 'https://boltdesignsystem.com',
+    },
+  };
+
+  const deprecatedData = {
+    sources: [
+      {
+        name: 'facebook',
+        url:
+          'https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse',
+      },
+      {
+        name: 'twitter',
+        url:
+          'https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!',
+      },
+      {
+        name: 'linkedin',
+        url:
+          'https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com',
+      },
+      {
+        name: 'email',
+        url:
+          'mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com',
+      },
+    ],
+    copy_to_clipboard: {
+      text_to_copy: 'https://boltdesignsystem.com',
+    },
+  };
+
+  fixtures = {
+    defaultData,
+    deprecatedData,
+  };
+});
+
+describe('Bolt Share', () => {
+  test(`default`, async () => {
+    const results = await render('@bolt-components-share/share.twig', {
+      ...fixtures.defaultData,
     });
-    expect(results.ok).toBe(true);
-    expect(results.html).toMatchSnapshot();
+
+    await expect(results.ok).toBe(true);
+    await expect(results.html).toMatchSnapshot();
   });
 
-  size.enum.forEach(async sizeChoice => {
-    test(`share size: ${sizeChoice}`, async () => {
+  test(`url deprecated test`, async () => {
+    const results = await render('@bolt-components-share/share.twig', {
+      ...fixtures.deprecatedData,
+    });
+
+    await expect(results.ok).toBe(true);
+    await expect(results.html).toMatchSnapshot();
+  });
+});
+
+describe('Bolt Share Props', () => {
+  test(`display menu test`, async () => {
+    const results = await render('@bolt-components-share/share.twig', {
+      ...fixtures.defaultData,
+      display: 'menu',
+    });
+
+    await expect(results.ok).toBe(true);
+    await expect(results.html).toMatchSnapshot();
+
+    const deprecatedResults = await render(
+      '@bolt-components-share/share.twig',
+      {
+        ...fixtures.deprecatedData,
+        display: 'menu',
+      },
+    );
+
+    await expect(deprecatedResults.ok).toBe(true);
+    await expect(deprecatedResults.html).toMatchSnapshot();
+  });
+
+  size.enum.forEach(async option => {
+    test(`size items: ${option}`, async () => {
       const results = await render('@bolt-components-share/share.twig', {
-        size: sizeChoice,
-        sources: [
-          {
-            name: 'facebook',
-            url:
-              'https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse',
-          },
-          {
-            name: 'twitter',
-            url:
-              'https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!',
-          },
-          {
-            name: 'linkedin',
-            url:
-              'https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com',
-          },
-          {
-            name: 'email',
-            url:
-              'mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com',
-          },
-        ],
+        ...fixtures.defaultData,
+        size: option,
       });
-      expect(results.ok).toBe(true);
-      expect(results.html).toMatchSnapshot();
+
+      await expect(results.ok).toBe(true);
+      await expect(results.html).toMatchSnapshot();
     });
   });
 
-  opacity.enum.forEach(async opacityChoice => {
-    test(`share opacity: ${opacityChoice}`, async () => {
+  opacity.enum.forEach(async option => {
+    test(`opacity items: ${option}`, async () => {
       const results = await render('@bolt-components-share/share.twig', {
-        opacity: opacityChoice,
-        sources: [
-          {
-            name: 'facebook',
-            url:
-              'https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse',
-          },
-          {
-            name: 'twitter',
-            url:
-              'https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!',
-          },
-          {
-            name: 'linkedin',
-            url:
-              'https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com',
-          },
-          {
-            name: 'email',
-            url:
-              'mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com',
-          },
-        ],
+        ...fixtures.defaultData,
+        opacity: option,
       });
-      expect(results.ok).toBe(true);
-      expect(results.html).toMatchSnapshot();
+
+      await expect(results.ok).toBe(true);
+      await expect(results.html).toMatchSnapshot();
     });
   });
 
-  align.enum.forEach(async alignChoice => {
-    test(`share align: ${alignChoice}`, async () => {
+  align.enum.forEach(async option => {
+    test(`align items: ${option}`, async () => {
       const results = await render('@bolt-components-share/share.twig', {
-        align: alignChoice,
-        sources: [
-          {
-            name: 'facebook',
-            url:
-              'https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse',
-          },
-          {
-            name: 'twitter',
-            url:
-              'https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!',
-          },
-          {
-            name: 'linkedin',
-            url:
-              'https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com',
-          },
-          {
-            name: 'email',
-            url:
-              'mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com',
-          },
-        ],
+        ...fixtures.defaultData,
+        align: option,
       });
-      expect(results.ok).toBe(true);
-      expect(results.html).toMatchSnapshot();
+
+      await expect(results.ok).toBe(true);
+      await expect(results.html).toMatchSnapshot();
     });
   });
 });

--- a/packages/components/bolt-share/share.schema.js
+++ b/packages/components/bolt-share/share.schema.js
@@ -52,9 +52,15 @@ module.exports = {
             description: 'Name of the social media source.',
             enum: ['facebook', 'twitter', 'linkedin', 'email'],
           },
+          attributes: {
+            type: 'object',
+            description:
+              'A Drupal-style attributes object with extra attributes to append to this component.',
+          },
           url: {
-            type: 'string',
-            description: 'The specifically formed share URL with query string.',
+            title: 'DEPRECATED',
+            description:
+              'Please pass the href value through the source attributes object.',
           },
         },
       },

--- a/packages/components/bolt-share/src/share.twig
+++ b/packages/components/bolt-share/src/share.twig
@@ -45,7 +45,14 @@
 
 {% for source in sources %}
   {% set source_name = source.name %}
-  {% set source_url = source.url %}
+  {% set source_attributes_data = source.attributes|default({}) %}
+
+  {# DEPRECATED.  Use the property `attributes.href` instead of `url`. #}
+  {% if source.url %}
+    {% set source_attributes_data = source_attributes_data|merge({ href: source.url }) %}
+  {% endif %}
+
+  {% set source_attributes = create_attribute(source_attributes_data) %}
 
   {% if 'facebook' == source_name %}
     {% set source_text = 'Share via Facebook'|t %}
@@ -65,7 +72,7 @@
 
   {% if source_text %}
     {% set source_inline_items %}
-      <a class="{{ base_class }}__link js-bolt-share__link--{{ source_name }}" href="{{ source_url }}" target="_blank">
+      <a {{ source_attributes.addClass(base_class ~ '__link js-bolt-share__link--' ~ source_name).setAttribute('target', '_blank') }}>
         {% include '@bolt-components-icon/icon.twig' with {
           name: source_icon,
           size: size,
@@ -84,15 +91,24 @@
       } only %}
     {% endset %}
     {% set source_menu_items %}
-      {% include '@bolt-components-menu/_menu-item.twig' with {
+
+      {% set menu_item_props = {
         content: source_text,
-        url: source_url,
         icon_before: icon_before,
-        attributes: {
-          class: 'js-bolt-share__link--' ~ source_name,
-          target: '_blank',
-        }
-      } only %}
+      } %}
+
+      {# Map "href" back onto "url" as required by Menu component #}
+      {% if source_attributes_data.href %}
+        {% set menu_item_props = menu_item_props|merge({ url: source_attributes_data.href }) %}
+      {% endif %}
+
+      {# Cannot use source_attributes here, must use plain data not Drupal Attributes Object #}
+      {% set menu_item_attributes = source_attributes_data|without('href') %}
+
+      {# The 'js-' class added here is currently filtered out in the "menu" display. @todo: rework Menu component to allow passing classes. #}
+      {% set menu_item_attributes = menu_item_attributes|merge({ target: '_blank', class: 'js-bolt-share__link--' ~ source_name }) %}
+
+      {% include '@bolt-components-menu/_menu-item.twig' with menu_item_props|merge({ attributes: menu_item_attributes }) only %}
     {% endset %}
     {% set menu_items %}
       {{ menu_items }}

--- a/packages/components/bolt-teaser/__tests__/teaser.js
+++ b/packages/components/bolt-teaser/__tests__/teaser.js
@@ -57,21 +57,29 @@ describe('Twig usage', () => {
       sources: [
         {
           name: 'facebook',
-          url:
-            'https://www.facebook.com/sharer/sharer.php?u=https://pega.com&amp;src=sdkpreparse',
+          attributes: {
+            href:
+              'https://www.facebook.com/sharer/sharer.php?u=https://pega.com&amp;src=sdkpreparse',
+          },
         },
         {
           name: 'twitter',
-          url:
-            'https://twitter.com/intent/tweet?url=https://pega.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!',
+          attributes: {
+            href:
+              'https://twitter.com/intent/tweet?url=https://pega.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!',
+          },
         },
         {
           name: 'linkedin',
-          url: 'https://www.linkedin.com/shareArticle?url=https://pega.com',
+          attributes: {
+            href: 'https://www.linkedin.com/shareArticle?url=https://pega.com',
+          },
         },
         {
           name: 'email',
-          url: 'mailto:?&body=Sample%20Text%20--%20https%3A//pega.com',
+          attributes: {
+            href: 'mailto:?&body=Sample%20Text%20--%20https%3A//pega.com',
+          },
         },
       ],
       copy_to_clipboard: {


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-476

## Summary

Deprecated the URL prop on the Share component to allow for more flexible Drupal integration

## Details

- Added 'attributes' to the share and menu item items schema to allow for data attributes to the added to the bolt-share on both the "display="inline" and display="menu" types.
- Rewrote the share component jest test to the latest standards (added a deprecated test and added a 'display' prop test)
- Updated the Teaser jest test to the new snapshot
- Updated the doc site with the new share schema structure

## How to test

Pull down this branch and confirm that the share functionality is still work

## Release notes

Able to pass in data attributes to the share component for custom functionality
