### PR TITLE
WWW-960: mobile nav top link color

### DIFF
--- a/packages/components/bolt-page-header/src/_page-header-mobile.scss
+++ b/packages/components/bolt-page-header/src/_page-header-mobile.scss
@@ -183,11 +183,6 @@
     padding-left: $bolt-page-header-mobile-expanded-content-spacing-x;
     color: var(--m-bolt-text);
     border-radius: 0;
-
-    &:hover,
-    &:focus {
-      color: var(--m-bolt-headline);
-    }
   }
 
   .c-bolt-page-header__nav-list-item.is-selected .c-bolt-page-header__nav-link {

--- a/packages/components/bolt-page-header/src/_page-header-mobile.scss
+++ b/packages/components/bolt-page-header/src/_page-header-mobile.scss
@@ -183,6 +183,11 @@
     padding-left: $bolt-page-header-mobile-expanded-content-spacing-x;
     color: var(--m-bolt-text);
     border-radius: 0;
+
+    &:hover,
+    &:focus {
+      color: var(--m-bolt-headline);
+    }
   }
 
   .c-bolt-page-header__nav-list-item.is-selected .c-bolt-page-header__nav-link {

--- a/packages/components/bolt-page-header/src/_page-header-settings-and-tools.scss
+++ b/packages/components/bolt-page-header/src/_page-header-settings-and-tools.scss
@@ -132,10 +132,6 @@ $bolt-page-header-mobile-expanded-content-spacing-x: calc(
     }
   }
 
-  &[aria-expanded='true'] {
-    color: var(--m-bolt-headline);
-  }
-
   > * {
     position: relative;
   }

--- a/packages/components/bolt-page-header/src/_page-header-settings-and-tools.scss
+++ b/packages/components/bolt-page-header/src/_page-header-settings-and-tools.scss
@@ -132,6 +132,10 @@ $bolt-page-header-mobile-expanded-content-spacing-x: calc(
     }
   }
 
+  &[aria-expanded='true'] {
+    color: var(--m-bolt-body);
+  }
+
   > * {
     position: relative;
   }


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/WWW-960

## Summary

Makes unselected top-level mobile links black for consistency

## Details

See screenshots in the "visual changes" section below.  All other colors should be unchanged.

## How to test

See screenshots in the "visual changes" section below.  All other colors should be unchanged.

## Release notes

### Visual changes

In the global nav, top-level links are now black instead of dark navy when not selected.  For example, on https://boltdesignsystem.com/pattern-lab/?p=components-page-header-example-main-site-with-subnav

Before:
<img width="322" alt="Screen Shot 2021-09-10 at 10 44 12 AM" src="https://user-images.githubusercontent.com/3027663/132872320-bd33095d-3a1e-453f-a50f-c457542069e4.png">

After:
<img width="322" alt="Screen Shot 2021-09-10 at 10 44 24 AM" src="https://user-images.githubusercontent.com/3027663/132872358-be6b336d-d77e-4f36-86bb-cbf1cebe1bed.png">



