### PR TITLE
Fix missing icons

### DIFF
--- a/packages/components/bolt-code-snippet/src/code-snippet.js
+++ b/packages/components/bolt-code-snippet/src/code-snippet.js
@@ -1,6 +1,6 @@
 import Prism from 'prismjs';
 import { html, render, ifDefined, unsafeCSS, unsafeHTML } from '@bolt/element';
-import { iconCopyToClipboard } from '@bolt/elements-icon';
+import { iconCopyToClipboard } from '@bolt/elements-icon/src/icons/js/copy-to-clipboard';
 import iconStyles from '@bolt/elements-icon/index.scss';
 import cx from 'classnames/bind';
 import ClipboardJS from 'clipboard';

--- a/packages/components/bolt-typeahead/typeahead.js
+++ b/packages/components/bolt-typeahead/typeahead.js
@@ -6,7 +6,8 @@ import {
   unsafeCSS,
   unsafeHTML,
 } from '@bolt/element';
-import { iconSearch, iconCloseSolid } from '@bolt/elements-icon';
+import { iconSearch } from '@bolt/elements-icon/src/icons/js/search';
+import { iconCloseSolid } from '@bolt/elements-icon/src/icons/js/close-solid';
 import { props } from 'skatejs';
 import { withLitEvents } from '@bolt/core-v3.x/renderers/with-events';
 import iconStyles from '@bolt/elements-icon/index.scss';


### PR DESCRIPTION
## Jira

n/a

## Summary

Fix missing icons in Code Snippet and Typeahead.

## Details

In the conversion to individually exported icons, a couple got missed.

## How to test

Run locally and open Code Snippet and Typeahead demos. Verify there's no console error.