### PR TITLE
WWW-920 Add preview image chip and re-order preview and checklist in mobile view

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/75-optimized-campaign-landing/-05-oclp-gated-pdf.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/75-optimized-campaign-landing/-05-oclp-gated-pdf.twig
@@ -167,16 +167,25 @@
     {% set carousel_and_list %}
       {% set carousel %}
         {% set slide %}
-          {% include '@bolt-elements-image/image.twig' with {
-            fill: true,
-            attributes: {
-              alt: 'Alt text.',
-              src: 'https://via.placeholder.com/400x225',
-              width: 400,
-              height: 225,
-              loading: 'lazy',
-            },
-          } only %}
+          <div class="c-base-ocpl-image-preview">
+            {% include '@bolt-elements-image/image.twig' with {
+              fill: true,
+              attributes: {
+                alt: 'Alt text.',
+                src: 'https://via.placeholder.com/400x225',
+                width: 400,
+                height: 225,
+                loading: 'lazy',
+              },
+            } only %}
+            <div class="c-base-ocpl-image-preview__chip">
+              {% include '@bolt-components-chip/chip.twig' with {
+                text: 'Preview',
+                border_radius: 'small',
+                color: 'violet',
+              } only %}
+            </div>
+          </div>
         {% endset %}
         {% include '@bolt-components-carousel/carousel.twig' with {
           slides: [

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/75-optimized-campaign-landing/-05-oclp-gated-pdf.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/75-optimized-campaign-landing/-05-oclp-gated-pdf.twig
@@ -157,126 +157,144 @@
       tag: 'h1',
       size: 'xxxlarge',
     } only %}
-    {% include '@bolt-components-headline/text.twig' with {
-      text: 'This is the body. Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis numquam quidem vitae minus deserunt, qui libero autem, modi dolorem cum nisi asperiores beatae error hic architecto nobis saepe, maiores eligendi.Lorem ipsum dolor, sit amet consectetur adipisicing elit. Iure quam ipsum commodi accusantium eligendi, soluta, unde incidunt omnis officiis eos aut quae culpa laudantium consequatur! Quasi repellat odit doloremque rerum.',
-    } only %}
-    {% include '@bolt-components-headline/text.twig' with {
-      text: 'Veritatis numquam quidem vitae minus deserunt, qui libero autem, modi dolorem cum nisi asperiores beatae error hic architecto nobis saepe, maiores eligendi. Lorem ipsum dolor, sit amet consectetur adipisicing elit. Iure quam ipsum commodi accusantium eligendi, soluta.',
-    } only %}
+
+    {% set text_content %}
+      {% include '@bolt-components-headline/text.twig' with {
+        text: 'This is the body. Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis numquam quidem vitae minus deserunt, qui libero autem, modi dolorem cum nisi asperiores beatae error hic architecto nobis saepe, maiores eligendi.Lorem ipsum dolor, sit amet consectetur adipisicing elit. Iure quam ipsum commodi accusantium eligendi, soluta, unde incidunt omnis officiis eos aut quae culpa laudantium consequatur! Quasi repellat odit doloremque rerum.',
+      } only %}
+      {% include '@bolt-components-headline/text.twig' with {
+        text: 'Veritatis numquam quidem vitae minus deserunt, qui libero autem, modi dolorem cum nisi asperiores beatae error hic architecto nobis saepe, maiores eligendi. Lorem ipsum dolor, sit amet consectetur adipisicing elit. Iure quam ipsum commodi accusantium eligendi, soluta.',
+      } only %}
+    {% endset %}
 
     {% set carousel_and_list %}
-      {% set carousel %}
-        {% set slide %}
-          <div class="c-base-ocpl-image-preview">
-            {% include '@bolt-elements-image/image.twig' with {
-              fill: true,
-              attributes: {
-                alt: 'Alt text.',
-                src: 'https://via.placeholder.com/400x225',
-                width: 400,
-                height: 225,
-                loading: 'lazy',
-              },
-            } only %}
-            <div class="c-base-ocpl-image-preview__chip">
-              {% include '@bolt-components-chip/chip.twig' with {
-                text: 'Preview',
-                border_radius: 'small',
-                color: 'violet',
+      {% set layout_content %}
+        {% set carousel %}
+          {% set slide %}
+            <div class="c-base-ocpl-image-preview">
+              {% include '@bolt-elements-image/image.twig' with {
+                fill: true,
+                attributes: {
+                  alt: 'Alt text.',
+                  src: 'https://via.placeholder.com/400x225',
+                  width: 400,
+                  height: 225,
+                  loading: 'lazy',
+                },
               } only %}
+              <div class="c-base-ocpl-image-preview__chip">
+                {% include '@bolt-components-chip/chip.twig' with {
+                  text: 'Preview',
+                  border_radius: 'small',
+                  color: 'violet',
+                } only %}
+              </div>
             </div>
-          </div>
-        {% endset %}
-        {% include '@bolt-components-carousel/carousel.twig' with {
-          slides: [
-            slide,
-            slide,
-            slide,
-            slide,
-            slide,
-          ],
-          nav_button_position: 'outside',
-        } only %}
-      {% endset %}
-      {% set list %}
-        {% set list_content %}
-          {% set icon_check_solid %}
-            {% include '@bolt-elements-icon/icon.twig' with {
-              name: 'check-solid',
-              size: 'medium',
-              color: 'teal',
-            } only %}
           {% endset %}
-          {% set list_text %}
-            {% include '@bolt-components-headline/text.twig' with {
-              text: 'Check list item. Lorem ipsum dolor sit amet consectetur adipisicing elit.',
-              size: 'small',
-              attributes: {
-                class: 'u-bolt-margin-top-xxsmall',
-              }
-            } only %}
-          {% endset %}
-          {% include '@bolt-layouts-layout/layout-item.twig' with {
-            content: icon_check_solid,
-          } only %}
-          {% include '@bolt-layouts-layout/layout-item.twig' with {
-            content: list_text,
-          } only %}
-          {% include '@bolt-layouts-layout/layout-item.twig' with {
-            content: icon_check_solid,
-          } only %}
-          {% include '@bolt-layouts-layout/layout-item.twig' with {
-            content: list_text,
-          } only %}
-          {% include '@bolt-layouts-layout/layout-item.twig' with {
-            content: icon_check_solid,
-          } only %}
-          {% include '@bolt-layouts-layout/layout-item.twig' with {
-            content: list_text,
-          } only %}
-          {% include '@bolt-layouts-layout/layout-item.twig' with {
-            content: icon_check_solid,
-          } only %}
-          {% include '@bolt-layouts-layout/layout-item.twig' with {
-            content: list_text,
-          } only %}
-          {% include '@bolt-layouts-layout/layout-item.twig' with {
-            content: icon_check_solid,
-          } only %}
-          {% include '@bolt-layouts-layout/layout-item.twig' with {
-            content: list_text,
+          {% include '@bolt-components-carousel/carousel.twig' with {
+            slides: [
+              slide,
+              slide,
+              slide,
+              slide,
+              slide,
+            ],
+            nav_button_position: 'outside',
           } only %}
         {% endset %}
-        {% include '@bolt-layouts-layout/layout.twig' with {
-          content: list_content,
-          gutter: 'small',
-          row_gutter: 'small',
-          template: [
-            'flag',
-          ],
-          attributes: {
-            style: '--l-bolt-layout-flag-media-width: 1.5rem',
-          },
+        {% set list %}
+          {% set list_content %}
+            {% set icon_check_solid %}
+              {% include '@bolt-elements-icon/icon.twig' with {
+                name: 'check-solid',
+                size: 'medium',
+                color: 'teal',
+              } only %}
+            {% endset %}
+            {% set list_text %}
+              {% include '@bolt-components-headline/text.twig' with {
+                text: 'Check list item. Lorem ipsum dolor sit amet consectetur adipisicing elit.',
+                size: 'small',
+                attributes: {
+                  class: 'u-bolt-margin-top-xxsmall',
+                }
+              } only %}
+            {% endset %}
+            {% include '@bolt-layouts-layout/layout-item.twig' with {
+              content: icon_check_solid,
+            } only %}
+            {% include '@bolt-layouts-layout/layout-item.twig' with {
+              content: list_text,
+            } only %}
+            {% include '@bolt-layouts-layout/layout-item.twig' with {
+              content: icon_check_solid,
+            } only %}
+            {% include '@bolt-layouts-layout/layout-item.twig' with {
+              content: list_text,
+            } only %}
+            {% include '@bolt-layouts-layout/layout-item.twig' with {
+              content: icon_check_solid,
+            } only %}
+            {% include '@bolt-layouts-layout/layout-item.twig' with {
+              content: list_text,
+            } only %}
+            {% include '@bolt-layouts-layout/layout-item.twig' with {
+              content: icon_check_solid,
+            } only %}
+            {% include '@bolt-layouts-layout/layout-item.twig' with {
+              content: list_text,
+            } only %}
+            {% include '@bolt-layouts-layout/layout-item.twig' with {
+              content: icon_check_solid,
+            } only %}
+            {% include '@bolt-layouts-layout/layout-item.twig' with {
+              content: list_text,
+            } only %}
+          {% endset %}
+          {% include '@bolt-layouts-layout/layout.twig' with {
+            content: list_content,
+            gutter: 'small',
+            row_gutter: 'small',
+            template: [
+              'flag',
+            ],
+            attributes: {
+              style: '--l-bolt-layout-flag-media-width: 1.5rem',
+            },
+          } only %}
+        {% endset %}
+        {% include '@bolt-layouts-layout/layout-item.twig' with {
+          content: carousel,
+        } only %}
+        {% include '@bolt-layouts-layout/layout-item.twig' with {
+          content: list,
         } only %}
       {% endset %}
+      {% include '@bolt-layouts-layout/layout.twig' with {
+        content: layout_content,
+        gutter: 'large',
+        padding_top: 'small',
+        padding_bottom: 'small',
+        template: [
+          'tiles@from-medium',
+        ],
+        attributes: {
+          style: '--l-bolt-layout-tile-min-width: 300px',
+        }
+      } only %}
+    {% endset %}
+
+    {% set layout_content %}
       {% include '@bolt-layouts-layout/layout-item.twig' with {
-        content: carousel,
+        content: carousel_and_list,
       } only %}
       {% include '@bolt-layouts-layout/layout-item.twig' with {
-        content: list,
+        content: text_content,
+        order: 'first@from-medium',
       } only %}
     {% endset %}
     {% include '@bolt-layouts-layout/layout.twig' with {
-      content: carousel_and_list,
-      gutter: 'large',
-      padding_top: 'small',
-      padding_bottom: 'small',
-      template: [
-        'tiles@from-medium',
-      ],
-      attributes: {
-        style: '--l-bolt-layout-tile-min-width: 300px',
-      }
+      content: layout_content,
     } only %}
   {% endset %}
   {% set form_content %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/75-optimized-campaign-landing/-10-oclp-gated-external-link.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/75-optimized-campaign-landing/-10-oclp-gated-external-link.twig
@@ -157,140 +157,163 @@
       tag: 'h1',
       size: 'xxxlarge',
     } only %}
-    {% include '@bolt-components-headline/text.twig' with {
-      text: 'This is the body. Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis numquam quidem vitae minus deserunt, qui libero autem, modi dolorem cum nisi asperiores beatae error hic architecto nobis saepe, maiores eligendi.Lorem ipsum dolor, sit amet consectetur adipisicing elit. Iure quam ipsum commodi accusantium eligendi, soluta, unde incidunt omnis officiis eos aut quae culpa laudantium consequatur! Quasi repellat odit doloremque rerum.',
-    } only %}
+    
+    {% set text_content %}
+      {% include '@bolt-components-headline/text.twig' with {
+        text: 'This is the body. Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis numquam quidem vitae minus deserunt, qui libero autem, modi dolorem cum nisi asperiores beatae error hic architecto nobis saepe, maiores eligendi.Lorem ipsum dolor, sit amet consectetur adipisicing elit. Iure quam ipsum commodi accusantium eligendi, soluta, unde incidunt omnis officiis eos aut quae culpa laudantium consequatur! Quasi repellat odit doloremque rerum.',
+      } only %}
+    {% endset %}
 
     {% set preview_and_list %}
-      {% set preview %}
-        {% set preview_image %}
-          <div class="c-base-ocpl-image-preview">
-            {% include '@bolt-elements-image/image.twig' with {
-              fill: true,
-              attributes: {
-                src: 'https://via.placeholder.com/2400x1800',
-                alt: 'Alt text.',
-                width: 2400,
-                height: 1800,
-                loading: 'lazy',
-              }
-            } only %}
-            <div class="c-base-ocpl-image-preview__chip">
-              {% include '@bolt-components-chip/chip.twig' with {
-                text: 'Preview',
-                border_radius: 'small',
-                color: 'violet',
+      {% set layout_content %}
+        {% set preview %}
+          {% set preview_image %}
+            <div class="c-base-ocpl-image-preview">
+              {% include '@bolt-elements-image/image.twig' with {
+                fill: true,
+                attributes: {
+                  src: 'https://via.placeholder.com/2400x1800',
+                  alt: 'Alt text.',
+                  width: 2400,
+                  height: 1800,
+                  loading: 'lazy',
+                }
               } only %}
+              <div class="c-base-ocpl-image-preview__chip">
+                {% include '@bolt-components-chip/chip.twig' with {
+                  text: 'Preview',
+                  border_radius: 'small',
+                  color: 'violet',
+                } only %}
+              </div>
             </div>
-          </div>
-        {% endset %}
-        {% include '@bolt-components-trigger/trigger.twig' with {
-          content: preview_image,
-          display: 'block',
-          cursor: 'zoom-in',
-          attributes: {
-            'data-bolt-modal-target': '#js-bolt-modal-preview-image',
-          },
-        } only %}
-        {% include '@bolt-components-modal/modal.twig' with {
-          content: preview_image,
-          theme: 'none',
-          spacing: 'none',
-          width: 'regular',
-          scroll: 'overall',
-          attributes: {
-            id: 'js-bolt-modal-preview-image',
-          },
-        } only %}
-        {% include '@bolt-components-headline/text.twig' with {
-          text: 'Click to enlarge',
-          size: 'xsmall',
-          align: 'center',
-        } only %}
-      {% endset %}
-      {% set list %}
-        {% set list_content %}
-          {% set icon_check_solid %}
-            {% include '@bolt-elements-icon/icon.twig' with {
-              name: 'check-solid',
-              size: 'medium',
-              color: 'teal',
-            } only %}
           {% endset %}
-          {% set list_text %}
-            {% include '@bolt-components-headline/text.twig' with {
-              text: 'Check list item. Lorem ipsum dolor sit amet consectetur adipisicing elit.',
-              size: 'small',
-              attributes: {
-                class: 'u-bolt-margin-top-xxsmall',
-              }
-            } only %}
-          {% endset %}
-          {% include '@bolt-layouts-layout/layout-item.twig' with {
-            content: icon_check_solid,
+          {% include '@bolt-components-trigger/trigger.twig' with {
+            content: preview_image,
+            display: 'block',
+            cursor: 'zoom-in',
+            attributes: {
+              'data-bolt-modal-target': '#js-bolt-modal-preview-image',
+            },
           } only %}
-          {% include '@bolt-layouts-layout/layout-item.twig' with {
-            content: list_text,
+          {% include '@bolt-components-modal/modal.twig' with {
+            content: preview_image,
+            theme: 'none',
+            spacing: 'none',
+            width: 'regular',
+            scroll: 'overall',
+            attributes: {
+              id: 'js-bolt-modal-preview-image',
+            },
           } only %}
-          {% include '@bolt-layouts-layout/layout-item.twig' with {
-            content: icon_check_solid,
-          } only %}
-          {% include '@bolt-layouts-layout/layout-item.twig' with {
-            content: list_text,
-          } only %}
-          {% include '@bolt-layouts-layout/layout-item.twig' with {
-            content: icon_check_solid,
-          } only %}
-          {% include '@bolt-layouts-layout/layout-item.twig' with {
-            content: list_text,
-          } only %}
-          {% include '@bolt-layouts-layout/layout-item.twig' with {
-            content: icon_check_solid,
-          } only %}
-          {% include '@bolt-layouts-layout/layout-item.twig' with {
-            content: list_text,
-          } only %}
-          {% include '@bolt-layouts-layout/layout-item.twig' with {
-            content: icon_check_solid,
-          } only %}
-          {% include '@bolt-layouts-layout/layout-item.twig' with {
-            content: list_text,
+          {% include '@bolt-components-headline/text.twig' with {
+            text: 'Click to enlarge',
+            size: 'xsmall',
+            align: 'center',
           } only %}
         {% endset %}
-        {% include '@bolt-layouts-layout/layout.twig' with {
-          content: list_content,
-          gutter: 'small',
-          row_gutter: 'small',
-          template: [
-            'flag',
-          ],
-          attributes: {
-            style: '--l-bolt-layout-flag-media-width: 1.5rem',
-          },
+        {% set list %}
+          {% set list_content %}
+            {% set icon_check_solid %}
+              {% include '@bolt-elements-icon/icon.twig' with {
+                name: 'check-solid',
+                size: 'medium',
+                color: 'teal',
+              } only %}
+            {% endset %}
+            {% set list_text %}
+              {% include '@bolt-components-headline/text.twig' with {
+                text: 'Check list item. Lorem ipsum dolor sit amet consectetur adipisicing elit.',
+                size: 'small',
+                attributes: {
+                  class: 'u-bolt-margin-top-xxsmall',
+                }
+              } only %}
+            {% endset %}
+            {% include '@bolt-layouts-layout/layout-item.twig' with {
+              content: icon_check_solid,
+            } only %}
+            {% include '@bolt-layouts-layout/layout-item.twig' with {
+              content: list_text,
+            } only %}
+            {% include '@bolt-layouts-layout/layout-item.twig' with {
+              content: icon_check_solid,
+            } only %}
+            {% include '@bolt-layouts-layout/layout-item.twig' with {
+              content: list_text,
+            } only %}
+            {% include '@bolt-layouts-layout/layout-item.twig' with {
+              content: icon_check_solid,
+            } only %}
+            {% include '@bolt-layouts-layout/layout-item.twig' with {
+              content: list_text,
+            } only %}
+            {% include '@bolt-layouts-layout/layout-item.twig' with {
+              content: icon_check_solid,
+            } only %}
+            {% include '@bolt-layouts-layout/layout-item.twig' with {
+              content: list_text,
+            } only %}
+            {% include '@bolt-layouts-layout/layout-item.twig' with {
+              content: icon_check_solid,
+            } only %}
+            {% include '@bolt-layouts-layout/layout-item.twig' with {
+              content: list_text,
+            } only %}
+          {% endset %}
+          {% include '@bolt-layouts-layout/layout.twig' with {
+            content: list_content,
+            gutter: 'small',
+            row_gutter: 'small',
+            template: [
+              'flag',
+            ],
+            attributes: {
+              style: '--l-bolt-layout-flag-media-width: 1.5rem',
+            },
+          } only %}
+        {% endset %}
+        {% include '@bolt-layouts-layout/layout-item.twig' with {
+          content: preview,
+        } only %}
+        {% include '@bolt-layouts-layout/layout-item.twig' with {
+          content: list,
         } only %}
       {% endset %}
+      {% include '@bolt-layouts-layout/layout.twig' with {
+        content: layout_content,
+        gutter: 'large',
+        padding_top: 'small',
+        padding_bottom: 'small',
+        template: [
+          'tiles@from-medium',
+        ],
+        attributes: {
+          style: '--l-bolt-layout-tile-min-width: 300px',
+        }
+      } only %}
+    {% endset %}
+
+    {% set text_disclaimer %}
+      {% include '@bolt-components-headline/text.twig' with {
+        text: 'Veritatis numquam quidem vitae minus deserunt, qui libero autem, modi dolorem cum nisi asperiores beatae error hic architecto nobis saepe, maiores eligendi. Lorem ipsum dolor, sit amet consectetur adipisicing elit. Iure quam ipsum commodi accusantium eligendi, soluta.',
+      } only %}
+    {% endset %}
+
+    {% set layout_content %}
       {% include '@bolt-layouts-layout/layout-item.twig' with {
-        content: preview,
+        content: preview_and_list,
       } only %}
       {% include '@bolt-layouts-layout/layout-item.twig' with {
-        content: list,
+        content: text_content,
+        order: 'first@from-medium',
+      } only %}
+      {% include '@bolt-layouts-layout/layout-item.twig' with {
+        content: text_disclaimer,
       } only %}
     {% endset %}
     {% include '@bolt-layouts-layout/layout.twig' with {
-      content: preview_and_list,
-      gutter: 'large',
-      padding_top: 'small',
-      padding_bottom: 'small',
-      template: [
-        'tiles@from-medium',
-      ],
-      attributes: {
-        style: '--l-bolt-layout-tile-min-width: 300px',
-      }
-    } only %}
-
-    {% include '@bolt-components-headline/text.twig' with {
-      text: 'Veritatis numquam quidem vitae minus deserunt, qui libero autem, modi dolorem cum nisi asperiores beatae error hic architecto nobis saepe, maiores eligendi. Lorem ipsum dolor, sit amet consectetur adipisicing elit. Iure quam ipsum commodi accusantium eligendi, soluta.',
+      content: layout_content,
     } only %}
   {% endset %}
   {% set form_content %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/75-optimized-campaign-landing/-10-oclp-gated-external-link.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/75-optimized-campaign-landing/-10-oclp-gated-external-link.twig
@@ -164,16 +164,25 @@
     {% set preview_and_list %}
       {% set preview %}
         {% set preview_image %}
-          {% include '@bolt-elements-image/image.twig' with {
-            fill: true,
-            attributes: {
-              src: 'https://via.placeholder.com/2400x1800',
-              alt: 'Alt text.',
-              width: 2400,
-              height: 1800,
-              loading: 'lazy',
-            }
-          } only %}
+          <div class="c-base-ocpl-image-preview">
+            {% include '@bolt-elements-image/image.twig' with {
+              fill: true,
+              attributes: {
+                src: 'https://via.placeholder.com/2400x1800',
+                alt: 'Alt text.',
+                width: 2400,
+                height: 1800,
+                loading: 'lazy',
+              }
+            } only %}
+            <div class="c-base-ocpl-image-preview__chip">
+              {% include '@bolt-components-chip/chip.twig' with {
+                text: 'Preview',
+                border_radius: 'small',
+                color: 'violet',
+              } only %}
+            </div>
+          </div>
         {% endset %}
         {% include '@bolt-components-trigger/trigger.twig' with {
           content: preview_image,

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/75-optimized-campaign-landing/-15-oclp-gated-video.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/75-optimized-campaign-landing/-15-oclp-gated-video.twig
@@ -149,14 +149,17 @@
       tag: 'h1',
       size: 'xxxlarge',
     } only %}
-    {% include '@bolt-components-headline/text.twig' with {
-      text: 'This is the body. Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis numquam quidem vitae minus deserunt, qui libero autem, modi dolorem cum nisi asperiores beatae error hic architecto nobis saepe, maiores eligendi.Lorem ipsum dolor, sit amet consectetur adipisicing elit. Iure quam ipsum commodi accusantium eligendi, soluta, unde incidunt omnis officiis eos aut quae culpa laudantium consequatur! Quasi repellat odit doloremque rerum.',
-    } only %}
-    {% include '@bolt-components-headline/text.twig' with {
-      text: 'Veritatis numquam quidem vitae minus deserunt, qui libero autem, modi dolorem cum nisi asperiores beatae error hic architecto nobis saepe, maiores eligendi. Lorem ipsum dolor, sit amet consectetur adipisicing elit. Iure quam ipsum commodi accusantium eligendi, soluta.',
-    } only %}
 
-    <bolt-stack>
+    {% set text_content %}
+      {% include '@bolt-components-headline/text.twig' with {
+        text: 'This is the body. Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis numquam quidem vitae minus deserunt, qui libero autem, modi dolorem cum nisi asperiores beatae error hic architecto nobis saepe, maiores eligendi.Lorem ipsum dolor, sit amet consectetur adipisicing elit. Iure quam ipsum commodi accusantium eligendi, soluta, unde incidunt omnis officiis eos aut quae culpa laudantium consequatur! Quasi repellat odit doloremque rerum.',
+      } only %}
+      {% include '@bolt-components-headline/text.twig' with {
+        text: 'Veritatis numquam quidem vitae minus deserunt, qui libero autem, modi dolorem cum nisi asperiores beatae error hic architecto nobis saepe, maiores eligendi. Lorem ipsum dolor, sit amet consectetur adipisicing elit. Iure quam ipsum commodi accusantium eligendi, soluta.',
+      } only %}
+    {% endset %}
+
+    {% set video %}
       {% set video %}
         {% set video_embed %}
           <video-js
@@ -216,66 +219,84 @@
           id: 'js-bolt-modal-video',
         },
       } only %}
-    </bolt-stack>
+    {% endset %}
+    
+    {% set checklist %}
+      {% set layout_content %}
+        {% set icon_check_solid %}
+          {% include '@bolt-elements-icon/icon.twig' with {
+            name: 'check-solid',
+            size: 'medium',
+            color: 'teal',
+          } only %}
+        {% endset %}
+        {% set list_text %}
+          {% include '@bolt-components-headline/text.twig' with {
+            text: 'Check list item. Lorem ipsum dolor sit amet consectetur adipisicing elit.',
+            size: 'small',
+            attributes: {
+              class: 'u-bolt-margin-top-xxsmall',
+            }
+          } only %}
+        {% endset %}
+        {% include '@bolt-layouts-layout/layout-item.twig' with {
+          content: icon_check_solid,
+        } only %}
+        {% include '@bolt-layouts-layout/layout-item.twig' with {
+          content: list_text,
+        } only %}
+        {% include '@bolt-layouts-layout/layout-item.twig' with {
+          content: icon_check_solid,
+        } only %}
+        {% include '@bolt-layouts-layout/layout-item.twig' with {
+          content: list_text,
+        } only %}
+        {% include '@bolt-layouts-layout/layout-item.twig' with {
+          content: icon_check_solid,
+        } only %}
+        {% include '@bolt-layouts-layout/layout-item.twig' with {
+          content: list_text,
+        } only %}
+        {% include '@bolt-layouts-layout/layout-item.twig' with {
+          content: icon_check_solid,
+        } only %}
+        {% include '@bolt-layouts-layout/layout-item.twig' with {
+          content: list_text,
+        } only %}
+        {% include '@bolt-layouts-layout/layout-item.twig' with {
+          content: icon_check_solid,
+        } only %}
+        {% include '@bolt-layouts-layout/layout-item.twig' with {
+          content: list_text,
+        } only %}
+      {% endset %}
+      {% include '@bolt-layouts-layout/layout.twig' with {
+        content: layout_content,
+        gutter: 'small',
+        row_gutter: 'small',
+        template: [
+          'flag',
+        ],
+        attributes: {
+          style: '--l-bolt-layout-flag-media-width: 1.5rem',
+        },
+      } only %}
+    {% endset %}
 
-    {% set list_content %}
-      {% set icon_check_solid %}
-        {% include '@bolt-elements-icon/icon.twig' with {
-          name: 'check-solid',
-          size: 'medium',
-          color: 'teal',
-        } only %}
-      {% endset %}
-      {% set list_text %}
-        {% include '@bolt-components-headline/text.twig' with {
-          text: 'Check list item. Lorem ipsum dolor sit amet consectetur adipisicing elit.',
-          size: 'small',
-          attributes: {
-            class: 'u-bolt-margin-top-xxsmall',
-          }
-        } only %}
-      {% endset %}
+    {% set layout_content %}
       {% include '@bolt-layouts-layout/layout-item.twig' with {
-        content: icon_check_solid,
+        content: video,
       } only %}
       {% include '@bolt-layouts-layout/layout-item.twig' with {
-        content: list_text,
+        content: checklist,
       } only %}
       {% include '@bolt-layouts-layout/layout-item.twig' with {
-        content: icon_check_solid,
-      } only %}
-      {% include '@bolt-layouts-layout/layout-item.twig' with {
-        content: list_text,
-      } only %}
-      {% include '@bolt-layouts-layout/layout-item.twig' with {
-        content: icon_check_solid,
-      } only %}
-      {% include '@bolt-layouts-layout/layout-item.twig' with {
-        content: list_text,
-      } only %}
-      {% include '@bolt-layouts-layout/layout-item.twig' with {
-        content: icon_check_solid,
-      } only %}
-      {% include '@bolt-layouts-layout/layout-item.twig' with {
-        content: list_text,
-      } only %}
-      {% include '@bolt-layouts-layout/layout-item.twig' with {
-        content: icon_check_solid,
-      } only %}
-      {% include '@bolt-layouts-layout/layout-item.twig' with {
-        content: list_text,
+        content: text_content,
+        order: 'first@from-medium',
       } only %}
     {% endset %}
     {% include '@bolt-layouts-layout/layout.twig' with {
-      content: list_content,
-      gutter: 'small',
-      row_gutter: 'small',
-      template: [
-        'flag',
-      ],
-      attributes: {
-        style: '--l-bolt-layout-flag-media-width: 1.5rem',
-      },
+      content: layout_content,
     } only %}
   {% endset %}
   {% set form_content %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/75-optimized-campaign-landing/oclp.scss
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/75-optimized-campaign-landing/oclp.scss
@@ -115,3 +115,17 @@
     margin-top: calc(var(--bolt-spacing-y-xlarge) * -1);
   }
 }
+
+.c-base-ocpl-image-preview {
+  display: block;
+  position: relative;
+}
+
+.c-base-ocpl-image-preview__chip {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 0;
+  padding: var(--bolt-spacing-y-small) var(--bolt-spacing-x-small);
+  pointer-events: none;
+}


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/WWW-920

## Summary

Updates the Optimized Campaign Landing Page templates with a "preview" chip for image and image carousel, and fixes mobile ordering of preview and checklist.

## Details

1. Added CSS to position the chip
2. Added markup to contain the image and the chip
3. Moved preview and checklist above text content in mobile view for Gated templates

## How to test

Run the branch locally and check the Optimized Campaign Landing Pages. For both Gated PDF and Gated External Link templates, the image or image carousel should have a preview chip in the same style as the preview chip for videos. For all Gated templates, the preview and checklist should render right after the headline in mobile view.