### PR TITLE
DS-335 Set up site layout

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/30-layouts/site/00-site-docs.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/30-layouts/site/00-site-docs.twig
@@ -1,0 +1,13 @@
+{% set usage %}{% verbatim %}
+{% include '@bolt-layouts-site/site.twig' with {
+  header: 'This is the header.',
+  content: 'This is the content.',
+  footer: 'This is the footer.',
+} only %}
+{% endverbatim %}{% endset %}
+
+{% include '@utils/docs.twig' with {
+  componentName: 'site',
+  componentGroup: 'layouts',
+  usage: usage
+} only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/30-layouts/site/00-site-docs.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/30-layouts/site/00-site-docs.twig
@@ -1,7 +1,12 @@
 {% set usage %}{% verbatim %}
 {% include '@bolt-layouts-site/site.twig' with {
   header: 'This is the header.',
-  content: 'This is the content.',
+  main: {
+    content: 'This is the main content.',
+    attributes: {
+      'data-foo': 'bar',
+    }
+  },
   footer: 'This is the footer.',
 } only %}
 {% endverbatim %}{% endset %}

--- a/docs-site/src/pages/pattern-lab/_patterns/30-layouts/site/05-site.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/30-layouts/site/05-site.twig
@@ -35,11 +35,25 @@
 
 {% set twig_markup %}
 {% verbatim %}
+// Include method
 {% include '@bolt-layouts-site/site.twig' with {
   header: 'This is the header.',
   content: 'This is the main content.',
   footer: 'This is the footer.',
 } only %}
+
+// Embed method
+{% embed '@bolt-layouts-site/site.twig' %}
+  {% block site_header %}
+    This is the header.
+  {% endblock %}
+  {% block site_content %}
+    This is the main content.
+  {% endblock %}
+  {% block site_footer %}
+    This is the footer.
+  {% endblock %}
+{% endembed %}
 {% endverbatim %}
 {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/30-layouts/site/05-site.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/30-layouts/site/05-site.twig
@@ -37,7 +37,6 @@
 
 {% set twig_markup %}
 {% verbatim %}
-// Include method
 {% include '@bolt-layouts-site/site.twig' with {
   header: 'This is the header.',
   main: {

--- a/docs-site/src/pages/pattern-lab/_patterns/30-layouts/site/05-site.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/30-layouts/site/05-site.twig
@@ -1,0 +1,68 @@
+{% set notes %}
+  <bolt-ol>
+    <bolt-li>The <bolt-code-snippet display="inline">content</bolt-code-snippet> is already rendered inside a <bolt-code-snippet display="inline">&lt;main&gt;</bolt-code-snippet> element, do not pass another <bolt-code-snippet display="inline">&lt;main&gt;</bolt-code-snippet> element to the prop. <bolt-code-snippet display="inline">site_content</bolt-code-snippet> block is also available.</bolt-li>
+    <bolt-li>The <bolt-code-snippet display="inline">header</bolt-code-snippet> and <bolt-code-snippet display="inline">footer</bolt-code-snippet> are freeform, the props are expecting <bolt-code-snippet display="inline">&lt;header&gt;</bolt-code-snippet> and <bolt-code-snippet display="inline">&lt;footer&gt;</bolt-code-snippet> elements repectively. <bolt-code-snippet display="inline">site_header</bolt-code-snippet> and <bolt-code-snippet display="inline">site_footer</bolt-code-snippet> blocks are also available.</bolt-li>
+    <bolt-li>The site layout must only contain <bolt-code-snippet display="inline">&lt;header&gt;</bolt-code-snippet>, <bolt-code-snippet display="inline">&lt;main&gt;</bolt-code-snippet>, and <bolt-code-snippet display="inline">&lt;footer&gt;</bolt-code-snippet> as immediate children. No additional elements can be a child.</bolt-li>
+  </bolt-ol>
+{% endset %}
+
+{% set demo %}
+  {% set header %}
+    <header class="t-bolt-dark u-bolt-padding-small">
+      This is the header.
+    </header>
+  {% endset %}
+  {% set content %}
+    <div class="u-bolt-padding-small">
+      This is the main content. The site layout is at least 100% of viewport height and the footer is always positioned on the bottom.
+    </div>
+  {% endset %}
+  {% set footer %}
+    <footer class="t-bolt-dark u-bolt-padding-small">
+      This is the footer.
+    </footer>
+  {% endset %}
+  {% include '@bolt-layouts-site/site.twig' with {
+    header: header,
+    content: content,
+    footer: footer,
+    attributes: {
+      class: 't-bolt-light',
+    },
+  } only %}
+{% endset %}
+
+{% set twig_markup %}
+{% verbatim %}
+{% include '@bolt-layouts-site/site.twig' with {
+  header: 'This is the header.',
+  content: 'This is the main content.',
+  footer: 'This is the footer.',
+} only %}
+{% endverbatim %}
+{% endset %}
+
+{% set html_markup %}
+{% verbatim %}
+<div class="l-bolt-site">
+  <header>
+    // This is the header
+  </header>
+  <main>
+    // This is the main content
+  </main>
+  <footer>
+    // This is the footer
+  </footer>
+</div>
+{% endverbatim %}
+{% endset %}
+
+{% include '@utils/pattern-doc-page.twig' with {
+  title: 'Basic Site Layout',
+  description: description,
+  notes: notes,
+  demo: demo,
+  twig_markup: twig_markup,
+  html_markup: html_markup,
+} only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/30-layouts/site/05-site.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/30-layouts/site/05-site.twig
@@ -13,7 +13,7 @@
       This is the header.
     </header>
   {% endset %}
-  {% set content %}
+  {% set main_content %}
     <div class="u-bolt-padding-small">
       This is the main content. The site layout is at least 100% of viewport height and the footer is always positioned on the bottom.
     </div>
@@ -25,7 +25,9 @@
   {% endset %}
   {% include '@bolt-layouts-site/site.twig' with {
     header: header,
-    content: content,
+    main: {
+      content: main_content,
+    },
     footer: footer,
     attributes: {
       class: 't-bolt-light',
@@ -38,7 +40,12 @@
 // Include method
 {% include '@bolt-layouts-site/site.twig' with {
   header: 'This is the header.',
-  content: 'This is the main content.',
+  main: {
+    content: 'This is the main content.',
+    attributes: {
+      'data-foo': 'bar',
+    }
+  },
   footer: 'This is the footer.',
 } only %}
 
@@ -63,7 +70,7 @@
   <header>
     // This is the header
   </header>
-  <main>
+  <main id="main-content">
     // This is the main content
   </main>
   <footer>

--- a/docs-site/src/pages/pattern-lab/_patterns/30-layouts/site/05-site.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/30-layouts/site/05-site.twig
@@ -48,19 +48,6 @@
   },
   footer: 'This is the footer.',
 } only %}
-
-// Embed method
-{% embed '@bolt-layouts-site/site.twig' %}
-  {% block site_header %}
-    This is the header.
-  {% endblock %}
-  {% block site_content %}
-    This is the main content.
-  {% endblock %}
-  {% block site_footer %}
-    This is the footer.
-  {% endblock %}
-{% endembed %}
 {% endverbatim %}
 {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/30-layouts/site/05-site.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/30-layouts/site/05-site.twig
@@ -3,6 +3,7 @@
     <bolt-li>The <bolt-code-snippet display="inline">content</bolt-code-snippet> is already rendered inside a <bolt-code-snippet display="inline">&lt;main&gt;</bolt-code-snippet> element, do not pass another <bolt-code-snippet display="inline">&lt;main&gt;</bolt-code-snippet> element to the prop. <bolt-code-snippet display="inline">site_content</bolt-code-snippet> block is also available.</bolt-li>
     <bolt-li>The <bolt-code-snippet display="inline">header</bolt-code-snippet> and <bolt-code-snippet display="inline">footer</bolt-code-snippet> are freeform, the props are expecting <bolt-code-snippet display="inline">&lt;header&gt;</bolt-code-snippet> and <bolt-code-snippet display="inline">&lt;footer&gt;</bolt-code-snippet> elements repectively. <bolt-code-snippet display="inline">site_header</bolt-code-snippet> and <bolt-code-snippet display="inline">site_footer</bolt-code-snippet> blocks are also available.</bolt-li>
     <bolt-li>The site layout must only contain <bolt-code-snippet display="inline">&lt;header&gt;</bolt-code-snippet>, <bolt-code-snippet display="inline">&lt;main&gt;</bolt-code-snippet>, and <bolt-code-snippet display="inline">&lt;footer&gt;</bolt-code-snippet> as immediate children. No additional elements can be a child.</bolt-li>
+    <bolt-li>This is the replacement for the <bolt-code-snippet display="inline">.c-bolt-site</bolt-code-snippet> class.</bolt-li>
   </bolt-ol>
 {% endset %}
 

--- a/packages/base-starter-kit/.boltrc.js
+++ b/packages/base-starter-kit/.boltrc.js
@@ -72,6 +72,7 @@ module.exports = {
       '@bolt/components-video',
       '@bolt/components-video-thumbnail',
       '@bolt/layouts-holy-grail',
+      '@bolt/layouts-site',
       '@bolt/analytics-autolink',
     ],
   },

--- a/packages/base-starter-kit/package.json
+++ b/packages/base-starter-kit/package.json
@@ -81,7 +81,8 @@
     "@bolt/elements-text-link": "^3.8.0",
     "@bolt/global": "^3.8.0",
     "@bolt/layouts-holy-grail": "^3.8.0",
-    "@bolt/layouts-list": "^3.6.0"
+    "@bolt/layouts-list": "^3.6.0",
+    "@bolt/layouts-site": "^3.8.0"
   },
   "devDependencies": {
     "deepmerge": "^4.2.2",

--- a/packages/layouts/bolt-site/README.md
+++ b/packages/layouts/bolt-site/README.md
@@ -1,0 +1,7 @@
+Site is part of the collection of components, visual styles, and build tools that power the the [Bolt Design System](https://www.boltdesignsystem.com).
+
+###### Install via NPM
+
+```
+npm install @bolt/layouts-site
+```

--- a/packages/layouts/bolt-site/index.scss
+++ b/packages/layouts/bolt-site/index.scss
@@ -1,0 +1,1 @@
+@import 'src/site.scss';

--- a/packages/layouts/bolt-site/package.json
+++ b/packages/layouts/bolt-site/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@bolt/layouts-site",
+  "version": "3.8.0",
+  "description": "The classic pancake stack site layout that enables the footer to be always positioned on the bottom.",
+  "keywords": [
+    "bolt design system",
+    "bolt",
+    "ui toolkit",
+    "design system"
+  ],
+  "homepage": "https://boltdesignsystem.com",
+  "bugs": "https://github.com/boltdesignsystem/bolt/issues",
+  "repository": "https://github.com/boltdesignsystem/bolt/tree/master/packages/layouts/bolt-site",
+  "license": "MIT",
+  "style": "index.scss",
+  "dependencies": {
+    "@bolt/core-v3.x": "^3.6.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "gitHead": "d41aa75ae3d195d9d7fb3952eed5e0ae80988133",
+  "maintainers": [
+    {
+      "name": "Andrew Rivera",
+      "web": "https://github.com/andrewmriv"
+    },
+    {
+      "name": "CJ White",
+      "web": "https://github.com/cjwhitedev"
+    },
+    {
+      "name": "Colby Cook",
+      "web": "https://github.com/colbytcook"
+    },
+    {
+      "name": "Dan Morse",
+      "web": "https://github.com/danielamorse"
+    },
+    {
+      "name": "Mike Mai",
+      "web": "http://mikemai.net"
+    },
+    {
+      "name": "Rémy Denton",
+      "web": "https://github.com/remydenton"
+    },
+    {
+      "name": "Tadeusz Adam Szałapski",
+      "web": "https://github.com/adamszalapski"
+    }
+  ],
+  "schema": "site.schema.js",
+  "twig": "src/site.twig"
+}

--- a/packages/layouts/bolt-site/site.schema.js
+++ b/packages/layouts/bolt-site/site.schema.js
@@ -8,10 +8,22 @@ module.exports = {
       description:
         'A Drupal attributes object. Applies extra HTML attributes to the parent element.',
     },
-    content: {
-      type: 'any',
+    main: {
+      type: 'object',
       description:
         'The main content of the site. <code>site_content</code> block is also available.',
+      properties: {
+        attributes: {
+          type: 'object',
+          description:
+            'A Drupal attributes object. Applies extra HTML attributes to the main element.',
+        },
+        content: {
+          type: 'any',
+          description:
+            'The main content of the site. <code>site_content</code> block is also available.',
+        },
+      },
     },
     header: {
       type: 'any',

--- a/packages/layouts/bolt-site/site.schema.js
+++ b/packages/layouts/bolt-site/site.schema.js
@@ -8,32 +8,29 @@ module.exports = {
       description:
         'A Drupal attributes object. Applies extra HTML attributes to the parent element.',
     },
+    header: {
+      type: 'any',
+      description: 'The header of the site.',
+    },
     main: {
       type: 'object',
       description:
-        'The main content of the site. <code>site_content</code> block is also available.',
+        'The main area of the site. This creates the <code>&lt;main&gt;</code> element.',
       properties: {
         attributes: {
           type: 'object',
           description:
-            'A Drupal attributes object. Applies extra HTML attributes to the main element.',
+            'A Drupal attributes object. Applies extra HTML attributes to the <code>&lt;main&gt;</code> element.',
         },
         content: {
           type: 'any',
-          description:
-            'The main content of the site. <code>site_content</code> block is also available.',
+          description: 'The main content of the site.',
         },
       },
     },
-    header: {
-      type: 'any',
-      description:
-        'The header of the site. <code>site_header</code> block is also available.',
-    },
     footer: {
       type: 'any',
-      description:
-        'The footer of the site. <code>site_footer</code> block is also available.',
+      description: 'The footer of the site.',
     },
   },
 };

--- a/packages/layouts/bolt-site/site.schema.js
+++ b/packages/layouts/bolt-site/site.schema.js
@@ -1,0 +1,27 @@
+module.exports = {
+  $schema: 'http://json-schema.org/draft-04/schema#',
+  title: 'Site',
+  type: 'object',
+  properties: {
+    attributes: {
+      type: 'object',
+      description:
+        'A Drupal attributes object. Applies extra HTML attributes to the parent element.',
+    },
+    content: {
+      type: 'any',
+      description:
+        'The main content of the site. <code>site_content</code> block is also available.',
+    },
+    header: {
+      type: 'any',
+      description:
+        'The header of the site. <code>site_header</code> block is also available.',
+    },
+    footer: {
+      type: 'any',
+      description:
+        'The footer of the site. <code>site_footer</code> block is also available.',
+    },
+  },
+};

--- a/packages/layouts/bolt-site/src/site.scss
+++ b/packages/layouts/bolt-site/src/site.scss
@@ -1,0 +1,27 @@
+@import '@bolt/core-v3.x';
+
+/**
+ * Site
+ */
+
+.l-bolt-site {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  grid-template-areas:
+    'header'
+    'main'
+    'footer';
+  min-height: 100vh;
+
+  > *:last-child:not(main) {
+    grid-area: footer;
+  }
+
+  > *:only-child {
+    grid-area: main !important;
+  }
+
+  > main {
+    grid-area: main;
+  }
+}

--- a/packages/layouts/bolt-site/src/site.twig
+++ b/packages/layouts/bolt-site/src/site.twig
@@ -1,0 +1,57 @@
+{# Schema Validation #}
+{% set schema = bolt.data.components['@bolt-layouts-site'].schema %}
+{% if enable_json_schema_validation %}
+  {{ validate_data_schema(schema, _self)|raw }}
+{% endif %}
+
+{# Variables #}
+{% set this = init(schema) %}
+{% set attributes = create_attribute(attributes|default({})) %}
+
+{# Array of classes based on the defined + default props #}
+{% set classes = [
+  'l-bolt-site',
+] %}
+
+{# Template #}
+<div {{ attributes.addClass(classes) }}>
+  {% if header %}
+    {{ header }}
+  {% else %}
+    {% block site_header %}
+      {#
+      /**
+      *  This must be a single element, for example:
+      *  <header>
+      *    ...
+      *  </header>
+      */
+      #}
+    {% endblock %}
+  {% endif %}
+
+  <main id="main-content" class="c-bolt-site__content">
+    {% if content %}
+      {{ content }}
+    {% else %}
+      {% block site_content %}
+        {# Main content goes here #}
+      {% endblock %}
+    {% endif %}
+  </main>
+
+  {% if footer %}
+    {{ footer }}
+  {% else %}
+    {% block site_footer %}
+      {#
+      /**
+      *  This must be a single element, for example:
+      *  <footer>
+      *    ...
+      *  </footer>
+      */
+      #}
+    {% endblock %}
+  {% endif %}
+</div>

--- a/packages/layouts/bolt-site/src/site.twig
+++ b/packages/layouts/bolt-site/src/site.twig
@@ -15,38 +15,34 @@
 
 {# Template #}
 <div {{ attributes.addClass(classes) }}>
-  {#
-  /**
-  *  The contents of `header` must be a single element, for example:
-  *  <header>
-  *    ...
-  *  </header>
-  */
-  #}
-  {{ header }}
+  {% block site_header %}
+    {#
+    /**
+    *  The contents of `header` must be a single element, for example:
+    *  <header>
+    *    ...
+    *  </header>
+    */
+    #}
+    {{ header }}
+  {% endblock %}
 
-  <main id="main-content" class="c-bolt-site__content">
-    {% if content %}
-      {{ content }}
-    {% else %}
-      {% block site_content %}
-        {# Main content goes here #}
-      {% endblock %}
-    {% endif %}
+  <main id="main-content" {{ main.attributes }}>
+    {% block site_content %}
+      {# Main content goes here #}
+      {{ main.content }}
+    {% endblock %}
   </main>
 
-  {% if footer %}
+  {% block site_footer %}
+    {#
+    /**
+    *  This must be a single element, for example:
+    *  <footer>
+    *    ...
+    *  </footer>
+    */
+    #}
     {{ footer }}
-  {% else %}
-    {% block site_footer %}
-      {#
-      /**
-      *  This must be a single element, for example:
-      *  <footer>
-      *    ...
-      *  </footer>
-      */
-      #}
-    {% endblock %}
-  {% endif %}
+  {% endblock %}
 </div>

--- a/packages/layouts/bolt-site/src/site.twig
+++ b/packages/layouts/bolt-site/src/site.twig
@@ -15,20 +15,15 @@
 
 {# Template #}
 <div {{ attributes.addClass(classes) }}>
-  {% if header %}
-    {{ header }}
-  {% else %}
-    {% block site_header %}
-      {#
-      /**
-      *  This must be a single element, for example:
-      *  <header>
-      *    ...
-      *  </header>
-      */
-      #}
-    {% endblock %}
-  {% endif %}
+  {#
+  /**
+  *  The contents of `header` must be a single element, for example:
+  *  <header>
+  *    ...
+  *  </header>
+  */
+  #}
+  {{ header }}
 
   <main id="main-content" class="c-bolt-site__content">
     {% if content %}

--- a/packages/layouts/bolt-site/src/site.twig
+++ b/packages/layouts/bolt-site/src/site.twig
@@ -26,10 +26,8 @@
   {{ header }}
 
   <main id="main-content" {{ main.attributes }}>
-    {% block site_content %}
-      {# Main content goes here #}
-      {{ main.content }}
-    {% endblock %}
+    {# Main content goes here #}
+    {{ main.content }}
   </main>
 
   {#

--- a/packages/layouts/bolt-site/src/site.twig
+++ b/packages/layouts/bolt-site/src/site.twig
@@ -15,17 +15,15 @@
 
 {# Template #}
 <div {{ attributes.addClass(classes) }}>
-  {% block site_header %}
-    {#
-    /**
-    *  The contents of `header` must be a single element, for example:
-    *  <header>
-    *    ...
-    *  </header>
-    */
-    #}
-    {{ header }}
-  {% endblock %}
+  {#
+  /**
+   * The contents of `header` must be a single element, for example:
+   * <header>
+   *   ...
+   * </header>
+   */
+  #}
+  {{ header }}
 
   <main id="main-content" {{ main.attributes }}>
     {% block site_content %}
@@ -34,15 +32,13 @@
     {% endblock %}
   </main>
 
-  {% block site_footer %}
-    {#
-    /**
-    *  This must be a single element, for example:
-    *  <footer>
-    *    ...
-    *  </footer>
-    */
-    #}
-    {{ footer }}
-  {% endblock %}
+  {#
+  /**
+   *  This must be a single element, for example:
+   *  <footer>
+   *    ...
+   *  </footer>
+   */
+  #}
+  {{ footer }}
 </div>


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-335

## Summary

Introduces a Layout called Site. The classic pancake stack site layout that enables the footer to be always positioned on the bottom.

## Details

1. Site added under Layouts.
2. This replaces `.c-bolt-site`.
3. Once this is implemented into the base theme and all sites convert to use the base theme template without overrides, we can remove everything related to `.c-bolt-site`.

## How to test

Run the branch locally and check all the docs under Layouts > Site. Make sure all props and blocks work as expected.