### PR TITLE
Fix: typo on theming system doc

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/10-visual-styles/00-color/10-theming-system.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/10-visual-styles/00-color/10-theming-system.twig
@@ -53,7 +53,7 @@
               <thead>
                 <tr>
                   <td></td>
-                  <th>Scss function</th>
+                  <th>CSS custom property</th>
                 </tr>
               </thead>
               <tbody>


### PR DESCRIPTION
## Summary

Fixed a typo on the Theming System doc page.