### PR TITLE
Fix: layout demo typos

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/30-layouts/layout/-10-layout-template.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/30-layouts/layout/-10-layout-template.twig
@@ -192,7 +192,10 @@
 {% set twig_markup %}
 {% verbatim %}
 {% include '@bolt-layouts-layout/layout.twig' with {
-  template: '67/33@from-small 75/25@from-medium',
+  template: [
+    '67/33@from-small',
+    '75/25@from-medium',
+  ],
   ...
 } only %}
 {% endverbatim %}

--- a/docs-site/src/pages/pattern-lab/_patterns/30-layouts/layout/-15-layout-sub-template.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/30-layouts/layout/-15-layout-sub-template.twig
@@ -55,7 +55,9 @@
   {% endset %}
   {% include '@bolt-layouts-layout/layout.twig' with {
     content: layout_items,
-    template: 'full-vertical-push-last-item',
+    template: [
+      'full-vertical-push-last-item',
+    ],
   } only %}
 {% endset %}
 
@@ -70,7 +72,9 @@
 {% endset %}
 {% include '@bolt-layouts-layout/layout.twig' with {
   content: layout_items,
-  template: 'halves@from-small',
+  template: [
+    'halves@from-small',
+  ],
 } only %}
 {% endverbatim %}
 {% endset %}

--- a/docs-site/src/pages/pattern-lab/_patterns/30-layouts/layout/-35-layout-horizontal-alignment.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/30-layouts/layout/-35-layout-horizontal-alignment.twig
@@ -8,7 +8,7 @@
 {% endset %}
 
 {% set demo %}
-  {% set schema = bolt.data.components['@bolt-layouts-layout'].schema %}
+  {% set schema = bolt.data.components['@bolt-layouts-layout'].schema['layout'] %}
   {% for alignment in schema.properties.align_items.enum %}
     <bolt-layout template="75" align-items="{{ alignment }}">
       <bolt-layout-item>
@@ -21,7 +21,9 @@
 {% set twig_markup %}
 {% verbatim %}
 {% include '@bolt-layouts-layout/layout.twig' with {
-  template: '75',
+  template: [
+    '75',
+  ],
   align_items: 'center',
   ...
 } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/30-layouts/layout/-40-layout-vertical-alignment.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/30-layouts/layout/-40-layout-vertical-alignment.twig
@@ -9,7 +9,7 @@
 {% endset %}
 
 {% set demo %}
-  {% set schema = bolt.data.components['@bolt-layouts-layout'].schema %}
+  {% set schema = bolt.data.components['@bolt-layouts-layout'].schema['layout'] %}
   {% for alignment in schema.properties.valign_items.enum %}
     <bolt-text headline font-size="xxsmall" text-transform="uppercase" letter-spacing="wide">Vertically aligned {{ alignment }}</bolt-text>
     <bolt-layout template="halves" valign-items="{{ alignment }}" padding-top="none">
@@ -30,7 +30,9 @@
 {% set twig_markup %}
 {% verbatim %}
 {% include '@bolt-layouts-layout/layout.twig' with {
-  template: 'halves',
+  template: [
+    'halves',
+  ],
   valign_items: 'center',
   ...
 } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/30-layouts/layout/-45-layout-item-vertical-alignment.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/30-layouts/layout/-45-layout-item-vertical-alignment.twig
@@ -136,7 +136,9 @@
 
 {% include '@bolt-layouts-layout/layout.twig' with {
   content: layout_items,
-  template: 'halves',
+  template: [
+    'halves',
+  ],
 } only %}
 {% endverbatim %}
 {% endset %}

--- a/docs-site/src/pages/pattern-lab/_patterns/30-layouts/layout/-50-layout-item-order.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/30-layouts/layout/-50-layout-item-order.twig
@@ -45,7 +45,9 @@
 
 {% include '@bolt-layouts-layout/layout.twig' with {
   content: layout_items,
-  template: 'thirds@from-small',
+  template: [
+    'thirds@from-small',
+  ],
 } only %}
 {% endverbatim %}
 {% endset %}


### PR DESCRIPTION
## Summary

Fixes a few typos in the Layout docs.

## How to test

Run the branch locally and check the layout docs. Make sure whenever example code is demonstrating `template`, the values are passed as array, not string.