### PR TITLE
DS-304 add subheadline sizes to match Drupal admin ui

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/headline/40-headline-numbered.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/headline/40-headline-numbered.twig
@@ -187,7 +187,7 @@
     <bolt-stack>
       {% include '@bolt-components-headline/headline.twig' with {
         size: size,
-        text: 'Numbered Headline (#{size})',
+        text: 'Numbered Headline (' ~ size ~ ')',
         numberText: loop.index,
         numberColor: 'navy',
       } only %}

--- a/packages/components/bolt-headline/headline.schema.js
+++ b/packages/components/bolt-headline/headline.schema.js
@@ -14,8 +14,8 @@ module.exports = {
     tag: {
       type: 'string',
       description: 'Set the semantic HTML tag for the headline.',
-      default: 'p',
-      enum: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'span', 'cite', 'div'],
+      default: 'div',
+      enum: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'span', 'div', 'p', 'cite'],
     },
     align: {
       description: 'Set the text alignment of the headline.',

--- a/packages/components/bolt-headline/headline.schema.js
+++ b/packages/components/bolt-headline/headline.schema.js
@@ -14,8 +14,8 @@ module.exports = {
     tag: {
       type: 'string',
       description: 'Set the semantic HTML tag for the headline.',
-      default: 'div',
-      enum: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'span', 'div', 'p', 'cite'],
+      default: 'p',
+      enum: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'span', 'cite', 'div'],
     },
     align: {
       description: 'Set the text alignment of the headline.',

--- a/packages/components/bolt-headline/src/_typography.twig
+++ b/packages/components/bolt-headline/src/_typography.twig
@@ -4,7 +4,7 @@
   {{ validate_data_schema(schema, _self) | raw }}
 {% endif %}
 
-{% set types = ["headline", "subheadline", "eyebrow", "text"] %} {# Pre-defined types #}
+{% set types = ['headline', 'subheadline', 'eyebrow', 'text'] %} {# Pre-defined types #}
 {% set tags = schema.properties.tag.enum %}
 {% set weights = schema.properties.weight.enum %}
 {% set styles = schema.properties.style.enum %}
@@ -12,85 +12,85 @@
 {% set sizes = schema.properties.size.enum %}
 {% set alignments = schema.properties.align.enum %}
 
-{% if tags != "any" %}
+{% if tags != 'any' %}
   {% set tag = tag in tags ? tag : schema.properties.tag.default %}
 {% else %}
   {% set tag = tag ?? schema.properties.tag.default %}
 {% endif %}
 {% set weight = weight | default(schema.properties.weight.default) %}
 {% set style = style | default(schema.properties.style.default) %}
-{% set type = type in types ? type : "text" %}
+{% set type = type in types ? type : 'text' %}
 {% set size = size | default(schema.properties.size.default) %}
 
-{% set numberSize = "auto" %}
+{% set numberSize = 'auto' %}
 {% set autoshrink = autoshrink is defined ? autoshrink : schema.properties.autoshrink.default %}
 
 {# For backwards compatibility only, setting icon to exactly 'false' is the same as specifying 'none'.  Deprecated. #}
 {% if icon is same as(false) %}
-  {% set icon = "none" %}
+  {% set icon = 'none' %}
 {% endif %}
 
 {# If this is a link, use a chevron-right icon unless explicitly requested otherwise. #}
-{% set fallbackIconName = url ? "chevron-right" : "none" %}
+{% set fallbackIconName = url ? 'chevron-right' : 'none' %}
 
 {# iconName is a string representing the name of the icon or "none" if no icon should be shown. #}
 {% set iconName = icon is iterable ? icon.name : icon | default(fallbackIconName)%}
 
 {# Validate iconName.  If invalid, we'll use the default #}
 {#{% set iconSchema = bolt.data.components['@bolt-components-icon'].schema %}#}
-{#{% if iconName not in iconSchema.properties.name.enum and iconName != "none" %}#}
+{#{% if iconName not in iconSchema.properties.name.enum and iconName != 'none' %}#}
   {#{% set iconName = fallbackIconName %}#}
 {#{% endif %}#}
 
 {# If icon was a string, initialize it as an empty object. #}
 {% set icon = icon is iterable ? icon : {} %}
 
-{% if iconName == "none" %}
+{% if iconName == 'none' %}
   {% set icon = false %}
 {% else %}
   {% set icon = icon | merge({ name: iconName }) %}
 {% endif %}
 
 {# Covers backward compatibility with use of both left and before to describe icon position #}
-{% set iconPosition = icon.position == "left" ? "before" : icon.position  %}
+{% set iconPosition = icon.position == 'left' ? 'before' : icon.position  %}
 
-{% set prefix = "c-bolt-" %}
+{% set prefix = 'c-bolt-' %}
 {% set baseClass = prefix ~ type %}
 {% set attributes = create_attribute(attributes|default({})) %}
 
-{% if (size == "xxxlarge") and (text|length >= 60) and autoshrink == true %}
+{% if (size == 'xxxlarge') and (text|length >= 60) and autoshrink == true %}
   {% set longTitle = true %}
 {% endif %}
 
 {% if slot %}
-  {% set attributes = attributes.setAttribute("slot", slot) %}
+  {% set attributes = attributes.setAttribute('slot', slot) %}
 {% endif %}
 
 {% set classes = [
   baseClass,
-  numberText ? baseClass ~ "--" ~ "bulleted" : "",
-  quoted ? baseClass ~ "--" ~ "quoted" : "",
-  weight in weights ? baseClass ~ "--" ~ weight : "",
-  align in alignments and align != null ? baseClass ~ "--" ~ align : "",
-  style in styles and type == "text" ? baseClass ~ "--" ~ style : "",
-  size in sizes and type != "eyebrow" ? longTitle and type == "headline" ? baseClass ~ "--" ~ size ~ "-min" : baseClass ~ "--" ~ size : "",
-  transform in transformProps and transform != "" ? baseClass ~ "--" ~ transform : "",
-  url ? baseClass ~ "--link" : "",
-  iconPosition ? baseClass ~ "--icon-position-" ~ iconPosition : ""
+  numberText ? baseClass ~ '--' ~ 'bulleted' : '',
+  quoted ? baseClass ~ '--' ~ 'quoted' : '',
+  weight in weights ? baseClass ~ '--' ~ weight : '',
+  align in alignments and align != null ? baseClass ~ '--' ~ align : '',
+  style in styles and type == 'text' ? baseClass ~ '--' ~ style : '',
+  size in sizes and type != 'eyebrow' ? longTitle and type == 'headline' ? baseClass ~ '--' ~ size ~ '-min' : baseClass ~ '--' ~ size : '',
+  transform in transformProps and transform != '' ? baseClass ~ '--' ~ transform : '',
+  url ? baseClass ~ '--link' : '',
+  iconPosition ? baseClass ~ '--icon-position-' ~ iconPosition : ''
 ] %}
 
 {% set iconBefore %}{% apply spaceless %}
-  {% if icon and not url and iconPosition == "before" %}
+  {% if icon and not url and iconPosition == 'before' %}
     <span class="c-bolt-headline__icon c-bolt-headline__icon--position-before">
-      {% include "@bolt-elements-icon/icon.twig" with icon only %}
+      {% include '@bolt-elements-icon/icon.twig' with icon only %}
     </span>
   {% endif %}
 {% endapply %}{% endset %}
 
 {% set iconAfter %}{% apply spaceless %}
-  {% if icon and not url and iconPosition != "before" %}
+  {% if icon and not url and iconPosition != 'before' %}
     <span class="c-bolt-headline__icon c-bolt-headline__icon--position-after">
-      {% include "@bolt-elements-icon/icon.twig" with icon only %}
+      {% include '@bolt-elements-icon/icon.twig' with icon only %}
     </span>
   {% endif %}
 {% endapply %}{% endset %}
@@ -119,7 +119,7 @@
 
     {% set _link_props = {
       content: text,
-      reversed_underline: (type != "text"),
+      reversed_underline: (type != 'text'),
       attributes: _link_attributes,
     } %}
 
@@ -135,7 +135,7 @@
       {% endif %}
     {% endif %}
 
-    {% include "@bolt-elements-text-link/text-link.twig" with _link_props only %}
+    {% include '@bolt-elements-text-link/text-link.twig' with _link_props only %}
   {%- else -%}
     {% if hasIcon or quoted %}<span class="c-bolt-headline__text">{% endif %}
       {{- iconBefore -}}

--- a/packages/components/bolt-headline/src/eyebrow.twig
+++ b/packages/components/bolt-headline/src/eyebrow.twig
@@ -1,7 +1,5 @@
-{% extends "@bolt/_typography.twig" %}
-{% set type = "eyebrow" %}
-{% set sizes = ["xsmall"] %}
-{% set tag = "p" %}
-{% set weights = ["regular", "bold"] %}
-{% set size = size | default("xsmall") %}
-{% set weight = weight | default("regular") %}
+{% extends '@bolt-components-headline/_typography.twig' %}
+{% set type = 'eyebrow' %}
+{% set size = 'xsmall' %}
+{% set weight = weight | default('regular') %}
+{% set tag = tag | default('p') %}

--- a/packages/components/bolt-headline/src/headline.scss
+++ b/packages/components/bolt-headline/src/headline.scss
@@ -142,6 +142,7 @@
   * 1. Only include max-width rule on larger font sizes
   */
 .c-bolt-text--xxxlarge,
+.c-bolt-subheadline--xxxlarge,
 .c-bolt-headline--xxxlarge {
   font-size: calc(var(--bolt-type-font-size-xxxlarge) * 1.06);
   line-height: var(--bolt-type-line-height-xxxlarge);
@@ -174,24 +175,29 @@
   line-height: var(--bolt-type-line-height-large);
 }
 
-.c-bolt-text--medium {
+.c-bolt-text--medium,
+.c-bolt-subheadline--medium,
+.c-bolt-headline--medium {
   font-size: var(--bolt-type-font-size-medium);
   line-height: var(--bolt-type-line-height-medium);
 }
 
 .c-bolt-text--small,
+.c-bolt-subheadline--small,
 .c-bolt-headline--small {
   font-size: var(--bolt-type-font-size-small);
   line-height: var(--bolt-type-line-height-small);
 }
 
 .c-bolt-text--xsmall,
+.c-bolt-subheadline--xsmall,
 .c-bolt-headline--xsmall {
   font-size: var(--bolt-type-font-size-xsmall);
   line-height: var(--bolt-type-line-height-xsmall);
 }
 
 .c-bolt-text--xxsmall,
+.c-bolt-subheadline--xxsmall,
 .c-bolt-headline--xxsmall {
   font-size: var(--bolt-type-font-size-xxsmall);
   line-height: var(--bolt-type-line-height-xxsmall);

--- a/packages/components/bolt-headline/src/headline.twig
+++ b/packages/components/bolt-headline/src/headline.twig
@@ -1,36 +1,13 @@
-{% extends "@bolt/_typography.twig" %}
-
-{% set type = "headline" %}
-
-{% set styles = ["normal", "italic"] %}
-{% set style = style | default("normal") %}
-
-{# @todo @Salem, not sure if span should be allowed or not. There should not be two overrides of tags here. See Subheadline as well #}
-{% set tags = ["h1", "h2", "h3", "h4", "h5", "h6", "p", "span"] %} {# Allowed Tags #}
-{% set tags = [
-  "h1",
-  "h2",
-  "h3",
-  "h4",
-  "h5",
-  "h6",
-  "p",
-] %}
-{% set sizes = [
-  "xsmall",
-  "small",
-  "large",
-  "xlarge",
-  "xxlarge",
-  "xxxlarge"
-] %}
-
-{% set size = size | default("xlarge") %}
+{% extends '@bolt-components-headline/_typography.twig' %}
+{% set type = 'headline' %}
+{% set weights = ['regular', 'bold'] %}
+{% set style = style | default('normal') %}
+{% set size = size | default('xlarge') %}
 
 {# replicate existing functionality where small headlines are uppercase by default - however allow this to still be overwritten if specified #}
-{% if size == "small" %}
-  {% set transform = transform | default("uppercase") %}
+{% if size == 'small' %}
+  {% set transform = transform | default('uppercase') %}
 {% endif %}
 
-{% set weight = weight | default("bold") %}
-{% set tag = tag | default("h2") %}
+{% set weight = weight | default('bold') %}
+{% set tag = tag | default('h2') %}

--- a/packages/components/bolt-headline/src/lead.twig
+++ b/packages/components/bolt-headline/src/lead.twig
@@ -1,14 +1,11 @@
 {# Sample Usage
-  {% include "@bolt/lead.twig" with {
-    text: "This is a lead paragraph. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam in dui mauris. Vivamus hendrerit arcu sed erat molestie vehicula."
+  {% include '@bolt-components-headline/lead.twig' with {
+    text: 'This is a lead paragraph. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam in dui mauris. Vivamus hendrerit arcu sed erat molestie vehicula.'
   } only %}
 #}
 
-
-{% extends "@bolt/_typography.twig" %}
-{% set type = "lead" %}
-{% set sizes = ["large"] %}
-{% set weights = ["regular"] %}
-{% set tag = "p" %}
-{% set size = size | default("large") %}
-{% set weight = weight | default("regular") %}
+{% extends '@bolt-components-headline/_typography.twig' %}
+{% set type = 'lead' %}
+{% set size = 'large' %}
+{% set weight = 'regular' %}
+{% set tag = tag | default('p') %}

--- a/packages/components/bolt-headline/src/subheadline.twig
+++ b/packages/components/bolt-headline/src/subheadline.twig
@@ -1,19 +1,6 @@
-{% extends "@bolt/_typography.twig" %}
-{% set type = "subheadline" %}
-{# @todo @Salem, not sure if span should be allowed or not. There should not be two overrides of tags here. See headline as well #}
-{% set tags = ["h1", "h2", "h3", "h4", "h5", "h6", "p", "span"] %} {# Allowed Tags #}
-{% set tags = [
-  "h1",
-  "h2",
-  "h3",
-  "h4",
-  "h5",
-  "h6",
-  "p",
-] %}
-{% set sizes = ["xxlarge", "xlarge", "large"] %}
-{% set size = size | default("xlarge") %}
-{% set weight = "regular" %}
-
-{% set styles = ["normal", "italic"] %}
-{% set style = style | default("normal") %}
+{% extends '@bolt-components-headline/_typography.twig' %}
+{% set type = 'subheadline' %}
+{% set size = size | default('xlarge') %}
+{% set weight = 'regular' %}
+{% set style = style | default('normal') %}
+{% set tag = tag | default('p') %}

--- a/packages/components/bolt-headline/src/text.twig
+++ b/packages/components/bolt-headline/src/text.twig
@@ -1,8 +1,6 @@
-{% extends "@bolt/_typography.twig" %}
-{% set type = "text" %}
-{% set tag = tag | default("p") %}
-{% set weights = ["regular", "bold", "semibold"] %}
-{% set styles = ["normal", "italic"] %}
-{% set size = size | default("medium") %}
-{% set weight = weight | default("regular") %}
-{% set style = style | default("normal") %}
+{% extends '@bolt-components-headline/_typography.twig' %}
+{% set type = 'text' %}
+{% set size = size | default('medium') %}
+{% set weight = weight | default('regular') %}
+{% set style = style | default('normal') %}
+{% set tag = tag | default('p') %}


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-304

## Summary

Fixes a mismatch between the headline component and Drupal admin ui's authoring options.

## Details

1. Enabled subheadline to use any size and tag options (although this is against the design guidelines, subheadline should only be used at large, xlarge, and xxlarge sizes, and its tag can be just headings or paragraph).
2. Fixed a doc error where the size variable is not rendering on the numbered headline docs.

We are making this change rather than fixing the Drupal implementation because it's safer. Efforts will be put in to refactor foundational Drupal paragraphs (including headline) in the future, and the headline component will need a refactor (downgrade to element) on the design system side as well.

## How to test

Run the branch locally and check the headline docs. Nothing should be visually different compared to master.