### PR TITLE
DS-467 remove card deprecations

### DIFF
--- a/packages/components/bolt-card-replacement/card-replacement.schema.js
+++ b/packages/components/bolt-card-replacement/card-replacement.schema.js
@@ -2,13 +2,6 @@ module.exports = {
   $schema: 'http://json-schema.org/draft-04/schema#',
   title: 'Card',
   type: 'object',
-  not: {
-    anyOf: [
-      {
-        required: ['borderRadius'],
-      },
-    ],
-  },
   properties: {
     attributes: {
       type: 'object',
@@ -167,10 +160,6 @@ module.exports = {
       description:
         'Manually switch on / off the raised (shadow + animation effect) treament. By default this config option is applied if the card-replacement contains a bolt-card-replacement-link OR includes the `url` prop.',
       hidden: true,
-    },
-    borderRadius: {
-      title: 'DEPRECATED',
-      description: 'Use border_radius instead.',
     },
   },
 };

--- a/packages/components/bolt-card-replacement/card-replacement.schema.js
+++ b/packages/components/bolt-card-replacement/card-replacement.schema.js
@@ -2,6 +2,13 @@ module.exports = {
   $schema: 'http://json-schema.org/draft-04/schema#',
   title: 'Card',
   type: 'object',
+  not: {
+    anyOf: [
+      {
+        required: ['borderRadius'],
+      },
+    ],
+  },
   properties: {
     attributes: {
       type: 'object',

--- a/packages/components/bolt-card-replacement/src/card-replacement/card-replacement.twig
+++ b/packages/components/bolt-card-replacement/src/card-replacement/card-replacement.twig
@@ -4,11 +4,6 @@
   {{ validate_data_schema(schema, _self)|raw }}
 {% endif %}
 
-{# DEPRECATED.  Use the property `border_radius` instead of `borderRadius`. #}
-{% if borderRadius %}
-  {% set border_radius = borderRadius %}
-{% endif %}
-
 {# Variables #}
 {% set this = init(schema) %}
 {% set inner_attributes = create_attribute({}) %}


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-467

## Summary

Removes deprecated borderRadius prop from card component

## Details

borderRadius has been replaced with border_radius and will be removed in 4.0

## Release notes

The `borderRadius` prop in the card component has been renamed to `border_radius`.  Usage of the `borderRadius` prop will no longer work starting in Bolt 4.0.
