### PR TITLE
DS-562 Remove unexpected margin bottom on Navbar title

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/navbar/22-navbar-title-tags.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/navbar/22-navbar-title-tags.twig
@@ -1,0 +1,101 @@
+{% extends "@pl/_default-page-template.twig" %}
+
+{% block main_content %}
+
+{% set navbar_data = [
+  {
+    link: {
+      content: 'Section 1',
+      attributes: {
+        href: '#section-1'
+      }
+    }
+  },
+  {
+    link: {
+      content: 'Button',
+      attributes: {
+        type: 'button',
+        'data-foo': 'bar'
+      }
+    }
+  },
+  {
+    link: {
+      content: 'External Link',
+      attributes: {
+        href: 'http://google.com/',
+        target: '_blank'
+      }
+    }
+  },
+  {
+    link: {
+      content: 'Section 2',
+      attributes: {
+        href: '#section-2'
+      }
+    }
+  },
+  {
+    link: {
+      content: 'External Link',
+      attributes: {
+        href: 'http://google.com/'
+      }
+    }
+  },
+  {
+    link: {
+      content: 'Button',
+      attributes: {
+        type: 'button',
+        onclick: 'alert("test")'
+      }
+    }
+  },
+  {
+    link: {
+      content: 'Section 3',
+      attributes: {
+        href: '#section-3'
+      }
+    }
+  }
+] %}
+
+{% set navbar_items %}
+  {% for item in navbar_data %}
+    {% include '@bolt-components-navbar/navbar-li.twig' with item only %}
+  {% endfor %}
+{% endset %}
+
+{% set navbar_links %}
+  {% include '@bolt-components-navbar/navbar-ul.twig' with { content: navbar_items } only %}
+{% endset %}
+
+{% include '@bolt-components-navbar/navbar.twig' with {
+  title: {
+    content: 'Navbar title h1',
+    tag: 'h1'
+  },
+  links: navbar_links
+} only %}
+<br>
+{% include '@bolt-components-navbar/navbar.twig' with {
+  title: {
+    content: 'Navbar title h2',
+    tag: 'h2'
+  },
+  links: navbar_links
+} only %}
+<br>
+{% include '@bolt-components-navbar/navbar.twig' with {
+  title: {
+    content: 'Navbar title h3',
+    tag: 'h3'
+  },
+  links: navbar_links
+} only %}
+
+{% endblock %}

--- a/packages/components/bolt-navbar/src/navbar.scss
+++ b/packages/components/bolt-navbar/src/navbar.scss
@@ -119,9 +119,8 @@
 
 // Title
 .c-bolt-navbar__title {
+  all: unset; // 'unset' all styles when title uses heading tag
   display: flex;
-  margin-bottom: 0; // Override global heading styles when title uses heading tag
-  font-weight: initial;
   color: var(--m-bolt-headline);
   white-space: nowrap;
 

--- a/packages/components/bolt-navbar/src/navbar.scss
+++ b/packages/components/bolt-navbar/src/navbar.scss
@@ -120,6 +120,7 @@
 // Title
 .c-bolt-navbar__title {
   display: flex;
+  margin-bottom: 0; // Override global heading styles when title uses heading tag
   font-weight: initial;
   color: var(--m-bolt-headline);
   white-space: nowrap;


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-562

## Summary

Removes unexpected margin-bottom when you use a heading tag (`h1`, `h2`, etc.) with Navbar title.

## Details

If Navbar title uses a heading tag, it inherits global heading styles. This PR removes the margin-bottom that global styles add.

## How to test

- Review changed files
- View [test page](http://localhost:3001/pattern-lab/?p=tests-navbar-title-tags) to verify there is no margin-bottom on Navbar titles.