### PR TITLE
Background Component Updates

### DIFF
--- a/packages/base-starter-kit/.boltrc.js
+++ b/packages/base-starter-kit/.boltrc.js
@@ -1,8 +1,6 @@
 module.exports = {
   components: {
     global: [
-      '@bolt/components-info-section',
-      '@bolt/components-profile',
       '@bolt/core-v3.x',
       '@bolt/global',
       '@bolt/elements-article',
@@ -40,9 +38,10 @@ module.exports = {
       '@bolt/components-grid',
       '@bolt/components-headline',
       '@bolt/components-hero',
-      '@bolt/components-li',
       '@bolt/components-icon',
       '@bolt/components-image',
+      '@bolt/components-info-section',
+      '@bolt/components-li',
       '@bolt/components-link',
       '@bolt/components-list',
       '@bolt/components-listing-teaser',
@@ -56,6 +55,7 @@ module.exports = {
       '@bolt/components-page-footer',
       '@bolt/components-placeholder',
       '@bolt/components-popover',
+      '@bolt/components-profile',
       '@bolt/components-progress-bar',
       '@bolt/components-share',
       '@bolt/components-side-nav',

--- a/packages/components/bolt-background/package.json
+++ b/packages/components/bolt-background/package.json
@@ -15,7 +15,8 @@
   "style": "src/background.scss",
   "dependencies": {
     "@bolt/components-background-shapes": "^5.0.0",
-    "@bolt/core-v3.x": "^5.0.0"
+    "@bolt/core-v3.x": "^5.0.0",
+    "@bolt/elements-image": "^5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/testing/testing-nightwatch/package.json
+++ b/packages/testing/testing-nightwatch/package.json
@@ -18,7 +18,7 @@
   "main": "nightwatch.js",
   "dependencies": {
     "@zeit/fetch-retry": "^4.0.1",
-    "chromedriver": "^95.0.0",
+    "chromedriver": "^96.0.0",
     "ci-utils": "^0.6.0",
     "geckodriver": "^1.16.2",
     "globby": "^10.0.1",

--- a/packages/testing/testing-utils/__tests__/test-utils.test.js
+++ b/packages/testing/testing-utils/__tests__/test-utils.test.js
@@ -17,6 +17,7 @@ describe('test-utils', () => {
       '@bolt/components-background',
       '@bolt/components-background-shapes',
       '@bolt/element',
+      '@bolt/elements-image',
       '@bolt/lazy-queue',
       '@bolt/polyfills',
     ].sort();

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -23,7 +23,7 @@
     "querystring": "^0.2.0"
   },
   "optionalDependencies": {
-    "chromedriver": "^95.0.0",
+    "chromedriver": "^96.0.0",
     "geckodriver": "^1.19.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5183,10 +5183,10 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@^95.0.0:
-  version "95.0.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-95.0.0.tgz#ecf854cac6df5137a651dcc132edf55612d3db7f"
-  integrity sha512-HwSg7S0ZZYsHTjULwxFHrrUqEpz1+ljDudJM3eOquvqD5QKnR5pSe/GlBTY9UU2tVFRYz8bEHYC4Y8qxciQiLQ==
+chromedriver@^96.0.0:
+  version "96.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-96.0.0.tgz#c8473498e4c94950fa168187b112019cce9e5c6c"
+  integrity sha512-4g6Hn5RHGsbaBmOrJbDlz/hdVPOc22eRsbvoAAMqkZxR2NJCcddHzCw2FAQeW8lX/C7xWVz3nyDsKX3fE9lIIw==
   dependencies:
     "@testim/chrome-version" "^1.0.7"
     axios "^0.21.2"


### PR DESCRIPTION
## Summary

Updated dependencies for the background component updates.

## Details

* Added the "@bolt-components-images" as a backgroumd component dependency
* Reordered the .boltrc.js to ABC order
* Fixed a test-util jest test error

## How to test

* Review the changes
* run `yarn clean`, `yarn setup`, `yarn start`, `yarn test:js` and `yarn` to confirm that all the commands work