### PR TITLE
Hotfix: DS-649 Navbar schema key name (take 2)

### DIFF
--- a/packages/components/bolt-navbar/src/navbar-li.twig
+++ b/packages/components/bolt-navbar/src/navbar-li.twig
@@ -1,4 +1,4 @@
-{% set schema = bolt.data.components['@bolt-components-navbar'].schema['navbar-item'] %}
+{% set schema = bolt.data.components['@bolt-components-navbar'].schema['navbar-li'] %}
 {% if enable_json_schema_validation %}
   {{ validate_data_schema(schema, _self)|raw }}
 {% endif %}

--- a/packages/components/bolt-navbar/src/navbar-ul.twig
+++ b/packages/components/bolt-navbar/src/navbar-ul.twig
@@ -1,4 +1,4 @@
-{% set schema = bolt.data.components['@bolt-components-navbar'].schema['navbar-list'] %}
+{% set schema = bolt.data.components['@bolt-components-navbar'].schema['navbar-ul'] %}
 {% if enable_json_schema_validation %}
   {{ validate_data_schema(schema, _self)|raw }}
 {% endif %}


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-649

## Summary
> Note: accidentally merged https://github.com/boltdesignsystem/bolt/pull/2337 into `master`. This one points at `release/4/x`.

Fixes Navbar schema name, broken in https://github.com/boltdesignsystem/bolt/pull/2316 which was released in `v4.5.0`.

## How to test

- Go to Navbar demo: https://boltdesignsystem.com/pattern-lab/?p=components-navbar
- See bugs in console
- Repeat on this hotfix branch and note the bugs are gone