### PR TITLE
DS-577 Fix toolbar breadcrumb centering

### DIFF
--- a/packages/components/bolt-toolbar/toolbar.scss
+++ b/packages/components/bolt-toolbar/toolbar.scss
@@ -75,7 +75,7 @@
   line-height: var(--bolt-type-line-height-medium);
 }
 
-bolt-breadcrumb {
+.c-bolt-toolbar__breadcrumbs {
   grid-area: breadcrumbs;
 }
 

--- a/packages/components/bolt-toolbar/toolbar.twig
+++ b/packages/components/bolt-toolbar/toolbar.twig
@@ -18,10 +18,14 @@
             {% endblock %}
           {% endif %}
 
-          {%  if block("content_before") is defined %}
-            {{ block("content_before") }}
-          {% else %}
-            {{ content_before }}
+          {% if block('content_before') is defined or content_before %}
+            <div class="c-bolt-toolbar__breadcrumbs">
+              {%  if block("content_before") is defined %}
+                {{ block("content_before") }}
+              {% else %}
+                {{ content_before }}
+              {% endif %}
+            </div>
           {% endif %}
         </div>
       {% endif %}


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-577

## Summary

Fixes edge case where breadcrumbs content is passed with wrapping `<div>` and vertical centering is thrown off.

## Details

Adds wrapping `<div>` to Toolbar component and targets _that_ for vertical alignment, rather than counting on `bolt-breadcrumb` being the top-level element passed as `content_before`.

> Note: this was originally intended as hotfix to `4.1.x`, but at this point let's just merge into `master` and release with `4.2.0`. The effort of cutting all these hotfixes is really adding up. Sites can just skip to `v4.2.0`.

## How to test

- Review code changes
- See Academy demo (link TBD) and verify breadcrumb is vertically aligned