### PR TITLE
DS-563 twig init() fixes

### DIFF
--- a/packages/components/bolt-band/band.schema.js
+++ b/packages/components/bolt-band/band.schema.js
@@ -94,7 +94,7 @@ module.exports = {
         'If set to true, the band will take the full width of the page.',
     },
     theme: {
-      type: 'any',
+      type: 'string',
       description: 'Controls the theme of the band.',
       default: 'dark',
       enum: ['none', 'xlight', 'light', 'dark', 'xdark', 'xxdark'],

--- a/packages/twig-integration/twig-extensions-shared/src/Utils.php
+++ b/packages/twig-integration/twig-extensions-shared/src/Utils.php
@@ -203,7 +203,7 @@ class Utils {
       return FALSE;
     }
     elseif (is_string($type)) {
-      if ($type == "array" || $type == "object") {
+      if ($type == "array" || $type == "object" || $type == "any") {
         return FALSE;
       }
     }

--- a/packages/twig-integration/twig-extensions-shared/src/Utils.php
+++ b/packages/twig-integration/twig-extensions-shared/src/Utils.php
@@ -236,7 +236,8 @@ class Utils {
     $props = isset($items["attributes"]) ? $items["attributes"] : [];
 
     // Convert props to an attributes object if it's not already one.
-    $props = is_array($props) ? new Attribute($props) : $props;
+    // If it is already an object, clone it so that we don't unintentionally update the original below.
+    $props = is_array($props) ? new Attribute($props) : clone $props;
 
     if (!empty($schema["properties"])) {
       foreach ($schema["properties"] as $propName => $propSchema) {


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-563

## Summary

Fixes two separate but related bugs in the twig `init()` function

## Details

Fixes these two bugs:

1. If an attributes object is already present in the current `context` when `init()` is called, it will be unintentionally populated by `init()`.
2. If a schema property type is `array` or `object`, it's ignored by `init()`.  However, if the type is `any`, it will not be ignored, but it should be.

Note, we may want to consider waiting to merge this until the 4.0 hotfixes needed in https://pegadigitalit.atlassian.net/browse/DS-562 are ready too.

## How to test
(I have not tested with these exact steps, I'm testing directly in Drupal where the problem was discovered).
Issue 1
* Create a navbar in pattern lab.  Then create an empty attributes object (it must by an object, not an array-- is this possible in PL?) and pass it to your navbar.  Then, below the navbar, print/dump the attributes object again and confirm it is no longer empty.
* Check out this branch and repeat the above.  Confirm that the attributes object is still empty after passing to navbar/init().

Issue 2
* Confirm that a property of type `any` (such as `links` or `content` in the [new navbar](https://v4-0-1.boltdesignsystem.com/pattern-lab/?p=viewall-components-navbar)) is not excluded from `this.props` or `this.data`.
* Check out this branch and confirm that a property of type `any` is excluded from `this.props` and `this.data`.
