### PR TITLE
Add icon-only class to element button docs.

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/20-elements/button/25-button-with-icon-only.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/20-elements/button/25-button-with-icon-only.twig
@@ -44,7 +44,7 @@
 {% set notes %}
   <bolt-ol>
     <bolt-li>It is recommended that icon only buttons to be used in tandem with tooltip to give the user more context about the button&rsquo;s function.</bolt-li>
-    <bolt-li>When writing in plain HTML, <bolt-code-snippet display="inline">aria-label</bolt-code-snippet> is required, and it must equal to the button text. For example: <bolt-code-snippet display="inline" lang="html">&lt;button type="button" class="e-bolt-button e-bolt-button--icon-only" aria-label="Download"&gt;</bolt-code-snippet>. Text should not be used inside the button when using <bolt-code-snippet display="inline">aria-label</bolt-code-snippet>.</bolt-li>
+    <bolt-li>When writing in plain HTML, <bolt-code-snippet display="inline">aria-label</bolt-code-snippet> is required to render the button text. For example: <bolt-code-snippet display="inline" lang="html">&lt;button type="button" class="e-bolt-button e-bolt-button--icon-only" aria-label="Download"&gt;</bolt-code-snippet>. Text should not be used inside the button when using <bolt-code-snippet display="inline">aria-label</bolt-code-snippet>.</bolt-li>
     <bolt-li>When writing in plain HTML, <bolt-code-snippet display="inline" lang="html">&lt;span class="e-bolt-button__icon-center"&gt;</bolt-code-snippet> is required to wrap around the icon markup. The wrapper ensures that the icon will always center within the button.</bolt-li>
   </bolt-ol>
 {% endset %}

--- a/docs-site/src/pages/pattern-lab/_patterns/20-elements/button/25-button-with-icon-only.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/20-elements/button/25-button-with-icon-only.twig
@@ -44,7 +44,7 @@
 {% set notes %}
   <bolt-ol>
     <bolt-li>It is recommended that icon only buttons to be used in tandem with tooltip to give the user more context about the button&rsquo;s function.</bolt-li>
-    <bolt-li>When writing in plain HTML, <bolt-code-snippet display="inline">aria-label</bolt-code-snippet> is required, and it must equal to the button text. For example: <bolt-code-snippet display="inline" lang="html">&lt;button type="button" class="e-bolt-button" aria-label="Download"&gt;</bolt-code-snippet>. Text should not be used inside the button when using <bolt-code-snippet display="inline">aria-label</bolt-code-snippet>.</bolt-li>
+    <bolt-li>When writing in plain HTML, <bolt-code-snippet display="inline">aria-label</bolt-code-snippet> is required, and it must equal to the button text. For example: <bolt-code-snippet display="inline" lang="html">&lt;button type="button" class="e-bolt-button e-bolt-button--icon-only" aria-label="Download"&gt;</bolt-code-snippet>. Text should not be used inside the button when using <bolt-code-snippet display="inline">aria-label</bolt-code-snippet>.</bolt-li>
     <bolt-li>When writing in plain HTML, <bolt-code-snippet display="inline" lang="html">&lt;span class="e-bolt-button__icon-center"&gt;</bolt-code-snippet> is required to wrap around the icon markup. The wrapper ensures that the icon will always center within the button.</bolt-li>
   </bolt-ol>
 {% endset %}
@@ -77,7 +77,9 @@
 {% verbatim %}
 // Icon only button combined with tooltip
 <bolt-tooltip>
-  <button type="button" class="e-bolt-button" aria-label="Download"><span class="e-bolt-button__icon-center"><bolt-icon name="download"></bolt-icon></span></button>
+  <button type="button" class="e-bolt-button e-bolt-button--icon-only" aria-label="Download">
+    <span class="e-bolt-button__icon-center"><bolt-icon name="download"></bolt-icon></span>
+  </button>
   <span slot="content">File size: 25MB</span>
 </bolt-tooltip>
 {% endverbatim %}


### PR DESCRIPTION
## Summary

Add `e-bolt-button--icon-only` to element button doc demos.

## Details

It wasn't obvious that we needed this class so i added it to the demo to hopefully save someone in the future some time.

