### PR TITLE
Background Component Image Update

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/background/00-background-docs.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/background/00-background-docs.twig
@@ -9,7 +9,10 @@
   content_items: [
     {
       pattern: 'image',
-      src: '/images/content/backgrounds/background-tall-4.jpg'
+      src: '/images/content/backgrounds/background-tall-4.jpg',
+      srcset: '/images/content/backgrounds/background-tall-4-50.jpg 50w, /images/content/backgrounds/background-tall-4-100.jpg 100w, /images/content/backgrounds/background-tall-4-200.jpg 200w, /images/content/backgrounds/background-tall-4-320.jpg 320w, /images/content/backgrounds/background-tall-4-480.jpg 480w, /images/content/backgrounds/background-tall-4-640.jpg 640w, /images/content/backgrounds/background-tall-4-800.jpg 800w, /images/content/backgrounds/background-tall-4-1024.jpg 1024w, /images/content/backgrounds/background-tall-4-1366.jpg 1366w, /images/content/backgrounds/background-tall-4-1536.jpg 1536w, /images/content/backgrounds/background-tall-4-1920.jpg 1920w, /images/content/backgrounds/background-tall-4-2560.jpg 2560w, /images/content/backgrounds/background-tall-4-2880.jpg 2880w, /images/content/backgrounds/background-tall-4.jpg 3840w',
+      width: 3840,
+      height: 2160
     }
   ]
 } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/background/05-background.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/background/05-background.twig
@@ -12,8 +12,8 @@
         pattern: 'image',
         src: '/images/content/backgrounds/background-tall-4.jpg',
         srcset: '/images/content/backgrounds/background-tall-4-50.jpg 50w, /images/content/backgrounds/background-tall-4-100.jpg 100w, /images/content/backgrounds/background-tall-4-200.jpg 200w, /images/content/backgrounds/background-tall-4-320.jpg 320w, /images/content/backgrounds/background-tall-4-480.jpg 480w, /images/content/backgrounds/background-tall-4-640.jpg 640w, /images/content/backgrounds/background-tall-4-800.jpg 800w, /images/content/backgrounds/background-tall-4-1024.jpg 1024w, /images/content/backgrounds/background-tall-4-1366.jpg 1366w, /images/content/backgrounds/background-tall-4-1536.jpg 1536w, /images/content/backgrounds/background-tall-4-1920.jpg 1920w, /images/content/backgrounds/background-tall-4-2560.jpg 2560w, /images/content/backgrounds/background-tall-4-2880.jpg 2880w, /images/content/backgrounds/background-tall-4.jpg 3840w',
-        width: 823,
-        height: 400
+        width: 3840,
+        height: 2160
       }
     ]
 } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/background/05-background.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/background/05-background.twig
@@ -10,7 +10,10 @@
     content_items: [
       {
         pattern: 'image',
-        src: '/images/content/backgrounds/background-tall-4.jpg'
+        src: '/images/content/backgrounds/background-tall-4.jpg',
+        srcset: '/images/content/backgrounds/background-tall-4-50.jpg 50w, /images/content/backgrounds/background-tall-4-100.jpg 100w, /images/content/backgrounds/background-tall-4-200.jpg 200w, /images/content/backgrounds/background-tall-4-320.jpg 320w, /images/content/backgrounds/background-tall-4-480.jpg 480w, /images/content/backgrounds/background-tall-4-640.jpg 640w, /images/content/backgrounds/background-tall-4-800.jpg 800w, /images/content/backgrounds/background-tall-4-1024.jpg 1024w, /images/content/backgrounds/background-tall-4-1366.jpg 1366w, /images/content/backgrounds/background-tall-4-1536.jpg 1536w, /images/content/backgrounds/background-tall-4-1920.jpg 1920w, /images/content/backgrounds/background-tall-4-2560.jpg 2560w, /images/content/backgrounds/background-tall-4-2880.jpg 2880w, /images/content/backgrounds/background-tall-4.jpg 3840w',
+        width: 823,
+        height: 400
       }
     ]
 } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/background/10-background-opacity-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/background/10-background-opacity-variations.twig
@@ -12,10 +12,10 @@
     content_items: [
       {
         pattern: 'image',
-        src: '/images/content/backgrounds/background-tall-2.jpg',
-        srcset: '/images/content/backgrounds/background-tall-2-50.jpg 50w, /images/content/backgrounds/background-tall-2-100.jpg 100w, /images/content/backgrounds/background-tall-2-200.jpg 200w, /images/content/backgrounds/background-tall-2-320.jpg 320w, /images/content/backgrounds/background-tall-2-480.jpg 480w, /images/content/backgrounds/background-tall-2-640.jpg 640w, /images/content/backgrounds/background-tall-2-800.jpg 800w, /images/content/backgrounds/background-tall-2-1024.jpg 1024w, /images/content/backgrounds/background-tall-2-1366.jpg 1366w, /images/content/backgrounds/background-tall-2-1536.jpg 1536w, /images/content/backgrounds/background-tall-2-1920.jpg 1920w, /images/content/backgrounds/background-tall-2-2560.jpg 2560w, /images/content/backgrounds/background-tall-2-2880.jpg 2880w, /images/content/backgrounds/background-tall-2.jpg 4320w',
-        width: 823,
-        height: 549
+          src: '/images/content/backgrounds/background-tall-2.jpg',
+          srcset: '/images/content/backgrounds/background-tall-2-50.jpg 50w, /images/content/backgrounds/background-tall-2-100.jpg 100w, /images/content/backgrounds/background-tall-2-200.jpg 200w, /images/content/backgrounds/background-tall-2-320.jpg 320w, /images/content/backgrounds/background-tall-2-480.jpg 480w, /images/content/backgrounds/background-tall-2-640.jpg 640w, /images/content/backgrounds/background-tall-2-800.jpg 800w, /images/content/backgrounds/background-tall-2-1024.jpg 1024w, /images/content/backgrounds/background-tall-2-1366.jpg 1366w, /images/content/backgrounds/background-tall-2-1536.jpg 1536w, /images/content/backgrounds/background-tall-2-1920.jpg 1920w, /images/content/backgrounds/background-tall-2-2560.jpg 2560w, /images/content/backgrounds/background-tall-2-2880.jpg 2880w, /images/content/backgrounds/background-tall-2.jpg 4320w',
+          width: 4320,
+          height: 2880
       }
     ]
   }

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/background/10-background-opacity-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/background/10-background-opacity-variations.twig
@@ -12,7 +12,10 @@
     content_items: [
       {
         pattern: 'image',
-        src: '/images/content/backgrounds/background-tall-2.jpg'
+        src: '/images/content/backgrounds/background-tall-2.jpg',
+        srcset: '/images/content/backgrounds/background-tall-2-50.jpg 50w, /images/content/backgrounds/background-tall-2-100.jpg 100w, /images/content/backgrounds/background-tall-2-200.jpg 200w, /images/content/backgrounds/background-tall-2-320.jpg 320w, /images/content/backgrounds/background-tall-2-480.jpg 480w, /images/content/backgrounds/background-tall-2-640.jpg 640w, /images/content/backgrounds/background-tall-2-800.jpg 800w, /images/content/backgrounds/background-tall-2-1024.jpg 1024w, /images/content/backgrounds/background-tall-2-1366.jpg 1366w, /images/content/backgrounds/background-tall-2-1536.jpg 1536w, /images/content/backgrounds/background-tall-2-1920.jpg 1920w, /images/content/backgrounds/background-tall-2-2560.jpg 2560w, /images/content/backgrounds/background-tall-2-2880.jpg 2880w, /images/content/backgrounds/background-tall-2.jpg 4320w',
+        width: 823,
+        height: 549
       }
     ]
   }

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/background/15-background-focal-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/background/15-background-focal-variations.twig
@@ -13,7 +13,10 @@
       content_items: [
         {
           pattern: 'image',
-          src: '/images/content/backgrounds/background-tall-4.jpg'
+          src: '/images/content/backgrounds/background-tall-4.jpg',
+          srcset: '/images/content/backgrounds/background-tall-4-50.jpg 50w, /images/content/backgrounds/background-tall-4-100.jpg 100w, /images/content/backgrounds/background-tall-4-200.jpg 200w, /images/content/backgrounds/background-tall-4-320.jpg 320w, /images/content/backgrounds/background-tall-4-480.jpg 480w, /images/content/backgrounds/background-tall-4-640.jpg 640w, /images/content/backgrounds/background-tall-4-800.jpg 800w, /images/content/backgrounds/background-tall-4-1024.jpg 1024w, /images/content/backgrounds/background-tall-4-1366.jpg 1366w, /images/content/backgrounds/background-tall-4-1536.jpg 1536w, /images/content/backgrounds/background-tall-4-1920.jpg 1920w, /images/content/backgrounds/background-tall-4-2560.jpg 2560w, /images/content/backgrounds/background-tall-4-2880.jpg 2880w, /images/content/backgrounds/background-tall-4.jpg 3840w',
+          width: 823,
+          height: 400
         }
       ]
     },

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/background/15-background-focal-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/background/15-background-focal-variations.twig
@@ -15,8 +15,8 @@
           pattern: 'image',
           src: '/images/content/backgrounds/background-tall-4.jpg',
           srcset: '/images/content/backgrounds/background-tall-4-50.jpg 50w, /images/content/backgrounds/background-tall-4-100.jpg 100w, /images/content/backgrounds/background-tall-4-200.jpg 200w, /images/content/backgrounds/background-tall-4-320.jpg 320w, /images/content/backgrounds/background-tall-4-480.jpg 480w, /images/content/backgrounds/background-tall-4-640.jpg 640w, /images/content/backgrounds/background-tall-4-800.jpg 800w, /images/content/backgrounds/background-tall-4-1024.jpg 1024w, /images/content/backgrounds/background-tall-4-1366.jpg 1366w, /images/content/backgrounds/background-tall-4-1536.jpg 1536w, /images/content/backgrounds/background-tall-4-1920.jpg 1920w, /images/content/backgrounds/background-tall-4-2560.jpg 2560w, /images/content/backgrounds/background-tall-4-2880.jpg 2880w, /images/content/backgrounds/background-tall-4.jpg 3840w',
-          width: 823,
-          height: 400
+          width: 3840,
+          height: 2160
         }
       ]
     },

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/background/25-background-fill-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/background/25-background-fill-variations.twig
@@ -1,7 +1,8 @@
-<p>Fill: Color</p>
+{% for fill in ['color', 'gradient'] %}
+<p>Fill: {{ fill|capitalize }}</p>
 {% include './_00-background-band-demo.twig' with {
   background: {
-    fill: 'color',
+    fill: fill,
     opacity: 'medium',
     focal_point: {
       vertical: 'center',
@@ -12,30 +13,10 @@
         pattern: 'image',
         src: '/images/content/backgrounds/background-tall-2.jpg',
         srcset: '/images/content/backgrounds/background-tall-2-50.jpg 50w, /images/content/backgrounds/background-tall-2-100.jpg 100w, /images/content/backgrounds/background-tall-2-200.jpg 200w, /images/content/backgrounds/background-tall-2-320.jpg 320w, /images/content/backgrounds/background-tall-2-480.jpg 480w, /images/content/backgrounds/background-tall-2-640.jpg 640w, /images/content/backgrounds/background-tall-2-800.jpg 800w, /images/content/backgrounds/background-tall-2-1024.jpg 1024w, /images/content/backgrounds/background-tall-2-1366.jpg 1366w, /images/content/backgrounds/background-tall-2-1536.jpg 1536w, /images/content/backgrounds/background-tall-2-1920.jpg 1920w, /images/content/backgrounds/background-tall-2-2560.jpg 2560w, /images/content/backgrounds/background-tall-2-2880.jpg 2880w, /images/content/backgrounds/background-tall-2.jpg 4320w',
-        width: 823,
-        height: 549
+        width: 4320,
+        height: 2880
       }
     ]
   }
 } %}
-
-<p>Fill: Gradient</p>
-{% include './_00-background-band-demo.twig' with {
-  background: {
-    fill: 'gradient',
-    opacity: 'medium',
-    focal_point: {
-      vertical: 'center',
-      horizontal: 'center'
-    },
-    content_items: [
-      {
-        pattern: 'image',
-        src: '/images/content/backgrounds/background-tall-2.jpg',
-        srcset: '/images/content/backgrounds/background-tall-2-50.jpg 50w, /images/content/backgrounds/background-tall-2-100.jpg 100w, /images/content/backgrounds/background-tall-2-200.jpg 200w, /images/content/backgrounds/background-tall-2-320.jpg 320w, /images/content/backgrounds/background-tall-2-480.jpg 480w, /images/content/backgrounds/background-tall-2-640.jpg 640w, /images/content/backgrounds/background-tall-2-800.jpg 800w, /images/content/backgrounds/background-tall-2-1024.jpg 1024w, /images/content/backgrounds/background-tall-2-1366.jpg 1366w, /images/content/backgrounds/background-tall-2-1536.jpg 1536w, /images/content/backgrounds/background-tall-2-1920.jpg 1920w, /images/content/backgrounds/background-tall-2-2560.jpg 2560w, /images/content/backgrounds/background-tall-2-2880.jpg 2880w, /images/content/backgrounds/background-tall-2.jpg 4320w',
-        width: 823,
-        height: 549
-      }
-    ]
-  }
-} %}
+{% endfor %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/background/25-background-fill-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/background/25-background-fill-variations.twig
@@ -10,7 +10,10 @@
     content_items: [
       {
         pattern: 'image',
-        src: '/images/content/backgrounds/background-tall-2.jpg'
+        src: '/images/content/backgrounds/background-tall-2.jpg',
+        srcset: '/images/content/backgrounds/background-tall-2-50.jpg 50w, /images/content/backgrounds/background-tall-2-100.jpg 100w, /images/content/backgrounds/background-tall-2-200.jpg 200w, /images/content/backgrounds/background-tall-2-320.jpg 320w, /images/content/backgrounds/background-tall-2-480.jpg 480w, /images/content/backgrounds/background-tall-2-640.jpg 640w, /images/content/backgrounds/background-tall-2-800.jpg 800w, /images/content/backgrounds/background-tall-2-1024.jpg 1024w, /images/content/backgrounds/background-tall-2-1366.jpg 1366w, /images/content/backgrounds/background-tall-2-1536.jpg 1536w, /images/content/backgrounds/background-tall-2-1920.jpg 1920w, /images/content/backgrounds/background-tall-2-2560.jpg 2560w, /images/content/backgrounds/background-tall-2-2880.jpg 2880w, /images/content/backgrounds/background-tall-2.jpg 4320w',
+        width: 823,
+        height: 549
       }
     ]
   }
@@ -28,7 +31,10 @@
     content_items: [
       {
         pattern: 'image',
-        src: '/images/content/backgrounds/background-tall-2.jpg'
+        src: '/images/content/backgrounds/background-tall-2.jpg',
+        srcset: '/images/content/backgrounds/background-tall-2-50.jpg 50w, /images/content/backgrounds/background-tall-2-100.jpg 100w, /images/content/backgrounds/background-tall-2-200.jpg 200w, /images/content/backgrounds/background-tall-2-320.jpg 320w, /images/content/backgrounds/background-tall-2-480.jpg 480w, /images/content/backgrounds/background-tall-2-640.jpg 640w, /images/content/backgrounds/background-tall-2-800.jpg 800w, /images/content/backgrounds/background-tall-2-1024.jpg 1024w, /images/content/backgrounds/background-tall-2-1366.jpg 1366w, /images/content/backgrounds/background-tall-2-1536.jpg 1536w, /images/content/backgrounds/background-tall-2-1920.jpg 1920w, /images/content/backgrounds/background-tall-2-2560.jpg 2560w, /images/content/backgrounds/background-tall-2-2880.jpg 2880w, /images/content/backgrounds/background-tall-2.jpg 4320w',
+        width: 823,
+        height: 549
       }
     ]
   }

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/background/35-background-valign-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/background/35-background-valign-variations.twig
@@ -16,6 +16,9 @@
         {
           pattern: 'image',
           src: '/images/content/backgrounds/background-tall-2.jpg',
+          srcset: '/images/content/backgrounds/background-tall-2-50.jpg 50w, /images/content/backgrounds/background-tall-2-100.jpg 100w, /images/content/backgrounds/background-tall-2-200.jpg 200w, /images/content/backgrounds/background-tall-2-320.jpg 320w, /images/content/backgrounds/background-tall-2-480.jpg 480w, /images/content/backgrounds/background-tall-2-640.jpg 640w, /images/content/backgrounds/background-tall-2-800.jpg 800w, /images/content/backgrounds/background-tall-2-1024.jpg 1024w, /images/content/backgrounds/background-tall-2-1366.jpg 1366w, /images/content/backgrounds/background-tall-2-1536.jpg 1536w, /images/content/backgrounds/background-tall-2-1920.jpg 1920w, /images/content/backgrounds/background-tall-2-2560.jpg 2560w, /images/content/backgrounds/background-tall-2-2880.jpg 2880w, /images/content/backgrounds/background-tall-2.jpg 4320w',
+          width: 823,
+          height: 549,
           valign: image_valign
         }
       ]

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/background/35-background-valign-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/background/35-background-valign-variations.twig
@@ -17,8 +17,8 @@
           pattern: 'image',
           src: '/images/content/backgrounds/background-tall-2.jpg',
           srcset: '/images/content/backgrounds/background-tall-2-50.jpg 50w, /images/content/backgrounds/background-tall-2-100.jpg 100w, /images/content/backgrounds/background-tall-2-200.jpg 200w, /images/content/backgrounds/background-tall-2-320.jpg 320w, /images/content/backgrounds/background-tall-2-480.jpg 480w, /images/content/backgrounds/background-tall-2-640.jpg 640w, /images/content/backgrounds/background-tall-2-800.jpg 800w, /images/content/backgrounds/background-tall-2-1024.jpg 1024w, /images/content/backgrounds/background-tall-2-1366.jpg 1366w, /images/content/backgrounds/background-tall-2-1536.jpg 1536w, /images/content/backgrounds/background-tall-2-1920.jpg 1920w, /images/content/backgrounds/background-tall-2-2560.jpg 2560w, /images/content/backgrounds/background-tall-2-2880.jpg 2880w, /images/content/backgrounds/background-tall-2.jpg 4320w',
-          width: 823,
-          height: 549,
+          width: 4320,
+          height: 2880,
           valign: image_valign
         }
       ]

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/band/35-band-with-background.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/band/35-band-with-background.twig
@@ -26,7 +26,9 @@
         {
           pattern: 'image',
           src: '/images/content/backgrounds/background-short-1.jpg',
-          lazyload: false
+          lazyload: false,
+          width: 2320,
+          height: 800
         },
       ]
     },

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/band/40-band-nested.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/band/40-band-nested.twig
@@ -31,7 +31,9 @@
       {
         pattern: 'image',
         src: '/images/content/backgrounds/background-short-1.jpg',
-        lazyload: false
+        lazyload: false,
+        width: 2320,
+        height: 800
       },
     ]
   },

--- a/packages/components/bolt-background/src/background-item.twig
+++ b/packages/components/bolt-background/src/background-item.twig
@@ -21,27 +21,39 @@
 {% if item.pattern %}
   <div class="{{ 'c-bolt-background__item' }}">
     {% if item.pattern == 'image' %}
-      {% set _srcset = item.srcset ? item.srcset : '' %}
-      {% set _width = item.width ? item.width : '' %}
-      {% set _height = item.height ? item.height : '' %}
+      {% set attributes = {} %}
+
+      {% if item.srcset %}
+        {% set attributes = attributes|merge({ srcset: item.srcset }) %}
+      {% endif %}
+
+      {% if item.width %}
+        {% set attributes = attributes|merge({ width: item.width }) %}
+      {% endif %}
+
+      {% if item.height %}
+        {% set attributes = attributes|merge({ height: item.height }) %}
+      {% endif %}
+
+      {% if item.align or item.valign %}
+        {% set _align = item.align ? item.align : 'center' %}
+        {% set _valign = item.valign ? item.valign : 'center' %}
+        {% set _alignment = _align ~ ' ' ~ _valign %}
+        {% set attributes = attributes|merge({ style:  '--e-bolt-image-position: ' ~ _alignment ~ ';' }) %}
+      {% endif %}
+
       {% set _sizes = item.sizes ? item.sizes : '100vw' %}
+
       {# Found both of these spellings, expanding the conditional to catch both #}
       {% set _loading = item.lazyLoad or item.lazyload ? 'lazy' : 'eager' %}
-      {% set _align = item.align ? item.align : 'center' %}
-      {% set _valign = item.valign ? item.valign : 'center' %}
-      {% set _alignment = _align ~ ' ' ~ _valign %}
 
       {% include '@bolt-elements-image/image.twig' with {
         background: true,
-        attributes: {
+        attributes: attributes|merge({
           src: item.src,
-          srcset: _srcset,
           sizes: _sizes,
-          width: _width,
-          height: _height,
           loading: _loading,
-          style: 'object-position: ' ~ _alignment ~ ';'
-        },
+        })
       } only %}
     {% else %}
       {% include pattern_template(item.pattern) with item|merge({

--- a/packages/components/bolt-background/src/background-item.twig
+++ b/packages/components/bolt-background/src/background-item.twig
@@ -20,11 +20,36 @@
 {# todo: in v4.0 nix the pattern_template pattern #}
 {% if item.pattern %}
   <div class="{{ 'c-bolt-background__item' }}">
-    {% include pattern_template(item.pattern) with item|merge({
-      ratio: _ratio_value,
-      lazyload: item.lazyload ?? true,
-      cover: item.cover ?? true
-    }) only %}
+    {% if item.pattern == 'image' %}
+      {% set _srcset = item.srcset ? item.srcset : '' %}
+      {% set _width = item.width ? item.width : '' %}
+      {% set _height = item.height ? item.height : '' %}
+      {% set _sizes = item.sizes ? item.sizes : '100vw' %}
+      {# Found both of these spellings, expanding the conditional to catch both #}
+      {% set _loading = item.lazyLoad or item.lazyload ? 'lazy' : 'eager' %}
+      {% set _align = item.align ? item.align : 'center' %}
+      {% set _valign = item.valign ? item.valign : 'center' %}
+      {% set _alignment = _align ~ ' ' ~ _valign %}
+
+      {% include '@bolt-elements-image/image.twig' with {
+        background: true,
+        attributes: {
+          src: item.src,
+          srcset: _srcset,
+          sizes: _sizes,
+          width: _width,
+          height: _height,
+          loading: _loading,
+          style: 'object-position: ' ~ _alignment ~ ';'
+        },
+      } only %}
+    {% else %}
+      {% include pattern_template(item.pattern) with item|merge({
+        ratio: _ratio_value,
+        lazyload: item.lazyload ?? true,
+        cover: item.cover ?? true
+      }) only %}
+    {% endif %}
   </div>
 {% elseif (item is iterable) %}
   <div class="{{ 'c-bolt-background__item' }}">


### PR DESCRIPTION
## Summary

Updated the Background Component to use the Image Element instead of the Image Component

## Details

In order to allow for a more performant Hero, we need to remove all the Image Component. On of the steps to do that is to replace the Image Element from the Background Component so we can leverage more perforrmant methods (for example, appending `loading="eager"` to all images in a hero).

## How to test

* Review the code and pull down the branch.
* Review the Bolt Background, and the Bolt Band docs.
* Review the docs "Pages" folder

## Release notes

The Background Component now leverages the Image Element instead of the Image Component. This is a step to create a more performant Hero

