### PR TITLE
COM-780 keyboard input styles

### DIFF
--- a/packages/global/styles/04-elements/_elements-code.scss
+++ b/packages/global/styles/04-elements/_elements-code.scss
@@ -29,7 +29,7 @@ code {
   margin: 0;
   padding: 2px 0.25rem 2px 0.3rem; // [Mai] 0.25rem on the right offsets the 0.05rem letter-spacing.
   font-family: var(--bolt-type-font-family-code);
-  font-size: var(--bolt-type-font-size-small);
+  font-size: 0.8em;
   font-weight: var(--bolt-type-font-weight-regular);
   line-height: var(--bolt-type-line-height-small);
   letter-spacing: 0.05rem;

--- a/packages/global/styles/04-elements/_elements-misc.scss
+++ b/packages/global/styles/04-elements/_elements-misc.scss
@@ -100,10 +100,10 @@ sup {
 }
 
 kbd {
-  padding: 0.2em 0.4em;
+  padding: 1px 0.2em;
   font-family: var(--bolt-type-font-family-code);
   color: var(--m-bolt-text);
   border-radius: bolt-border-radius(small);
-  box-shadow: 0 1px 2px 1px var(--m-bolt-text);
+  box-shadow: 0 1px 3px 0 var(--m-bolt-text);
   background-color: var(--m-bolt-bg);
 }


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/COM-780

## Summary

Fixes `kbd` styles so that it doesn't overlap other content.

## Details

1. Updated the `kbd` styles to reduce the padding.
2. Updated `code` font-size to match `kbd`, allowing code text to relatively update its size along with neighboring text.

## How to test

Run the branch locally, create a dummy page with some placeholder text, add some `kbd` and `code` in the text content. Make sure these elements don't overlap each other when they are close.