### PR TITLE
Release v4.0.0

### DIFF
--- a/auto-release.js
+++ b/auto-release.js
@@ -41,6 +41,7 @@ async function init() {
       (await shell
         .exec(`./node_modules/.bin/auto version --from v${currentVersion}`, {
           silent: true,
+          maxBuffer: 20 * 1024 * 1024,
         })
         .stdout.trim()) || 'minor';
 


### PR DESCRIPTION
## Summary

One more try at fixing auto-release. Then I will just run it locally where `maxBuffer` does not appear to be an issue.