### PR TITLE
Upgrade chromedriver

### DIFF
--- a/packages/testing/testing-nightwatch/package.json
+++ b/packages/testing/testing-nightwatch/package.json
@@ -18,7 +18,7 @@
   "main": "nightwatch.js",
   "dependencies": {
     "@zeit/fetch-retry": "^4.0.1",
-    "chromedriver": "latest",
+    "chromedriver": "*",
     "ci-utils": "^0.6.0",
     "geckodriver": "^1.16.2",
     "globby": "^10.0.1",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -23,7 +23,7 @@
     "querystring": "^0.2.0"
   },
   "optionalDependencies": {
-    "chromedriver": "latest",
+    "chromedriver": "*",
     "geckodriver": "^1.19.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5174,10 +5174,10 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@latest:
-  version "91.0.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-91.0.0.tgz#b8c07d715c1bde2ed5817757e923bd65565c8f94"
-  integrity sha512-0eQGLDWvfVd1apkqQpt4452bCATrsj50whhVzMqPiazNSfCXXwfYWRonYxx3DVFCG3+RwSCLvsk8/vpuojCyJA==
+chromedriver@*:
+  version "92.0.2"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-92.0.2.tgz#18816e741722e37cf528697fa7012583d056cd2d"
+  integrity sha512-WMBQju3eJ80gdA+JggWpuGwob5dGpuFXaab8Bxs9oN3W1WuxzRShQ4dkwvtXm4lYyBIjoNbETNk0JvsqRe5mzg==
   dependencies:
     "@testim/chrome-version" "^1.0.7"
     axios "^0.21.1"


### PR DESCRIPTION
## Jira

n/a

## Summary

Force upgrade `chromedriver`.

## Details

Change `chromedriver` dependency syntax from `latest` to `*` to see if it makes any difference in the future. If this fails again, both npm and Travis are getting hardcoded. cc @remydenton @colbytcook @adamszalapski 

## How to test

Build is passing