### PR TITLE
DS-524: Fix smooth scroll bug on deep linked Tabs

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/tabs/10-tabs-deep-linking.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/tabs/10-tabs-deep-linking.twig
@@ -1,0 +1,21 @@
+<div style="min-height: 50vh"></div>
+{% include "@bolt-components-tabs/tabs.twig" with {
+  panels: [
+    {
+      label: "Tab label 1",
+      content: "Tab content 1",
+      id: "tab-1",
+    },
+    {
+      label: "Tab label 2",
+      content: "Tab content 2",
+      id: "tab-2",
+    },
+    {
+      label: "Tab label 3",
+      content: "Tab content 3",
+      id: "tab-3",
+    }
+  ]
+} only %}
+<div style="min-height: 100vh"></div>

--- a/packages/components/bolt-tabs/src/tabs.js
+++ b/packages/components/bolt-tabs/src/tabs.js
@@ -445,7 +445,7 @@ class BoltTabs extends withContext(BoltElement) {
 
         smoothScroll.animateScroll(targetTab, 0, {
           header: this.scrollOffsetSelector,
-          offset: this.scrollOffset,
+          offset: this.scrollOffset || 0,
           speed: 750,
           easing: 'easeInOutCubic',
           updateURL: false,


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-524

## Summary

Fix smooth scroll bug that prevents user from scrolling after navigating to a deep linked tab.

## Details

There is a bug that prevents the user from scrolling after navigating to a deep-linked Tab. Oddly this does not appear to happen in production, but you can see it in PL if you:
1. Go to https://master.boltdesignsystem.com/pattern-lab/patterns/40-components-tabs-45-tabs-deep-linking/40-components-tabs-45-tabs-deep-linking.html?selected-tab=tab-3
2. In the inspector add padding to the body (so you can scroll)
3. Try to scroll

The solution was just to add a fallback `offset` value to smoothScroll. Apparently if you pass this `undefined` it breaks completely.

## How to test

- Review files changed
- See test page and verify you can scroll after initial scroll-to #tab-2: https://bugfix-ds-524-deep-linking.boltdesignsystem.com/pattern-lab/patterns/999-tests-tabs-10-tabs-deep-linking/999-tests-tabs-10-tabs-deep-linking.html?selected-tab=tab-2