### PR TITLE
Hotfix v4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@auto-it/npm": "^8.7.3",
     "@auto-it/omit-commits": "^8.7.3",
     "@auto-it/released": "^8.7.3",
-    "@bolt/testing-utils": "^3.0.0",
+    "@bolt/testing-utils": "^4.0.0",
     "@open-wc/testing-helpers": "^1.0.10",
     "@slack/webhook": "^5.0.2",
     "auto": "^8.7.3",


### PR DESCRIPTION
Upgrade `@bolt/testing-utils` to fix yarn error that is breaking the release process.