### PR TITLE
DS-669 side nav and holy grail layout enhancements

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/30-layouts/holy-grail/10-holy-grail-use-case-navigation.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/30-layouts/holy-grail/10-holy-grail-use-case-navigation.twig
@@ -45,7 +45,7 @@
     } only %}
     {% include '@bolt-components-side-nav/side-nav-li.twig' with {
       link: {
-        content: 'Level 1 page (current)',
+        content: 'Level 1 page (current) and it has long string of text! Lorem ipsum dolor sit amet consectetur adipisicing elit odio doloremque nam voluptas debitis ab Dolor autem Illo est sit Eaque veniam tenetur nihil sapiente sint dolor incidunt labore accusamus quaerat',
         attributes: {
           href: 'https://google.com',
         },

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/70-community/-community-doc-layout.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/70-community/-community-doc-layout.twig
@@ -551,7 +551,7 @@
     } only %}
     {% include '@bolt-components-side-nav/side-nav-li.twig' with {
       link: {
-        content: 'Level 1 page (current)',
+        content: 'Level 1 page (current) and it has long string of text! Lorem ipsum dolor sit amet consectetur adipisicing elit odio doloremque nam voluptas debitis ab Dolor autem Illo est sit Eaque veniam tenetur nihil sapiente sint dolor incidunt labore accusamus quaerat',
         attributes: {
           href: 'https://google.com',
         },

--- a/packages/components/bolt-side-nav/src/side-nav.scss
+++ b/packages/components/bolt-side-nav/src/side-nav.scss
@@ -288,8 +288,8 @@
     }
 
     &:after {
-      content: '\25BA';
-      font-size: 0.6em;
+      content: '\25B6';
+      font-size: 0.7em;
       transition: transform var(--bolt-transition);
     }
 

--- a/packages/layouts/bolt-holy-grail/src/holy-grail.scss
+++ b/packages/layouts/bolt-holy-grail/src/holy-grail.scss
@@ -71,6 +71,7 @@ $_bolt-holy-grail-sidebar-overflow-offset: 2rem;
 
     position: sticky;
     top: var(--bolt-page-header-height);
+    max-width: 35vw;
     max-height: calc(100vh - var(--bolt-page-header-height));
 
     > .l-bolt-holy-grail__sidebar__content {


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-669

## Summary

Fixes the triangle symbol in Side Nav links to render better in Windows and Holy Grail sidebar to have a max-width.

## Details

1. Used a different HTML entity to render the triangle in side nav so it appears normal in Windows
2. Set a max-width on the holy grail sidebar so any long side nav link text would not make the sidebar so wide that it squishes the main content

## How to test

Run the branch locally and check the Community Doc Layout page in Windows. Make sure the triangle in the side nav looks similar to what you see in Mac. Also the side nav at any breakpoint is at a reasonable width that doesn't squish the main article content too hard.