### PR TITLE
DS-554: Remove Text Align Left Update

### DIFF
--- a/packages/components/bolt-accordion/src/AccordionItem/accordion-item.scss
+++ b/packages/components/bolt-accordion/src/AccordionItem/accordion-item.scss
@@ -102,7 +102,6 @@ bolt-accordion-item {
   font-size: var(--bolt-type-font-size-medium);
   color: var(--m-bolt-text);
   line-height: var(--bolt-type-line-height-medium);
-  text-align: left; // Fixes center aligned accordion items in the Shadow DOM.
   text-align: start; // For internationalization, will fall back to left if start is not supported.
   user-select: none;
   border: none;

--- a/packages/components/bolt-banner/src/banner.scss
+++ b/packages/components/bolt-banner/src/banner.scss
@@ -102,7 +102,6 @@
  * Align prop
  */
 .c-bolt-banner--align-start {
-  text-align: left;
   text-align: start;
 }
 

--- a/packages/components/bolt-button/src/button.scss
+++ b/packages/components/bolt-button/src/button.scss
@@ -234,7 +234,6 @@ bolt-button[width='full@small'],
 
 .c-bolt-button__item {
   display: inline-flex;
-  text-align: left;
   text-align: start;
 }
 

--- a/packages/components/bolt-list/src/list.scss
+++ b/packages/components/bolt-list/src/list.scss
@@ -33,7 +33,6 @@
   font-weight: var(--bolt-type-font-weight-regular); // [1]
   list-style: none;
   line-height: var(--bolt-type-line-height-medium);
-  text-align: left; // [2]
   text-align: start; // [2]
 }
 

--- a/packages/components/bolt-video/brightcove/_video.scss
+++ b/packages/components/bolt-video/brightcove/_video.scss
@@ -339,7 +339,6 @@ video-js.c-base-video {
     &.vjs-overlay-top-left,
     &.vjs-overlay-bottom-left {
       left: 0;
-      text-align: left;
       text-align: start;
     }
 

--- a/packages/components/bolt-video/src/_videojs-enhancements.scss
+++ b/packages/components/bolt-video/src/_videojs-enhancements.scss
@@ -302,7 +302,6 @@ $bolt-video-js-button-shadow-level-hover: 'level-40';
     &.vjs-overlay-top-left,
     &.vjs-overlay-bottom-left {
       left: 0;
-      text-align: left;
       text-align: start;
     }
 


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-554

## Summary

Remove `text-align: left;` if `text-align: start;` is present

## Details

Codebase was searched for `text-align: left;`

## How to test

Search the codebase for `text-align: start;`. If `text-align: start;` is defined there should not be `text-align: left;` in the same ruleset. 