### PR TITLE
Revert "DS-432: Remove deprecated props from link component"

### DIFF
--- a/packages/components/bolt-link/link.schema.js
+++ b/packages/components/bolt-link/link.schema.js
@@ -27,6 +27,22 @@ module.exports = {
   title: 'Link',
   description: 'Text link.',
   type: 'object',
+  not: {
+    anyOf: [
+      {
+        required: ['href'],
+      },
+      {
+        required: ['isHeadline'],
+      },
+      {
+        required: ['onClick'],
+      },
+      {
+        required: ['onClickTarget'],
+      },
+    ],
+  },
   properties: {
     attributes: {
       type: 'object',
@@ -66,5 +82,13 @@ module.exports = {
     },
     icon: iconSchema,
     ...onClickProps,
+    href: {
+      title: 'DEPRECATED',
+      description: 'Use url instead.',
+    },
+    isHeadline: {
+      title: 'DEPRECATED',
+      description: 'Use is_headline instead.',
+    },
   },
 };

--- a/packages/components/bolt-link/src/link.twig
+++ b/packages/components/bolt-link/src/link.twig
@@ -6,6 +6,26 @@
   {{ validate_data_schema(schema, _self) | raw }}
 {% endif %}
 
+{# DEPRECATED.  Use the property `url` instead of `href`. #}
+{% if href %}
+  {% set url = href %}
+{% endif %}
+
+{# DEPRECATED.  Use the property `is_headline` instead of `isHeadline`. #}
+{% if isHeadline %}
+  {% set is_headline = isHeadline %}
+{% endif %}
+
+{# DEPRECATED.  Use the property `on_click` instead of `onClick`. #}
+{% if onClick %}
+  {% set on_click = onClick %}
+{% endif %}
+
+{# DEPRECATED.  Use the property `on_click_target` instead of `onClickTarget`. #}
+{% if onClickTarget %}
+  {% set on_click_target = onClickTarget %}
+{% endif %}
+
 {# Variables #}
 {% set this = init(schema) %}
 {% set inner_attributes = create_attribute({}) %}


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-432

## Summary

Adds back in support for deprecated link props removed in #2220

## Details

As decided in dev huddle, we want to deprecate the link component altogether in favor of the link element.   It's not that spending time on removing deprecated props is wrong, but that the time is better spent elsewhere.

## How to test
- Checkout the branch locally
- Set `schemaErrorReporting` to `none` in [pattern lab's boltrc](https://github.com/boltdesignsystem/bolt/blob/master/docs-site/.boltrc.js#L24) to allow it to build when deprecated props are passed.
- Try adding any of the four deprecated props that this PR adds back and confirm they work

(testing probably isn't required since this just reverts previously existing code)
