### PR TITLE
WWW-745: Allow attributes to be passed from share to copy to clipboard

### DIFF
--- a/packages/components/bolt-share/src/share.twig
+++ b/packages/components/bolt-share/src/share.twig
@@ -161,12 +161,16 @@
     </div>
   {% endset %}
   {% set inline_copy_to_clipboard_include %}
-    {% include '@bolt-components-copy-to-clipboard/copy-to-clipboard.twig' with {
+    {% set copy_to_clipboard_props = {
       text_to_copy: text_to_copy,
       custom_trigger: inline_custom_trigger,
       custom_transition: inline_custom_transition,
       custom_confirmation: inline_custom_confirmation,
-    } only %}
+    } %}
+    {% if copy_to_clipboard.attributes %}
+      {% set copy_to_clipboard_props = copy_to_clipboard_props|merge({ attributes: copy_to_clipboard.attributes }) %}
+    {% endif %}
+    {% include '@bolt-components-copy-to-clipboard/copy-to-clipboard.twig' with copy_to_clipboard_props only %}
   {% endset %}
   {% set inline_items = inline_items|merge([inline_copy_to_clipboard_include]) %}
 


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/WWW-745

## Summary

Adds support for attributes on copy to clipboard within share

## Details

The copy to clipboard component supports attributes, but there was previously no way to pass them through the share component.  Now there is.

## How to test

- In the [_share-variables.twig partial](https://github.com/boltdesignsystem/bolt/blob/master/docs-site/src/pages/pattern-lab/_patterns/40-components/share/_share-variables.twig#L32), add attributes to the demo_copy_to_clipboard array
```
{% set demo_copy_to_clipboard =  {
  text_to_copy: 'https://boltdesignsystem.com',
  attributes: {id: 'foo'},
} %}
``` 
- Confirm that without this PR, attributes do no appear on the copy to clipboard element, but after they do.
