### PR TITLE
DOCS-189: Fix Code Snippet bugs when used inside Table component

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/code-snippet/15-code-snippet-table.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/code-snippet/15-code-snippet-table.twig
@@ -1,0 +1,246 @@
+<div class="c-bolt-code-snippet" data-mode="light">
+  <pre><code>{
+  "FullName": "OpportunityEvents_chn_OpportunityChangeEvent",
+  "Metadata": {
+    "enrichedFields": [
+      {"name": "OwnerId"},
+      {"name": "Name"},
+      {"name": "CloseDate"},
+      {"name": "Probability"}, 
+      {"name": "LastModifiedDate"},
+      {"name": "LastModifiedById"},
+      {"name": "IsClosed"},
+      {"name": "AccountId"},
+      {"name": "CreatedById"},
+      {"name": "CreatedDate"}
+    ],
+    "eventChannel": "OpportunityEvents__chn",
+    "selectedEntity": "OpportunityChangeEvent"
+  }
+} </code></pre>
+</div>
+
+<bolt-table>
+  <table>
+    <thead>
+      <tr>
+        <td style="width: 50%;">Element</td>
+        <td style="width: 89%;">Value</td>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Method</td>
+        <td><code>POST</code></td>
+      </tr>
+      <tr>
+        <td>Request URL</td>
+        <td>Instance URL received in the access token response with a
+          <code>/services/data/v51.0/tooling/sobjects/PlatformEventChannelMember</code>
+          part, for example
+          <code>https://sales-sample-URL.my.salesforce.com/services/data/v51.0/tooling/sobjects/PlatformEventChannelMember</code>
+        </td>
+      </tr>
+      <tr>
+        <td>Sample request body of JSON type with enrichment fields
+          added in an
+          <samp>OpportunityEvents__chn</samp>
+          channel member for an Opportunity entity
+        </td>
+        <td>
+          <div class="c-bolt-code-snippet some-other-class" data-mode="light">
+            <pre><code>{
+  "FullName": "OpportunityEvents_chn_OpportunityChangeEvent",
+  "Metadata": {
+    "enrichedFields": [
+      {"name": "OwnerId"},
+      {"name": "Name"},
+      {"name": "CloseDate"},
+      {"name": "Probability"}, 
+      {"name": "LastModifiedDate"},
+      {"name": "LastModifiedById"},
+      {"name": "IsClosed"},
+      {"name": "AccountId"},
+      {"name": "CreatedById"},
+      {"name": "CreatedDate"}
+    ],
+    "eventChannel": "OpportunityEvents__chn",
+    "selectedEntity": "OpportunityChangeEvent"
+  }
+} </code></pre>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td>Sample request body of JSON type with enrichment fields
+          added in an
+          <samp>OpportunityEvents__chn</samp>
+          channel member for an Opportunity entity
+        </td>
+        <td>
+          <div class="c-bolt-code-snippet some-other-class" data-mode="light">
+            <pre><code>{
+  "FullName": "OpportunityEvents_chn_OpportunityChangeEvent",
+  "Metadata": {
+    "enrichedFields": [
+      {"name": "OwnerId"},
+      {"name": "Name"},
+      {"name": "CloseDate"},
+      {"name": "Probability"}, 
+      {"name": "LastModifiedDate"},
+      {"name": "LastModifiedById"},
+      {"name": "IsClosed"},
+      {"name": "AccountId"},
+      {"name": "CreatedById"},
+      {"name": "CreatedDate"}
+    ],
+    "eventChannel": "OpportunityEvents__chn",
+    "selectedEntity": "OpportunityChangeEvent"
+  }
+} </code></pre>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td>Sample request body of JSON type with enrichment fields
+          added in a <samp>WorkOrderEvents__chn</samp>
+          channel member for a Work Order entity
+        </td>
+        <td>
+          <pre><code>{
+  "FullName": "WorkOrderEvents_chn_ WorkOrderChangeEvent",
+  "Metadata": {
+    "enrichedFields": [
+      {"name": "OwnerId"},
+      {"name": "Subject"},
+      {"name": "WorkOrderNumber"},
+      {"name": "Priority"}, 
+      {"name": "LastModifiedDate"},
+      {"name": "LastModifiedById"},
+      {"name": "IsClosed"},
+      {"name": "AccountId"},
+      {"name": "CreatedById"},
+      {"name": "CreatedDate"}
+    ],
+    "eventChannel": "WorkOrderEvents__chn",
+    "selectedEntity": "WorkOrderChangeEvent"
+  }
+} </code></pre>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</bolt-table>
+
+<bolt-table>
+  <table>
+    <thead>
+      <tr>
+        <td style="width: 50%;">Element</td>
+        <td style="width: 89%;">Value</td>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Method</td>
+        <td><code>POST</code></td>
+      </tr>
+      <tr>
+        <td>Request URL</td>
+        <td>Instance URL received in the access token response with a
+          <code>/services/data/v51.0/tooling/sobjects/PlatformEventChannelMember</code>
+          part, for example
+          <code>https://sales-sample-URL.my.salesforce.com/services/data/v51.0/tooling/sobjects/PlatformEventChannelMember</code>
+        </td>
+      </tr>
+      <tr>
+        <td>Sample request body of JSON type with enrichment fields
+          added in an
+          <samp>OpportunityEvents__chn</samp>
+          channel member for an Opportunity entity
+        </td>
+        <td>
+          <div class="c-bolt-code-snippet some-other-class" data-mode="light">
+            <pre><code>{
+  "FullName": "OpportunityEvents_chn_OpportunityChangeEvent",
+  "Metadata": {
+    "enrichedFields": [
+      {"name": "OwnerId"},
+      {"name": "Name"},
+      {"name": "CloseDate"},
+      {"name": "Probability"}, 
+      {"name": "LastModifiedDate"},
+      {"name": "LastModifiedById"},
+      {"name": "IsClosed"},
+      {"name": "AccountId"},
+      {"name": "CreatedById"},
+      {"name": "CreatedDate"}
+    ],
+    "eventChannel": "OpportunityEvents__chn",
+    "selectedEntity": "OpportunityChangeEvent"
+  }
+} </code></pre>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td>Sample request body of JSON type with enrichment fields
+          added in an
+          <samp>OpportunityEvents__chn</samp>
+          channel member for an Opportunity entity
+        </td>
+        <td>
+          <div class="c-bolt-code-snippet some-other-class" data-mode="light">
+            <pre><code>{
+  "FullName": "OpportunityEvents_chn_OpportunityChangeEvent",
+  "Metadata": {
+    "enrichedFields": [
+      {"name": "OwnerId"},
+      {"name": "Name"},
+      {"name": "CloseDate"},
+      {"name": "Probability"}, 
+      {"name": "LastModifiedDate"},
+      {"name": "LastModifiedById"},
+      {"name": "IsClosed"},
+      {"name": "AccountId"},
+      {"name": "CreatedById"},
+      {"name": "CreatedDate"}
+    ],
+    "eventChannel": "OpportunityEvents__chn",
+    "selectedEntity": "OpportunityChangeEvent"
+  }
+} </code></pre>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td>Sample request body of JSON type with enrichment fields
+          added in a <samp>WorkOrderEvents__chn</samp>
+          channel member for a Work Order entity
+        </td>
+        <td>
+          <pre><code>{
+  "FullName": "WorkOrderEvents_chn_ WorkOrderChangeEvent",
+  "Metadata": {
+    "enrichedFields": [
+      {"name": "OwnerId"},
+      {"name": "Subject"},
+      {"name": "WorkOrderNumber"},
+      {"name": "Priority"}, 
+      {"name": "LastModifiedDate"},
+      {"name": "LastModifiedById"},
+      {"name": "IsClosed"},
+      {"name": "AccountId"},
+      {"name": "CreatedById"},
+      {"name": "CreatedDate"}
+    ],
+    "eventChannel": "WorkOrderEvents__chn",
+    "selectedEntity": "WorkOrderChangeEvent"
+  }
+} </code></pre>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <div slot="caption">This is a table caption</div>
+</bolt-table>

--- a/packages/components/bolt-code-snippet/index.js
+++ b/packages/components/bolt-code-snippet/index.js
@@ -4,7 +4,12 @@ if (codeSnippets.length) {
   import(/* webpackChunkName: 'bolt-code-snippet' */ './src/code-snippet').then(
     ({ BoltCodeSnippet }) => {
       codeSnippets.forEach(el => {
-        const codeSnippetComponent = new BoltCodeSnippet(el);
+        // Workaround for Bolt Table...
+        // Table stringifies the DOM, losing any event binding setup by the Code Snippet component.
+        // So, we don't init any Code Snippets inside tables and let the Table component init them itself when it's ready.
+        if (!el.closest('bolt-table')) {
+          const codeSnippetComponent = new BoltCodeSnippet(el);
+        }
       });
     },
   );

--- a/packages/components/bolt-code-snippet/src/code-snippet.js
+++ b/packages/components/bolt-code-snippet/src/code-snippet.js
@@ -31,7 +31,12 @@ export class BoltCodeSnippet {
   constructor(el) {
     if (!el) return;
     this.el = el;
-    this.init();
+
+    // Ensure component doesn't init twice
+    // @TODO: Enable component to be properly re-initialized?
+    if (!this.el.hasAttribute('data-bolt-ready')) {
+      this.init();
+    }
   }
 
   init() {

--- a/packages/components/bolt-table/package.json
+++ b/packages/components/bolt-table/package.json
@@ -16,6 +16,7 @@
   "main": "index.js",
   "style": "index.scss",
   "dependencies": {
+    "@bolt/components-code-snippet": "^4.6.0",
     "@bolt/core-v3.x": "^4.6.0",
     "@bolt/lazy-queue": "^4.3.0",
     "himalaya": "^1.1.0"

--- a/packages/components/bolt-table/src/table.js
+++ b/packages/components/bolt-table/src/table.js
@@ -1,4 +1,5 @@
 import { html, customElement, BoltElement, unsafeCSS } from '@bolt/element';
+import { BoltCodeSnippet } from '@bolt/components-code-snippet/src/code-snippet';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html';
 import { ifDefined } from 'lit-html/directives/if-defined';
 import { parse, stringify } from 'himalaya';
@@ -52,7 +53,9 @@ class BoltTable extends BoltElement {
   stripWhitespace(nodes) {
     return nodes.map(node => {
       if (node.type === 'element') {
-        node.children = this.stripWhitespace(node.children);
+        if (node.tagName !== 'code') {
+          node.children = this.stripWhitespace(node.children);
+        }
       } else {
         node.content =
           node.content.trim().length === 0
@@ -134,6 +137,14 @@ class BoltTable extends BoltElement {
         td.innerHTML = '';
       }
     });
+
+    // Init Code Snippets once Table has been updated, @see packages/components/bolt-code-snippet/index.js
+    const codeSnippets = this.querySelectorAll('.c-bolt-code-snippet');
+    if (codeSnippets.length) {
+      codeSnippets.forEach(el => {
+        const codeSnippetComponent = new BoltCodeSnippet(el);
+      });
+    }
   }
 
   render() {


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DOCS-189

## Summary

Fixes Code Snippet bugs when used inside Table component.

## Details

Table component strips whitespace around tags and text and in the process rewrites the DOM for every element inside. This breaks indentation on Code Snippets and loses any event handlers added prior to Table initializing.

Long term, Table will be rewritten to not do any of this. Short term, this PR tells Code Snippet to not automatically initialize when inside a Table. Then, tells Table to call the Code Snippet initialization after the Table is rendered.

I had to add Code Snippet as a dependency of Table, which means Code Snippet is loaded whenever a Table is present (not just when a Code Snippet is present). I did a few lighthouse checks and didn't notice any difference before and after.

## How to test

- Review code changes
- Review Code Snippet and Table demos for regressions
- Review test page (`http://localhost:3000/pattern-lab/patterns/999-tests-code-snippet-15-code-snippet-table/999-tests-code-snippet-15-code-snippet-table.html`) which shows the use case we're solving for. Verify the Code Snippets are properly indented and the Copy button works.
