### PR TITLE
DS-574: Disable cssnano `calc` optimizations

### DIFF
--- a/packages/build-tools/create-webpack-config.js
+++ b/packages/build-tools/create-webpack-config.js
@@ -346,6 +346,7 @@ async function createWebpackConfig(buildConfig) {
               zindex: false, // don't alter `z-index` values
               mergeRules: false, // this MUST be disabled - otherwise certain selectors (ex. ::slotted(*), which IE 11 can't parse) break
               reduceTransforms: false, // this will convert translate3d(0,0,0) to tranlateZ(0) which breaks animation transitions
+              calc: false, // don't optimize calc, can change calculations in unexpected ways, especially when CSS vars are involved
             },
           ],
         },


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-574

## Summary

Disable `cssnano` "calc" optimizations.

## Details

`cssnano` is breaking certain "calc" rules when it tries to optimize them.

We use the ["default" config option](https://cssnano.co/docs/optimisations) with a handful of [additional options disabled](https://github.com/boltdesignsystem/bolt/blob/7aa85514e8309775f1bb6c25c1d1c53998af19cc/packages/build-tools/create-webpack-config.js#L344-L349). I'm adding "calc" to the list of disabled optimizations.

Down the road we will switch to the "lite" config. For now, just to be safe, disable only "calc".

## How to test

- Review files changed
- Smoke test of PL site