### PR TITLE
DS-582 Add information about twig file name on schema section

### DIFF
--- a/docs-site/src/components/pattern-lab-utils/schema-docs.twig
+++ b/docs-site/src/components/pattern-lab-utils/schema-docs.twig
@@ -10,7 +10,12 @@
     {% for schema in schemas %}
       {% set title = schema.title %}
       <bolt-accordion-item{% if loop.first %} open{% endif %}>
-        {% if title %}<strong slot="trigger">{{ title }}</strong>{% endif %}
+        {% if title %}
+          <div slot="trigger">
+            <strong>{{ title }}</strong>
+            <span>({{ title|replace({' ': '-'})|lower }}.twig)</span>
+          </div>
+        {% endif %}
         {{ macros.schemaWrapper(schema) }}
       </bolt-accordion-item>
     {% endfor %}

--- a/packages/components/bolt-navbar/navbar-li.schema.js
+++ b/packages/components/bolt-navbar/navbar-li.schema.js
@@ -15,7 +15,7 @@ iconSchema.description =
 
 module.exports = {
   $schema: 'http://json-schema.org/draft-04/schema#',
-  title: 'Navbar item',
+  title: 'Navbar li',
   type: 'object',
   required: ['link'],
   properties: {

--- a/packages/components/bolt-navbar/navbar-ul.schema.js
+++ b/packages/components/bolt-navbar/navbar-ul.schema.js
@@ -1,6 +1,6 @@
 module.exports = {
   $schema: 'http://json-schema.org/draft-04/schema#',
-  title: 'Navbar list',
+  title: 'Navbar ul',
   type: 'object',
   required: ['content'],
   properties: {

--- a/packages/layouts/bolt-layout/layout-item.schema.js
+++ b/packages/layouts/bolt-layout/layout-item.schema.js
@@ -1,6 +1,6 @@
 module.exports = {
   $schema: 'http://json-schema.org/draft-04/schema#',
-  title: 'Layout-Item',
+  title: 'Layout Item',
   type: 'object',
   properties: {
     attributes: {

--- a/packages/layouts/bolt-layout/layout-item.schema.js
+++ b/packages/layouts/bolt-layout/layout-item.schema.js
@@ -1,6 +1,6 @@
 module.exports = {
   $schema: 'http://json-schema.org/draft-04/schema#',
-  title: 'Layout Item',
+  title: 'Layout item',
   type: 'object',
   properties: {
     attributes: {


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-582

## Summary

Add information about the twig file name on the schema section.

## Details

Applies to components with multiple schemas:
- packages/components/bolt-listing-teaser
- packages/components/bolt-navbar
- packages/components/bolt-page-footer
- packages/components/bolt-page-header
- packages/components/bolt-side-nav
- packages/layouts/bolt-holy-grail
- packages/layouts/bolt-layout

## How to test

Run this code locally and check if the twig file name is shown on components with multiple schemas and it's not visible on single schemas.