### PR TITLE
DS-468 Fix input height on focus

### DIFF
--- a/packages/components/bolt-form/src/form.scss
+++ b/packages/components/bolt-form/src/form.scss
@@ -616,8 +616,13 @@ $bolt-strength-indicator-transition: var(--bolt-transition);
 
     .c-bolt-input.is-filled,
     .c-bolt-input:focus {
-      padding-top: var(--bolt-spacing-y-small);
-      padding-bottom: var(--bolt-spacing-y-small);
+      padding: calc(var(--bolt-spacing-y-medium) / 2 - 1px)
+        var(--bolt-spacing-x-small); // [Mai] medium/2 matches button vertical spacing.
+
+      @include bolt-mq($until: small) {
+        padding-top: calc(var(--bolt-spacing-y-medium) / 2 - 0.1875rem);
+        padding-bottom: calc(var(--bolt-spacing-y-medium) / 2 - 0.25rem);
+      }
     }
   }
 }


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-468

## Summary

Prevent inputs with label "before" from shifting height on focus.

## Details

As part of https://pegadigitalit.atlassian.net/browse/DS-468, this PR fixes the shift in height that you see when you focus on an input with label "before". Fixing this helps us match the height between the current input and the Multi-select component.

## How to test

- View demo with `labelDisplay: "before"`: `/pattern-lab/?p=components-form-label-positions`
- Click into the input and verify input height does not change.

## Release notes

### Visual changes

Form inputs with label "before" the field (not floating inside) will no longer shift in height when they get focus.
