### PR TITLE
DS-481: Fix popover/tooltip when shadow dom disabled

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/popover/05-popover-no-shadow.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/popover/05-popover-no-shadow.twig
@@ -1,0 +1,34 @@
+{% set link %}
+  {% include '@bolt-components-link/link.twig' with {
+    text: 'call to action',
+    url: 'https://pega.com',
+  } only %}
+{% endset %}
+
+{% set trigger %}
+  {% include '@bolt-components-button/button.twig' with {
+    text: 'This triggers a popover',
+    type: 'button'
+  } only %}
+{% endset %}
+
+{% set content %}
+  This is the content of the popover with a {{ link }}.
+{% endset %}
+
+<h2>Popover with no-shadow</h2>
+{% include '@bolt-components-popover/popover.twig' with {
+  trigger: trigger,
+  content: content,
+  attributes: {
+    'no-shadow': ''
+  }
+} only %}
+
+<h2>Popover in a form</h2>
+<form action="">
+  {% include '@bolt-components-popover/popover.twig' with {
+    trigger: trigger,
+    content: content
+  } only %}
+</form>

--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/tooltip/00-tooltip-no-shadow.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/tooltip/00-tooltip-no-shadow.twig
@@ -1,0 +1,24 @@
+{% set tooltip %}
+  {% include "@bolt-components-tooltip/tooltip.twig" with {
+    trigger: "this piece of text",
+    content: "This is what we call a tooltip."
+  } only %}
+{% endset %}
+
+{% set tooltip_no_shadow %}
+  {% include "@bolt-components-tooltip/tooltip.twig" with {
+    trigger: "this piece of text",
+    content: "This is what we call a tooltip.",
+    attributes: {
+      'no-shadow': ''
+    }
+  } only %}
+{% endset %}
+
+<h2>Tooltip with no-shadow</h2>
+<p>A tooltip is used to provide descriptive help to the user about the control that the mouse is over. For instance, moving the mouse over {{ tooltip }} for a second can display a small popup label containing more detailed description. When the mouse is moved again, the tooltip disappears. This is a useful means of providing additional details about a user interface without cluttering up the main interface.</p>
+
+<h2>Tooltip in a form</h2>
+<form action="">
+<p>A tooltip is used to provide descriptive help to the user about the control that the mouse is over. For instance, moving the mouse over {{ tooltip_no_shadow }} for a second can display a small popup label containing more detailed description. When the mouse is moved again, the tooltip disappears. This is a useful means of providing additional details about a user interface without cluttering up the main interface.</p>
+</form>

--- a/packages/components/bolt-popover/src/popover.js
+++ b/packages/components/bolt-popover/src/popover.js
@@ -129,7 +129,7 @@ class BoltPopover extends BoltElement {
 
   render() {
     return html`
-      ${this.slotify('default')}
+      ${this.slotify('default')} ${this.slotify('content')}
     `;
   }
 }

--- a/packages/components/bolt-popover/src/popover.scss
+++ b/packages/components/bolt-popover/src/popover.scss
@@ -14,7 +14,8 @@
 bolt-popover {
   display: inline;
 
-  &:not([ready]) [slot='content'] {
+  // This element is copied by Tippy and appended to the document.body
+  [slot='content'] {
     display: none;
   }
 }

--- a/packages/components/bolt-tooltip/src/tooltip.js
+++ b/packages/components/bolt-tooltip/src/tooltip.js
@@ -104,7 +104,7 @@ class BoltTooltip extends BoltElement {
 
   render() {
     return html`
-      ${this.slotify('default')}
+      ${this.slotify('default')} ${this.slotify('content')}
     `;
   }
 }

--- a/packages/components/bolt-tooltip/src/tooltip.scss
+++ b/packages/components/bolt-tooltip/src/tooltip.scss
@@ -12,7 +12,8 @@
 bolt-tooltip {
   display: inline;
 
-  &:not([ready]) [slot='content'] {
+  // This element is copied by Tippy and appended to the document.body
+  [slot='content'] {
     display: none;
   }
 


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-481

## Summary

Fix popover and tooltip when rendered to light dom, for example when inside a `<form>`.

## Details

Popover and tooltip were breaking when inside a `<form>` where shadow dom is disabled (for legacy reasons). It was breaking because the "content" slot was not actually being rendered in the light dom version of these components. It is automatically rendered when using the shadow dom version, but not rendered at all when shadow dom is disabled. To fix this, I'm now explicitly rendering the "content" slot and hiding it via CSS. This now works when shadow dom is on and off.

This wasn't discovered earlier because rendering a popover or tooltip to the light dom is an edge case, but this is a good reminder to include light dom testing when we're working with our web components.

## How to test

- Review code
- See tooltip/popover docs, verify continue to work as expected
- See two new test pages where components are rendered to light dom, verify they work as expected:
  - http://localhost:3000/pattern-lab/?p=tests-popover-no-shadow
  - http://localhost:3000/pattern-lab/?p=tests-tooltip-no-shadow