### PR TITLE
WWW-467 fix page header link font-size and color

### DIFF
--- a/packages/components/bolt-page-header/src/_page-header-desktop.scss
+++ b/packages/components/bolt-page-header/src/_page-header-desktop.scss
@@ -306,7 +306,7 @@
           --c-bolt-page-header-desktop-primary-nav-link-font-size,
           var(--bolt-type-font-size-small)
         );
-        color: var(--m-bolt-headline);
+        color: var(--m-bolt-text);
         line-height: calc(#{$bolt-page-header-click-target-size} / 2 - 4px);
         white-space: nowrap;
         transition: var(--bolt-transition);
@@ -472,9 +472,9 @@
         }
 
         .c-bolt-page-header__nav-list-item--view-all {
-          font-size: var(--bolt-type-font-size-small);
+          font-size: var(--bolt-type-font-size-xsmall);
           font-weight: var(--bolt-type-font-weight-semibold);
-          line-height: var(--bolt-type-line-height-small);
+          line-height: var(--bolt-type-line-height-xsmall);
 
           .c-bolt-page-header__nav-link {
             color: var(--m-bolt-link);


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/WWW-467?focusedCommentId=35239

## Summary

Updates desktop top level links to black and view-all links to same font-size as other links on the same level.

## How to test

View page header docs and confirm the 2 changes.

## Release notes

### Visual changes

1. Page header desktop top level links are now black
2. Page header view-all links are slightly smaller
