### PR TITLE
DS-648 Update "information" banner colors

### DIFF
--- a/packages/components/bolt-banner/src/banner.scss
+++ b/packages/components/bolt-banner/src/banner.scss
@@ -76,26 +76,12 @@
 
 .c-bolt-banner--status-information {
   position: relative;
-  color: var(--m-bolt-text);
-  border-left-color: var(--m-bolt-link);
+  color: var(--bolt-color-info-dark);
+  border-left-color: var(--bolt-color-info-dark);
   border-left-style: $bolt-border-style;
   border-left-width: $bolt-border-width * 3;
   box-shadow: 0 0 var(--bolt-spacing-y-xsmall) var(--m-bolt-border);
-  background-color: var(--m-bolt-bg);
-
-  &:before {
-    content: '';
-    display: block;
-    opacity: 0.2;
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    pointer-events: none;
-    user-select: none;
-    background-color: var(--bolt-color-white);
-  }
+  background-color: var(--bolt-color-info-light);
 }
 
 /**

--- a/packages/components/bolt-banner/src/banner.scss
+++ b/packages/components/bolt-banner/src/banner.scss
@@ -56,6 +56,14 @@
   --m-bolt-link: var(--bolt-color-black); /* [2] */
 }
 
+@include bolt-repeat-rule(
+  ('bolt-banner[status=information]', ':host(bolt-banner[status=information])')
+) {
+  --m-bolt-text: var(--bolt-color-info-dark); /* [2] */
+  --m-bolt-headline: var(--bolt-color-info-dark); /* [2] */
+  --m-bolt-link: var(--bolt-color-info-dark); /* [2] */
+}
+
 .c-bolt-banner--status-error,
 .c-bolt-banner--status-success {
   color: var(--bolt-color-white);
@@ -77,7 +85,7 @@
 .c-bolt-banner--status-information {
   position: relative;
   color: var(--bolt-color-info-dark);
-  border-left-color: var(--bolt-color-info-dark);
+  border-left-color: var(--bolt-color-info);
   border-left-style: $bolt-border-style;
   border-left-width: $bolt-border-width * 3;
   box-shadow: 0 0 var(--bolt-spacing-y-xsmall) var(--m-bolt-border);


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-648

## Summary

Update the background and text colors of "information" banner.

## Details

As requested by Academy/Collaboration Center, banners with "information" status will now have light blue background and dark blue text.

## How to test

- Review code changes
- Review Banner demos, particularly "status" demo

## Release notes

### Visual changes
- Banner with status "information" are now light blue with dark blue text. Previously they were white with black text.