### PR TITLE
DS-528 Fix PL homepage navbar

### DIFF
--- a/docs-site/src/templates/homepage.twig
+++ b/docs-site/src/templates/homepage.twig
@@ -74,7 +74,6 @@
 
       {% include '@bolt-components-navbar/navbar.twig' with {
         theme: 'none',
-        static: true,
         title: {
           tag: 'h1',
           content: '<span aria-label="Bolt Design System">Bolt</span>',

--- a/packages/components/bolt-navbar/src/navbar.scss
+++ b/packages/components/bolt-navbar/src/navbar.scss
@@ -120,6 +120,7 @@
 // Title
 .c-bolt-navbar__title {
   display: flex;
+  font-weight: initial;
   color: var(--m-bolt-headline);
   white-space: nowrap;
 


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-528

## Summary

Fix version selector on PL homepage.

## Details

If you try to use the version selector on https://boltdesignsystem.com/ you will see that the menu is unclickable once open and the font-weight is bold when it should be normal. This PR fixes both by setting the navbar to sticky (gives it a higher z-index order) and sets the Navbar title to `font-weight: initital` so that is a header tag is passed the font-weight is unchanged.

## How to test

- Run locally and verify version selector on homepage is usable
- Verify the version selector menu items have normal font-weight, not bold
- Verify no other regressions to title font-weight elsewhere in the Navbar docs