### PR TITLE
DS-563: Fix boolean attribute syntax

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/navbar/05-navbar-with-active-link.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/navbar/05-navbar-with-active-link.twig
@@ -1,0 +1,63 @@
+{% set navbar_data = [
+  {
+    link: {
+      content: 'Section 1',
+      attributes: {
+        href: '#section-1'
+      }
+    }
+  },
+  {
+    link: {
+      content: 'Section 2',
+      attributes: {
+        href: '#section-2'
+      }
+    }
+  },
+  {
+    link: {
+      content: 'Section 3',
+      attributes: {
+        href: '#section-3'
+      }
+    }
+  },
+  {
+    link: {
+      content: 'Section 4',
+      attributes: {
+        href: '#section-4'
+      }
+    },
+    current: true
+  },
+  {
+    link: {
+      content: 'Section 5',
+      attributes: {
+        href: '#section-5'
+      }
+    }
+  }
+] %}
+
+{% set navbar_items %}
+  {% for item in navbar_data %}
+    {% include '@bolt-components-navbar/navbar-li.twig' with item only %}
+  {% endfor %}
+{% endset %}
+
+{% set navbar_list %}
+  {% include '@bolt-components-navbar/navbar-ul.twig' with { content: navbar_items } only %}
+{% endset %}
+
+{% include '@bolt-components-navbar/navbar.twig' with {
+  title: {
+    content: 'Title Text',
+    icon: {
+      name: 'marketing-gray'
+    }
+  },
+  links: navbar_list
+} only %}

--- a/packages/components/bolt-navbar/src/navbar-li.twig
+++ b/packages/components/bolt-navbar/src/navbar-li.twig
@@ -15,11 +15,11 @@
 ] %}
 
 {% if this.data.current.value is sameas(true) %}
-  {% set attributes = attributes.setAttribute('data-bolt-current') %}
+  {% set attributes = attributes.setAttribute('data-bolt-current', true) %}
 {% endif %}
 
 {# [data-scroll-ignore] opts out of automatic smoothscroll behavior, @see packages/bolt-smooth-scroll #}
-{% set _link_attributes = _link_attributes.setAttribute('data-scroll-ignore', '') %}
+{% set _link_attributes = _link_attributes.setAttribute('data-scroll-ignore', true) %}
 
 {% if link.icon %}
   {% set _icon_position = link.icon.position in schema.properties.link.properties.icon.properties.position.enum ? link.icon.position : schema.properties.link.properties.icon.properties.position.default %}


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-533 (bug discovered during implementation)

## Summary

Fix boolean attribute syntax in navbar

## Details

When trying to set the `current` attribute to `true` in Drupal, I got an error that `setAttribute()` was missing an argument (only had one instead of two).  This PR fixes the syntax by passing `TRUE` as the second argument to boolean attributes.

The Drupal docs don't explicitly address boolean attributes, but this seems correct to me based on the other docs at https://www.drupal.org/docs/8/theming-drupal-8/using-attributes-in-templates#s-attributessetattributeattribute-value

## How to test

This may only be a problem in Drupal, but it seems like you should be able to test by creating a navbar item with `current` set to `true`.  If attributes behave the same in pattern lab as they do in Drupal, it will throw an error, or perhaps just not respect the prop.
