### PR TITLE
DS-600 Replace Link in Headline Component

### DIFF
--- a/packages/components/bolt-headline/__tests__/__snapshots__/headline.js.snap
+++ b/packages/components/bolt-headline/__tests__/__snapshots__/headline.js.snap
@@ -311,41 +311,31 @@ exports[`<bolt-headline> Component basic usage text 1`] = `
 
 exports[`<bolt-headline> Component headline with associated link 1`] = `
 <h2 class="c-bolt-headline c-bolt-headline--bold c-bolt-headline--xlarge c-bolt-headline--link">
-  <bolt-link url="www.testurl.com"
-             is-headline
+  <a href="www.testurl.com"
+     class="e-bolt-text-link e-bolt-text-link--reversed-underline"
   >
-    <a href="www.testurl.com"
-       target="_self"
-       class="c-bolt-link c-bolt-link--headline c-bolt-link--display-inline c-bolt-link--valign-center"
+    this is a headline
+    <span class="e-bolt-text-link__icon-after"
+          aria-hidden="true"
     >
-      <ssr-keep for="bolt-link"
-                class="c-bolt-link__text"
+      <bolt-icon name="chevron-right"
+                 aria-hidden="true"
       >
-        this is a headline
-      </ssr-keep>
-      <ssr-keep for="bolt-link"
-                class="c-bolt-link__icon"
-      >
-        <bolt-icon slot="after"
-                   name="chevron-right"
-                   aria-hidden="true"
-        >
-          <span class="c-bolt-icon c-bolt-icon--chevron-right">
-            <svg class="c-bolt-icon__icon"
-                 xmlns="http://www.w3.org/2000/svg"
-                 viewbox="0 0 32 32"
+        <span class="c-bolt-icon c-bolt-icon--chevron-right">
+          <svg class="c-bolt-icon__icon"
+               xmlns="http://www.w3.org/2000/svg"
+               viewbox="0 0 32 32"
+          >
+            <path fill="var(--bolt-theme-icon, currentColor)"
+                  fill-rule="evenodd"
+                  d="M13 7c-.6-.5-1.4-.5-2 0-.5.6-.5 1.4 0 2l7.1 7-7 7a1.3 1.3 0 00.9 2.3c.3 0 .7-.1 1-.4l8-8c.5-.5.5-1.3 0-1.8l-8-8z"
             >
-              <path fill="var(--bolt-theme-icon, currentColor)"
-                    fill-rule="evenodd"
-                    d="M13 7c-.6-.5-1.4-.5-2 0-.5.6-.5 1.4 0 2l7.1 7-7 7a1.3 1.3 0 00.9 2.3c.3 0 .7-.1 1-.4l8-8c.5-.5.5-1.3 0-1.8l-8-8z"
-              >
-              </path>
-            </svg>
-          </span>
-        </bolt-icon>
-      </ssr-keep>
-    </a>
-  </bolt-link>
+            </path>
+          </svg>
+        </span>
+      </bolt-icon>
+    </span>
+  </a>
 </h2>
 `;
 

--- a/packages/components/bolt-headline/package.json
+++ b/packages/components/bolt-headline/package.json
@@ -16,8 +16,8 @@
   "style": "src/headline.scss",
   "dependencies": {
     "@bolt/components-icon": "^4.4.0",
-    "@bolt/components-link": "^4.4.0",
-    "@bolt/core-v3.x": "^4.4.0"
+    "@bolt/core-v3.x": "^4.4.0",
+    "@bolt/elements-text-link": "^4.4.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/components/bolt-headline/src/_typography.twig
+++ b/packages/components/bolt-headline/src/_typography.twig
@@ -106,18 +106,36 @@
     </span>
   {% endif %}
   {%- if url -%}
-    {% set linkVars = {
-      text: text,
-      url: url,
-      is_headline: (type != "text")
+
+    {% set _link_attributes = {
+      href: url
     } %}
+
     {% if target %}
-      {% set linkVars = linkVars | merge({ target: target }) %}
+      {% set _link_attributes = _link_attributes|merge({
+        target: target
+      }) %}
     {% endif %}
+
+    {% set _link_props = {
+      content: text,
+      reversed_underline: (type != "text"),
+      attributes: _link_attributes,
+    } %}
+
     {% if icon %}
-      {% set linkVars = linkVars | merge({ icon: icon }) %}
+      {% set _icon_rendered %}
+        {% include '@bolt-components-icon/icon.twig' with icon only %}
+      {% endset %}
+
+      {% if iconPosition == 'before' %}
+        {% set _link_props = _link_props | merge({ icon_before: _icon_rendered }) %}
+      {% else %}
+        {% set _link_props = _link_props | merge({ icon_after: _icon_rendered }) %}
+      {% endif %}
     {% endif %}
-    {% include "@bolt-components-link/link.twig" with linkVars only %}
+
+    {% include "@bolt-elements-text-link/text-link.twig" with _link_props only %}
   {%- else -%}
     {% if hasIcon or quoted %}<span class="c-bolt-headline__text">{% endif %}
       {{- iconBefore -}}

--- a/packages/components/bolt-headline/src/_typography.twig
+++ b/packages/components/bolt-headline/src/_typography.twig
@@ -129,9 +129,9 @@
       {% endset %}
 
       {% if iconPosition == 'before' %}
-        {% set _link_props = _link_props | merge({ icon_before: _icon_rendered }) %}
+        {% set _link_props = _link_props|merge({ icon_before: _icon_rendered }) %}
       {% else %}
-        {% set _link_props = _link_props | merge({ icon_after: _icon_rendered }) %}
+        {% set _link_props = _link_props|merge({ icon_after: _icon_rendered }) %}
       {% endif %}
     {% endif %}
 


### PR DESCRIPTION
## Jira

[https://pegadigitalit.atlassian.net/browse/DS-600](https://pegadigitalit.atlassian.net/browse/DS-600)

## Summary

Replace `component-link` with `element-text-link` in the `bolt-headline` component.

## Details

This is part of the ongoing campaign to deprecate the `component-link`.

## How to test

Review the code changes and the text demo for `bolt-headline`.

## Release notes

Replace component-link with element-text-link in the bolt-headline component.
