### PR TITLE
DS-248 Update sticky classes

### DIFF
--- a/packages/components/bolt-navbar/__tests__/__snapshots__/navbar.js.snap
+++ b/packages/components/bolt-navbar/__tests__/__snapshots__/navbar.js.snap
@@ -3,7 +3,7 @@
 exports[`Bolt Navbar Props Navbar centered 1`] = `
 <nav data-bolt-more-text="More"
      aria-labelledby="js-bolt-navbar-title-12345"
-     class="c-bolt-navbar c-bolt-navbar--center c-bolt-navbar--spacing-small t-bolt-dark"
+     class="c-bolt-navbar js-bolt-sticky c-bolt-navbar--center c-bolt-navbar--spacing-small t-bolt-dark"
 >
   <div class="c-bolt-navbar__inner">
     <div class="c-bolt-navbar__title">
@@ -62,7 +62,7 @@ exports[`Bolt Navbar Props Navbar centered 1`] = `
 exports[`Bolt Navbar Props Navbar spacing 1`] = `
 <nav data-bolt-more-text="More"
      aria-labelledby="js-bolt-navbar-title-12345"
-     class="c-bolt-navbar c-bolt-navbar--spacing-none t-bolt-dark"
+     class="c-bolt-navbar js-bolt-sticky c-bolt-navbar--spacing-none t-bolt-dark"
 >
   <div class="c-bolt-navbar__inner">
     <div class="c-bolt-navbar__title">
@@ -121,7 +121,7 @@ exports[`Bolt Navbar Props Navbar spacing 1`] = `
 exports[`Bolt Navbar Props Navbar spacing 2`] = `
 <nav data-bolt-more-text="More"
      aria-labelledby="js-bolt-navbar-title-12345"
-     class="c-bolt-navbar c-bolt-navbar--spacing-xsmall t-bolt-dark"
+     class="c-bolt-navbar js-bolt-sticky c-bolt-navbar--spacing-xsmall t-bolt-dark"
 >
   <div class="c-bolt-navbar__inner">
     <div class="c-bolt-navbar__title">
@@ -180,7 +180,7 @@ exports[`Bolt Navbar Props Navbar spacing 2`] = `
 exports[`Bolt Navbar Props Navbar spacing 3`] = `
 <nav data-bolt-more-text="More"
      aria-labelledby="js-bolt-navbar-title-12345"
-     class="c-bolt-navbar c-bolt-navbar--spacing-small t-bolt-dark"
+     class="c-bolt-navbar js-bolt-sticky c-bolt-navbar--spacing-small t-bolt-dark"
 >
   <div class="c-bolt-navbar__inner">
     <div class="c-bolt-navbar__title">
@@ -239,7 +239,7 @@ exports[`Bolt Navbar Props Navbar spacing 3`] = `
 exports[`Bolt Navbar Props Navbar spacing 4`] = `
 <nav data-bolt-more-text="More"
      aria-labelledby="js-bolt-navbar-title-12345"
-     class="c-bolt-navbar c-bolt-navbar--spacing-medium t-bolt-dark"
+     class="c-bolt-navbar js-bolt-sticky c-bolt-navbar--spacing-medium t-bolt-dark"
 >
   <div class="c-bolt-navbar__inner">
     <div class="c-bolt-navbar__title">
@@ -358,7 +358,7 @@ exports[`Bolt Navbar Props Navbar static 1`] = `
 exports[`Bolt Navbar Props Navbar theme 1`] = `
 <nav data-bolt-more-text="More"
      aria-labelledby="js-bolt-navbar-title-12345"
-     class="c-bolt-navbar c-bolt-navbar--spacing-small t-bolt-xlight"
+     class="c-bolt-navbar js-bolt-sticky c-bolt-navbar--spacing-small t-bolt-xlight"
 >
   <div class="c-bolt-navbar__inner">
     <div class="c-bolt-navbar__title">
@@ -417,7 +417,7 @@ exports[`Bolt Navbar Props Navbar theme 1`] = `
 exports[`Bolt Navbar Props Navbar theme 2`] = `
 <nav data-bolt-more-text="More"
      aria-labelledby="js-bolt-navbar-title-12345"
-     class="c-bolt-navbar c-bolt-navbar--spacing-small t-bolt-light"
+     class="c-bolt-navbar js-bolt-sticky c-bolt-navbar--spacing-small t-bolt-light"
 >
   <div class="c-bolt-navbar__inner">
     <div class="c-bolt-navbar__title">
@@ -476,7 +476,7 @@ exports[`Bolt Navbar Props Navbar theme 2`] = `
 exports[`Bolt Navbar Props Navbar theme 3`] = `
 <nav data-bolt-more-text="More"
      aria-labelledby="js-bolt-navbar-title-12345"
-     class="c-bolt-navbar c-bolt-navbar--spacing-small t-bolt-dark"
+     class="c-bolt-navbar js-bolt-sticky c-bolt-navbar--spacing-small t-bolt-dark"
 >
   <div class="c-bolt-navbar__inner">
     <div class="c-bolt-navbar__title">
@@ -535,7 +535,7 @@ exports[`Bolt Navbar Props Navbar theme 3`] = `
 exports[`Bolt Navbar Props Navbar theme 4`] = `
 <nav data-bolt-more-text="More"
      aria-labelledby="js-bolt-navbar-title-12345"
-     class="c-bolt-navbar c-bolt-navbar--spacing-small t-bolt-xdark"
+     class="c-bolt-navbar js-bolt-sticky c-bolt-navbar--spacing-small t-bolt-xdark"
 >
   <div class="c-bolt-navbar__inner">
     <div class="c-bolt-navbar__title">
@@ -594,7 +594,7 @@ exports[`Bolt Navbar Props Navbar theme 4`] = `
 exports[`Bolt Navbar Props Navbar theme 5`] = `
 <nav data-bolt-more-text="More"
      aria-labelledby="js-bolt-navbar-title-12345"
-     class="c-bolt-navbar c-bolt-navbar--spacing-small"
+     class="c-bolt-navbar js-bolt-sticky c-bolt-navbar--spacing-small"
 >
   <div class="c-bolt-navbar__inner">
     <div class="c-bolt-navbar__title">
@@ -653,7 +653,7 @@ exports[`Bolt Navbar Props Navbar theme 5`] = `
 exports[`Bolt Navbar Props Navbar width 1`] = `
 <nav data-bolt-more-text="More"
      aria-labelledby="js-bolt-navbar-title-12345"
-     class="c-bolt-navbar c-bolt-navbar--auto-width c-bolt-navbar--spacing-small t-bolt-dark"
+     class="c-bolt-navbar js-bolt-sticky c-bolt-navbar--auto-width c-bolt-navbar--spacing-small t-bolt-dark"
 >
   <div class="c-bolt-navbar__inner">
     <div class="c-bolt-navbar__title">
@@ -712,7 +712,7 @@ exports[`Bolt Navbar Props Navbar width 1`] = `
 exports[`Bolt Navbar Props Navbar with a linked title and icon 1`] = `
 <nav data-bolt-more-text="More"
      aria-labelledby="js-bolt-navbar-title-12345"
-     class="c-bolt-navbar c-bolt-navbar--spacing-small t-bolt-dark"
+     class="c-bolt-navbar js-bolt-sticky c-bolt-navbar--spacing-small t-bolt-dark"
 >
   <div class="c-bolt-navbar__inner">
     <div class="c-bolt-navbar__title">
@@ -806,7 +806,7 @@ exports[`Bolt Navbar Props Navbar with a linked title and icon 1`] = `
 exports[`Twig Usage Navbar default 1`] = `
 <nav data-bolt-more-text="More"
      aria-labelledby="js-bolt-navbar-title-12345"
-     class="c-bolt-navbar c-bolt-navbar--spacing-small t-bolt-dark"
+     class="c-bolt-navbar js-bolt-sticky c-bolt-navbar--spacing-small t-bolt-dark"
 >
   <div class="c-bolt-navbar__inner">
     <div class="c-bolt-navbar__title">
@@ -864,7 +864,7 @@ exports[`Twig Usage Navbar default 1`] = `
 
 exports[`Twig Usage Navbar without a title 1`] = `
 <nav data-bolt-more-text="More"
-     class="c-bolt-navbar c-bolt-navbar--spacing-small t-bolt-dark"
+     class="c-bolt-navbar js-bolt-sticky c-bolt-navbar--spacing-small t-bolt-dark"
 >
   <div class="c-bolt-navbar__inner">
     <div class="c-bolt-navbar__title">
@@ -921,7 +921,7 @@ exports[`Twig Usage Navbar without a title 1`] = `
 exports[`Twig Usage Navbar without links 1`] = `
 <nav data-bolt-more-text="More"
      aria-labelledby="js-bolt-navbar-title-12345"
-     class="c-bolt-navbar c-bolt-navbar--spacing-small t-bolt-dark"
+     class="c-bolt-navbar js-bolt-sticky c-bolt-navbar--spacing-small t-bolt-dark"
 >
   <div class="c-bolt-navbar__inner">
     <div class="c-bolt-navbar__title">

--- a/packages/components/bolt-navbar/src/navbar.js
+++ b/packages/components/bolt-navbar/src/navbar.js
@@ -245,7 +245,7 @@ export class BoltNavbar {
   setupOffsets() {
     // Default sticky elements
     const defaultStickyElements = document.querySelectorAll(
-      '[data-bolt-sticky-header], .js-global-header.is-fixed',
+      '.js-bolt-sticky-page-header, .js-global-header.is-fixed',
     ); // First selector covers new header, second covers old header
 
     // Sticky offsets

--- a/packages/components/bolt-navbar/src/navbar.twig
+++ b/packages/components/bolt-navbar/src/navbar.twig
@@ -11,7 +11,7 @@
 {# Array of classes based on the defined + default props #}
 {% set classes = [
   'c-bolt-navbar',
-  this.data.static.value ? 'c-bolt-navbar--static' : '',
+  this.data.static.value ? 'c-bolt-navbar--static' : 'js-bolt-sticky',
   this.data.width.value == 'auto' ? 'c-bolt-navbar--auto-width',
   this.data.center.value ? 'c-bolt-navbar--center' : '',
   this.data.spacing.value ? 'c-bolt-navbar--spacing-' ~ this.data.spacing.value : '',

--- a/packages/components/bolt-page-header/src/page-header.twig
+++ b/packages/components/bolt-page-header/src/page-header.twig
@@ -12,7 +12,7 @@
 
 {% set classes = [
   'c-bolt-page-header',
-  this.data.static.value ? 'c-bolt-page-header--static',
+  this.data.static.value ? 'c-bolt-page-header--static' : 'js-bolt-sticky-page-header',
   this.data.theme.value ? 't-bolt-' ~ this.data.theme.value,
 ] %}
 

--- a/packages/components/bolt-sticky/index.js
+++ b/packages/components/bolt-sticky/index.js
@@ -1,5 +1,0 @@
-import { lazyQueue } from '@bolt/lazy-queue';
-
-lazyQueue(['bolt-sticky'], async () => {
-  await import(/* webpackChunkName: "bolt-sticky" */ './src/sticky.js');
-});

--- a/packages/components/bolt-sticky/package.json
+++ b/packages/components/bolt-sticky/package.json
@@ -13,12 +13,10 @@
   "bugs": "https://github.com/bolt-design-system/bolt/issues",
   "repository": "https://github.com/bolt-design-system/bolt/tree/master/packages/components/bolt-sticky",
   "license": "MIT",
-  "main": "index.js",
   "style": "src/sticky.scss",
   "dependencies": {
     "@bolt/core-v3.x": "^3.6.0",
-    "@bolt/lazy-queue": "^3.1.0",
-    "stickyfilljs": "^2.0.3"
+    "@bolt/lazy-queue": "^3.1.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/components/bolt-sticky/src/sticky.js
+++ b/packages/components/bolt-sticky/src/sticky.js
@@ -1,4 +1,0 @@
-import Stickyfill from 'stickyfilljs';
-
-var elements = document.querySelectorAll('.js-bolt-sticky');
-Stickyfill.add(elements);

--- a/yarn.lock
+++ b/yarn.lock
@@ -18470,10 +18470,6 @@ stealthy-require@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
 
-stickyfilljs@^2.0.3:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/stickyfilljs/-/stickyfilljs-2.1.0.tgz#46dabb599d8275d185bdb97db597f86a2e3afa7b"
-
 stream-browserify@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b"


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-248

## Summary

Update classes used for tracking sticky elements in Navbar and Page Header components.

## Details

Adds class `js-bolt-sticky` to Navbar and `js-sticky-page-header` to Page Header. This allows us to track sticky elements globally via the former class and track the sticky page header specifically via the latter class. This is required to calculate the page offset when we smooth scroll to an element. These classes are used internally by Navbar, but primarily used in base theme where smooth scroll code is integrated.

In the future, when we rebuild smooth scroll, this convention may change. In the meantime, this at least standardizes our approach.

I'm also removing an unnecessary [sticky polyfill](https://caniuse.com/css-sticky). The polyfill was applying to all `js-bolt-sticky` classes. So removing the polyfill altogether avoids any extra JS execution.

## How to test

- Review files changed
- Verify Page Header and Navbar work as expected
- Verify Sticky component works as expected