### PR TITLE
DS-526: Replace Button in Carousel Component

### DIFF
--- a/packages/components/bolt-carousel/__tests__/__snapshots__/carousel.js.snap
+++ b/packages/components/bolt-carousel/__tests__/__snapshots__/carousel.js.snap
@@ -89,8 +89,7 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders 1`] = `
        aria-label="Previous slide"
        aria-disabled="true"
   >
-    <span type="button"
-          class="e-bolt-button
+    <span class="e-bolt-button
         e-bolt-button--medium
         e-bolt-button--border-radius-full
         e-bolt-button--secondary
@@ -111,8 +110,7 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders 1`] = `
        aria-label="Next slide"
        aria-disabled="false"
   >
-    <span type="button"
-          class="e-bolt-button
+    <span class="e-bolt-button
         e-bolt-button--medium
         e-bolt-button--border-radius-full
         e-bolt-button--secondary
@@ -489,8 +487,7 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders w/ Variable (Auto) Slide
        aria-label="Previous slide"
        aria-disabled="true"
   >
-    <span type="button"
-          class="e-bolt-button
+    <span class="e-bolt-button
         e-bolt-button--medium
         e-bolt-button--border-radius-full
         e-bolt-button--secondary
@@ -517,8 +514,7 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders w/ Variable (Auto) Slide
        aria-label="Next slide"
        aria-disabled="false"
   >
-    <span type="button"
-          class="e-bolt-button
+    <span class="e-bolt-button
         e-bolt-button--medium
         e-bolt-button--border-radius-full
         e-bolt-button--secondary
@@ -719,8 +715,7 @@ exports[`carousel Basic 7 Slide <bolt-carousel> Renders 1`] = `
        aria-label="Previous slide"
        aria-disabled="true"
   >
-    <span type="button"
-          class="e-bolt-button
+    <span class="e-bolt-button
         e-bolt-button--medium
         e-bolt-button--border-radius-full
         e-bolt-button--secondary
@@ -747,8 +742,7 @@ exports[`carousel Basic 7 Slide <bolt-carousel> Renders 1`] = `
        aria-label="Next slide"
        aria-disabled="false"
   >
-    <span type="button"
-          class="e-bolt-button
+    <span class="e-bolt-button
         e-bolt-button--medium
         e-bolt-button--border-radius-full
         e-bolt-button--secondary

--- a/packages/components/bolt-carousel/__tests__/__snapshots__/carousel.js.snap
+++ b/packages/components/bolt-carousel/__tests__/__snapshots__/carousel.js.snap
@@ -95,7 +95,7 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders 1`] = `
         e-bolt-button--border-radius-full
         e-bolt-button--secondary
         e-bolt-button--icon-only"
-          aria-label="Previous"
+          aria-hidden="true"
     >
       <span class="e-bolt-button__icon-center">
         <bolt-icon size="large"
@@ -117,7 +117,7 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders 1`] = `
         e-bolt-button--border-radius-full
         e-bolt-button--secondary
         e-bolt-button--icon-only"
-          aria-label="Next"
+          aria-hidden="true"
     >
       <span class="e-bolt-button__icon-center">
         <bolt-icon size="large"
@@ -219,10 +219,10 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders w/ Nav Controls 1`] = `
        aria-label="Previous slide"
        aria-disabled="true"
   >
-    <button class="e-bolt-button e-bolt-button--border-radius-full e-bolt-button--secondary e-bolt-button--icon-only"
-            aria-label="Previous"
-            slot="previous-btn"
-            tabindex="-1"
+    <span class="e-bolt-button e-bolt-button--border-radius-full e-bolt-button--secondary e-bolt-button--icon-only"
+          aria-hidden="true"
+          slot="previous-btn"
+          tabindex="-1"
     >
       <span class="e-bolt-button__icon-center">
         <bolt-icon name="chevron-left"
@@ -236,7 +236,7 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders w/ Nav Controls 1`] = `
           </span>
         </bolt-icon>
       </span>
-    </button>
+    </span>
   </div>
   <div class="c-bolt-carousel__button c-bolt-carousel__button--next c-bolt-carousel__button--inside"
        tabindex="0"
@@ -244,10 +244,10 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders w/ Nav Controls 1`] = `
        aria-label="Next slide"
        aria-disabled="false"
   >
-    <button class="e-bolt-button e-bolt-button--border-radius-full e-bolt-button--secondary e-bolt-button--icon-only"
-            aria-label="Next"
-            slot="next-btn"
-            tabindex="-1"
+    <span class="e-bolt-button e-bolt-button--border-radius-full e-bolt-button--secondary e-bolt-button--icon-only"
+          aria-hidden="true"
+          slot="next-btn"
+          tabindex="-1"
     >
       <span class="e-bolt-button__icon-center">
         <bolt-icon name="chevron-right"
@@ -261,7 +261,7 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders w/ Nav Controls 1`] = `
           </span>
         </bolt-icon>
       </span>
-    </button>
+    </span>
   </div>
 </bolt-carousel>
 `;
@@ -357,10 +357,10 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders w/ Outer Nav Controls 1`
        aria-label="Previous slide"
        aria-disabled="true"
   >
-    <button class="e-bolt-button e-bolt-button--border-radius-full e-bolt-button--secondary e-bolt-button--icon-only"
-            aria-label="Previous"
-            slot="previous-btn"
-            tabindex="-1"
+    <span class="e-bolt-button e-bolt-button--border-radius-full e-bolt-button--secondary e-bolt-button--icon-only"
+          aria-hidden="true"
+          slot="previous-btn"
+          tabindex="-1"
     >
       <span class="e-bolt-button__icon-center">
         <bolt-icon name="chevron-left"
@@ -374,7 +374,7 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders w/ Outer Nav Controls 1`
           </span>
         </bolt-icon>
       </span>
-    </button>
+    </span>
   </div>
   <div class="c-bolt-carousel__button c-bolt-carousel__button--next c-bolt-carousel__button--outside"
        tabindex="0"
@@ -382,10 +382,10 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders w/ Outer Nav Controls 1`
        aria-label="Next slide"
        aria-disabled="false"
   >
-    <button class="e-bolt-button e-bolt-button--border-radius-full e-bolt-button--secondary e-bolt-button--icon-only"
-            aria-label="Next"
-            slot="next-btn"
-            tabindex="-1"
+    <span class="e-bolt-button e-bolt-button--border-radius-full e-bolt-button--secondary e-bolt-button--icon-only"
+          aria-hidden="true"
+          slot="next-btn"
+          tabindex="-1"
     >
       <span class="e-bolt-button__icon-center">
         <bolt-icon name="chevron-right"
@@ -399,7 +399,7 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders w/ Outer Nav Controls 1`
           </span>
         </bolt-icon>
       </span>
-    </button>
+    </span>
   </div>
 </bolt-carousel>
 `;
@@ -495,7 +495,7 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders w/ Variable (Auto) Slide
         e-bolt-button--border-radius-full
         e-bolt-button--secondary
         e-bolt-button--icon-only"
-          aria-label="Previous"
+          aria-hidden="true"
     >
       <span class="e-bolt-button__icon-center">
         <bolt-icon size="large"
@@ -523,7 +523,7 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders w/ Variable (Auto) Slide
         e-bolt-button--border-radius-full
         e-bolt-button--secondary
         e-bolt-button--icon-only"
-          aria-label="Next"
+          aria-hidden="true"
     >
       <span class="e-bolt-button__icon-center">
         <bolt-icon size="large"
@@ -725,7 +725,7 @@ exports[`carousel Basic 7 Slide <bolt-carousel> Renders 1`] = `
         e-bolt-button--border-radius-full
         e-bolt-button--secondary
         e-bolt-button--icon-only"
-          aria-label="Previous"
+          aria-hidden="true"
     >
       <span class="e-bolt-button__icon-center">
         <bolt-icon size="large"
@@ -753,7 +753,7 @@ exports[`carousel Basic 7 Slide <bolt-carousel> Renders 1`] = `
         e-bolt-button--border-radius-full
         e-bolt-button--secondary
         e-bolt-button--icon-only"
-          aria-label="Next"
+          aria-hidden="true"
     >
       <span class="e-bolt-button__icon-center">
         <bolt-icon size="large"

--- a/packages/components/bolt-carousel/__tests__/__snapshots__/carousel.js.snap
+++ b/packages/components/bolt-carousel/__tests__/__snapshots__/carousel.js.snap
@@ -89,18 +89,21 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders 1`] = `
        aria-label="Previous slide"
        aria-disabled="true"
   >
-    <bolt-button size="medium"
-                 border-radius="full"
-                 color="secondary"
-                 icon-only
+    <button type="button"
+            class="e-bolt-button
+        e-bolt-button--medium
+        e-bolt-button--border-radius-full
+        e-bolt-button--secondary
+        e-bolt-button--icon-only"
+            aria-label="Previous"
     >
-      Previous
-      <bolt-icon size="large"
-                 slot="before"
-                 name="chevron-left"
-      >
-      </bolt-icon>
-    </bolt-button>
+      <span class="e-bolt-button__icon-center">
+        <bolt-icon size="large"
+                   name="chevron-left"
+        >
+        </bolt-icon>
+      </span>
+    </button>
   </div>
   <div class="c-bolt-carousel__button c-bolt-carousel__button--next c-bolt-carousel__button--inside"
        tabindex="0"
@@ -108,18 +111,21 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders 1`] = `
        aria-label="Next slide"
        aria-disabled="false"
   >
-    <bolt-button size="medium"
-                 border-radius="full"
-                 color="secondary"
-                 icon-only
+    <button type="button"
+            class="e-bolt-button
+        e-bolt-button--medium
+        e-bolt-button--border-radius-full
+        e-bolt-button--secondary
+        e-bolt-button--icon-only"
+            aria-label="Next"
     >
-      Next
-      <bolt-icon size="large"
-                 slot="before"
-                 name="chevron-right"
-      >
-      </bolt-icon>
-    </bolt-button>
+      <span class="e-bolt-button__icon-center">
+        <bolt-icon size="large"
+                   name="chevron-right"
+        >
+        </bolt-icon>
+      </span>
+    </button>
   </div>
 </bolt-carousel>
 `;
@@ -213,24 +219,24 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders w/ Nav Controls 1`] = `
        aria-label="Previous slide"
        aria-disabled="true"
   >
-    <bolt-button slot="previous-btn"
-                 color="secondary"
-                 border-radius="full"
-                 icon-only
-                 tabindex="-1"
+    <button class="e-bolt-button e-bolt-button--border-radius-full e-bolt-button--secondary e-bolt-button--icon-only"
+            aria-label="Previous"
+            slot="previous-btn"
+            tabindex="-1"
     >
-      Previous
-      <bolt-icon slot="before"
-                 name="chevron-left"
-      >
-        <span class="c-bolt-icon c-bolt-icon--chevron-left c-bolt-icon--auto">
-          <svg class="c-bolt-icon__icon">
-            <use href="#chevron-left">
-            </use>
-          </svg>
-        </span>
-      </bolt-icon>
-    </bolt-button>
+      <span class="e-bolt-button__icon-center">
+        <bolt-icon name="chevron-left"
+                   size="large"
+        >
+          <span class="c-bolt-icon c-bolt-icon--large c-bolt-icon--chevron-left c-bolt-icon--auto">
+            <svg class="c-bolt-icon__icon c-bolt-icon__icon--large">
+              <use href="#chevron-left">
+              </use>
+            </svg>
+          </span>
+        </bolt-icon>
+      </span>
+    </button>
   </div>
   <div class="c-bolt-carousel__button c-bolt-carousel__button--next c-bolt-carousel__button--inside"
        tabindex="0"
@@ -238,24 +244,24 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders w/ Nav Controls 1`] = `
        aria-label="Next slide"
        aria-disabled="false"
   >
-    <bolt-button slot="next-btn"
-                 color="secondary"
-                 border-radius="full"
-                 icon-only
-                 tabindex="-1"
+    <button class="e-bolt-button e-bolt-button--border-radius-full e-bolt-button--secondary e-bolt-button--icon-only"
+            aria-label="Next"
+            slot="next-btn"
+            tabindex="-1"
     >
-      Next
-      <bolt-icon slot="after"
-                 name="chevron-right"
-      >
-        <span class="c-bolt-icon c-bolt-icon--chevron-right c-bolt-icon--auto">
-          <svg class="c-bolt-icon__icon">
-            <use href="#chevron-right">
-            </use>
-          </svg>
-        </span>
-      </bolt-icon>
-    </bolt-button>
+      <span class="e-bolt-button__icon-center">
+        <bolt-icon name="chevron-right"
+                   size="large"
+        >
+          <span class="c-bolt-icon c-bolt-icon--large c-bolt-icon--chevron-right c-bolt-icon--auto">
+            <svg class="c-bolt-icon__icon c-bolt-icon__icon--large">
+              <use href="#chevron-right">
+              </use>
+            </svg>
+          </span>
+        </bolt-icon>
+      </span>
+    </button>
   </div>
 </bolt-carousel>
 `;
@@ -351,24 +357,24 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders w/ Outer Nav Controls 1`
        aria-label="Previous slide"
        aria-disabled="true"
   >
-    <bolt-button slot="previous-btn"
-                 color="secondary"
-                 border-radius="full"
-                 icon-only
-                 tabindex="-1"
+    <button class="e-bolt-button e-bolt-button--border-radius-full e-bolt-button--secondary e-bolt-button--icon-only"
+            aria-label="Previous"
+            slot="previous-btn"
+            tabindex="-1"
     >
-      Previous
-      <bolt-icon slot="before"
-                 name="chevron-left"
-      >
-        <span class="c-bolt-icon c-bolt-icon--chevron-left c-bolt-icon--auto">
-          <svg class="c-bolt-icon__icon">
-            <use href="#chevron-left">
-            </use>
-          </svg>
-        </span>
-      </bolt-icon>
-    </bolt-button>
+      <span class="e-bolt-button__icon-center">
+        <bolt-icon name="chevron-left"
+                   size="large"
+        >
+          <span class="c-bolt-icon c-bolt-icon--large c-bolt-icon--chevron-left c-bolt-icon--auto">
+            <svg class="c-bolt-icon__icon c-bolt-icon__icon--large">
+              <use href="#chevron-left">
+              </use>
+            </svg>
+          </span>
+        </bolt-icon>
+      </span>
+    </button>
   </div>
   <div class="c-bolt-carousel__button c-bolt-carousel__button--next c-bolt-carousel__button--outside"
        tabindex="0"
@@ -376,24 +382,24 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders w/ Outer Nav Controls 1`
        aria-label="Next slide"
        aria-disabled="false"
   >
-    <bolt-button slot="next-btn"
-                 color="secondary"
-                 border-radius="full"
-                 icon-only
-                 tabindex="-1"
+    <button class="e-bolt-button e-bolt-button--border-radius-full e-bolt-button--secondary e-bolt-button--icon-only"
+            aria-label="Next"
+            slot="next-btn"
+            tabindex="-1"
     >
-      Next
-      <bolt-icon slot="after"
-                 name="chevron-right"
-      >
-        <span class="c-bolt-icon c-bolt-icon--chevron-right c-bolt-icon--auto">
-          <svg class="c-bolt-icon__icon">
-            <use href="#chevron-right">
-            </use>
-          </svg>
-        </span>
-      </bolt-icon>
-    </bolt-button>
+      <span class="e-bolt-button__icon-center">
+        <bolt-icon name="chevron-right"
+                   size="large"
+        >
+          <span class="c-bolt-icon c-bolt-icon--large c-bolt-icon--chevron-right c-bolt-icon--auto">
+            <svg class="c-bolt-icon__icon c-bolt-icon__icon--large">
+              <use href="#chevron-right">
+              </use>
+            </svg>
+          </span>
+        </bolt-icon>
+      </span>
+    </button>
   </div>
 </bolt-carousel>
 `;
@@ -483,24 +489,27 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders w/ Variable (Auto) Slide
        aria-label="Previous slide"
        aria-disabled="true"
   >
-    <bolt-button size="medium"
-                 border-radius="full"
-                 color="secondary"
-                 icon-only
+    <button type="button"
+            class="e-bolt-button
+        e-bolt-button--medium
+        e-bolt-button--border-radius-full
+        e-bolt-button--secondary
+        e-bolt-button--icon-only"
+            aria-label="Previous"
     >
-      Previous
-      <bolt-icon size="large"
-                 slot="before"
-                 name="chevron-left"
-      >
-        <span class="c-bolt-icon c-bolt-icon--large c-bolt-icon--chevron-left c-bolt-icon--auto">
-          <svg class="c-bolt-icon__icon c-bolt-icon__icon--large">
-            <use href="#chevron-left">
-            </use>
-          </svg>
-        </span>
-      </bolt-icon>
-    </bolt-button>
+      <span class="e-bolt-button__icon-center">
+        <bolt-icon size="large"
+                   name="chevron-left"
+        >
+          <span class="c-bolt-icon c-bolt-icon--large c-bolt-icon--chevron-left c-bolt-icon--auto">
+            <svg class="c-bolt-icon__icon c-bolt-icon__icon--large">
+              <use href="#chevron-left">
+              </use>
+            </svg>
+          </span>
+        </bolt-icon>
+      </span>
+    </button>
   </div>
   <div class="c-bolt-carousel__button c-bolt-carousel__button--next c-bolt-carousel__button--inside"
        tabindex="0"
@@ -508,24 +517,27 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders w/ Variable (Auto) Slide
        aria-label="Next slide"
        aria-disabled="false"
   >
-    <bolt-button size="medium"
-                 border-radius="full"
-                 color="secondary"
-                 icon-only
+    <button type="button"
+            class="e-bolt-button
+        e-bolt-button--medium
+        e-bolt-button--border-radius-full
+        e-bolt-button--secondary
+        e-bolt-button--icon-only"
+            aria-label="Next"
     >
-      Next
-      <bolt-icon size="large"
-                 slot="before"
-                 name="chevron-right"
-      >
-        <span class="c-bolt-icon c-bolt-icon--large c-bolt-icon--chevron-right c-bolt-icon--auto">
-          <svg class="c-bolt-icon__icon c-bolt-icon__icon--large">
-            <use href="#chevron-right">
-            </use>
-          </svg>
-        </span>
-      </bolt-icon>
-    </bolt-button>
+      <span class="e-bolt-button__icon-center">
+        <bolt-icon size="large"
+                   name="chevron-right"
+        >
+          <span class="c-bolt-icon c-bolt-icon--large c-bolt-icon--chevron-right c-bolt-icon--auto">
+            <svg class="c-bolt-icon__icon c-bolt-icon__icon--large">
+              <use href="#chevron-right">
+              </use>
+            </svg>
+          </span>
+        </bolt-icon>
+      </span>
+    </button>
   </div>
 </bolt-carousel>
 `;
@@ -707,24 +719,27 @@ exports[`carousel Basic 7 Slide <bolt-carousel> Renders 1`] = `
        aria-label="Previous slide"
        aria-disabled="true"
   >
-    <bolt-button size="medium"
-                 border-radius="full"
-                 color="secondary"
-                 icon-only
+    <button type="button"
+            class="e-bolt-button
+        e-bolt-button--medium
+        e-bolt-button--border-radius-full
+        e-bolt-button--secondary
+        e-bolt-button--icon-only"
+            aria-label="Previous"
     >
-      Previous
-      <bolt-icon size="large"
-                 slot="before"
-                 name="chevron-left"
-      >
-        <span class="c-bolt-icon c-bolt-icon--large c-bolt-icon--chevron-left c-bolt-icon--auto">
-          <svg class="c-bolt-icon__icon c-bolt-icon__icon--large">
-            <use href="#chevron-left">
-            </use>
-          </svg>
-        </span>
-      </bolt-icon>
-    </bolt-button>
+      <span class="e-bolt-button__icon-center">
+        <bolt-icon size="large"
+                   name="chevron-left"
+        >
+          <span class="c-bolt-icon c-bolt-icon--large c-bolt-icon--chevron-left c-bolt-icon--auto">
+            <svg class="c-bolt-icon__icon c-bolt-icon__icon--large">
+              <use href="#chevron-left">
+              </use>
+            </svg>
+          </span>
+        </bolt-icon>
+      </span>
+    </button>
   </div>
   <div class="c-bolt-carousel__button c-bolt-carousel__button--next c-bolt-carousel__button--inside"
        tabindex="0"
@@ -732,24 +747,27 @@ exports[`carousel Basic 7 Slide <bolt-carousel> Renders 1`] = `
        aria-label="Next slide"
        aria-disabled="false"
   >
-    <bolt-button size="medium"
-                 border-radius="full"
-                 color="secondary"
-                 icon-only
+    <button type="button"
+            class="e-bolt-button
+        e-bolt-button--medium
+        e-bolt-button--border-radius-full
+        e-bolt-button--secondary
+        e-bolt-button--icon-only"
+            aria-label="Next"
     >
-      Next
-      <bolt-icon size="large"
-                 slot="before"
-                 name="chevron-right"
-      >
-        <span class="c-bolt-icon c-bolt-icon--large c-bolt-icon--chevron-right c-bolt-icon--auto">
-          <svg class="c-bolt-icon__icon c-bolt-icon__icon--large">
-            <use href="#chevron-right">
-            </use>
-          </svg>
-        </span>
-      </bolt-icon>
-    </bolt-button>
+      <span class="e-bolt-button__icon-center">
+        <bolt-icon size="large"
+                   name="chevron-right"
+        >
+          <span class="c-bolt-icon c-bolt-icon--large c-bolt-icon--chevron-right c-bolt-icon--auto">
+            <svg class="c-bolt-icon__icon c-bolt-icon__icon--large">
+              <use href="#chevron-right">
+              </use>
+            </svg>
+          </span>
+        </bolt-icon>
+      </span>
+    </button>
   </div>
 </bolt-carousel>
 `;

--- a/packages/components/bolt-carousel/__tests__/__snapshots__/carousel.js.snap
+++ b/packages/components/bolt-carousel/__tests__/__snapshots__/carousel.js.snap
@@ -89,13 +89,13 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders 1`] = `
        aria-label="Previous slide"
        aria-disabled="true"
   >
-    <button type="button"
-            class="e-bolt-button
+    <span type="button"
+          class="e-bolt-button
         e-bolt-button--medium
         e-bolt-button--border-radius-full
         e-bolt-button--secondary
         e-bolt-button--icon-only"
-            aria-label="Previous"
+          aria-label="Previous"
     >
       <span class="e-bolt-button__icon-center">
         <bolt-icon size="large"
@@ -103,7 +103,7 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders 1`] = `
         >
         </bolt-icon>
       </span>
-    </button>
+    </span>
   </div>
   <div class="c-bolt-carousel__button c-bolt-carousel__button--next c-bolt-carousel__button--inside"
        tabindex="0"
@@ -111,13 +111,13 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders 1`] = `
        aria-label="Next slide"
        aria-disabled="false"
   >
-    <button type="button"
-            class="e-bolt-button
+    <span type="button"
+          class="e-bolt-button
         e-bolt-button--medium
         e-bolt-button--border-radius-full
         e-bolt-button--secondary
         e-bolt-button--icon-only"
-            aria-label="Next"
+          aria-label="Next"
     >
       <span class="e-bolt-button__icon-center">
         <bolt-icon size="large"
@@ -125,7 +125,7 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders 1`] = `
         >
         </bolt-icon>
       </span>
-    </button>
+    </span>
   </div>
 </bolt-carousel>
 `;
@@ -489,13 +489,13 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders w/ Variable (Auto) Slide
        aria-label="Previous slide"
        aria-disabled="true"
   >
-    <button type="button"
-            class="e-bolt-button
+    <span type="button"
+          class="e-bolt-button
         e-bolt-button--medium
         e-bolt-button--border-radius-full
         e-bolt-button--secondary
         e-bolt-button--icon-only"
-            aria-label="Previous"
+          aria-label="Previous"
     >
       <span class="e-bolt-button__icon-center">
         <bolt-icon size="large"
@@ -509,7 +509,7 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders w/ Variable (Auto) Slide
           </span>
         </bolt-icon>
       </span>
-    </button>
+    </span>
   </div>
   <div class="c-bolt-carousel__button c-bolt-carousel__button--next c-bolt-carousel__button--inside"
        tabindex="0"
@@ -517,13 +517,13 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders w/ Variable (Auto) Slide
        aria-label="Next slide"
        aria-disabled="false"
   >
-    <button type="button"
-            class="e-bolt-button
+    <span type="button"
+          class="e-bolt-button
         e-bolt-button--medium
         e-bolt-button--border-radius-full
         e-bolt-button--secondary
         e-bolt-button--icon-only"
-            aria-label="Next"
+          aria-label="Next"
     >
       <span class="e-bolt-button__icon-center">
         <bolt-icon size="large"
@@ -537,7 +537,7 @@ exports[`carousel Basic 3 Slide <bolt-carousel> Renders w/ Variable (Auto) Slide
           </span>
         </bolt-icon>
       </span>
-    </button>
+    </span>
   </div>
 </bolt-carousel>
 `;
@@ -719,13 +719,13 @@ exports[`carousel Basic 7 Slide <bolt-carousel> Renders 1`] = `
        aria-label="Previous slide"
        aria-disabled="true"
   >
-    <button type="button"
-            class="e-bolt-button
+    <span type="button"
+          class="e-bolt-button
         e-bolt-button--medium
         e-bolt-button--border-radius-full
         e-bolt-button--secondary
         e-bolt-button--icon-only"
-            aria-label="Previous"
+          aria-label="Previous"
     >
       <span class="e-bolt-button__icon-center">
         <bolt-icon size="large"
@@ -739,7 +739,7 @@ exports[`carousel Basic 7 Slide <bolt-carousel> Renders 1`] = `
           </span>
         </bolt-icon>
       </span>
-    </button>
+    </span>
   </div>
   <div class="c-bolt-carousel__button c-bolt-carousel__button--next c-bolt-carousel__button--inside"
        tabindex="0"
@@ -747,13 +747,13 @@ exports[`carousel Basic 7 Slide <bolt-carousel> Renders 1`] = `
        aria-label="Next slide"
        aria-disabled="false"
   >
-    <button type="button"
-            class="e-bolt-button
+    <span type="button"
+          class="e-bolt-button
         e-bolt-button--medium
         e-bolt-button--border-radius-full
         e-bolt-button--secondary
         e-bolt-button--icon-only"
-            aria-label="Next"
+          aria-label="Next"
     >
       <span class="e-bolt-button__icon-center">
         <bolt-icon size="large"
@@ -767,7 +767,7 @@ exports[`carousel Basic 7 Slide <bolt-carousel> Renders 1`] = `
           </span>
         </bolt-icon>
       </span>
-    </button>
+    </span>
   </div>
 </bolt-carousel>
 `;

--- a/packages/components/bolt-carousel/__tests__/carousel.js
+++ b/packages/components/bolt-carousel/__tests__/carousel.js
@@ -49,8 +49,12 @@ const carouselSlideImage = `
 `;
 
 const carouselButtonControls = `
-  <bolt-button slot="previous-btn" color="secondary" border-radius="full" icon-only>Previous <bolt-icon slot="before" name="chevron-left"></bolt-icon></bolt-button>
-  <bolt-button slot="next-btn" color="secondary" border-radius="full" icon-only>Next <bolt-icon slot="after" name="chevron-right"></bolt-icon></bolt-button>
+<button class="e-bolt-button e-bolt-button--border-radius-full e-bolt-button--secondary e-bolt-button--icon-only"  aria-label="Previous" slot="previous-btn">
+<span class="e-bolt-button__icon-center"><bolt-icon name="chevron-left"size="large"></bolt-icon></span>
+</button>
+<button class="e-bolt-button e-bolt-button--border-radius-full e-bolt-button--secondary e-bolt-button--icon-only"  aria-label="Next" slot="next-btn">
+<span class="e-bolt-button__icon-center"><bolt-icon name="chevron-right"size="large"></bolt-icon></span>
+</button>
 `;
 
 describe('carousel', () => {

--- a/packages/components/bolt-carousel/__tests__/carousel.js
+++ b/packages/components/bolt-carousel/__tests__/carousel.js
@@ -49,12 +49,12 @@ const carouselSlideImage = `
 `;
 
 const carouselButtonControls = `
-<button class="e-bolt-button e-bolt-button--border-radius-full e-bolt-button--secondary e-bolt-button--icon-only"  aria-label="Previous" slot="previous-btn">
+<span class="e-bolt-button e-bolt-button--border-radius-full e-bolt-button--secondary e-bolt-button--icon-only" aria-hidden="true" slot="previous-btn">
 <span class="e-bolt-button__icon-center"><bolt-icon name="chevron-left"size="large"></bolt-icon></span>
-</button>
-<button class="e-bolt-button e-bolt-button--border-radius-full e-bolt-button--secondary e-bolt-button--icon-only"  aria-label="Next" slot="next-btn">
+</span>
+<span class="e-bolt-button e-bolt-button--border-radius-full e-bolt-button--secondary e-bolt-button--icon-only" aria-hidden="true" slot="next-btn">
 <span class="e-bolt-button__icon-center"><bolt-icon name="chevron-right"size="large"></bolt-icon></span>
-</button>
+</span>
 `;
 
 describe('carousel', () => {

--- a/packages/components/bolt-carousel/src/_carousel.next-previous-buttons.scss
+++ b/packages/components/bolt-carousel/src/_carousel.next-previous-buttons.scss
@@ -27,7 +27,7 @@ bolt-carousel:not(.is-ready) > [slot='next-btn'] {
   border-radius: 50px;
   transition: all 0.2s ease;
 
-  bolt-button {
+  .e-bolt-button {
     pointer-events: none;
   }
 

--- a/packages/components/bolt-carousel/src/carousel.js
+++ b/packages/components/bolt-carousel/src/carousel.js
@@ -503,7 +503,7 @@ class BoltCarousel extends BoltElement {
       },
     );
 
-    const buttonTemplate = (text, iconName) => html`
+    const buttonTemplate = iconName => html`
       <span
         type="button"
         class="e-bolt-button
@@ -511,7 +511,7 @@ class BoltCarousel extends BoltElement {
         e-bolt-button--border-radius-full
         e-bolt-button--secondary
         e-bolt-button--icon-only"
-        aria-label="${text}"
+        aria-hidden="true"
       >
         <span class="e-bolt-button__icon-center">
           <bolt-icon size="large" name="${iconName}"></bolt-icon>
@@ -547,7 +547,7 @@ class BoltCarousel extends BoltElement {
             >
               ${this.slotMap.get('previous-btn')
                 ? this.slotify('previous-btn')
-                : buttonTemplate('Previous', 'chevron-left')}
+                : buttonTemplate('chevron-left')}
             </div>
             <div
               class="${nextButton}"
@@ -556,7 +556,7 @@ class BoltCarousel extends BoltElement {
             >
               ${this.slotMap.get('next-btn')
                 ? this.slotify('next-btn')
-                : buttonTemplate('Next', 'chevron-right')}
+                : buttonTemplate('chevron-right')}
             </div>
           `}
     `;

--- a/packages/components/bolt-carousel/src/carousel.js
+++ b/packages/components/bolt-carousel/src/carousel.js
@@ -505,7 +505,6 @@ class BoltCarousel extends BoltElement {
 
     const buttonTemplate = iconName => html`
       <span
-        type="button"
         class="e-bolt-button
         e-bolt-button--medium
         e-bolt-button--border-radius-full

--- a/packages/components/bolt-carousel/src/carousel.js
+++ b/packages/components/bolt-carousel/src/carousel.js
@@ -504,15 +504,19 @@ class BoltCarousel extends BoltElement {
     );
 
     const buttonTemplate = (text, iconName) => html`
-      <bolt-button
-        size="medium"
-        border-radius="full"
-        color="secondary"
-        icon-only
+      <button
+        type="button"
+        class="e-bolt-button
+        e-bolt-button--medium
+        e-bolt-button--border-radius-full
+        e-bolt-button--secondary
+        e-bolt-button--icon-only"
+        aria-label="${text}"
       >
-        ${text}
-        <bolt-icon size="large" slot="before" name="${iconName}"></bolt-icon>
-      </bolt-button>
+        <span class="e-bolt-button__icon-center">
+          <bolt-icon size="large" name="${iconName}"></bolt-icon>
+        </span>
+      </button>
     `;
 
     return html`

--- a/packages/components/bolt-carousel/src/carousel.js
+++ b/packages/components/bolt-carousel/src/carousel.js
@@ -504,7 +504,7 @@ class BoltCarousel extends BoltElement {
     );
 
     const buttonTemplate = (text, iconName) => html`
-      <button
+      <span
         type="button"
         class="e-bolt-button
         e-bolt-button--medium
@@ -516,7 +516,7 @@ class BoltCarousel extends BoltElement {
         <span class="e-bolt-button__icon-center">
           <bolt-icon size="large" name="${iconName}"></bolt-icon>
         </span>
-      </button>
+      </span>
     `;
 
     return html`

--- a/packages/components/bolt-carousel/src/carousel.twig
+++ b/packages/components/bolt-carousel/src/carousel.twig
@@ -38,11 +38,11 @@
   {% endblock %}
 
   {% block controls %}
-    <button class="e-bolt-button e-bolt-button--border-radius-full e-bolt-button--secondary e-bolt-button--icon-only"  aria-label="Previous" slot="previous-btn">
+    <span class="e-bolt-button e-bolt-button--border-radius-full e-bolt-button--secondary e-bolt-button--icon-only"  aria-label="Previous" slot="previous-btn">
       <span class="e-bolt-button__icon-center"><bolt-icon name="chevron-left"size="large"></bolt-icon></span>
-    </button>
-    <button class="e-bolt-button e-bolt-button--border-radius-full e-bolt-button--secondary e-bolt-button--icon-only"  aria-label="Next" slot="next-btn">
+    </span>
+    <span class="e-bolt-button e-bolt-button--border-radius-full e-bolt-button--secondary e-bolt-button--icon-only"  aria-label="Next" slot="next-btn">
       <span class="e-bolt-button__icon-center"><bolt-icon name="chevron-right"size="large"></bolt-icon></span>
-    </button>
+    </span>
   {% endblock %}
 </bolt-carousel>

--- a/packages/components/bolt-carousel/src/carousel.twig
+++ b/packages/components/bolt-carousel/src/carousel.twig
@@ -38,7 +38,11 @@
   {% endblock %}
 
   {% block controls %}
-    <bolt-button slot="previous-btn" color="secondary" size="medium" border-radius="full" icon-only>Previous <bolt-icon size="large" slot="before" name="chevron-left"></bolt-icon></bolt-button>
-    <bolt-button slot="next-btn" color="secondary" size="medium" border-radius="full" icon-only>Next <bolt-icon size="large" slot="after" name="chevron-right"></bolt-icon></bolt-button>
+    <button class="e-bolt-button e-bolt-button--border-radius-full e-bolt-button--secondary e-bolt-button--icon-only"  aria-label="Previous" slot="previous-btn">
+      <span class="e-bolt-button__icon-center"><bolt-icon name="chevron-left"size="large"></bolt-icon></span>
+    </button>
+    <button class="e-bolt-button e-bolt-button--border-radius-full e-bolt-button--secondary e-bolt-button--icon-only"  aria-label="Next" slot="next-btn">
+      <span class="e-bolt-button__icon-center"><bolt-icon name="chevron-right"size="large"></bolt-icon></span>
+    </button>
   {% endblock %}
 </bolt-carousel>

--- a/packages/components/bolt-carousel/src/carousel.twig
+++ b/packages/components/bolt-carousel/src/carousel.twig
@@ -38,10 +38,10 @@
   {% endblock %}
 
   {% block controls %}
-    <span class="e-bolt-button e-bolt-button--border-radius-full e-bolt-button--secondary e-bolt-button--icon-only"  aria-label="Previous" slot="previous-btn">
+    <span class="e-bolt-button e-bolt-button--border-radius-full e-bolt-button--secondary e-bolt-button--icon-only" aria-hidden="true" slot="previous-btn">
       <span class="e-bolt-button__icon-center"><bolt-icon name="chevron-left"size="large"></bolt-icon></span>
     </span>
-    <span class="e-bolt-button e-bolt-button--border-radius-full e-bolt-button--secondary e-bolt-button--icon-only"  aria-label="Next" slot="next-btn">
+    <span class="e-bolt-button e-bolt-button--border-radius-full e-bolt-button--secondary e-bolt-button--icon-only" aria-hidden="true" slot="next-btn">
       <span class="e-bolt-button__icon-center"><bolt-icon name="chevron-right"size="large"></bolt-icon></span>
     </span>
   {% endblock %}


### PR DESCRIPTION
## Jira

[https://pegadigitalit.atlassian.net/browse/DS-526](https://pegadigitalit.atlassian.net/browse/DS-526)

## Summary

Replace component button with element button in carousel component.

## Details

we're deprecating and removingt the button component. this replaces instance of the button component in carousel with the button element.

## How to test

look at the demos in pattern lab as well as the code and the updated jest snap.

## Release notes

### Visual changes

The button element is slightly larger than the button component for accessibility purposes, this is expected.
