### PR TITLE
DS-619 Add support for attributes to each form select option

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/form/60-form-full-campaign-landing.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/form/60-form-full-campaign-landing.twig
@@ -54,22 +54,34 @@
       {
         'type': 'option',
         'value': '',
-        'label': '- Select a Country -'
+        'label': '- Select a Country -',
+        'attributes' : {
+          'disabled': true
+        }
       },
       {
         'type': 'option',
         'value': 'a',
-        'label': 'Argentina'
+        'label': 'Argentina',
+        'attributes' : {
+          'disabled': true
+        }
       },
       {
         'type': 'option',
         'value': 'b',
-        'label': 'Belgium'
+        'label': 'Belgium',
+        'attributes' : {
+          'disabled': true
+        }
       },
       {
         'type': 'option',
         'value': 'c',
-        'label': 'Croatia'
+        'label': 'Croatia',
+        'attributes' : {
+          'disabled': true
+        }
       }
     ]
   } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/modal/55-modal-usage-form.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/modal/55-modal-usage-form.twig
@@ -58,22 +58,34 @@
         {
           type: 'option',
           value: '',
-          label: '- Select a Country -'
+          label: '- Select a Country -',
+          attributes: {
+            disabled: true,
+          }
         },
         {
           type: 'option',
           value: 'a',
-          label: 'Argentina'
+          label: 'Argentina',
+          attributes: {
+            disabled: true,
+          }
         },
         {
           type: 'option',
           value: 'b',
-          label: 'Belgium'
+          label: 'Belgium',
+          attributes: {
+            disabled: true,
+          }
         },
         {
           type: 'option',
           value: 'c',
-          label: 'Croatia'
+          label: 'Croatia',
+          attributes: {
+            disabled: true,
+          }
         }
       ]
     } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/50-d8-careers/00-careers-homepage.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/50-d8-careers/00-careers-homepage.twig
@@ -119,22 +119,34 @@
                 {
                   type: 'option',
                   value: '',
-                  label: '- Select a Country -'
+                  label: '- Select a Country -',
+                  attributes: {
+                    disabled: true,
+                  }
                 },
                 {
                   type: 'option',
                   value: 'a',
-                  label: 'Argentina'
+                  label: 'Argentina',
+                  attributes: {
+                    disabled: true,
+                  }
                 },
                 {
                   type: 'option',
                   value: 'b',
-                  label: 'Belgium'
+                  label: 'Belgium',
+                  attributes: {
+                    disabled: true,
+                  }
                 },
                 {
                   type: 'option',
                   value: 'c',
-                  label: 'Croatia'
+                  label: 'Croatia',
+                  attributes: {
+                    disabled: true,
+                  }
                 }
               ]
             } only %}
@@ -149,12 +161,18 @@
                 {
                   type: 'option',
                   value: '',
-                  label: '- Select a Category -'
+                  label: '- Select a Category -',
+                  attributes: {
+                    disabled: true,
+                  }
                 },
                 {
                   type: 'option',
                   value: 'sales',
-                  label: 'Sales'
+                  label: 'Sales',
+                  attributes: {
+                    disabled: true,
+                  }
                 }
               ]
             } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-customers.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-customers.twig
@@ -485,16 +485,25 @@
               type: 'option',
               value: 'most-viewed',
               label: 'Most viewed',
+              attributes: {
+                disabled: true,
+              },
             },
             {
               type: 'option',
               value: 'most-recent',
               label: 'Most recent',
+              attributes: {
+                disabled: true,
+              },
             },
             {
               type: 'option',
               value: 'alphabetical',
               label: 'Alphabetical',
+              attributes: {
+                disabled: true,
+              },
             }
           ],
           attributes: {

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-pegaworld.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-pegaworld.twig
@@ -367,16 +367,25 @@
               type: 'option',
               value: 'pegaworld-2020',
               label: 'Pegaworld 2020',
+              attributes: {
+                disabled: true,
+              },
             },
             {
               type: 'option',
               value: 'pegaworld-2019',
               label: 'Pegaworld 2019',
+              attributes: {
+                disabled: true,
+              },
             },
             {
               type: 'option',
               value: 'pegaworld-2018',
               label: 'Pegaworld 2018',
+              attributes: {
+                disabled: true,
+              },
             },
           ],
           attributes: {
@@ -539,16 +548,25 @@
               type: 'option',
               value: 'most-viewed',
               label: 'Most viewed',
+              attributes: {
+                disabled: true,
+              },
             },
             {
               type: 'option',
               value: 'most-recent',
               label: 'Most recent',
+              attributes: {
+                disabled: true,
+              },
             },
             {
               type: 'option',
               value: 'by-type',
               label: 'By type',
+              attributes: {
+                disabled: true,
+              },
             }
           ],
           attributes: {

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/70-community/-community-doc-layout.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/70-community/-community-doc-layout.twig
@@ -193,9 +193,9 @@
           type: 'option',
           value: 'published',
           label: 'Published',
+          selected: true,
           attributes: {
             disabled: true,
-            selected: true,
           },
         },
         {

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/70-community/-community-doc-layout.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/70-community/-community-doc-layout.twig
@@ -145,42 +145,66 @@
           type: 'option',
           value: 'draft',
           label: 'Draft',
+          attributes: {
+            disabled: true,
+          },
         },
         {
           type: 'option',
           value: 'sme-review',
           label: 'SME Review',
+          attributes: {
+            disabled: true,
+          },
         },
         {
           type: 'option',
           value: 'editor-review',
           label: 'Editor Review',
+          attributes: {
+            disabled: true,
+          },
         },
         {
           type: 'option',
           value: 'publisher-review',
           label: 'Publisher Review',
+          attributes: {
+            disabled: true,
+          },
         },
         {
           type: 'option',
           value: 'pending-publication',
           label: 'Pending Publication',
+          attributes: {
+            disabled: true,
+          },
         },
         {
           type: 'option',
           value: 'revision-requested',
           label: 'Revision Requested',
+          attributes: {
+            disabled: true,
+          },
         },
         {
           type: 'option',
           value: 'published',
           label: 'Published',
-          selected: true,
+          attributes: {
+            disabled: true,
+            selected: true,
+          },
         },
         {
           type: 'option',
           value: 'unpublished',
           label: 'Unpublished',
+          attributes: {
+            disabled: true,
+          },
         },
       ],
       attributes: {

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/75-optimized-campaign-landing/-05-oclp-gated-pdf.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/75-optimized-campaign-landing/-05-oclp-gated-pdf.twig
@@ -47,21 +47,33 @@
             type: 'option',
             value: '',
             label: 'Select a Country',
+            attributes: {
+              disabled: true,
+            },
           },
           {
             type: 'option',
             value: 'a',
             label: 'Argentina',
+            attributes: {
+              disabled: true,
+            },
           },
           {
             type: 'option',
             value: 'b',
             label: 'Belgium',
+            attributes: {
+              disabled: true,
+            },
           },
           {
             type: 'option',
             value: 'c',
             label: 'Croatia',
+            attributes: {
+              disabled: true,
+            },
           }
         ],
         attributes: {

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/75-optimized-campaign-landing/-10-oclp-gated-external-link.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/75-optimized-campaign-landing/-10-oclp-gated-external-link.twig
@@ -46,21 +46,33 @@
             type: 'option',
             value: '',
             label: 'Select a Country',
+            attributes: {
+              disabled: true,
+            },
           },
           {
             type: 'option',
             value: 'a',
             label: 'Argentina',
+            attributes: {
+              disabled: true,
+            },
           },
           {
             type: 'option',
             value: 'b',
             label: 'Belgium',
+            attributes: {
+              disabled: true,
+            },
           },
           {
             type: 'option',
             value: 'c',
             label: 'Croatia',
+            attributes: {
+              disabled: true,
+            },
           }
         ],
         attributes: {

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/75-optimized-campaign-landing/-15-oclp-gated-video.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/75-optimized-campaign-landing/-15-oclp-gated-video.twig
@@ -40,21 +40,33 @@
             type: 'option',
             value: '',
             label: 'Select a Country',
+            attributes: {
+              disabled: true,
+            },
           },
           {
             type: 'option',
             value: 'a',
             label: 'Argentina',
+            attributes: {
+              disabled: true,
+            },
           },
           {
             type: 'option',
             value: 'b',
             label: 'Belgium',
+            attributes: {
+              disabled: true,
+            },
           },
           {
             type: 'option',
             value: 'c',
             label: 'Croatia',
+            attributes: {
+              disabled: true,
+            },
           }
         ],
         attributes: {

--- a/packages/components/bolt-form/src/inputs/form-select.twig
+++ b/packages/components/bolt-form/src/inputs/form-select.twig
@@ -9,11 +9,11 @@
       {% if option.type == 'optgroup' %}
         <optgroup label="{{ option.label }}">
           {% for sub_option in option.options %}
-            <option value="{{ sub_option.value }}"{{ sub_option.selected ? ' selected="selected"' }}>{{ sub_option.label }}</option>
+            <option value="{{ sub_option.value }}"{{ sub_option.selected ? ' selected="selected"' }} {{ sub_option.disabled ? ' disabled="disabled"' }}>{{ sub_option.label }}</option>
           {% endfor %}
         </optgroup>
       {% elseif option.type == 'option' %}
-        <option value="{{ option.value }}"{{ option.selected ? ' selected="selected"' }}>{{ option.label }}</option>
+        <option value="{{ option.value }}"{{ option.selected ? ' selected="selected"' }} {{ option.disabled ? ' disabled="disabled"' }}>{{ option.label }}</option>
       {% endif %}
     {% endfor %}
   </select>

--- a/packages/components/bolt-form/src/inputs/form-select.twig
+++ b/packages/components/bolt-form/src/inputs/form-select.twig
@@ -6,17 +6,20 @@
 {% spaceless %}
   <select{{ attributes.addClass(classes) }}>
     {% for option in options %}
+      {% set form_select_attributes = option.attributes|default({}) %}
+      {% set option_attributes = create_attribute(form_select_attributes) %}
       {% if option.type == 'optgroup' %}
         <optgroup label="{{ option.label }}">
           {% for sub_option in option.options %}
-            <option value="{{ sub_option.value }}"{{ sub_option.selected ? ' selected="selected"' }} {{ sub_option.disabled ? ' disabled="disabled"' }}>{{ sub_option.label }}</option>
+            <option value="{{ sub_option.value }}"{{ sub_option.selected ? ' selected="selected"' }} {{ option_attributes }}>{{ sub_option.label }}</option>
           {% endfor %}
         </optgroup>
       {% elseif option.type == 'option' %}
-        <option value="{{ option.value }}"{{ option.selected ? ' selected="selected"' }} {{ option.disabled ? ' disabled="disabled"' }}>{{ option.label }}</option>
+        <option value="{{ option.value }}"{{ option.selected ? ' selected="selected"' }}>{{ option.label }}</option>
       {% endif %}
     {% endfor %}
   </select>
+
 
   {% if not attributes.multiple %}
 


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-619

## Summary

Support for attributes to each form select option was added.

## Details

- Every file from `/doc-site` which use `select-option` was updated with an `attributes object`.
- `Form-select.twig` was updated with `attributes object` usage.

## How to test

Make sure passed `props` added to `attributes object` renders properly and work as expected.

## Release notes

Added support for passing attributes to each form select option, see demo page (TODO: add demo page link) for reference.