### PR TITLE
DS-529: Pega.com: Add 'Download slides' CTA to PW Replays "Best Of" cards

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/30-teaser-status-and-actions.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/30-teaser-status-and-actions.twig
@@ -8,7 +8,7 @@
   <bolt-li>Locked status can be set via the <bolt-code-snippet display="inline">status.locked</bolt-code-snippet> prop. If this is set, a lock icon will appear with the signifier.</bolt-li>
   <bolt-li>Pass a like button into the <bolt-code-snippet display="inline">like</bolt-code-snippet> prop. Example code snippet is shown below.</bolt-li>
   <bolt-li>Pass a share popover menu into the <bolt-code-snippet display="inline">share</bolt-code-snippet> prop. Boundary is required on the popover. Example code snippet is shown below.</bolt-li>
-  <bolt-li>Pass a download cta button into the <bolt-code-snippet display="inline">download</bolt-code-snippet> prop. Example code snippet is shown below.</bolt-li>
+  <bolt-li>Pass a download link into the <bolt-code-snippet display="inline">download</bolt-code-snippet> prop. Example code snippet is shown below.</bolt-li>
 </bolt-ol>
 {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/30-teaser-status-and-actions.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/30-teaser-status-and-actions.twig
@@ -8,7 +8,7 @@
   <bolt-li>Locked status can be set via the <bolt-code-snippet display="inline">status.locked</bolt-code-snippet> prop. If this is set, a lock icon will appear with the signifier.</bolt-li>
   <bolt-li>Pass a like button into the <bolt-code-snippet display="inline">like</bolt-code-snippet> prop. Example code snippet is shown below.</bolt-li>
   <bolt-li>Pass a share popover menu into the <bolt-code-snippet display="inline">share</bolt-code-snippet> prop. Boundary is required on the popover. Example code snippet is shown below.</bolt-li>
-  <bolt-li>Pass a download cta button into the <bolt-code-snippet display="inline">download_cta</bolt-code-snippet> prop. Example code snippet is shown below.</bolt-li>
+  <bolt-li>Pass a download cta button into the <bolt-code-snippet display="inline">download</bolt-code-snippet> prop. Example code snippet is shown below.</bolt-li>
 </bolt-ol>
 {% endset %}
 
@@ -96,22 +96,14 @@
       boundary: '.js-bolt-target-teaser',
     } only %}
   {% endset %}
-  {% set download_cta %}
+  {% set download %}
     {% set icon_download %}
       {% include '@bolt-elements-icon/icon.twig' with {
         name: 'download',
       } only %}
     {% endset %}
-    {% set sr_only %}
-      {% include "@bolt-components-headline/text.twig" with {
-        text: "Downloads a PDF file.",
-        attributes: {
-          class: 'u-bolt-visuallyhidden'
-        }
-      } only %}
-    {% endset %}
     {% include '@bolt-elements-text-link/text-link.twig' with {
-      content: 'Download slides (PDF, 3 pages, 2.3mb)' ~ sr_only,
+      content: 'Download slides',
       icon_before: icon_download,
       reversed_underline: true,
       attributes: {
@@ -136,7 +128,7 @@
       },
       like: like,
       share: share,
-      download_cta: download_cta,
+      download: download,
       status: {
         views: '28k',
         locked: true,
@@ -199,22 +191,14 @@
     boundary: '.js-bolt-target-teaser', // JS target for containing the popover within the teaser.
   } only %}
 {% endset %}
-{% set download_cta %}
+{% set download %}
   {% set icon_download %}
     {% include '@bolt-elements-icon/icon.twig' with {
       name: 'download',
     } only %}
   {% endset %}
-  {% set sr_only %}
-    {% include "@bolt-components-headline/text.twig" with {
-      text: "Downloads a PDF file.",
-      attributes: {
-        class: 'u-bolt-visuallyhidden'
-      }
-    } only %}
-  {% endset %}
   {% include '@bolt-elements-text-link/text-link.twig' with {
-    content: 'Download slides (PDF, 3 pages, 2.3mb)' ~ sr_only,
+    content: 'Download slides',
     icon_before: icon_download,
     reversed_underline: true,
     attributes: {
@@ -227,7 +211,7 @@
 {% include '@bolt-components-teaser/teaser.twig' with {
   like: like,
   share: share,
-  download_cta: download_cta,
+  download: download,
   status: {
     views: '28k',
     locked: true,

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/30-teaser-status-and-actions.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/30-teaser-status-and-actions.twig
@@ -102,14 +102,17 @@
         name: 'download',
       } only %}
     {% endset %}
-    {% include '@bolt-elements-text-link/text-link.twig' with {
-      content: 'Download slides',
-      icon_before: icon_download,
-      reversed_underline: true,
-      attributes: {
-        href: 'https://www.pega.com/',
-      },
-    } only %}
+    <bolt-tooltip>
+      {% include '@bolt-elements-text-link/text-link.twig' with {
+        content: 'Download slides',
+        icon_before: icon_download,
+        reversed_underline: true,
+        attributes: {
+          href: 'https://www.pega.com/',
+        },
+      } only %}
+      <span slot="content">PDF, 3 pages, 2.3mb</span>
+    </bolt-tooltip>
   {% endset %}
 
   <div style="max-width: 60ch;">

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/30-teaser-status-and-actions.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/30-teaser-status-and-actions.twig
@@ -104,20 +104,18 @@
     {% endset %}
     {% set sr_only %}
       {% include "@bolt-components-headline/text.twig" with {
-        text: "Opens in a new window",
+        text: "Downloads a PDF file.",
         attributes: {
           class: 'u-bolt-visuallyhidden'
         }
       } only %}
     {% endset %}
     {% include '@bolt-elements-text-link/text-link.twig' with {
-      content: 'Download slides (PDF)' ~ sr_only,
+      content: 'Download slides (PDF, 3 pages, 2.3mb)' ~ sr_only,
       icon_before: icon_download,
       reversed_underline: true,
       attributes: {
-        href: 'https://www.pega.com/sample.pdf',
-        target: '_blank',
-        rel: 'noopener'
+        href: 'https://www.pega.com/',
       },
     } only %}
   {% endset %}
@@ -209,7 +207,7 @@
   {% endset %}
   {% set sr_only %}
     {% include "@bolt-components-headline/text.twig" with {
-      text: "Opens in a new window",
+      text: "Downloads a PDF file.",
       attributes: {
         class: 'u-bolt-visuallyhidden'
       }
@@ -220,9 +218,7 @@
     icon_before: icon_download,
     reversed_underline: true,
     attributes: {
-      href: 'https://www.pega.com/sample.pdf',
-      target: '_blank',
-      rel: 'noopener'
+      href: 'https://www.pega.com',
     },
   } only %}
 {% endset %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/30-teaser-status-and-actions.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/30-teaser-status-and-actions.twig
@@ -102,7 +102,7 @@
         name: 'download',
       } only %}
     {% endset %}
-    <bolt-tooltip>
+    {% set tooltip_trigger %}
       {% include '@bolt-elements-text-link/text-link.twig' with {
         content: 'Download slides',
         icon_before: icon_download,
@@ -111,8 +111,11 @@
           href: 'https://www.pega.com/',
         },
       } only %}
-      <span slot="content">PDF, 3 pages, 2.3mb</span>
-    </bolt-tooltip>
+    {% endset %}
+    {% include "@bolt-components-tooltip/tooltip.twig" with {
+      trigger: tooltip_trigger,
+      content: "PDF, 3 pages, 2.3mb",
+    } only %}
   {% endset %}
 
   <div style="max-width: 60ch;">
@@ -200,13 +203,19 @@
       name: 'download',
     } only %}
   {% endset %}
-  {% include '@bolt-elements-text-link/text-link.twig' with {
-    content: 'Download slides',
-    icon_before: icon_download,
-    reversed_underline: true,
-    attributes: {
-      href: 'https://www.pega.com',
-    },
+  {% set tooltip_trigger %}
+    {% include '@bolt-elements-text-link/text-link.twig' with {
+      content: 'Download slides',
+      icon_before: icon_download,
+      reversed_underline: true,
+      attributes: {
+        href: 'https://www.pega.com/',
+      },
+    } only %}
+  {% endset %}
+  {% include "@bolt-components-tooltip/tooltip.twig" with {
+    trigger: tooltip_trigger,
+    content: "PDF, 3 pages, 2.3mb",
   } only %}
 {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/30-teaser-status-and-actions.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/30-teaser-status-and-actions.twig
@@ -1,5 +1,5 @@
 {% set description %}
-  The <bolt-code-snippet display="inline">status</bolt-code-snippet> prop can be used to display status information about a resource such as locked and view count. Like and share buttons can be generated via the <bolt-code-snippet display="inline">actions</bolt-code-snippet> prop.
+  The <bolt-code-snippet display="inline">status</bolt-code-snippet> prop can be used to display status information about a resource such as locked and view count. Like, share and download buttons can be generated via the <bolt-code-snippet display="inline">actions</bolt-code-snippet> prop.
 {% endset %}
 
 {% set notes %}
@@ -8,6 +8,7 @@
   <bolt-li>Locked status can be set via the <bolt-code-snippet display="inline">status.locked</bolt-code-snippet> prop. If this is set, a lock icon will appear with the signifier.</bolt-li>
   <bolt-li>Pass a like button into the <bolt-code-snippet display="inline">like</bolt-code-snippet> prop. Example code snippet is shown below.</bolt-li>
   <bolt-li>Pass a share popover menu into the <bolt-code-snippet display="inline">share</bolt-code-snippet> prop. Boundary is required on the popover. Example code snippet is shown below.</bolt-li>
+  <bolt-li>Pass a download cta button into the <bolt-code-snippet display="inline">download_cta</bolt-code-snippet> prop. Example code snippet is shown below.</bolt-li>
 </bolt-ol>
 {% endset %}
 
@@ -95,6 +96,31 @@
       boundary: '.js-bolt-target-teaser',
     } only %}
   {% endset %}
+  {% set download_cta %}
+    {% set icon_download %}
+      {% include '@bolt-elements-icon/icon.twig' with {
+        name: 'download',
+      } only %}
+    {% endset %}
+    {% set sr_only %}
+      {% include "@bolt-components-headline/text.twig" with {
+        text: "Opens in a new window",
+        attributes: {
+          class: 'u-bolt-visuallyhidden'
+        }
+      } only %}
+    {% endset %}
+    {% include '@bolt-elements-text-link/text-link.twig' with {
+      content: 'Download slides (PDF)' ~ sr_only,
+      icon_before: icon_download,
+      reversed_underline: true,
+      attributes: {
+        href: 'https://www.pega.com/sample.pdf',
+        target: '_blank',
+        rel: 'noopener'
+      },
+    } only %}
+  {% endset %}
 
   <div style="max-width: 60ch;">
     {% include '@bolt-components-teaser/teaser.twig' with {
@@ -112,6 +138,7 @@
       },
       like: like,
       share: share,
+      download_cta: download_cta,
       status: {
         views: '28k',
         locked: true,
@@ -174,11 +201,37 @@
     boundary: '.js-bolt-target-teaser', // JS target for containing the popover within the teaser.
   } only %}
 {% endset %}
+{% set download_cta %}
+  {% set icon_download %}
+    {% include '@bolt-elements-icon/icon.twig' with {
+      name: 'download',
+    } only %}
+  {% endset %}
+  {% set sr_only %}
+    {% include "@bolt-components-headline/text.twig" with {
+      text: "Opens in a new window",
+      attributes: {
+        class: 'u-bolt-visuallyhidden'
+      }
+    } only %}
+  {% endset %}
+  {% include '@bolt-elements-text-link/text-link.twig' with {
+    content: 'Download slides (PDF)' ~ sr_only,
+    icon_before: icon_download,
+    reversed_underline: true,
+    attributes: {
+      href: 'https://www.pega.com/sample.pdf',
+      target: '_blank',
+      rel: 'noopener'
+    },
+  } only %}
+{% endset %}
 
 // Set up the component
 {% include '@bolt-components-teaser/teaser.twig' with {
   like: like,
   share: share,
+  download_cta: download_cta,
   status: {
     views: '28k',
     locked: true,

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/30-teaser-status-and-actions.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/30-teaser-status-and-actions.twig
@@ -214,7 +214,7 @@
     } only %}
   {% endset %}
   {% include '@bolt-elements-text-link/text-link.twig' with {
-    content: 'Download slides (PDF)' ~ sr_only,
+    content: 'Download slides (PDF, 3 pages, 2.3mb)' ~ sr_only,
     icon_before: icon_download,
     reversed_underline: true,
     attributes: {

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/-05-boc-homepage-phase0.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/-05-boc-homepage-phase0.twig
@@ -1,1 +1,0 @@
-{% include '@pl/_boc-homepage.twig' with { phase1: false, phase2: false } %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/-10-boc-gallery-phase0.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/-10-boc-gallery-phase0.twig
@@ -1,1 +1,0 @@
-{% include '@pl/_boc-gallery.twig' with { phase1: false, phase2: false } %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/-15-boc-homepage-phase1.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/-15-boc-homepage-phase1.twig
@@ -1,2 +1,0 @@
-{% include '@pl/_boc-homepage.twig' with { phase1: true } %}
-

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/-20-boc-gallery-phase1.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/-20-boc-gallery-phase1.twig
@@ -1,2 +1,0 @@
-{% include '@pl/_boc-gallery.twig' with { phase1: true, phase2: false } %}
-

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/-25-boc-listing-pegaworld-phase1.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/-25-boc-listing-pegaworld-phase1.twig
@@ -1,2 +1,0 @@
-{% include '@pl/_boc-listing-pegaworld.twig' with { phase1: true, phase2: false } %}
-

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/-30-boc-homepage-phase2.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/-30-boc-homepage-phase2.twig
@@ -1,2 +1,2 @@
-{% include '@pl/_boc-homepage.twig' with { phase1: true, phase2: true } %}
+{% include '@pl/_boc-homepage.twig' %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/-35-boc-gallery-phase2.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/-35-boc-gallery-phase2.twig
@@ -1,2 +1,2 @@
-{% include '@pl/_boc-gallery.twig' with { phase1: true, phase2: true } %}
+{% include '@pl/_boc-gallery.twig' %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/-40-boc-listing-pegaworld-phase2.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/-40-boc-listing-pegaworld-phase2.twig
@@ -1,2 +1,2 @@
-{% include '@pl/_boc-listing-pegaworld.twig' with { phase1: true, phase2: true } %}
+{% include '@pl/_boc-listing-pegaworld.twig' %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/-45-boc-listing-customers-phase2.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/-45-boc-listing-customers-phase2.twig
@@ -1,2 +1,2 @@
-{% include '@pl/_boc-listing-customers.twig' with { phase1: true, phase2: true } %}
+{% include '@pl/_boc-listing-customers.twig' %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/05-boc-homepage-phase0.md
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/05-boc-homepage-phase0.md
@@ -1,3 +1,0 @@
----
-title: (Phase 0) Homepage
----

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/10-boc-gallery-phase0.md
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/10-boc-gallery-phase0.md
@@ -1,3 +1,0 @@
----
-title: (Phase 0) Gallery
----

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/15-boc-homepage-phase1.md
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/15-boc-homepage-phase1.md
@@ -1,3 +1,0 @@
----
-title: (Phase 1) Homepage
----

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/20-boc-gallery-phase1.md
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/20-boc-gallery-phase1.md
@@ -1,3 +1,0 @@
----
-title: (Phase 1) Gallery
----

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/25-boc-listing-pegaworld-phase1.md
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/25-boc-listing-pegaworld-phase1.md
@@ -1,3 +1,0 @@
----
-title: (Phase 1) PegaWorld Replays
----

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/30-boc-homepage-phase2.md
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/30-boc-homepage-phase2.md
@@ -1,3 +1,3 @@
 ---
-title: (Phase 2) Homepage
+title: Homepage
 ---

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/35-boc-gallery-phase2.md
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/35-boc-gallery-phase2.md
@@ -1,3 +1,3 @@
 ---
-title: (Phase 2) Gallery
+title: Gallery
 ---

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/40-boc-listing-pegaworld-phase2.md
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/40-boc-listing-pegaworld-phase2.md
@@ -1,3 +1,3 @@
 ---
-title: (Phase 2) PegaWorld Replays
+title: PegaWorld Replays
 ---

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/45-boc-listing-customers-phase2.md
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/45-boc-listing-customers-phase2.md
@@ -1,3 +1,3 @@
 ---
-title: (Phase 2) Customers
+title: Customers
 ---

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-gallery.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-gallery.twig
@@ -108,6 +108,22 @@
       spacing: 'none',
     } only %}
   {% endset %}
+  
+  {% set download %}
+    {% set icon_download %}
+      {% include '@bolt-elements-icon/icon.twig' with {
+        name: 'download',
+      } only %}
+    {% endset %}
+    {% include '@bolt-elements-text-link/text-link.twig' with {
+      content: 'Download slides',
+      icon_before: icon_download,
+      reversed_underline: true,
+      attributes: {
+        href: 'https://www.pega.com/',
+      },
+    } only %}
+  {% endset %}
 
   {% set video_image %}
     {% include '@bolt-elements-image/image.twig' with {
@@ -250,7 +266,8 @@
   {% if phase1 or phase2 %}
     {% set video_teaser_props = video_teaser_props|merge({ 
       like: like,
-      share: share, 
+      share: share,
+      download: download
     }) %}
     {% set external_link_teaser_props = external_link_teaser_props|merge({ 
       like: like,

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-gallery.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-gallery.twig
@@ -108,7 +108,7 @@
       spacing: 'none',
     } only %}
   {% endset %}
-  
+
   {% set download %}
     {% set icon_download %}
       {% include '@bolt-elements-icon/icon.twig' with {
@@ -263,52 +263,36 @@
     chip_list: chip_list_content,
   } %}
 
-  {% if phase1 or phase2 %}
-    {% set video_teaser_props = video_teaser_props|merge({ 
-      like: like,
-      share: share,
-      download: download
-    }) %}
-    {% set external_link_teaser_props = external_link_teaser_props|merge({ 
-      like: like,
-      share: share, 
-    }) %}
-    {% set pdf_teaser_props = pdf_teaser_props|merge({ 
-      like: like,
-      share: share, 
-    }) %}
-    {% set locked_teaser_props = locked_teaser_props|merge({ 
-      like: like,
-      share: share, 
-      status: {
-        locked: true,
-      } 
-    }) %}
-  {% endif %}
-
-  {% if phase2 %}
-    {% set video_teaser_props = video_teaser_props|merge({ 
-      status: {
-        views: '27',
-      } 
-    }) %}
-    {% set external_link_teaser_props = external_link_teaser_props|merge({ 
-      status: {
-        views: '3k',
-      } 
-    }) %}
-    {% set pdf_teaser_props = pdf_teaser_props|merge({ 
-      status: {
-        views: '66',
-      } 
-    }) %}
-    {% set locked_teaser_props = locked_teaser_props|merge({ 
-      status: {
-        views: '20k',
-        locked: true,
-      } 
-    }) %}
-  {% endif %}
+  {% set video_teaser_props = video_teaser_props|merge({ 
+    like: like,
+    share: share,
+    download: download,
+    status: {
+      views: '27',
+    } 
+  }) %}
+  {% set external_link_teaser_props = external_link_teaser_props|merge({ 
+    like: like,
+    share: share,
+    status: {
+      views: '3k',
+    } 
+  }) %}
+  {% set pdf_teaser_props = pdf_teaser_props|merge({ 
+    like: like,
+    share: share,
+    status: {
+      views: '66',
+    } 
+  }) %}
+  {% set locked_teaser_props = locked_teaser_props|merge({ 
+    like: like,
+    share: share, 
+    status: {
+      views: '20k',
+      locked: true,
+    } 
+  }) %}
 
   {% set item_video %}
     {% include '@bolt-components-teaser/teaser.twig' with video_teaser_props only %}
@@ -343,9 +327,7 @@
         } only %}
       </div>
       <div class="o-bolt-grid__cell u-bolt-width-12/12">
-        {% if phase1 or phase2 %}
-          {% include '_boc-quick-filters.twig' %}
-        {% endif %}
+        {% include '_boc-quick-filters.twig' %}
       </div>
       <div class="o-bolt-grid__cell u-bolt-width-12/12 u-bolt-width-6/12@small u-bolt-width-4/12@medium">
         {{ item_video }}
@@ -515,7 +497,6 @@
     theme: 'xlight',
   } only %}
 
-  {% if phase1 or phase2 %}
-    {% include '@pl/_boc-like-button-js.twig' %}
-  {% endif %}
+  {% include '@pl/_boc-like-button-js.twig' %}
+
 {% endblock %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-homepage.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-homepage.twig
@@ -106,6 +106,21 @@
   } only %}
 {% endset %}
 
+{% set download %}
+  {% set icon_download %}
+    {% include '@bolt-elements-icon/icon.twig' with {
+      name: 'download',
+    } only %}
+  {% endset %}
+  {% include '@bolt-elements-text-link/text-link.twig' with {
+    content: 'Download slides',
+    icon_before: icon_download,
+    reversed_underline: true,
+    attributes: {
+      href: 'https://www.pega.com/',
+    },
+  } only %}
+{% endset %}
 {% set wide_image %}
   {% include '@bolt-elements-image/image.twig' with {
     attributes: {
@@ -224,14 +239,16 @@
     share: share, 
     status: {
       views: '27',
-    } 
+    },
+    download: download
   }) %}
   {% set side_teaser_1_props = side_teaser_1_props|merge({ 
     like: like,
     share: share, 
     status: {
       views: '35',
-    } 
+    },
+    download: download
   }) %}
   {% set side_teaser_2_props = side_teaser_2_props|merge({ 
     like: like,

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-homepage.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-homepage.twig
@@ -233,38 +233,36 @@
   chip_list: chip_list_content,
 } %}
 
-{% if phase2 %}
-  {% set main_teaser_props = main_teaser_props|merge({ 
-    like: like,
-    share: share, 
-    status: {
-      views: '27',
-    },
-    download: download
-  }) %}
-  {% set side_teaser_1_props = side_teaser_1_props|merge({ 
-    like: like,
-    share: share, 
-    status: {
-      views: '35',
-    },
-    download: download
-  }) %}
-  {% set side_teaser_2_props = side_teaser_2_props|merge({ 
-    like: like,
-    share: share, 
-    status: {
-      views: '66',
-    } 
-  }) %}
-  {% set side_teaser_3_props = side_teaser_3_props|merge({ 
-    like: like,
-    share: share, 
-    status: {
-      views: '14',
-    } 
-  }) %}
-{% endif %}
+{% set main_teaser_props = main_teaser_props|merge({ 
+  like: like,
+  share: share, 
+  status: {
+    views: '27',
+  },
+  download: download
+}) %}
+{% set side_teaser_1_props = side_teaser_1_props|merge({ 
+  like: like,
+  share: share, 
+  status: {
+    views: '35',
+  },
+  download: download
+}) %}
+{% set side_teaser_2_props = side_teaser_2_props|merge({ 
+  like: like,
+  share: share, 
+  status: {
+    views: '66',
+  } 
+}) %}
+{% set side_teaser_3_props = side_teaser_3_props|merge({ 
+  like: like,
+  share: share, 
+  status: {
+    views: '14',
+  } 
+}) %}
 
 {% set band_content %}
   {% set icon_eye %}
@@ -324,6 +322,4 @@
   },
 } only %}
 
-{% if phase1 or phase2 %}
-  {% include '@pl/_boc-like-button-js.twig' %}
-{% endif %}
+{% include '@pl/_boc-like-button-js.twig' %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-customers.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-customers.twig
@@ -109,6 +109,22 @@
     } only %}
   {% endset %}
 
+  {% set download %}
+    {% set icon_download %}
+      {% include '@bolt-elements-icon/icon.twig' with {
+        name: 'download',
+      } only %}
+    {% endset %}
+    {% include '@bolt-elements-text-link/text-link.twig' with {
+      content: 'Download slides',
+      icon_before: icon_download,
+      reversed_underline: true,
+      attributes: {
+        href: 'https://www.pega.com/',
+      },
+    } only %}
+  {% endset %}
+
   {% set video_image %}
     {% include '@bolt-elements-image/image.twig' with {
       attributes: {
@@ -251,6 +267,7 @@
     {% set video_teaser_props = video_teaser_props|merge({
       like: like,
       share: share,
+      download: download
     }) %}
     {% set external_link_teaser_props = external_link_teaser_props|merge({
       like: like,
@@ -263,6 +280,7 @@
     {% set featured_teaser_props = featured_teaser_props|merge({
       like: like,
       share: share,
+      download: download
     }) %}
   {% endif %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-customers.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-customers.twig
@@ -263,49 +263,36 @@
     time: '4:55',
   } %}
 
-  {% if phase1 or phase2 %}
-    {% set video_teaser_props = video_teaser_props|merge({
-      like: like,
-      share: share,
-      download: download
-    }) %}
-    {% set external_link_teaser_props = external_link_teaser_props|merge({
-      like: like,
-      share: share,
-    }) %}
-    {% set pdf_teaser_props = pdf_teaser_props|merge({
-      like: like,
-      share: share,
-    }) %}
-    {% set featured_teaser_props = featured_teaser_props|merge({
-      like: like,
-      share: share,
-      download: download
-    }) %}
-  {% endif %}
-
-  {% if phase2 %}
-    {% set video_teaser_props = video_teaser_props|merge({
-      status: {
-        views: '27',
-      }
-    }) %}
-    {% set external_link_teaser_props = external_link_teaser_props|merge({
-      status: {
-        views: '3k',
-      }
-    }) %}
-    {% set pdf_teaser_props = pdf_teaser_props|merge({
-      status: {
-        views: '66',
-      }
-    }) %}
-    {% set featured_teaser_props = featured_teaser_props|merge({
-      status: {
-        views: '20k',
-      }
-    }) %}
-  {% endif %}
+  {% set video_teaser_props = video_teaser_props|merge({
+    like: like,
+    share: share,
+    download: download,
+    status: {
+      views: '27',
+    }
+  }) %}
+  {% set external_link_teaser_props = external_link_teaser_props|merge({
+    like: like,
+    share: share,
+    status: {
+      views: '3k',
+    }
+  }) %}
+  {% set pdf_teaser_props = pdf_teaser_props|merge({
+    like: like,
+    share: share,
+    status: {
+      views: '66',
+    }
+  }) %}
+  {% set featured_teaser_props = featured_teaser_props|merge({
+    like: like,
+    share: share,
+    download: download,
+    status: {
+      views: '20k',
+    }
+  }) %}
 
   {% set item_video %}
     {% include '@bolt-components-teaser/teaser.twig' with video_teaser_props only %}
@@ -523,34 +510,26 @@
       } only %}
     {% endset %}
 
-    {% if phase1 or phase2 %}
-      <form class="c-bolt-form">
-        {% if phase1 and not phase2 %}
-          {% set form_items = []  %}
-        {% elseif phase2 %}
-          {% set form_items = [filter_button] %}
-        {% endif %}
+    <form class="c-bolt-form">
+      {% set form_items = [filter_button] %}
 
-        {% set form_list %}
-          {% include '@bolt-components-list/list.twig' with {
-            display: 'inline',
-            align: 'start',
-            items: form_items,
-          } only %}
-        {% endset %}
+      {% set form_list %}
+        {% include '@bolt-components-list/list.twig' with {
+          display: 'inline',
+          align: 'start',
+          items: form_items,
+        } only %}
+      {% endset %}
 
-        <div class="o-bolt-grid o-bolt-grid--flex o-bolt-grid--matrix o-bolt-grid--small">
-          <div class="o-bolt-grid__cell u-bolt-width-6/12@small u-bolt-flex-grow">
-            {{ form_list }}
-          </div>
-          <div class="o-bolt-grid__cell u-bolt-flex-shrink">
-            {% if phase2 %}
-              {{ sort_select }}
-            {% endif %}
-          </div>
+      <div class="o-bolt-grid o-bolt-grid--flex o-bolt-grid--matrix o-bolt-grid--small">
+        <div class="o-bolt-grid__cell u-bolt-width-6/12@small u-bolt-flex-grow">
+          {{ form_list }}
         </div>
-      </form>
-    {% endif %}
+        <div class="o-bolt-grid__cell u-bolt-flex-shrink">
+          {{ sort_select }}
+        </div>
+      </div>
+    </form>
 
     <div class="o-bolt-grid o-bolt-grid--flex o-bolt-grid--matrix">
       <div class="o-bolt-grid__cell u-bolt-width-12/12 u-bolt-width-6/12@small u-bolt-width-4/12@medium">
@@ -587,7 +566,6 @@
     theme: 'xlight',
   } only %}
 
-  {% if phase1 or phase2 %}
     {% include '@pl/_boc-like-button-js.twig' %}
-  {% endif %}
+
 {% endblock %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-pegaworld.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-pegaworld.twig
@@ -263,49 +263,36 @@
     time: '4:55',
   } %}
 
-  {% if phase1 or phase2 %}
-    {% set video_teaser_props = video_teaser_props|merge({
-      like: like,
-      share: share,
-      download: download
-    }) %}
-    {% set external_link_teaser_props = external_link_teaser_props|merge({
-      like: like,
-      share: share,
-    }) %}
-    {% set pdf_teaser_props = pdf_teaser_props|merge({
-      like: like,
-      share: share,
-    }) %}
-    {% set featured_teaser_props = featured_teaser_props|merge({
-      like: like,
-      share: share,
-      download: download
-    }) %}
-  {% endif %}
-
-  {% if phase2 %}
-    {% set video_teaser_props = video_teaser_props|merge({
-      status: {
-        views: '27',
-      }
-    }) %}
-    {% set external_link_teaser_props = external_link_teaser_props|merge({
-      status: {
-        views: '3k',
-      }
-    }) %}
-    {% set pdf_teaser_props = pdf_teaser_props|merge({
-      status: {
-        views: '66',
-      }
-    }) %}
-    {% set featured_teaser_props = featured_teaser_props|merge({
-      status: {
-        views: '20k',
-      }
-    }) %}
-  {% endif %}
+  {% set video_teaser_props = video_teaser_props|merge({
+    like: like,
+    share: share,
+    download: download,
+    status: {
+      views: '27',
+    }
+  }) %}
+  {% set external_link_teaser_props = external_link_teaser_props|merge({
+    like: like,
+    share: share,
+    status: {
+      views: '3k',
+    }
+  }) %}
+  {% set pdf_teaser_props = pdf_teaser_props|merge({
+    like: like,
+    share: share,
+    status: {
+      views: '66',
+    }
+  }) %}
+  {% set featured_teaser_props = featured_teaser_props|merge({
+    like: like,
+    share: share,
+    download: download,
+    status: {
+      views: '20k',
+    }
+  }) %}
 
   {% set item_video %}
     {% include '@bolt-components-teaser/teaser.twig' with video_teaser_props only %}
@@ -577,34 +564,26 @@
       } only %}
     {% endset %}
 
-    {% if phase1 or phase2 %}
-      <form class="c-bolt-form">
-        {% if phase1 %}
-          {% set form_items = [year_select, filter_button] %}
-        {% else %}
-          {% set form_items = []  %}
-        {% endif %}
+    <form class="c-bolt-form">
+      {% set form_items = [year_select, filter_button] %}
 
-        {% set form_list %}
-          {% include '@bolt-components-list/list.twig' with {
-            display: 'inline',
-            align: 'start',
-            items: form_items,
-          } only %}
-        {% endset %}
+      {% set form_list %}
+        {% include '@bolt-components-list/list.twig' with {
+          display: 'inline',
+          align: 'start',
+          items: form_items,
+        } only %}
+      {% endset %}
 
-        <div class="o-bolt-grid o-bolt-grid--flex o-bolt-grid--matrix o-bolt-grid--small">
-          <div class="o-bolt-grid__cell u-bolt-width-6/12@small u-bolt-flex-grow">
-            {{ form_list }}
-          </div>
-          <div class="o-bolt-grid__cell u-bolt-flex-shrink">
-            {% if phase2 %}
-              {{ sort_select }}
-            {% endif %}
-          </div>
+      <div class="o-bolt-grid o-bolt-grid--flex o-bolt-grid--matrix o-bolt-grid--small">
+        <div class="o-bolt-grid__cell u-bolt-width-6/12@small u-bolt-flex-grow">
+          {{ form_list }}
         </div>
-      </form>
-    {% endif %}
+        <div class="o-bolt-grid__cell u-bolt-flex-shrink">
+          {{ sort_select }}
+        </div>
+      </div>
+    </form>
 
     <div class="o-bolt-grid o-bolt-grid--flex o-bolt-grid--matrix">
       <div class="o-bolt-grid__cell u-bolt-width-12/12 u-bolt-width-6/12@small u-bolt-width-4/12@medium">
@@ -641,7 +620,6 @@
     theme: 'xlight',
   } only %}
 
-  {% if phase1 or phase2 %}
     {% include '@pl/_boc-like-button-js.twig' %}
-  {% endif %}
+    
 {% endblock %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-pegaworld.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-pegaworld.twig
@@ -108,6 +108,22 @@
       spacing: 'none',
     } only %}
   {% endset %}
+  
+  {% set download %}
+    {% set icon_download %}
+      {% include '@bolt-elements-icon/icon.twig' with {
+        name: 'download',
+      } only %}
+    {% endset %}
+    {% include '@bolt-elements-text-link/text-link.twig' with {
+      content: 'Download slides',
+      icon_before: icon_download,
+      reversed_underline: true,
+      attributes: {
+        href: 'https://www.pega.com/',
+      },
+    } only %}
+  {% endset %}
 
   {% set video_image %}
     {% include '@bolt-elements-image/image.twig' with {
@@ -251,6 +267,7 @@
     {% set video_teaser_props = video_teaser_props|merge({
       like: like,
       share: share,
+      download: download
     }) %}
     {% set external_link_teaser_props = external_link_teaser_props|merge({
       like: like,
@@ -263,6 +280,7 @@
     {% set featured_teaser_props = featured_teaser_props|merge({
       like: like,
       share: share,
+      download: download
     }) %}
   {% endif %}
 

--- a/packages/components/bolt-teaser/__tests__/__snapshots__/teaser.js.snap
+++ b/packages/components/bolt-teaser/__tests__/__snapshots__/teaser.js.snap
@@ -39,33 +39,25 @@ exports[`Twig usage adds class via Drupal Attributes 1`] = `
     </div>
     <div class="c-bolt-teaser__actions-and-views">
       <div class="c-bolt-teaser__views">
-        <bolt-icon name="eye"
-                   aria-hidden="true"
-        >
-          <span class="c-bolt-icon c-bolt-icon--eye">
-            <svg class="c-bolt-icon__icon"
-                 xmlns="http://www.w3.org/2000/svg"
-                 viewbox="0 0 24 24"
+        <span class="c-bolt-teaser__views--icon">
+          <svg class="e-bolt-icon"
+               aria-hidden="true"
+               enable-background="new 0 0 32 32"
+               viewbox="0 0 32 32"
+               xmlns="http://www.w3.org/2000/svg"
+          >
+            <g clip-rule="evenodd"
+               fill="#151619"
+               fill-rule="evenodd"
+               transform="translate(0 2)"
             >
-              <g fill="none"
-                 fill-rule="evenodd"
-              >
-                <path>
-                </path>
-                <path fill="var(--bolt-theme-icon, currentColor)"
-                      d="M19.4 12.4C17 14.8 14.6 16 12 16c-2.6 0-5-1.2-7.4-3.6A18.8 18.8 0 012.1 9c.4-.7 1.3-2 2.5-3.4C7 3.2 9.4 2 12 2c2.6 0 5 1.2 7.4 3.6A19 19 0 0121.9 9c-.4.7-1.3 2-2.5 3.4m4.5-3.8c0-.1-1.1-2.2-3-4.3A12.2 12.2 0 0012 0C8.9 0 5.8 1.5 3.1 4.3c-2 2.1-3 4.2-3 4.3a1 1 0 000 .9s1 2.1 3 4.2C5.8 16.5 9 18 12 18c3.1 0 6.2-1.5 8.9-4.3 1.9-2.1 3-4.2 3-4.3a1 1 0 000-.8"
-                      mask="url(#mask-2)"
-                      transform="translate(0 3)"
-                >
-                </path>
-                <path fill="var(--bolt-theme-icon, currentColor)"
-                      d="M12 14a2 2 0 01-2-2c0-1.1.9-2 2-2a2 2 0 012 2 2 2 0 01-2 2m0-6a4 4 0 100 8 4 4 0 000-8"
-                >
-                </path>
-              </g>
-            </svg>
-          </span>
-        </bolt-icon>
+              <path d="m25.8 18.5c-3 3.2-6.3 4.9-9.8 4.9s-6.8-1.6-9.8-4.9c-1.7-1.8-2.8-3.6-3.3-4.5.5-.9 1.7-2.7 3.3-4.5 3-3.2 6.3-4.9 9.8-4.9s6.8 1.6 9.8 4.9c1.7 1.8 2.8 3.6 3.3 4.5-.5.9-1.6 2.7-3.3 4.5m6.1-5.1c-.1-.1-1.4-2.9-4-5.6-3.6-3.8-7.7-5.8-11.9-5.8s-8.3 2-11.8 5.8c-2.6 2.8-4 5.5-4 5.6-.2.4-.2.8 0 1.2.1.1 1.4 2.9 4 5.6 3.5 3.8 7.6 5.8 11.8 5.8s8.3-2 11.8-5.8c2.6-2.8 4-5.5 4-5.6.2-.4.2-.8.1-1.2">
+              </path>
+              <path d="m16 16.7c-1.5 0-2.7-1.2-2.7-2.7s1.2-2.7 2.7-2.7 2.7 1.2 2.7 2.7-1.2 2.7-2.7 2.7m0-8c-2.9 0-5.3 2.4-5.3 5.3s2.4 5.3 5.3 5.3 5.3-2.4 5.3-5.3-2.4-5.3-5.3-5.3">
+              </path>
+            </g>
+          </svg>
+        </span>
         28k views
       </div>
     </div>
@@ -119,21 +111,17 @@ exports[`Twig usage basic usage 1`] = `
       10 min read
     </div>
     <div class="c-bolt-teaser__signifier-locked">
-      <bolt-icon name="lock-solid"
-                 aria-hidden="true"
+      <svg class="e-bolt-icon"
+           aria-hidden="true"
+           enable-background="new 0 0 32 32"
+           viewbox="0 0 32 32"
+           xmlns="http://www.w3.org/2000/svg"
       >
-        <span class="c-bolt-icon c-bolt-icon--lock-solid">
-          <svg class="c-bolt-icon__icon"
-               xmlns="http://www.w3.org/2000/svg"
-               viewbox="0 0 24 24"
-          >
-            <path fill="var(--bolt-theme-icon, currentColor)"
-                  d="M18.4 10h-.6V7a6 6 0 00-5.9-5.9 6 6 0 00-6 5.8v3h-.3a2 2 0 00-2 2v9c0 1.1.9 2 2 2h12.7a2 2 0 002-2v-9c.1-1-.8-1.9-1.9-1.9zm-2.8 0H8V7a3.8 3.8 0 117.6 0v3z"
-            >
-            </path>
-          </svg>
-        </span>
-      </bolt-icon>
+        <path d="m25.5 13.1h-.9v-4.4c0-4.8-4-8.7-8.7-8.7s-8.8 3.8-8.8 8.5v4.4h-.4c-1.6 0-2.9 1.3-2.9 2.9v13.2c0 1.6 1.3 2.9 2.9 2.9h18.6c1.6 0 2.9-1.3 2.9-2.9v-13.1c.2-1.5-1.1-2.8-2.7-2.8zm-4.1 0h-11.2v-4.4c0-3.1 2.5-5.6 5.6-5.6s5.6 2.5 5.6 5.6z"
+              fill="#151619"
+        >
+        </path>
+      </svg>
     </div>
   </div>
   <div class="c-bolt-teaser__content">
@@ -173,33 +161,25 @@ exports[`Twig usage basic usage 1`] = `
     </div>
     <div class="c-bolt-teaser__actions-and-views">
       <div class="c-bolt-teaser__views">
-        <bolt-icon name="eye"
-                   aria-hidden="true"
-        >
-          <span class="c-bolt-icon c-bolt-icon--eye">
-            <svg class="c-bolt-icon__icon"
-                 xmlns="http://www.w3.org/2000/svg"
-                 viewbox="0 0 24 24"
+        <span class="c-bolt-teaser__views--icon">
+          <svg class="e-bolt-icon"
+               aria-hidden="true"
+               enable-background="new 0 0 32 32"
+               viewbox="0 0 32 32"
+               xmlns="http://www.w3.org/2000/svg"
+          >
+            <g clip-rule="evenodd"
+               fill="#151619"
+               fill-rule="evenodd"
+               transform="translate(0 2)"
             >
-              <g fill="none"
-                 fill-rule="evenodd"
-              >
-                <path>
-                </path>
-                <path fill="var(--bolt-theme-icon, currentColor)"
-                      d="M19.4 12.4C17 14.8 14.6 16 12 16c-2.6 0-5-1.2-7.4-3.6A18.8 18.8 0 012.1 9c.4-.7 1.3-2 2.5-3.4C7 3.2 9.4 2 12 2c2.6 0 5 1.2 7.4 3.6A19 19 0 0121.9 9c-.4.7-1.3 2-2.5 3.4m4.5-3.8c0-.1-1.1-2.2-3-4.3A12.2 12.2 0 0012 0C8.9 0 5.8 1.5 3.1 4.3c-2 2.1-3 4.2-3 4.3a1 1 0 000 .9s1 2.1 3 4.2C5.8 16.5 9 18 12 18c3.1 0 6.2-1.5 8.9-4.3 1.9-2.1 3-4.2 3-4.3a1 1 0 000-.8"
-                      mask="url(#mask-2)"
-                      transform="translate(0 3)"
-                >
-                </path>
-                <path fill="var(--bolt-theme-icon, currentColor)"
-                      d="M12 14a2 2 0 01-2-2c0-1.1.9-2 2-2a2 2 0 012 2 2 2 0 01-2 2m0-6a4 4 0 100 8 4 4 0 000-8"
-                >
-                </path>
-              </g>
-            </svg>
-          </span>
-        </bolt-icon>
+              <path d="m25.8 18.5c-3 3.2-6.3 4.9-9.8 4.9s-6.8-1.6-9.8-4.9c-1.7-1.8-2.8-3.6-3.3-4.5.5-.9 1.7-2.7 3.3-4.5 3-3.2 6.3-4.9 9.8-4.9s6.8 1.6 9.8 4.9c1.7 1.8 2.8 3.6 3.3 4.5-.5.9-1.6 2.7-3.3 4.5m6.1-5.1c-.1-.1-1.4-2.9-4-5.6-3.6-3.8-7.7-5.8-11.9-5.8s-8.3 2-11.8 5.8c-2.6 2.8-4 5.5-4 5.6-.2.4-.2.8 0 1.2.1.1 1.4 2.9 4 5.6 3.5 3.8 7.6 5.8 11.8 5.8s8.3-2 11.8-5.8c2.6-2.8 4-5.5 4-5.6.2-.4.2-.8.1-1.2">
+              </path>
+              <path d="m16 16.7c-1.5 0-2.7-1.2-2.7-2.7s1.2-2.7 2.7-2.7 2.7 1.2 2.7 2.7-1.2 2.7-2.7 2.7m0-8c-2.9 0-5.3 2.4-5.3 5.3s2.4 5.3 5.3 5.3 5.3-2.4 5.3-5.3-2.4-5.3-5.3-5.3">
+              </path>
+            </g>
+          </svg>
+        </span>
         28k views
       </div>
       <ul class="c-bolt-teaser__action-list">

--- a/packages/components/bolt-teaser/src/teaser.scss
+++ b/packages/components/bolt-teaser/src/teaser.scss
@@ -289,11 +289,14 @@
 .c-bolt-teaser__views {
   display: grid;
   grid-template-columns: 1fr auto;
-  align-items: center;
   grid-gap: var(--bolt-spacing-x-xxsmall);
   margin-right: var(--bolt-spacing-y-small);
   font-size: var(--bolt-type-font-size-xsmall);
   line-height: var(--bolt-type-line-height-xsmall);
+
+  [class*='e-bolt-icon'] {
+    @include bolt-inline-icon-wrapper; /* [1] */
+  }
 }
 
 .c-bolt-teaser__action-list {
@@ -323,6 +326,11 @@
 .c-bolt-teaser__action-list-item {
   margin: 0;
   padding: 0;
+
+  .e-bolt-text-link {
+    display: grid;
+    grid-template-columns: 1fr auto;
+  }
 
   & + #{&} {
     margin-left: var(--bolt-spacing-y-small);

--- a/packages/components/bolt-teaser/src/teaser.scss
+++ b/packages/components/bolt-teaser/src/teaser.scss
@@ -301,7 +301,7 @@
   flex-wrap: nowrap;
   position: relative;
   z-index: 1; // Must use z-index to fix stacking order in FF.
-  margin: 0 0 0 auto;
+  margin: 0;
   padding: 0;
   font-size: var(--bolt-type-font-size-xsmall);
   list-style: none;

--- a/packages/components/bolt-teaser/src/teaser.scss
+++ b/packages/components/bolt-teaser/src/teaser.scss
@@ -293,10 +293,10 @@
   margin-right: var(--bolt-spacing-y-small);
   font-size: var(--bolt-type-font-size-xsmall);
   line-height: var(--bolt-type-line-height-xsmall);
+}
 
-  [class*='e-bolt-icon'] {
-    @include bolt-inline-icon-wrapper; /* [1] */
-  }
+.c-bolt-teaser__views--icon {
+  @include bolt-inline-icon-wrapper;
 }
 
 .c-bolt-teaser__action-list {

--- a/packages/components/bolt-teaser/src/teaser.twig
+++ b/packages/components/bolt-teaser/src/teaser.twig
@@ -95,7 +95,7 @@
       </div>
     {% endif %}
 
-    {% if status.views or like or share %}
+    {% if status.views or like or share or download_cta %}
       <div class="c-bolt-teaser__actions-and-views">
         {% if status.views %}
           <div class="c-bolt-teaser__views">
@@ -105,7 +105,7 @@
             {{ status.views }} {{ 'views'|t }}
           </div>
         {% endif %}
-        {% if like or share %}
+        {% if like or share or download_cta %}
           <ul class="c-bolt-teaser__action-list">
             {% if like %}
               <li class="c-bolt-teaser__action-list-item">
@@ -115,6 +115,11 @@
             {% if share %}
               <li class="c-bolt-teaser__action-list-item">
                 {{ share }}
+              </li>
+            {% endif %}
+            {% if download_cta %}
+              <li class="c-bolt-teaser__action-list-item">
+                {{ download_cta }}
               </li>
             {% endif %}
           </ul>

--- a/packages/components/bolt-teaser/src/teaser.twig
+++ b/packages/components/bolt-teaser/src/teaser.twig
@@ -42,7 +42,7 @@
 
       {% if status.locked %}
         <div class="c-bolt-teaser__signifier-locked">
-          {% include '@bolt-components-icon/icon.twig' with {
+          {% include '@bolt-elements-icon/icon.twig' with {
             name: 'lock-solid',
           } only %}
         </div>
@@ -98,12 +98,12 @@
     {% if status.views or like or share or download %}
       <div class="c-bolt-teaser__actions-and-views">
         {% if status.views %}
-          <div class="c-bolt-teaser__views">
-            {% include '@bolt-components-icon/icon.twig' with {
+          {% set _icon_eye %}
+            {% include '@bolt-elements-icon/icon.twig' with {
               name: 'eye',
             } only %}
-            {{ status.views }} {{ 'views'|t }}
-          </div>
+          {% endset %}
+          <div class="c-bolt-teaser__views"><span class="c-bolt-teaser__views--icon">{{ _icon_eye|spaceless }}</span>{{ status.views }} {{ 'views'|t }}</div>
         {% endif %}
         {% if like or share or download %}
           <ul class="c-bolt-teaser__action-list">

--- a/packages/components/bolt-teaser/src/teaser.twig
+++ b/packages/components/bolt-teaser/src/teaser.twig
@@ -95,7 +95,7 @@
       </div>
     {% endif %}
 
-    {% if status.views or like or share or download_cta %}
+    {% if status.views or like or share or download %}
       <div class="c-bolt-teaser__actions-and-views">
         {% if status.views %}
           <div class="c-bolt-teaser__views">
@@ -105,7 +105,7 @@
             {{ status.views }} {{ 'views'|t }}
           </div>
         {% endif %}
-        {% if like or share or download_cta %}
+        {% if like or share or download %}
           <ul class="c-bolt-teaser__action-list">
             {% if like %}
               <li class="c-bolt-teaser__action-list-item">
@@ -117,9 +117,9 @@
                 {{ share }}
               </li>
             {% endif %}
-            {% if download_cta %}
+            {% if download %}
               <li class="c-bolt-teaser__action-list-item">
-                {{ download_cta }}
+                {{ download }}
               </li>
             {% endif %}
           </ul>

--- a/packages/components/bolt-teaser/teaser.schema.js
+++ b/packages/components/bolt-teaser/teaser.schema.js
@@ -104,6 +104,10 @@ module.exports = {
       type: 'object',
       description: 'Render the share button. Share menu is expected here.',
     },
+    download_cta: {
+      type: 'object',
+      description: 'Render the download link. Link element is expected here.',
+    },
     chip_list: {
       type: 'object',
       description:

--- a/packages/components/bolt-teaser/teaser.schema.js
+++ b/packages/components/bolt-teaser/teaser.schema.js
@@ -104,7 +104,7 @@ module.exports = {
       type: 'object',
       description: 'Render the share button. Share menu is expected here.',
     },
-    download_cta: {
+    download: {
       type: 'object',
       description: 'Render the download link. Link element is expected here.',
     },

--- a/packages/core-v3.x/styles/02-tools/tools-inline-icon-wrapper/_tools-inline-icon-wrapper.scss
+++ b/packages/core-v3.x/styles/02-tools/tools-inline-icon-wrapper/_tools-inline-icon-wrapper.scss
@@ -17,12 +17,14 @@
     content: '\FEFF'; /* [2] */
   }
 
-  > img {
+  > img,
+  > svg {
     width: 1em; /* [1] */
     height: 1em; /* [1] */
   }
 
   > img,
+  > svg,
   > bolt-icon:not([size]) {
     display: inline-flex;
     transform: translateY(0.18em); /* [3] */


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-529

## Summary

Download slides CTA was added. All phases from the `Best-of-content` were removed and only one final version was kept.

## Details

Download slides CTA was added to the `bolt-teaser` component and to the `best-of-content` pages in relation to the proposed wireframe.

## How to test

Pull the branch. Check out the `bolt-teaser` component and `best-of-content` pages where the new `Download slides` CTA was added. Make sure the new CTA is correct in terms of semantics and accessibility.

## Release notes

- Added new CTA to the Listing Teaser actions list on the `bolt-teaser` component and the `best-of-content` page.

### Visual Changes

#### Teaser component

- Action list is now aligned to the left.