### PR TITLE
DS 578 Update patternlab with image element

### DIFF
--- a/docs-site/src/components/animated-logo/animated-logo.twig
+++ b/docs-site/src/components/animated-logo/animated-logo.twig
@@ -1,9 +1,10 @@
 <div class="c-bds-logo">
   <div class="c-bds-logo__inner">
-    {% include '@bolt-components-image/image.twig' with {
-      src: "/images/bolt-logo.svg",
-      alt: "Bolt Design System logo",
-      lazyload: false,
+    {% include '@bolt-elements-image/image.twig' with {
+      attributes: {
+        src: "/images/bolt-logo.svg",
+        alt: "Bolt Design System logo",
+      }
     } only %}
   </div>
 </div>

--- a/docs-site/src/pages/pattern-lab/_patterns/20-elements/text-link/30-text-link-expand-click-target.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/20-elements/text-link/30-text-link-expand-click-target.twig
@@ -17,10 +17,11 @@
 
 {% set demo %}
 <div class="u-bolt-position-relative u-bolt-shadow-level-20 u-bolt-border-radius-large u-bolt-padding-medium t-bolt-light" style="max-width: 66ch;">
-  {% include '@bolt-components-image/image.twig' with {
-    src: '/images/placeholders/landscape-16x9-mountains.jpg',
-    alt: 'A mountain',
+  {% include '@bolt-elements-image/image.twig' with {
     attributes: {
+      src: '/images/placeholders/landscape-16x9-mountains.jpg',
+      alt: 'A mountain',
+      loading: "lazy",
       class: [
         'u-bolt-margin-bottom-small',
         'u-bolt-border-radius-large',

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/accordion/40-accordion-content-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/accordion/40-accordion-content-variations.twig
@@ -88,9 +88,12 @@
 } only %}
 
 {% set image_content %}
-  {% include "@bolt-components-image/image.twig" with {
-    src: "/images/placeholders/tout-4x3-climber.jpg",
-    alt: "A Rock Climber",
+  {% include "@bolt-elements-image/image.twig" with {
+    attributes: {
+      src: "/images/placeholders/tout-4x3-climber.jpg",
+      alt: "A Rock Climber",
+      loading: "lazy",
+    }
   } only %}
 {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/action-blocks/35-action-blocks-freeform-content.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/action-blocks/35-action-blocks-freeform-content.twig
@@ -7,9 +7,12 @@
 {% endset %}
 
 {% set media_2 %}
-  {% include '@bolt-components-image/image.twig' with {
-    src: "/images/placeholders/tout-4x3-climber.jpg",
-    alt: "A Rock Climber",
+  {% include '@bolt-elements-image/image.twig' with {
+    attributes: {
+      src: "/images/placeholders/tout-4x3-climber.jpg",
+      alt: "A Rock Climber",
+      loading: "lazy",
+    }
   } only %}
 {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/card/06-card-horizontal.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/card/06-card-horizontal.twig
@@ -112,10 +112,13 @@
       {% set altHorizontalCardContent %}
         {% grid "o-bolt-grid--flex o-bolt-grid--matrix" %}
           {% cell "o-bolt-grid__cell" %}
-            {% include "@bolt-components-image/image.twig" with {
-              src: "/images/placeholders/thumb-square-abstract.jpg",
-              alt: "Image alt",
-              max_width: width,
+            {% include '@bolt-elements-image/image.twig' with {
+              attributes: {      
+                src: "/images/placeholders/thumb-square-abstract.jpg",
+                alt: "Image alt",
+                style: "max-width:" ~ width,
+                loading: "lazy",
+              }
             } only %}
           {% endcell %}
           {% cell "u-bolt-width-12/12 u-bolt-width-6/12@xsmall u-bolt-flex-grow u-bolt-margin-top-auto u-bolt-margin-bottom-auto" %}
@@ -146,9 +149,12 @@
               ]
             }
           } %}
-            {% include "@bolt-components-image/image.twig" with {
-              src: "/images/placeholders/thumb-square-abstract.jpg",
-              alt: "Image alt",
+            {% include "@bolt-elements-image/image.twig" with {
+              attributes: {
+                src: "/images/placeholders/thumb-square-abstract.jpg",
+                alt: "Image alt",
+                loading: 'lazy',
+              }
             } only %}
           {% endcell %}
           {% cell "u-bolt-width-12/12 u-bolt-width-6/12@xsmall u-bolt-flex-grow u-bolt-margin-top-auto u-bolt-margin-bottom-auto" %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/card/40-card-replacement-with-freeform-content.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/card/40-card-replacement-with-freeform-content.twig
@@ -2,11 +2,12 @@
   {% cell "u-bolt-width-6/12 u-bolt-width-4/12@small" %}
     <h3>Passing free-form content inside the card-replacement body only</h3>
     {% set card_replacement_body_content %}
-      {% include "@bolt-components-image/image.twig" with {
-        src: "/images/placeholders/tout-4x3-climber.jpg",
-        alt: "A Rock Climber",
+      {% include '@bolt-elements-image/image.twig' with {
         attributes: {
-          class: "u-bolt-margin-bottom-medium"
+          src: "/images/placeholders/tout-4x3-climber.jpg",
+          alt: "A Rock Climber",
+          class: "u-bolt-margin-bottom-medium",
+          loading: "lazy"
         }
       } only %}
       {% include "@bolt-components-headline/headline.twig" with {

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/carousel/25-carousel-basic-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/carousel/25-carousel-basic-variations.twig
@@ -222,16 +222,22 @@
 {% endset %}
 
 {% set figure_image_1 %}
-  {% include "@bolt-components-image/image.twig" with {
-    src: "/images/placeholders/landscape-16x9-mountains.jpg",
-    alt: "Image caption",
+  {% include "@bolt-elements-image/image.twig" with {
+    attributes: {
+      src: "/images/placeholders/landscape-16x9-mountains.jpg",
+      alt: "Image caption",
+      loading: "lazy",
+    }
   } only %}
 {% endset %}
 
 {% set figure_image_2 %}
-  {% include "@bolt-components-image/image.twig" with {
+  {% include "@bolt-elements-image/image.twig" with {
+    attributes: {
     src: "/images/placeholders/landscape-16x9-skyline.jpg",
     alt: "Image caption",
+    loading: "lazy",
+    }
   } only %}
 {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/carousel/30-carousel-advanced-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/carousel/30-carousel-advanced-variations.twig
@@ -149,9 +149,9 @@
         text: "Customer engagement meets intelligent automation.",
       } only %}
       <div style="text-align: center">
-        {% include "@bolt-components-image/image.twig" with {
-          src: "/images/logos/pw19-logo-diamond.png",
+        {% include "@bolt-elements-image/image.twig" with {
           attributes: {
+            src: "/images/logos/pw19-logo-diamond.png",
             class: "u-bolt-margin-bottom-medium",
             style: "max-width: 200px; margin: 0 auto;",
           },
@@ -199,11 +199,12 @@
         text: "Every enterprise success story starts with the right technology.",
       } only %}
       <div style="text-align: center">
-        {% include "@bolt-components-image/image.twig" with {
-          src: "/images/logos/pw19-logo-diamond.png",
+        {% include "@bolt-elements-image/image.twig" with {
           attributes: {
+            src: "/images/logos/pw19-logo-diamond.png",
             class: "u-bolt-margin-bottom-medium",
             style: "max-width: 200px; margin: 0 auto;",
+            loading: "lazy",
           },
         } only %}
         {% include "@bolt-elements-button/button.twig" with {

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/carousel/_archive/example-content/_band-carousel--slide-1.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/carousel/_archive/example-content/_band-carousel--slide-1.twig
@@ -51,10 +51,11 @@
                   <div>
                     <p class="text-align-center u-bolt-margin-top-large u-bolt-margin-bottom-large">
 
-                    {% include "@bolt-components-image/image.twig" with {
-                      src: "/images/logos/pw19-logo-diamond.png",
+                    {% include "@bolt-elements-image/image.twig" with {
                       attributes: {
+                        src: "/images/logos/pw19-logo-diamond.png",
                         style: "max-width: 200px; margin: 0 auto;",
+                        loading: "lazy",
                       },
                     } only %}
                     </p>

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/carousel/_archive/example-content/_band-carousel--slide-2.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/carousel/_archive/example-content/_band-carousel--slide-2.twig
@@ -50,10 +50,11 @@
 
                   <div>
                     <p class="text-align-center u-bolt-margin-top-large u-bolt-margin-bottom-large">
-                      {% include "@bolt-components-image/image.twig" with {
-                        src: "/images/logos/pw19-logo-diamond.png",
+                      {% include "@bolt-elements-image/image.twig" with {
                         attributes: {
+                          src: "/images/logos/pw19-logo-diamond.png",
                           style: "max-width: 200px; margin: 0 auto;",
+                          loading: "lazy",
                         },
                       } only %}
                     </p>

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/carousel/_archive/example-content/_carousel-slide-image.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/carousel/_archive/example-content/_carousel-slide-image.twig
@@ -1,3 +1,6 @@
-{% include "@bolt-components-image/image.twig" with {
-  src: "/images/content/backgrounds/background-tall-4.jpg"
+{% include "@bolt-elements-image/image.twig" with {
+  attributes: {
+    src: "/images/content/backgrounds/background-tall-4.jpg",
+    loading: "lazy",
+  }
 } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/device-viewer/00-device-viewer-docs.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/device-viewer/00-device-viewer-docs.twig
@@ -1,7 +1,10 @@
 {% set usage %}{% verbatim %}
 {% set content %}
-  {% include "@bolt-components-image/image.twig" with {
-    src: "/images/sample/product-device-screenshot--phone.jpg"
+  {% include "@bolt-elements-image/image.twig" with {
+    attributes: {
+      src: "/images/sample/product-device-screenshot--phone.jpg",
+      loading: "lazy",
+    }
   } only %}
 {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/device-viewer/05-device-viewer.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/device-viewer/05-device-viewer.twig
@@ -1,6 +1,9 @@
 {% set content %}
-  {% include "@bolt-components-image/image.twig" with {
-    src: "/images/content/screenshots/device-screenshot--phone.jpg"
+  {% include "@bolt-elements-image/image.twig" with {
+    attributes: {
+      src: "/images/content/screenshots/device-screenshot--phone.jpg",
+      loading: "lazy",
+    }
   } only %}
 {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/device-viewer/10-device-viewer-ipad-variation.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/device-viewer/10-device-viewer-ipad-variation.twig
@@ -3,9 +3,11 @@
 {% for color in schema.properties.color.enum if (color != 'gold') %}
   <p>Color: {{ color }}<br />Orientation: 'portrait'</p>
   {% set image_tablet_portrait %}
-    {% include "@bolt-components-image/image.twig" with {
-      placeholder_color: "#1b1b1b",
-      src: "/images/content/screenshots/device-screenshot--tablet-portrait.jpg",
+    {% include "@bolt-elements-image/image.twig" with {
+      attributes: {
+        src: "/images/content/screenshots/device-screenshot--tablet-portrait.jpg",
+        loading: "lazy",
+      }
     } only %}
   {% endset %}
 
@@ -18,9 +20,11 @@
 
   <p>Color: {{ color }}<br />Orientation: 'landscape'</p>
   {% set image_tablet_landscape %}
-    {% include "@bolt-components-image/image.twig" with {
-      placeholder_color: "#1b1b1b",
-      src: "/images/content/screenshots/device-screenshot--tablet-portrait.jpg",
+    {% include "@bolt-elements-image/image.twig" with {
+      attributes: {
+        src: "/images/content/screenshots/device-screenshot--tablet-portrait.jpg",
+        loading: "lazy",
+      }
     } only %}
   {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/device-viewer/15-device-viewer-iphone8-variation.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/device-viewer/15-device-viewer-iphone8-variation.twig
@@ -3,9 +3,11 @@
 {% for color in schema.properties.color.enum %}
   <p>Color: {{ color }}<br />Orientation: 'portrait'</p>
   {% set image_portrait %}
-    {% include "@bolt-components-image/image.twig" with {
-      placeholder_color: "#ececec",
-      src: "/images/content/screenshots/device-screenshot--phone.jpg",
+    {% include "@bolt-elements-image/image.twig" with {
+      attributes: {
+        src: "/images/content/screenshots/device-screenshot--phone.jpg",
+        loading: "lazy",
+      }
     } only %}
   {% endset %}
 
@@ -18,9 +20,11 @@
 
   <p>Color: {{ color }}<br />Orientation: 'landscape'</p>
   {% set image_landscape %}
-    {% include "@bolt-components-image/image.twig" with {
-      placeholder_color: "#ececec",
-      src: "/images/content/screenshots/device-screenshot--tablet.jpg",
+    {% include "@bolt-elements-image/image.twig" with {
+      attributes: {
+        src: "/images/content/screenshots/device-screenshot--tablet.jpg",
+        loading: "lazy",
+      }
     } only %}
   {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/device-viewer/20-device-viewer-macbook-variation.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/device-viewer/20-device-viewer-macbook-variation.twig
@@ -1,7 +1,9 @@
 {% set image %}
-  {% include "@bolt-components-image/image.twig" with {
-    placeholder_color: "#151619",
-    src: "/images/content/screenshots/device-screenshot--desktop.jpg",
+  {% include "@bolt-elements-image/image.twig" with {
+    attributes: {
+      src: "/images/content/screenshots/device-screenshot--desktop.jpg",
+      loading: "lazy",
+    }
   } only %}
 {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/device-viewer/30-device-viewer-content-magnifier-modal.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/device-viewer/30-device-viewer-content-magnifier-modal.twig
@@ -1,14 +1,18 @@
 {% set image %}
-  {% include "@bolt-components-image/image.twig" with {
-    placeholder_color: "#151619",
-    src: "/images/content/screenshots/device-screenshot--desktop.jpg",
+  {% include "@bolt-elements-image/image.twig" with {
+    attributes: {
+      src: "/images/content/screenshots/device-screenshot--desktop.jpg",
+      loading: "lazy",
+    }
   } only %}
 {% endset %}
 
 {% set thumbnail_image %}
-  {% include '@bolt-components-image/image.twig' with {
-    src: "/images/content/screenshots/device-screenshot--desktop.jpg",
-    max_width: "600px"
+  {% include '@bolt-elements-image/image.twig' with {
+    attributes: {
+      src: "/images/content/screenshots/device-screenshot--desktop.jpg",
+      style: "max-width: 600px"
+    }
   } only %}
 {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/figure/00-figure-docs.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/figure/00-figure-docs.twig
@@ -1,7 +1,10 @@
 {% set usage %}{% verbatim %}
 {% set image %}
-  {% include "@bolt-components-image/image.twig" with {
-    src: "/images/placeholders/500x500.jpg"
+  {% include "@bolt-elements-image/image.twig" with {
+    attributes: {
+      src: "/images/placeholders/500x500.jpg",
+      loading: "lazy",
+    }
   } only %}
 {% endset %}
 {% include "@bolt-components-figure/figure.twig" with {

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/figure/05-figure.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/figure/05-figure.twig
@@ -1,6 +1,9 @@
 {% set image %}
-  {% include "@bolt-components-image/image.twig" with {
-    src: "/images/placeholders/500x500.jpg"
+  {% include "@bolt-elements-image/image.twig" with {
+    attributes: {
+      src: "/images/placeholders/500x500.jpg",
+      loading: "lazy",
+    }
   } only %}
 {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/figure/10-figure-media-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/figure/10-figure-media-variations.twig
@@ -1,6 +1,9 @@
 {% set image %}
-  {% include "@bolt-components-image/image.twig" with {
-    src: "/images/placeholders/landscape-16x9-mountains.jpg",
+  {% include "@bolt-elements-image/image.twig" with {
+    attributes: {
+      src: "/images/placeholders/landscape-16x9-mountains.jpg",
+      loading: "lazy",
+    }
   } only %}
 {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/hero/20-hero--reverse-order.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/hero/20-hero--reverse-order.twig
@@ -5,11 +5,11 @@
 
 {% include "@bolt-components-hero/hero.twig" with {
   content: [
-    macros.include("@bolt-components-image/image.twig", {
-      src: "/images/heros/hero-foreground--orange--logo.svg",
-      alt: "PegaWorld iNspire logo",
-      lazyload: false,
+    macros.include("@bolt-elements-image/image.twig", {
       attributes: {
+        src: "/images/heros/hero-foreground--orange--logo.svg",
+        alt: "PegaWorld iNspire logo",
+        loading: "eager",
         class: [
           "u-bolt-margin-bottom-medium",
         ]

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/hero/50-hero--image-valign-top.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/hero/50-hero--image-valign-top.twig
@@ -5,11 +5,11 @@
 
 {% include "@bolt-components-hero/hero.twig" with {
   content: [
-    macros.include("@bolt-components-image/image.twig", {
-      src: "/images/heros/hero-foreground--orange--logo.svg",
-      alt: "PegaWorld iNspire logo",
-      lazyload: false,
+    macros.include("@bolt-elements-image/image.twig", {
       attributes: {
+        src: "/images/heros/hero-foreground--orange--logo.svg",
+        alt: "PegaWorld iNspire logo",
+        loading: "eager",
         class: [
           "u-bolt-margin-bottom-medium",
         ]

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/hero/60-hero--bg-valign.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/hero/60-hero--bg-valign.twig
@@ -32,6 +32,7 @@
     attributes: {
       src: "/images/placeholders/landscape-16x9-mountains.jpg",
       alt: "A mountainous landscape",
+      style: "object-position: center top;",
       background: true,
       loading: "eager",
     }
@@ -52,6 +53,7 @@
     attributes: {
       src: "/images/placeholders/landscape-16x9-mountains.jpg",
       alt: "A mountainous landscape",
+      style: "object-position: center bottom;",
       background: true,
       loading: "eager",
     }

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/hero/60-hero--bg-valign.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/hero/60-hero--bg-valign.twig
@@ -28,11 +28,13 @@
 <bolt-text>This demo sets the image's <code>valign</code> prop to <code>top</code>.</bolt-text>
 
 {% set background_image_top %}
-  {% include '@bolt-components-image/image.twig' with {
-    src: "/images/placeholders/landscape-16x9-mountains.jpg",
-    alt: "A mountainous landscape",
-    valign: "top",
-    cover: true
+  {% include '@bolt-elements-image/image.twig' with {
+    attributes: {
+      src: "/images/placeholders/landscape-16x9-mountains.jpg",
+      alt: "A mountainous landscape",
+      background: true,
+      loading: "eager",
+    }
   } only %}
 {% endset %}
 
@@ -46,11 +48,13 @@
 <bolt-text>This demo sets the image's <code>valign</code> prop to <code>bottom</code>.</bolt-text>
 
 {% set background_image_btm %}
-  {% include '@bolt-components-image/image.twig' with {
-    src: "/images/placeholders/landscape-16x9-mountains.jpg",
-    alt: "A mountainous landscape",
-    valign: "bottom",
-    cover: true
+  {% include '@bolt-elements-image/image.twig' with {
+    attributes: {
+      src: "/images/placeholders/landscape-16x9-mountains.jpg",
+      alt: "A mountainous landscape",
+      background: true,
+      loading: "eager",
+    }
   } only %}
 {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/listing-teaser/45-listing-teaser-layout.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/listing-teaser/45-listing-teaser-layout.twig
@@ -5,11 +5,12 @@
 {% set demo %}
   {% set signifier %}
     {% set image %}
-      {% include '@bolt-components-image/image.twig' with {
-        src: '/images/placeholders/tout-4x3-climber.jpg',
-        alt: 'A Rock Climber',
-        ratio: false,
-        cover: true,
+      {% include '@bolt-elements-image/image.twig' with {
+        attributes: {
+          src: '/images/placeholders/tout-4x3-climber.jpg',
+          alt: 'A Rock Climber',
+          background: true,
+        }
       } only %}
     {% endset %}
     {% include '@bolt-components-video-thumbnail/video-thumbnail.twig' with {

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/listing-teaser/45-listing-teaser-layout.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/listing-teaser/45-listing-teaser-layout.twig
@@ -9,6 +9,7 @@
         attributes: {
           src: '/images/placeholders/tout-4x3-climber.jpg',
           alt: 'A Rock Climber',
+          loading: 'lazy',
           background: true,
         }
       } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/listing-teaser/65-listing-teaser-use-case-search-result-list.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/listing-teaser/65-listing-teaser-use-case-search-result-list.twig
@@ -622,11 +622,12 @@
     } only %}
     {% set signifier %}
       {% set image %}
-        {% include '@bolt-components-image/image.twig' with {
-          src: '/images/placeholders/tout-4x3-climber.jpg',
-          alt: 'A Rock Climber',
-          ratio: false,
-          cover: true,
+        {% include '@bolt-elements-image/image.twig' with {
+          attributes: {
+            src: '/images/placeholders/tout-4x3-climber.jpg',
+            alt: 'A Rock Climber',
+            background: true,
+          }
         } only %}
       {% endset %}
       {% include '@bolt-components-video-thumbnail/video-thumbnail.twig' with {

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/listing-teaser/65-listing-teaser-use-case-search-result-list.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/listing-teaser/65-listing-teaser-use-case-search-result-list.twig
@@ -626,6 +626,7 @@
           attributes: {
             src: '/images/placeholders/tout-4x3-climber.jpg',
             alt: 'A Rock Climber',
+            loading: 'lazy',
             background: true,
           }
         } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/modal/25-modal-scroll-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/modal/25-modal-scroll-variations.twig
@@ -1,10 +1,12 @@
 {% set schema = bolt.data.components["@bolt-components-modal"].schema %}
 
 {% set modal_content %}
-  {% include "@bolt-components-image/image.twig" with {
-    src: "/images/content/screenshots/device-screenshot--tablet-portrait.jpg",
-    alt: "Tall image",
-    lazyload: false,
+  {% include "@bolt-elements-image/image.twig" with {
+    attributes: {
+      src: "/images/content/screenshots/device-screenshot--tablet-portrait.jpg",
+      alt: "Tall image",
+      loading: "lazy",
+    }
   } only %}
 {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/modal/30-modal-trigger-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/modal/30-modal-trigger-variations.twig
@@ -27,17 +27,22 @@
       <tr>
         <th>
           {% set trigger_content %}
-            {% include "@bolt-components-image/image.twig" with {
-              src: "/images/placeholders/tout-4x3-climber.jpg",
-              alt: "A Rock Climber",
+            {% include "@bolt-elements-image/image.twig" with {
+              attributes: {
+                src: "/images/placeholders/tout-4x3-climber.jpg",
+                alt: "A Rock Climber",
+                loading: "lazy",
+              }
             } only %}
           {% endset %}
 
           {% set modal_content %}
-            {% include "@bolt-components-image/image.twig" with {
-              src: "/images/placeholders/tout-4x3-climber.jpg",
-              alt: "A Rock Climber",
-              max_width: "640px",
+            {% include "@bolt-elements-image/image.twig" with {
+              attributes: {
+                src: "/images/placeholders/tout-4x3-climber.jpg",
+                alt: "A Rock Climber",
+                styles: "max-width: 640px",
+              }
             } only %}
           {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/modal/40-modal-usage-image-and-caption.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/modal/40-modal-usage-image-and-caption.twig
@@ -3,10 +3,12 @@
 
 <div class="t-bolt-light u-bolt-padding-medium u-bolt-margin-bottom-small">
   {% set image_content %}
-    {% include "@bolt-components-image/image.twig" with {
-      src: "/images/placeholders/tout-4x3-climber.jpg",
-      alt: "Image description.",
-      ratio: "none",
+    {% include "@bolt-elements-image/image.twig" with {
+      attributes: {
+        src: "/images/placeholders/tout-4x3-climber.jpg",
+        alt: "Image description.",
+        loading: "lazy",
+      }
     } only %}
   {% endset %}
   {% set caption %}
@@ -18,10 +20,12 @@
     </div>
   {% endset %}
   {% set modal_image_1 %}
-    {% include "@bolt-components-image/image.twig" with {
-      src: "/images/placeholders/tout-4x3-climber.jpg",
-      alt: "Image description.",
-      max_width: "1000px",
+    {% include "@bolt-eleemnts-image/image.twig" with {
+      attributes: {
+        src: "/images/placeholders/tout-4x3-climber.jpg",
+        alt: "Image description.",
+        styles: "max-width: 1000px",
+      }
     } only %}
   {% endset %}
   {% set modal_content %}
@@ -81,10 +85,12 @@
 
 <div class="t-bolt-light u-bolt-padding-medium u-bolt-margin-bottom-small">
   {% set image_content %}
-    {% include "@bolt-components-image/image.twig" with {
-      src: "/images/content/screenshots/device-screenshot--desktop.jpg",
-      alt: "Image description.",
-      ratio: "none",
+    {% include "@bolt-elements-image/image.twig" with {
+      attributes: {
+        src: "/images/content/screenshots/device-screenshot--desktop.jpg",
+        alt: "Image description.",
+        loading: "lazy",
+      }
     } only %}
   {% endset %}
   {% set caption %}
@@ -96,9 +102,12 @@
     </div>
   {% endset %}
   {% set modal_image_2 %}
-    {% include "@bolt-components-image/image.twig" with {
-      src: "/images/content/screenshots/device-screenshot--desktop.jpg",
-      alt: "Image description.",
+    {% include "@bolt-elements-image/image.twig" with {
+      attributes: {
+        src: "/images/content/screenshots/device-screenshot--desktop.jpg",
+        alt: "Image description.",
+        loading: "lazy",
+      }
     } only %}
   {% endset %}
   {% set modal_content %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/modal/_wip-modal-content-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/modal/_wip-modal-content-variations.twig
@@ -21,11 +21,11 @@
     {% include "@bolt-components-headline/text.twig" with {
       text: "In March 2016, the GRU began hacking the email accounts of Clinton Campaign volunteers and employees, including campaign chairman John Podesta. In April 2016, the GRU hacked into the computer networks of the Democratic Congressional Campaign Committee (DCCC) and the Democratic National Committee (DNC). The GRU stole hundreds of thousands of documents from the compromised email accounts and networks. Around the time that the DNC announced in mid-June 2016 the Russian government’s role in hacking its network, the GRU began disseminating stolen materials through the fictitious online personas “DCLeaks” and “Guccifer 2.0.” The GRU later released additional materials through the organization WikiLeaks."
     } only %}
-    {% include "@bolt-components-image/image.twig" with {
-      src: "/images/placeholders/tout-4x3-climber.jpg",
-      alt: "A Rock Climber",
-      lazyload: false,
+    {% include "@bolt-elements-image/image.twig" with {
       attributes: {
+        src: "/images/placeholders/tout-4x3-climber.jpg",
+        alt: "A Rock Climber",
+        loading: "lazy",
         class: "u-bolt-margin-bottom-medium",
       }
     } only %}
@@ -299,9 +299,12 @@
 
 <div class="u-bolt-margin-bottom-medium">
   {% set modal_content %}
-    {% include "@bolt-components-image/image.twig" with {
-      src: "/images/content/backgrounds/background-robotics-customer-service.jpg",
-      alt: "This is the alt text.",
+    {% include "@bolt-elements-image/image.twig" with {
+      attributes: {
+        src: "/images/content/backgrounds/background-robotics-customer-service.jpg",
+        alt: "This is the alt text.",
+        loading: "lazy",
+      }
     } only %}
   {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/modal/_wip-modal-usage-carousel.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/modal/_wip-modal-usage-carousel.twig
@@ -21,9 +21,12 @@
   {% set image_slide_1 %}
     <div class="u-bolt-padding-medium">
       {% set image %}
-        {% include '@bolt-components-image/image.twig' with {
-          src: '/images/placeholders/landscape-16x9-mountains.jpg',
-          alt: 'Alt text.',
+        {% include '@bolt-elements-image/image.twig' with {
+          attributes: {
+            src: '/images/placeholders/landscape-16x9-mountains.jpg',
+            alt: 'Alt text.',
+            loading: "lazy",
+          }
         } only %}
       {% endset %}
       {% include '@bolt-components-figure/figure.twig' with {
@@ -37,9 +40,12 @@
   {% set image_slide_2 %}
     <div class="u-bolt-padding-medium">
       {% set image %}
-        {% include '@bolt-components-image/image.twig' with {
-          src: '/images/placeholders/landscape-16x9-skyline.jpg',
-          alt: 'Alt text.',
+        {% include '@bolt-elements-image/image.twig' with {
+          attributes: {
+            src: '/images/placeholders/landscape-16x9-skyline.jpg',
+            alt: 'Alt text.',
+            loading: "lazy",
+          }
         } only %}
       {% endset %}
       {% include '@bolt-components-figure/figure.twig' with {
@@ -107,11 +113,12 @@
 
 <div class="t-bolt-light u-bolt-padding-medium u-bolt-margin-bottom-small">
   {% set portrait %}
-    {% include '@bolt-components-image/image.twig' with {
-      src: '/images/placeholders/500x500.jpg',
-      alt: 'Bill Murray',
+    {% include '@bolt-elements-image/image.twig' with {
       attributes: {
-        class: 'u-bolt-margin-bottom-small'
+        src: '/images/placeholders/500x500.jpg',
+        alt: 'Bill Murray',
+        class: 'u-bolt-margin-bottom-small',
+        loading: "lazy",
       },
     } only %}
     {% include '@bolt-components-headline/headline.twig' with {
@@ -164,11 +171,12 @@
   {% endset %}
 
   {% set portrait %}
-    {% include '@bolt-components-image/image.twig' with {
-      src: '/images/placeholders/500x500.jpg',
-      alt: 'Bill Murray',
+    {% include '@bolt-elements-image/image.twig' with {
       attributes: {
-        class: 'u-bolt-margin-bottom-small'
+        src: '/images/placeholders/500x500.jpg',
+        alt: 'Bill Murray',
+        class: 'u-bolt-margin-bottom-small',
+        loading: "lazy",
       },
     } only %}
     {% include '@bolt-components-headline/headline.twig' with {

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/table/35-table-item-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/table/35-table-item-variations.twig
@@ -1,7 +1,10 @@
 {% set inline_image %}
-  {% include '@bolt-components-image/image.twig' with {
-    src: "/images/placeholders/tout-4x3-climber.jpg",
-    alt: "A Rock Climber"
+  {% include '@bolt-elements-image/image.twig' with {
+    attributes: {
+      src: "/images/placeholders/tout-4x3-climber.jpg",
+      alt: "A Rock Climber",
+      loading: "lazy"
+    }
   } only %}
 {% endset %}
 
@@ -67,10 +70,12 @@
       cells: [
         "SR-43163",
         "This hotfix adds a list of post-update tasks to the <span>RuntimeConfig.xml </span>file. These tasks are run after files that match a pattern you specify are updated.",
-        include("@bolt-components-image/image.twig", {
-          src: "/images/placeholders/tout-4x3-climber.jpg",
-          alt: "A Rock Climber",
-          lazyload: false,
+        include("@bolt-elements-image/image.twig", {
+          attributes: {
+            src: "/images/placeholders/tout-4x3-climber.jpg",
+            alt: "A Rock Climber",
+            loading: "lazy",
+          }
         }),
       ]
     },

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/tabs/30-tabs-content.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/tabs/30-tabs-content.twig
@@ -1,7 +1,10 @@
 {% set image_content %}
-  {% include '@bolt-components-image/image.twig' with {
-    src: "/images/placeholders/landscape-16x9-mountains.jpg",
-    alt: "Mountains",
+  {% include '@bolt-elements-image/image.twig' with {
+    attributes: {
+      src: "/images/placeholders/landscape-16x9-mountains.jpg",
+      alt: "Mountains",
+      loading: "lazy",
+    }
   } only %}
 {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/tabs/40-tabs-use-case-tabbed-band.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/tabs/40-tabs-use-case-tabbed-band.twig
@@ -52,9 +52,11 @@
     {% endcell %}
     {% cell "u-bolt-width-12/12 u-bolt-width-7/12@small" %}
       {% set device_viewer_image %}
-        {% include '@bolt-components-image/image.twig' with {
-          src: "/images/content/screenshots/device-screenshot--tablet.jpg",
-          placeholder_color: "#ececec"
+        {% include '@bolt-elements-image/image.twig' with {
+          attributes: {
+            src: "/images/content/screenshots/device-screenshot--tablet.jpg",
+            loading: "lazy"
+          }
         } only %}
       {% endset %}
       {% include "@bolt-components-device-viewer/device-viewer.twig" with {
@@ -70,9 +72,11 @@
   {% grid "o-bolt-grid--flex o-bolt-grid--large o-bolt-grid--middle o-bolt-grid--matrix" %}
     {% cell "u-bolt-width-12/12 u-bolt-width-7/12@small" %}
       {% set device_viewer_image %}
-        {% include '@bolt-components-image/image.twig' with {
-          src: "/images/content/screenshots/device-screenshot--tablet-portrait.jpg",
-          placeholder_color: "#1c1c1c"
+        {% include '@bolt-elements-image/image.twig' with {
+          attributes: {
+            src: "/images/content/screenshots/device-screenshot--tablet-portrait.jpg",
+            loading: "lazy"
+          }
         } only %}
       {% endset %}
       {% include "@bolt-components-device-viewer/device-viewer.twig" with {
@@ -127,9 +131,11 @@
 {% set tab_content_3 %}
   {% grid "o-bolt-grid--flex o-bolt-grid--large o-bolt-grid--middle o-bolt-grid--matrix" %}
     {% cell "u-bolt-width-12/12 u-bolt-width-6/12@small" %}
-      {% include "@bolt-components-image/image.twig" with {
-        src: "/images/content/charts/decision-hub-chart.png",
-        lazyload: true
+      {% include "@bolt-elements-image/image.twig" with {
+        attributes: {
+          src: "/images/content/charts/decision-hub-chart.png",
+          loading: "lazy"
+        }
       } only %}
     {% endcell %}
     {% cell "u-bolt-width-12/12 u-bolt-width-6/12@small" %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/05-teaser.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/05-teaser.twig
@@ -14,9 +14,12 @@ A teaser is an interactive block element. Its main purpose is to display relevan
 {% set demo %}
   <div style="max-width: 60ch;">
     {% set image %}
-      {% include '@bolt-components-image/image.twig' with {
-        src: '/images/placeholders/signifier-pdf.jpg',
-        alt: 'Alt text.',
+      {% include '@bolt-elements-image/image.twig' with {
+        attributes: {
+          src: '/images/placeholders/signifier-pdf.jpg',
+          alt: 'Alt text.',
+          loading: 'lazy',
+        }
       } only %}
     {% endset %}
     {% include '@bolt-components-teaser/teaser.twig' with {

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/10-teaser-layout.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/10-teaser-layout.twig
@@ -11,15 +11,21 @@
 
 {% set demo %}
   {% set wide_image %}
-    {% include '@bolt-components-image/image.twig' with {
-      src: '/images/placeholders/signifier-pdf.jpg',
-      alt: 'Alt text.',
+    {% include '@bolt-elements-image/image.twig' with {
+      attributes: {
+        src: '/images/placeholders/signifier-pdf.jpg',
+        alt: 'Alt text.',
+        loading: 'lazy',
+      }
     } only %}
   {% endset %}
   {% set square_image %}
-    {% include '@bolt-components-image/image.twig' with {
-      src: '/images/placeholders/thumb-square-abstract.jpg',
-      alt: 'Alt text.',
+    {% include '@bolt-elements-image/image.twig' with {
+      attributes: {
+        src: '/images/placeholders/thumb-square-abstract.jpg',
+        alt: 'Alt text.',
+        loading: 'lazy',
+      }
     } only %}
   {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/15-teaser-gutter.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/15-teaser-gutter.twig
@@ -4,15 +4,21 @@
 
 {% set demo %}
   {% set wide_image %}
-    {% include '@bolt-components-image/image.twig' with {
-      src: '/images/placeholders/signifier-pdf.jpg',
-      alt: 'Alt text.',
+    {% include '@bolt-elements-image/image.twig' with {
+      attributes: {
+        src: '/images/placeholders/signifier-pdf.jpg',
+        alt: 'Alt text.',
+        loading: 'lazy',
+      }
     } only %}
   {% endset %}
   {% set square_image %}
-    {% include '@bolt-components-image/image.twig' with {
-      src: '/images/placeholders/thumb-square-abstract.jpg',
-      alt: 'Alt text.',
+    {% include '@bolt-elements-image/image.twig' with {
+      attributes: {
+        src: '/images/placeholders/thumb-square-abstract.jpg',
+        alt: 'Alt text.',
+        loading: 'lazy',
+      }
     } only %}
   {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/20-teaser-chips.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/20-teaser-chips.twig
@@ -4,9 +4,12 @@
 
 {% set demo %}
   {% set wide_image %}
-    {% include '@bolt-components-image/image.twig' with {
-      src: '/images/content/promos/promo-16x9-ai.jpg',
-      alt: 'Alt text.',
+    {% include '@bolt-elements-image/image.twig' with {
+      attributes: {
+        src: '/images/content/promos/promo-16x9-ai.jpg',
+        alt: 'Alt text.',
+        loading: 'lazy',
+      }
     } only %}
   {% endset %}
   {% set chip_list %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/25-teaser-type-and-time.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/25-teaser-type-and-time.twig
@@ -41,9 +41,12 @@
     },
   } only %}
   {% set wide_image %}
-    {% include '@bolt-components-image/image.twig' with {
-      src: '/images/content/promos/promo-16x9-ai.jpg',
-      alt: 'Alt text.',
+    {% include '@bolt-elements-image/image.twig' with {
+      attributes: {
+        src: '/images/content/promos/promo-16x9-ai.jpg',
+        alt: 'Alt text.',
+        loading: 'lazy',
+      }
     } only %}
   {% endset %}
   

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/30-teaser-status-and-actions.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/30-teaser-status-and-actions.twig
@@ -13,9 +13,12 @@
 
 {% set demo %}
   {% set wide_image %}
-    {% include '@bolt-components-image/image.twig' with {
-      src: '/images/placeholders/signifier-pdf.jpg',
-      alt: 'Alt text.',
+    {% include '@bolt-elements-image/image.twig' with {
+      attributes: {
+        src: '/images/placeholders/signifier-pdf.jpg',
+        alt: 'Alt text.',
+        loading: 'lazy',
+      }
     } only %}
   {% endset %}
   {% set like %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/35-teaser-text-options.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/35-teaser-text-options.twig
@@ -11,9 +11,12 @@
 
 {% set demo %}
   {% set wide_image %}
-    {% include '@bolt-components-image/image.twig' with {
-      src: '/images/placeholders/signifier-pdf.jpg',
-      alt: 'Alt text.',
+    {% include '@bolt-elements-image/image.twig' with {
+      attributes: {
+        src: '/images/placeholders/signifier-pdf.jpg',
+        alt: 'Alt text.',
+        loading: 'lazy',
+      }
     } only %}
   {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/40-teaser-description-on-hover.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/40-teaser-description-on-hover.twig
@@ -4,9 +4,12 @@
 
 {% set demo %}
   {% set wide_image %}
-    {% include '@bolt-components-image/image.twig' with {
-      src: '/images/placeholders/signifier-pdf.jpg',
-      alt: 'Alt text.',
+    {% include '@bolt-elements-image/image.twig' with {
+      attributes: {
+        src: '/images/placeholders/signifier-pdf.jpg',
+        alt: 'Alt text.',
+        laoding: 'lazy',
+      }
     } only %}
   {% endset %}
   <div class="o-bolt-grid o-bolt-grid--flex o-bolt-grid--matrix">

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/trigger/35-trigger-advanced-usage.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/trigger/35-trigger-advanced-usage.twig
@@ -3,17 +3,23 @@
 
 <div class="u-bolt-margin-bottom-medium">
   {% set thumbnail_content %}
-    {% include '@bolt-components-image/image.twig' with {
-      src: "/images/placeholders/tout-4x3-climber.jpg",
-      alt: "A Rock Climber",
-      max_width: "200px"
+    {% include '@bolt-elements-image/image.twig' with {
+      attributes: {
+        src: "/images/placeholders/tout-4x3-climber.jpg",
+        alt: "A Rock Climber",
+        style: "max-width: 200px",
+        loading: 'lazy',
+      }
     } only %}
   {% endset %}
 
   {% set image_content %}
-    {% include '@bolt-components-image/image.twig' with {
-      src: "/images/placeholders/tout-4x3-climber.jpg",
-      alt: "A Rock Climber",
+    {% include '@bolt-elements-image/image.twig' with {
+      attributes: {
+        src: "/images/placeholders/tout-4x3-climber.jpg",
+        alt: "A Rock Climber",
+        laoding: 'lazy',
+      }
     } only %}
   {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/video-thumbnail/05-video-thumbnail.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/video-thumbnail/05-video-thumbnail.twig
@@ -11,11 +11,13 @@
 {% set demo %}
   <div style="max-width: 60ch">
     {% set image %}
-      {% include '@bolt-components-image/image.twig' with {
-        src: '/images/placeholders/tout-4x3-climber.jpg',
-        alt: 'A Rock Climber',
-        ratio: false,
-        cover: true,
+      {% include '@bolt-elements-image/image.twig' with {
+        attributes: {
+          src: '/images/placeholders/tout-4x3-climber.jpg',
+          alt: 'A Rock Climber',
+          background: true,
+          loading: 'lzy',
+        }
       } only %}
     {% endset %}
     {% include '@bolt-components-video-thumbnail/video-thumbnail.twig' with {
@@ -28,11 +30,13 @@
 {% set twig_markup %}
 {% verbatim %}
 {% set image %}
-  {% include '@bolt-components-image/image.twig' with {
-    src: '/images/placeholders/tout-4x3-climber.jpg',
-    alt: 'A Rock Climber',
-    ratio: false,
-    cover: true,
+  {% include '@bolt-elements-image/image.twig' with {
+    attributes: {
+      src: '/images/placeholders/tout-4x3-climber.jpg',
+      alt: 'A Rock Climber',
+      background: true,
+      loading: 'lazy',
+    }
   } only %}
 {% endset %}
 {% include '@bolt-components-video-thumbnail/video-thumbnail.twig' with {

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/video-thumbnail/05-video-thumbnail.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/video-thumbnail/05-video-thumbnail.twig
@@ -16,7 +16,7 @@
           src: '/images/placeholders/tout-4x3-climber.jpg',
           alt: 'A Rock Climber',
           background: true,
-          loading: 'lzy',
+          loading: 'lazy',
         }
       } only %}
     {% endset %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/video-thumbnail/10-video-thumbnail-aspect-ratio.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/video-thumbnail/10-video-thumbnail-aspect-ratio.twig
@@ -5,11 +5,13 @@
 {% set demo %}
   <div style="max-width: 25ch">
     {% set image %}
-      {% include '@bolt-components-image/image.twig' with {
-        src: '/images/placeholders/tout-4x3-climber.jpg',
-        alt: 'A Rock Climber',
-        ratio: false,
-        cover: true,
+      {% include '@bolt-elements-image/image.twig' with {
+        attributes: {
+          src: '/images/placeholders/tout-4x3-climber.jpg',
+          alt: 'A Rock Climber',
+          background: true,
+          loading: 'lazy',
+        }
       } only %}
     {% endset %}
     {% include '@bolt-components-video-thumbnail/video-thumbnail.twig' with {

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/video-thumbnail/15-video-thumbnail-border-radius.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/video-thumbnail/15-video-thumbnail-border-radius.twig
@@ -1,11 +1,13 @@
 {% set demo %}
   <div style="max-width: 60ch">
     {% set image %}
-      {% include '@bolt-components-image/image.twig' with {
-        src: '/images/placeholders/tout-4x3-climber.jpg',
-        alt: 'A Rock Climber',
-        ratio: false,
-        cover: true,
+      {% include '@bolt-elements-image/image.twig' with {
+        attributes: {
+          src: '/images/placeholders/tout-4x3-climber.jpg',
+          alt: 'A Rock Climber',
+          background: true,
+          loading: 'lazy',
+        }
       } only %}
     {% endset %}
     {% include '@bolt-components-video-thumbnail/video-thumbnail.twig' with {

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/video-thumbnail/20-video-thumbnail-use-case-modal.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/video-thumbnail/20-video-thumbnail-use-case-modal.twig
@@ -21,11 +21,14 @@
   {% endset %}
   {% set video_thumbnail %}
     {% set image %}
-      {% include '@bolt-components-image/image.twig' with {
-        src: '/images/placeholders/tout-4x3-climber.jpg',
-        alt: 'A Rock Climber',
-        ratio: false,
-        cover: true,
+      {% include '@bolt-elements-image/image.twig' with {
+        attributes: {
+          src: '/images/placeholders/tout-4x3-climber.jpg',
+          alt: 'A Rock Climber',
+          ratio: false,
+          background: true,
+          loading: 'lazy',
+        }
       } only %}
     {% endset %}
     {% include '@bolt-components-video-thumbnail/video-thumbnail.twig' with {
@@ -58,11 +61,13 @@
 // Set up the trigger
 {% set video_thumbnail %}
   {% set image %}
-    {% include '@bolt-components-image/image.twig' with {
-      src: '/images/placeholders/tout-4x3-climber.jpg',
-      alt: 'A Rock Climber',
-      ratio: false,
-      cover: true,
+    {% include '@bolt-elements-image/image.twig' with {
+      attributes: {
+        src: '/images/placeholders/tout-4x3-climber.jpg',
+        alt: 'A Rock Climber',
+        background: true,
+        loading: 'lazy',
+      }
     } only %}
   {% endset %}
   {% include '@bolt-components-video-thumbnail/video-thumbnail.twig' with {

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/05-d8-homepage/00-d8-homepage.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/05-d8-homepage/00-d8-homepage.twig
@@ -269,8 +269,11 @@
     {% block band_content %}
       {% grid "o-bolt-grid--matrix o-bolt-grid--large o-bolt-grid--middle o-bolt-grid--center" %}
         {% cell "u-bolt-width-12/12 u-bolt-width-4/12@small" %}
-          {% include "@bolt-components-image/image.twig" with {
-            src: "/images/content/promos/promo-16x9-salesforce-vs-pega.png"
+          {% include "@bolt-elements-image/image.twig" with {
+            attributes: {
+              src: "/images/content/promos/promo-16x9-salesforce-vs-pega.png",
+              loading: "lazy"
+            }
           } only %}
         {% endcell %}
         {% cell "u-bolt-width-12/12 u-bolt-width-6/12@small" %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/05-d8-homepage/05-d8-homepage-japanese.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/05-d8-homepage/05-d8-homepage-japanese.twig
@@ -372,8 +372,11 @@
     {% block band_content %}
         {% grid "o-bolt-grid--matrix o-bolt-grid--large o-bolt-grid--middle o-bolt-grid--center" %}
           {% cell "u-bolt-width-1/1 u-bolt-width-4/12@small" %}
-            {% include "@bolt-components-image/image.twig" with {
-              src: "/images/content/promos/promo-16x9-salesforce-vs-pega.png"
+            {% include "@bolt-elements-image/image.twig" with {
+              attributes: {
+                src: "/images/content/promos/promo-16x9-salesforce-vs-pega.png",
+                loading: "lazy",
+              }
             } only %}
           {% endcell %}
           {% cell "u-bolt-width-1/1 u-bolt-width-6/12@small" %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/10-d8-product-pages/_product-t3-extra-videos.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/10-d8-product-pages/_product-t3-extra-videos.twig
@@ -238,8 +238,11 @@
 
       {% cell "u-bolt-width-1/1 u-bolt-width-7/12@small" %}
         {% set device_viewer_image %}
-          {% include "@bolt-components-image/image.twig" with {
-            src: "/images/content/screenshots/device-screenshot--tablet.jpg",
+          {% include "@bolt-elements-image/image.twig" with {
+            attributes: {
+              src: "/images/content/screenshots/device-screenshot--tablet.jpg",
+              loading: "lazy",
+            }
           } only %}
         {% endset %}
         {% include "@bolt/device-viewer.twig" with {
@@ -270,8 +273,11 @@
 
       {% cell "u-bolt-width-1/1 u-bolt-width-7/12@small" %}
         {% set device_viewer_image %}
-          {% include "@bolt-components-image/image.twig" with {
-            src: "/images/content/screenshots/device-screenshot--tablet-portrait.jpg",
+          {% include "@bolt-elements-image/image.twig" with {
+            attributes: {
+              src: "/images/content/screenshots/device-screenshot--tablet-portrait.jpg",
+              loading: "lazy",
+            }
           } only %}
         {% endset %}
         {% include "@bolt/device-viewer.twig" with {
@@ -392,8 +398,11 @@
 
       {% cell "u-bolt-width-1/1 u-bolt-width-7/12@small" %}
         {% set device_viewer_image %}
-          {% include "@bolt-components-image/image.twig" with {
-            src: "/images/content/screenshots/device-screenshot--phone.jpg",
+          {% include "@bolt-elements-image/image.twig" with {
+            attributes: {
+              src: "/images/content/screenshots/device-screenshot--phone.jpg",
+              loading: "lazy",
+            }
           } only %}
         {% endset %}
         {% include "@bolt/device-viewer.twig" with {
@@ -406,8 +415,11 @@
 
        {% cell "u-bolt-width-1/1 u-bolt-width-7/12@small" %}
          {% set device_viewer_image %}
-           {% include "@bolt-components-image/image.twig" with {
-             src: "/images/content/screenshots/device-screenshot--phone.jpg",
+           {% include "@bolt-elements-image/image.twig" with {
+             attributes: {
+              src: "/images/content/screenshots/device-screenshot--phone.jpg",
+              loading: "lazy",
+             }
            } only %}
          {% endset %}
         {% include "@bolt/device-viewer.twig" with {
@@ -420,8 +432,11 @@
 
       {% cell "u-bolt-width-1/1 u-bolt-width-7/12@small" %}
         {% set device_viewer_image %}
-          {% include "@bolt-components-image/image.twig" with {
-            src: "/images/content/screenshots/device-screenshot--phone.jpg",
+          {% include "@bolt-elements-image/image.twig" with {
+            attributes: {
+              src: "/images/content/screenshots/device-screenshot--phone.jpg",
+              loading: "lazy",
+            }
           } only %}
         {% endset %}
         {% include "@bolt/device-viewer.twig" with {
@@ -435,8 +450,11 @@
 
        {% cell "u-bolt-width-1/1" %}
          {% set device_viewer_image %}
-           {% include "@bolt-components-image/image.twig" with {
-             src: "/images/content/screenshots/device-screenshot--phone.jpg",
+           {% include "@bolt-elements-image/image.twig" with {
+             attributes: {
+                src: "/images/content/screenshots/device-screenshot--phone.jpg",
+                loading: "lazy",
+             }
            } only %}
          {% endset %}
          {% include "@bolt/device-viewer.twig" with {
@@ -530,8 +548,11 @@
 
       {% cell "u-bolt-width-1/1 u-bolt-width-6/12@small" %}
         {% set device_viewer_image %}
-          {% include "@bolt-components-image/image.twig" with {
-            src: "/images/content/screenshots/device-screenshot--desktop.jpg",
+          {% include "@bolt-elements-image/image.twig" with {
+            attributes: {
+              src: "/images/content/screenshots/device-screenshot--desktop.jpg",
+              loading: "lazy",
+            }
           } only %}
         {% endset %}
         {% include "@bolt/device-viewer.twig" with {

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/10-d8-product-pages/_product-t3.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/10-d8-product-pages/_product-t3.twig
@@ -239,8 +239,11 @@
 
       {% cell "u-bolt-width-1/1 u-bolt-width-7/12@small" %}
         {% set device_viewer_image %}
-          {% include "@bolt-components-image/image.twig" with {
-            src: "/images/content/screenshots/device-screenshot--tablet.jpg",
+          {% include "@bolt-elements-image/image.twig" with {
+            attributes: {
+              src: "/images/content/screenshots/device-screenshot--tablet.jpg",
+              loading: "lazy",
+            }
           } only %}
         {% endset %}
         {% include "@bolt/device-viewer.twig" with {
@@ -271,8 +274,11 @@
 
       {% cell "u-bolt-width-1/1 u-bolt-width-7/12@small" %}
         {% set device_viewer_image %}
-          {% include "@bolt-components-image/image.twig" with {
-            src: "/images/content/screenshots/device-screenshot--tablet-portrait.jpg",
+          {% include "@bolt-elements-image/image.twig" with {
+            attributes: {
+              src: "/images/content/screenshots/device-screenshot--tablet-portrait.jpg",
+              loading: "lazy",
+            }
           } only %}
         {% endset %}
         {% include "@bolt/device-viewer.twig" with {
@@ -393,8 +399,11 @@
 
       {% cell "u-bolt-width-1/1 u-bolt-width-7/12@small" %}
         {% set device_viewer_image %}
-          {% include "@bolt-components-image/image.twig" with {
-            src: "/images/content/screenshots/device-screenshot--phone.jpg",
+          {% include "@bolt-elements-image/image.twig" with {
+            attributes: {
+              src: "/images/content/screenshots/device-screenshot--phone.jpg",
+              loading: "lazy",
+            }
           } only %}
         {% endset %}
         {% include "@bolt/device-viewer.twig" with {
@@ -407,8 +416,11 @@
 
        {% cell "u-bolt-width-1/1 u-bolt-width-7/12@small" %}
          {% set device_viewer_image %}
-           {% include "@bolt-components-image/image.twig" with {
-             src: "/images/content/screenshots/device-screenshot--phone.jpg",
+           {% include "@bolt-elements-image/image.twig" with {
+             attributes: {
+                src: "/images/content/screenshots/device-screenshot--phone.jpg",
+                loading: "lazy",
+             }
            } only %}
          {% endset %}
         {% include "@bolt/device-viewer.twig" with {
@@ -421,8 +433,11 @@
 
       {% cell "u-bolt-width-1/1 u-bolt-width-7/12@small" %}
         {% set device_viewer_image %}
-          {% include "@bolt-components-image/image.twig" with {
-            src: "/images/content/screenshots/device-screenshot--phone.jpg",
+          {% include "@bolt-elements-image/image.twig" with {
+            attributes: {
+              src: "/images/content/screenshots/device-screenshot--phone.jpg",
+              loading: "lazy",
+            }
           } only %}
         {% endset %}
         {% include "@bolt/device-viewer.twig" with {
@@ -436,8 +451,11 @@
 
        {% cell "u-bolt-width-1/1" %}
          {% set device_viewer_image %}
-           {% include "@bolt-components-image/image.twig" with {
-             src: "/images/content/screenshots/device-screenshot--phone.jpg",
+           {% include "@bolt-elements-image/image.twig" with {
+             attributes: {
+                src: "/images/content/screenshots/device-screenshot--phone.jpg",
+                loading: "lazy",
+             }
            } only %}
          {% endset %}
         {% include "@bolt/device-viewer.twig" with {
@@ -531,8 +549,11 @@
 
       {% cell "u-bolt-width-1/1 u-bolt-width-6/12@small" %}
         {% set device_viewer_image %}
-          {% include "@bolt-components-image/image.twig" with {
-            src: "/images/content/screenshots/device-screenshot--desktop.jpg",
+          {% include "@bolt-elements-image/image.twig" with {
+            attributes: {
+              src: "/images/content/screenshots/device-screenshot--desktop.jpg",
+              loading: "lazy",
+            }
           } only %}
         {% endset %}
         {% include "@bolt/device-viewer.twig" with {

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/10-d8-product-pages/product-landing.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/10-d8-product-pages/product-landing.twig
@@ -215,9 +215,11 @@
     {% grid "o-bolt-grid--flex o-bolt-grid--large o-bolt-grid--middle o-bolt-grid--matrix" %}
 
       {% cell "u-bolt-width-1/1 u-bolt-width-7/12@small" %}
-        {% include "@bolt-components-image/image.twig" with {
-          src: "/images/content/charts/decision-hub-chart.png",
-          lazyload: true
+        {% include "@bolt-elements-image/image.twig" with {
+          attributes: {
+            src: "/images/content/charts/decision-hub-chart.png",
+            loading: "lazy",
+          }
         } only %}
       {% endcell %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/10-d8-product-pages/product-t2.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/10-d8-product-pages/product-t2.twig
@@ -248,11 +248,12 @@
 
       {% cell "u-bolt-width-1/1 u-bolt-width-7/12@small" %}
         {% set device_viewer_image %}
-          {% include "@bolt-components-image/image.twig" with {
-            src: "/images/content/screenshots/device-screenshot--tablet.jpg",
-            lazyload: true,
-            _sizes: "(min-width: 1400px) 40.64285714vw, (min-width: 600px) 41vw, 72.5vw",
-            placeholder_color: "#ececec",
+          {% include "@bolt-elements-image/image.twig" with {
+            attributes: {
+              src: "/images/content/screenshots/device-screenshot--tablet.jpg",
+              sizes: "(min-width: 1400px) 40.64285714vw, (min-width: 600px) 41vw, 72.5vw",
+              loading: "lazy",
+            }
           } only %}
         {% endset %}
         {% include "@bolt/device-viewer.twig" with {
@@ -277,9 +278,11 @@
 
       {% cell "u-bolt-width-1/1 u-bolt-width-7/12@small" %}
         {% set device_viewer_image %}
-          {% include "@bolt-components-image/image.twig" with {
-            src: "/images/content/screenshots/device-screenshot--tablet-portrait.jpg",
-            placeholder_color: "#1c1c1c"
+          {% include "@bolt-elements-image/image.twig" with {
+            attributes: {
+              src: "/images/content/screenshots/device-screenshot--tablet-portrait.jpg",
+              loading: "lazy",
+            }
           } only %}
         {% endset %}
         {% include "@bolt/device-viewer.twig" with {
@@ -392,9 +395,11 @@
 
       {% cell "u-bolt-width-1/1 u-bolt-width-7/12@small" %}
         {% set device_viewer_image %}
-          {% include "@bolt-components-image/image.twig" with {
-            src: "/images/content/screenshots/device-screenshot--phone.jpg",
-            placeholder_color: "#1c1c1c"
+          {% include "@bolt-elements-image/image.twig" with {
+            attributes: {
+              src: "/images/content/screenshots/device-screenshot--phone.jpg",
+              loading: "lazy",
+            }
           } only %}
         {% endset %}
         {% include "@bolt/device-viewer.twig" with {
@@ -466,9 +471,11 @@
 
       {% cell "u-bolt-width-1/1" %}
         {% set device_viewer_image %}
-          {% include "@bolt-components-image/image.twig" with {
-            src: "/images/content/screenshots/device-screenshot--desktop.jpg",
-            placeholder_color: "#ececec"
+          {% include "@bolt-elements-image/image.twig" with {
+            attributes: {
+              src: "/images/content/screenshots/device-screenshot--desktop.jpg",
+              loading: "lazy",
+            }
           } only %}
         {% endset %}
         {% include "@bolt/device-viewer.twig" with {

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/10-d8-product-pages/product-t4.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/10-d8-product-pages/product-t4.twig
@@ -264,8 +264,11 @@
 
       {% cell "u-bolt-width-1/1 u-bolt-width-7/12@small" %}
         {% set device_viewer_image %}
-          {% include "@bolt-components-image/image.twig" with {
-            src: "/images/content/screenshots/device-screenshot--tablet.jpg",
+          {% include "@bolt-elements-image/image.twig" with {
+            attributes: {
+              src: "/images/content/screenshots/device-screenshot--tablet.jpg",
+              loading: "lazy",
+            }
           } only %}
         {% endset %}
         {% include "@bolt/device-viewer.twig" with {
@@ -295,8 +298,11 @@
 
       {% cell "u-bolt-width-1/1 u-bolt-width-7/12@small" %}
         {% set device_viewer_image %}
-          {% include "@bolt-components-image/image.twig" with {
-            src: "/images/content/screenshots/device-screenshot--tablet-portrait.jpg",
+          {% include "@bolt-elements-image/image.twig" with {
+            attributes: {
+              src: "/images/content/screenshots/device-screenshot--tablet-portrait.jpg",
+              loading: "lazy",
+            }
           } only %}
         {% endset %}
         {% include "@bolt/device-viewer.twig" with {
@@ -457,8 +463,11 @@
 
         {% cell "u-bolt-width-1/1 u-bolt-width-7/12@small" %}
           {% set device_viewer_image %}
-            {% include "@bolt-components-image/image.twig" with {
-              src: "/images/content/screenshots/device-screenshot--phone.jpg",
+            {% include "@bolt-elements-image/image.twig" with {
+              attributes: {
+                src: "/images/content/screenshots/device-screenshot--phone.jpg",
+                loading: "lazy",
+              }
             } only %}
           {% endset %}
           {% include "@bolt/device-viewer.twig" with {
@@ -476,8 +485,11 @@
 
         {% cell "u-bolt-width-1/1 u-bolt-width-7/12@small" %}
           {% set device_viewer_image %}
-            {% include "@bolt-components-image/image.twig" with {
-              src: "/images/content/screenshots/device-screenshot--phone.jpg",
+            {% include "@bolt-elements-image/image.twig" with {
+              attributes: {
+                src: "/images/content/screenshots/device-screenshot--phone.jpg",
+                loading: "lazy",
+              }
             } only %}
           {% endset %}
           {% include "@bolt/device-viewer.twig" with {
@@ -578,8 +590,11 @@
 
         {% cell "u-bolt-width-1/1 u-bolt-width-7/12@small" %}
           {% set device_viewer_image %}
-            {% include "@bolt-components-image/image.twig" with {
-              src: "/images/content/screenshots/device-screenshot--phone.jpg",
+            {% include "@bolt-elements-image/image.twig" with {
+              attributes: {
+                src: "/images/content/screenshots/device-screenshot--phone.jpg",
+                loading: "lazy",
+              }
             } only %}
           {% endset %}
           {% include "@bolt/device-viewer.twig" with {
@@ -598,8 +613,11 @@
 
         {% cell "u-bolt-width-1/1 u-bolt-width-7/12@small" %}
           {% set device_viewer_image %}
-            {% include "@bolt-components-image/image.twig" with {
-              src: "/images/content/screenshots/device-screenshot--phone.jpg",
+            {% include "@bolt-elements-image/image.twig" with {
+              attributes: {
+                src: "/images/content/screenshots/device-screenshot--phone.jpg",
+                loading: "lazy",
+              }
             } only %}
           {% endset %}
           {% include "@bolt/device-viewer.twig" with {
@@ -785,8 +803,11 @@
 
       {% cell "u-bolt-width-1/1 u-bolt-width-6/12@small" %}
         {% set device_viewer_image %}
-          {% include "@bolt-components-image/image.twig" with {
-            src: "/images/content/screenshots/device-screenshot--desktop.jpg",
+          {% include "@bolt-elements-image/image.twig" with {
+            attributes: {
+              src: "/images/content/screenshots/device-screenshot--desktop.jpg",
+              loading: "lazy",
+            }
           } only %}
         {% endset %}
         {% include "@bolt/device-viewer.twig" with {

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/15-d8-resource-details-pages/00-resource-details-page.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/15-d8-resource-details-pages/00-resource-details-page.twig
@@ -18,9 +18,11 @@
 
         {# TODO: check if image exists #}
         {% cell 'u-bolt-width-1/1 u-bolt-width-5/12@medium' %}
-          {% include "@bolt-components-image/image.twig" with {
-            src: "/images/content/promos/promo-16x9-anthem.jpg",
-            lazyload: false
+          {% include "@bolt-elements-image/image.twig" with {
+            attributes: {
+              src: "/images/content/promos/promo-16x9-anthem.jpg",
+              loading: "lazy",
+            }
           } only %}
         {% endcell %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/20-d8-press-and-media/20-d8-details-page-press.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/20-d8-press-and-media/20-d8-details-page-press.twig
@@ -34,10 +34,12 @@
           </p>
 
         <div class="u-bolt-margin-bottom-medium">
-          {% include '@bolt-components-image/image.twig' with {
-            src: "https://pbs.twimg.com/media/De8QS1iUwAEHfJu.jpg",
-            alt: "Pega Community homepage",
-            lazyload: true,
+          {% include '@bolt-elements-image/image.twig' with {
+            attributes: {
+              src: "https://pbs.twimg.com/media/De8QS1iUwAEHfJu.jpg",
+              alt: "Pega Community homepage",
+              loading: "lazy",
+            }
           } only %}
         </div>
 

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/35-d8-events/00-event-landing.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/35-d8-events/00-event-landing.twig
@@ -283,9 +283,11 @@
                   {% block body %}
                     {% grid "o-bolt-grid--flex o-bolt-grid--matrix" %}
                       {% cell "u-bolt-width-1/1 u-bolt-width-1/4@small" %}
-                        {% include "@bolt-components-image/image.twig" with {
-                          src: "/images/placeholders/500x500.jpg",
-                          lazyload: false
+                        {% include "@bolt-elements-image/image.twig" with {
+                          attributes: {
+                            src: "/images/placeholders/500x500.jpg",
+                            loading: "lazy",
+                          }
                         } only %}
                       {% endcell %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/35-d8-events/05-event-detail.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/35-d8-events/05-event-detail.twig
@@ -359,8 +359,11 @@
       {% cell "u-bolt-width-1/1 u-bolt-width-1/2@small u-bolt-width-1/3@medium" %}
         {% grid %}
           {% cell "u-bolt-width-1/2" %}
-          {% include "@bolt-components-image/image.twig" with {
-                src: "/images/placeholders/events--speakers--placeholder.jpg",
+          {% include "@bolt-elements-image/image.twig" with {
+            attributes: {
+              src: "/images/placeholders/events--speakers--placeholder.jpg",
+              loading: "lazy",
+            }
           } only %}
           {% endcell %}
           {% cell "u-bolt-width-1/2" %}
@@ -388,8 +391,11 @@
       {% cell "u-bolt-width-1/1 u-bolt-width-1/2@small u-bolt-width-1/3@medium" %}
         {% grid %}
           {% cell "u-bolt-width-1/2" %}
-          {% include "@bolt-components-image/image.twig" with {
-                src: "/images/placeholders/events--speakers--placeholder.jpg"
+          {% include "@bolt-elements-image/image.twig" with {
+            attributes: {
+              src: "/images/placeholders/events--speakers--placeholder.jpg",
+              loading: "lazy",
+            }
           } only %}
           {% endcell %}
           {% cell "u-bolt-width-1/2" %}
@@ -412,8 +418,11 @@
       {% cell "u-bolt-width-1/1 u-bolt-width-1/2@small u-bolt-width-1/3@medium" %}
         {% grid %}
           {% cell "u-bolt-width-1/2" %}
-          {% include "@bolt-components-image/image.twig" with {
-                src: "/images/placeholders/events--speakers--placeholder.jpg"
+          {% include "@bolt-elements-image/image.twig" with {
+            attributes: {
+              src: "/images/placeholders/events--speakers--placeholder.jpg",
+              loading: "lazy",
+            }
           } only %}
           {% endcell %}
           {% cell "u-bolt-width-1/2" %}
@@ -436,8 +445,11 @@
       {% cell "u-bolt-width-1/1 u-bolt-width-1/2@small u-bolt-width-1/3@medium" %}
         {% grid %}
           {% cell "u-bolt-width-1/2" %}
-          {% include "@bolt-components-image/image.twig" with {
-                src: "/images/placeholders/events--speakers--placeholder.jpg"
+          {% include "@bolt-elements-image/image.twig" with {
+            attributes: {
+              src: "/images/placeholders/events--speakers--placeholder.jpg",
+              loading: "lzy",
+            }
           } only %}
           {% endcell %}
           {% cell "u-bolt-width-1/2" %}
@@ -460,8 +472,11 @@
       {% cell "u-bolt-width-1/1 u-bolt-width-1/2@small u-bolt-width-1/3@medium" %}
         {% grid %}
           {% cell "u-bolt-width-1/2" %}
-          {% include "@bolt-components-image/image.twig" with {
-                src: "/images/placeholders/events--speakers--placeholder.jpg"
+          {% include "@bolt-elements-image/image.twig" with {
+            attributes: {
+              src: "/images/placeholders/events--speakers--placeholder.jpg",
+              loading: "lazy",
+            }
           } only %}
           {% endcell %}
           {% cell "u-bolt-width-1/2" %}
@@ -484,8 +499,11 @@
       {% cell "u-bolt-width-1/1 u-bolt-width-1/2@small u-bolt-width-1/3@medium" %}
         {% grid %}
           {% cell "u-bolt-width-1/2" %}
-          {% include "@bolt-components-image/image.twig" with {
-                src: "/images/placeholders/events--speakers--placeholder.jpg"
+          {% include "@bolt-elements-image/image.twig" with {
+            attributes: {
+              src: "/images/placeholders/events--speakers--placeholder.jpg",
+              loading: "lazy",
+            }
           } only %}
           {% endcell %}
           {% cell "u-bolt-width-1/2" %}
@@ -644,8 +662,11 @@
           {% set logoImages = ["logo-incessant.png", "logo-capgemini.svg", "logo-cognizant.png", "logo-merkle.png", "logo-infosys.png"] %}
           {% for logoImage in logoImages %}
             {% cell "u-bolt-width-1/2 u-bolt-width-1/5@small" %}
-              {% include "@bolt-components-image/image.twig" with {
-                src: "/images/content/logos/" ~ logoImage
+              {% include "@bolt-elements-image/image.twig" with {
+                attributes: {
+                  src: "/images/content/logos/" ~ logoImage,
+                  loading: "lazy",
+                }
               } only %}
             {% endcell %}
           {% endfor %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/45-d8-blog/05-blog-post.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/45-d8-blog/05-blog-post.twig
@@ -62,10 +62,12 @@
   {% set hero %}
     {% grid "o-bolt-grid--flex o-bolt-grid--matrix o-bolt-grid--middle" %}
       {% cell "u-bolt-width-12/12 u-bolt-width-5/12@medium" %}
-        {% include "@bolt-components-image/image.twig" with {
-          src: featured_image,
-          alt: article_title,
-          lazyload: false,
+        {% include "@bolt-elements-image/image.twig" with {
+          attributes: {
+            src: featured_image,
+            alt: article_title,
+            loading: "lazy",
+          }
         } only %}
       {% endcell %}
       {% cell "u-bolt-width-12/12 u-bolt-width-7/12@medium" %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/50-d8-careers/00-careers-homepage.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/50-d8-careers/00-careers-homepage.twig
@@ -190,11 +190,12 @@
 {# Background Video #}
 {% set background_video %}
   <div class="c-pega-careers-background-video">
-    {% include '@bolt-components-image/image.twig' with {
-      src: hero_background_video_poster,
-      lazyload: false,
-      ratio: false,
-      cover: true
+    {% include '@bolt-elements-image/image.twig' with {
+      attributes: {
+        src: hero_background_video_poster,
+        background: true,
+        loading: "lazy",
+      }
     } only %}
     <div class="c-pega-careers-background-video__video">
       {% set video %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/55-d8-calculator/00-d8-calculator.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/55-d8-calculator/00-d8-calculator.twig
@@ -248,11 +248,12 @@
 } only %}
   {% block band_background %}
     <div class="c-www-calculator-background" aria-hidden="true">
-      {% include "@bolt-components-image/image.twig" with {
-        src: "/images/backgrounds/calculator-landing-shapes-transparent.png",
-        alt: "Decorative shapes.",
+      {% include "@bolt-elements-image/image.twig" with {
         attributes: {
-          class: "c-www-calculator-background__image"
+          src: "/images/backgrounds/calculator-landing-shapes-transparent.png",
+          alt: "Decorative shapes.",
+          loading: "lazy",
+          class: "c-www-calculator-background__image",
         }
       } only %}
     </div>

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/01-atoms/_badge.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/01-atoms/_badge.twig
@@ -1,10 +1,11 @@
 {% grid "o-bolt-grid--flex o-bolt-grid--center" %}
   {% cell "u-bolt-flex-shrink" %}
     <div class="c-acd-badge">
-      {% include "@bolt-components-image/image.twig" with {
-        src: "/images/mission-test-badge-example.svg",
-        max_width: "200px",
+      {% include "@bolt-elements-image/image.twig" with {
         attributes: {
+          src: "/images/mission-test-badge-example.svg",
+          style: "max-width: 200px",
+          loading: "lazy",
           class: [
             locked ? "u-bolt-opacity-20" : "",
           ]

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/02-molecules/cards/_card.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/02-molecules/cards/_card.twig
@@ -17,10 +17,13 @@
     {% cell "u-bolt-flex-shrink" %}
       {% grid "o-bolt-grid--flex o-bolt-grid--middle u-bolt-height-full" %}
         {% cell "u-bolt-width-1/1" %}
-          {% include "@bolt-components-image/image.twig" with {
-            src: "/images/placeholders/thumb-comet.jpg",
-            alt: "Image alt.",
-            max_width: "100px",
+          {% include "@bolt-elements-image/image.twig" with {
+            attributes: {
+              src: "/images/placeholders/thumb-comet.jpg",
+              alt: "Image alt.",
+              style: "max-width: 100px",
+              loading: "lazy",
+            }
           } only %}
         {% endcell %}
       {% endgrid %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/03-organisms/modals/_test-completed-modal--after-submit.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/03-organisms/modals/_test-completed-modal--after-submit.twig
@@ -19,10 +19,11 @@
       macros.include("@bolt-components-card-replacement/_card-replacement-body.twig", {
         body: {
           content: [
-            macros.include("@bolt-components-image/image.twig", {
-              src: "/images/mission-test-badge-example.svg",
-              max_width: "200px",
+            macros.include("@bolt-elements-image/image.twig", {
               attributes: {
+                src: "/images/mission-test-badge-example.svg",
+                style: "max-width: 200px",
+                loading: "lazy",
                 class: [
                   "u-bolt-margin-top-medium",
                   "u-bolt-margin-left-auto",
@@ -30,6 +31,7 @@
                   "u-bolt-margin-bottom-medium"
                 ]
               }
+  
             }),
             macros.include("@bolt-components-headline/headline.twig", {
               size: "xxxlarge",

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/03-organisms/modals/_test-completed-modal--before-submit.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/03-organisms/modals/_test-completed-modal--before-submit.twig
@@ -19,10 +19,11 @@
       macros.include("@bolt-components-card-replacement/_card-replacement-body.twig", {
         body: {
           content: [
-            macros.include("@bolt-components-image/image.twig", {
-              src: "/images/mission-test-badge-example.svg",
-              max_width: "200px",
+            macros.include("@bolt-elements-image/image.twig", {
               attributes: {
+                src: "/images/mission-test-badge-example.svg",
+                style: "max-width: 200px",
+                loading: "lazy",
                 class: [
                   "u-bolt-margin-top-medium",
                   "u-bolt-margin-left-auto",

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/04-templates/_academy-detail-page-template.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/04-templates/_academy-detail-page-template.twig
@@ -48,10 +48,13 @@
             {% grid "o-bolt-grid--flex o-bolt-grid--matrix o-bolt-grid--border" %}
               {% cell "u-bolt-width-12/12 u-bolt-width-4/12@small" %}
                 <div class="u-bolt-flex u-bolt-align-items-center u-bolt-justify-content-center u-bolt-height-full u-bolt-padding-xsmall">
-                  {% include '@bolt-components-image/image.twig' with {
-                    src: "/images/pega-community.svg",
-                    alt: "Pega Community logo",
-                    max_width: "250px",
+                  {% include '@bolt-elements-image/image.twig' with {
+                    attributes: {
+                      src: "/images/pega-community.svg",
+                      alt: "Pega Community logo",
+                      style: "max-width: 250px",
+                      loading: "lazy",
+                    }
                   } only %}
                 </div>
               {% endcell %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/05-pages/t1-landing-pages/certification-exam/acd-certification-exam-page.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/05-pages/t1-landing-pages/certification-exam/acd-certification-exam-page.twig
@@ -95,10 +95,11 @@
                     class: "u-bolt-margin-bottom-none",
                   }
                 }),
-                logo: macros.include("@bolt-components-image/image.twig", {
-                  src: "/images/pearson-logo.svg",
+                logo: macros.include("@bolt-elements-image/image.twig", {
                   attributes: {
+                    src: "/images/pearson-logo.svg",
                     style: "max-width: 170px;",
+                    loading: "lazy",
                     class: [
                       "u-bolt-margin-left-auto@small"
                     ]

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/05-pages/t2-inner-pages/challenge-details/acd-challenge-detail-page.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/05-pages/t2-inner-pages/challenge-details/acd-challenge-detail-page.twig
@@ -52,8 +52,11 @@
 
   {% include "@bolt-components-figure/figure.twig" with {
     media: {
-      content: macros.include("@bolt-components-image/image.twig", {
-        src: "/images/placeholders/500x500.jpg",
+      content: macros.include("@bolt-elements-image/image.twig", {
+        attributes: {
+          src: "/images/placeholders/500x500.jpg",
+          loading: "lazy",
+        }
       }),
     },
     caption: "Fig. 1: This is Bill. He is awesome."

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/05-pages/t2-inner-pages/topic-details/acd-topic-detail-page.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/60-academy/05-pages/t2-inner-pages/topic-details/acd-topic-detail-page.twig
@@ -126,10 +126,13 @@
   {% set trigger_content %}
     {% include "@bolt-components-figure/figure.twig" with {
       media: {
-        content: macros.include("@bolt-components-image/image.twig", {
-          src: "/images/placeholders/1920x1200.jpg",
-          alt: "A placeholder image",
-          max_width: "450px",
+        content: macros.include("@bolt-elements-image/image.twig", {
+          attributes: {
+            src: "/images/placeholders/1920x1200.jpg",
+            alt: "A placeholder image",
+            style: "max-width: 450px",
+            loading: "lazy",
+          }
         }),
       },
       caption: "Example of an image with caption + modal.",
@@ -137,10 +140,13 @@
   {% endset %}
 
   {% set modal_content %}
-    {% include "@bolt-components-image/image.twig" with {
-      src: "/images/placeholders/1920x1200.jpg",
-      alt: "Example of a larger version of an image that can be viewed in a modal.",
-      max_width: "1920px",
+    {% include "@bolt-elements-image/image.twig" with {
+      attributes: {
+        src: "/images/placeholders/1920x1200.jpg",
+        alt: "Example of a larger version of an image that can be viewed in a modal.",
+        style: "max-width: 1920px",
+        loading: "lazy",
+      }
     } only %}
   {% endset %}
 
@@ -194,8 +200,11 @@
 
     {% include "@bolt-components-figure/figure.twig" with {
       media: {
-        content: macros.include("@bolt-components-image/image.twig", {
-          src: "/images/placeholders/1920x1440.jpg",
+        content: macros.include("@bolt-elements-image/image.twig", {
+          attributes: {
+            src: "/images/placeholders/1920x1440.jpg",
+            loading: "lazy",
+          }
         }),
       },
       caption: "Lorem ipsum caption for the thumbnail.",
@@ -234,8 +243,11 @@
 
     {% include "@bolt-components-figure/figure.twig" with {
       media: {
-        content: macros.include("@bolt-components-image/image.twig", {
-          src: "/images/placeholders/1920x960.jpg",
+        content: macros.include("@bolt-elements-image/image.twig", {
+          attributes: {
+            src: "/images/placeholders/1920x960.jpg",
+            loading: "lazy",
+          }
         }),
       },
       caption: "Lorem ipsum caption for the thumbnail.",

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-gallery.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-gallery.twig
@@ -110,30 +110,42 @@
   {% endset %}
 
   {% set video_image %}
-    {% include '@bolt-components-image/image.twig' with {
-      src: '/images/content/promos/promo-16x9-ai.jpg',
-      alt: 'Alt text.',
+    {% include '@bolt-elements-image/image.twig' with {
+      attributes: {
+        src: '/images/content/promos/promo-16x9-ai.jpg',
+        alt: 'Alt text.',
+        loading: 'lazy',
+      }
     } only %}
   {% endset %}
 
   {% set external_link_image %}
-    {% include '@bolt-components-image/image.twig' with {
-      src: '/images/placeholders/signifier-external-link.jpg',
-      alt: 'Alt text.',
+    {% include '@bolt-elements-image/image.twig' with {
+      attributes: {
+        src: '/images/placeholders/signifier-external-link.jpg',
+        alt: 'Alt text.',
+        loading: 'lazy',
+      }
     } only %}
   {% endset %}
 
   {% set pdf_image %}
-    {% include '@bolt-components-image/image.twig' with {
-      src: '/images/placeholders/signifier-pdf.jpg',
-      alt: 'Alt text.',
+    {% include '@bolt-elements-image/image.twig' with {
+      attributes: {
+        src: '/images/placeholders/signifier-pdf.jpg',
+        alt: 'Alt text.',
+        loading: 'lazy',
+      }
     } only %}
   {% endset %}
 
   {% set locked_image %}
-    {% include '@bolt-components-image/image.twig' with {
-      src: '/images/content/promos/promo-16x9-mask.jpg',
-      alt: 'Alt text.',
+    {% include '@bolt-elements-image/image.twig' with {
+      attributes: {
+        src: '/images/content/promos/promo-16x9-mask.jpg',
+        alt: 'Alt text.',
+        loading: 'lazy',
+      }
     } only %}
   {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-homepage.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-homepage.twig
@@ -107,16 +107,22 @@
 {% endset %}
 
 {% set wide_image %}
-  {% include '@bolt-components-image/image.twig' with {
-    src: '/images/content/promos/promo-16x9-ai.jpg',
-    alt: 'Alt text.',
+  {% include '@bolt-elements-image/image.twig' with {
+    attributes: {
+      src: '/images/content/promos/promo-16x9-ai.jpg',
+      alt: 'Alt text.',
+      loading: 'lazy',
+    }
   } only %}
 {% endset %}
 
 {% set square_image %}
-  {% include '@bolt-components-image/image.twig' with {
-    src: '/images/placeholders/thumb-square-abstract.jpg',
-    alt: 'Alt text.',
+  {% include '@bolt-elements-image/image.twig' with {
+    attributes: {
+      src: '/images/placeholders/thumb-square-abstract.jpg',
+      alt: 'Alt text.',
+      loading: 'lazy',
+    }
   } only %}
 {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-customers.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-customers.twig
@@ -110,30 +110,42 @@
   {% endset %}
 
   {% set video_image %}
-    {% include '@bolt-components-image/image.twig' with {
-      src: '/images/content/promos/promo-16x9-ai.jpg',
-      alt: 'Alt text.',
+    {% include '@bolt-elements-image/image.twig' with {
+      attributes: {
+        src: '/images/content/promos/promo-16x9-ai.jpg',
+        alt: 'Alt text.',
+        loading: 'lazy',
+      }
     } only %}
   {% endset %}
 
   {% set external_link_image %}
-    {% include '@bolt-components-image/image.twig' with {
-      src: '/images/placeholders/signifier-external-link.jpg',
-      alt: 'Alt text.',
+    {% include '@bolt-elements-image/image.twig' with {
+      attributes: {
+        src: '/images/placeholders/signifier-external-link.jpg',
+        alt: 'Alt text.',
+        loading: 'lazy',
+      }
     } only %}
   {% endset %}
 
   {% set pdf_image %}
-    {% include '@bolt-components-image/image.twig' with {
-      src: '/images/placeholders/signifier-pdf.jpg',
-      alt: 'Alt text.',
+    {% include '@bolt-elements-image/image.twig' with {
+      attributes: {
+        src: '/images/placeholders/signifier-pdf.jpg',
+        alt: 'Alt text.',
+        loading: 'lzy',
+      }
     } only %}
   {% endset %}
 
   {% set featured_image %}
-    {% include '@bolt-components-image/image.twig' with {
-      src: '/images/content/promos/promo-16x9-mask.jpg',
-      alt: 'Alt text.',
+    {% include '@bolt-elements-image/image.twig' with {
+      attributes: {
+        src: '/images/content/promos/promo-16x9-mask.jpg',
+        alt: 'Alt text.',
+        laoding: 'lazy'
+      }
     } only %}
   {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-customers.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-customers.twig
@@ -134,7 +134,7 @@
       attributes: {
         src: '/images/placeholders/signifier-pdf.jpg',
         alt: 'Alt text.',
-        loading: 'lzy',
+        loading: 'lazy',
       }
     } only %}
   {% endset %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-pegaworld.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-pegaworld.twig
@@ -110,30 +110,42 @@
   {% endset %}
 
   {% set video_image %}
-    {% include '@bolt-components-image/image.twig' with {
-      src: '/images/content/promos/promo-16x9-ai.jpg',
-      alt: 'Alt text.',
+    {% include '@bolt-elements-image/image.twig' with {
+      attributes: {
+        src: '/images/content/promos/promo-16x9-ai.jpg',
+        alt: 'Alt text.',
+        loading: 'lazy',
+      }
     } only %}
   {% endset %}
 
   {% set external_link_image %}
-    {% include '@bolt-components-image/image.twig' with {
-      src: '/images/placeholders/signifier-external-link.jpg',
-      alt: 'Alt text.',
+    {% include '@bolt-elements-image/image.twig' with {
+      attributes: {
+        src: '/images/placeholders/signifier-external-link.jpg',
+        alt: 'Alt text.',
+        loading: 'lazy',
+      }
     } only %}
   {% endset %}
 
   {% set pdf_image %}
-    {% include '@bolt-components-image/image.twig' with {
-      src: '/images/placeholders/signifier-pdf.jpg',
-      alt: 'Alt text.',
+    {% include '@bolt-elements-image/image.twig' with {
+      attributes: {
+        src: '/images/placeholders/signifier-pdf.jpg',
+        alt: 'Alt text.',
+        loading: 'lazy',
+      }
     } only %}
   {% endset %}
 
   {% set featured_image %}
-    {% include '@bolt-components-image/image.twig' with {
-      src: '/images/content/promos/promo-16x9-mask.jpg',
-      alt: 'Alt text.',
+    {% include '@bolt-elements-image/image.twig' with {
+      attributes: {
+        src: '/images/content/promos/promo-16x9-mask.jpg',
+        alt: 'Alt text.',
+        loading: 'lazy',
+      }
     } only %}
   {% endset %}
 


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-578

## Summary

The examples of an Image Component are replaced with the Image Element in the PatternLab site.

## Details

`@bolt-components-image/image.twig` was replaced with `@bolt-elements-image/image.twig`

## How to test

Make sure all the examples are replaced in the existing components