### PR TITLE
DS-680 Select icon placement bug

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/55-d8-calculator/00-d8-results.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/55-d8-calculator/00-d8-results.twig
@@ -20,12 +20,12 @@
   {
     number: churn_rate ~ '%',
     description: 'Your churn rate today',
-    color: 'gray'
+    color: 't-bolt-navy-dark'
   },
   {
     number: churn_rate_with_pega ~ '%',
     description: 'Your churn rate with Pega Customer Decision Hub',
-    color: 'navy'
+    color: 't-bolt-navy-light'
   }
 ] %}
 
@@ -33,12 +33,12 @@
   {
     number: '$' ~ customer_value|number_format,
     description: 'Your current value of a customer',
-    color: 'gray'
+    color: 't-bolt-navy-dark'
   },
   {
     number: '$' ~ customer_value_with_pega|number_format,
     description: 'Your value of a customer with Pega Customer Decision Hub',
-    color: 'navy'
+    color: 't-bolt-navy-light'
   }
 ] %}
 
@@ -50,7 +50,7 @@
 {% macro resultsGraph(graph_array) %}
   <div class="c-www-results-graph">
     {% for item in graph_array %}
-      {% set color_class = ' c-www-results-graph__box--' ~ item.color %}
+      {% set color_class = item.color %}
       <div class="c-www-results-graph__box {{ color_class }}">
         <h4 class="c-www-results-stat">
           <span class="c-www-results-stat__text">{{ item.description }}</span>

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-customers.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-customers.twig
@@ -471,6 +471,9 @@
         {% include '@bolt-components-form/form-label.twig' with {
           title: 'Sort by',
           displayType: 'floating',
+          attributes: {
+            for: 'sort-by'
+          }
         } only %}
       {% endset %}
       {% set select %}
@@ -502,8 +505,8 @@
             }
           ],
           attributes: {
-            id: 'sort-select',
-            name: 'sort-select',
+            id: 'sort-by',
+            name: 'sort-by',
           },
         } only %}
       {% endset %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-customers.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-customers.twig
@@ -483,7 +483,7 @@
             {
               type: 'option',
               value: '',
-              label: '- Choose an option -',
+              label: '- Choose sorting option -',
               attributes: {
                 disabled: true
               }

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-customers.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-customers.twig
@@ -470,17 +470,21 @@
       {% set label %}
         {% include '@bolt-components-form/form-label.twig' with {
           title: 'Sort by',
-          displayType: 'block',
-          attributes: {
-            for: 'sort-select',
-            class: 'u-bolt-visuallyhidden',
-          },
+          displayType: 'floating',
         } only %}
       {% endset %}
       {% set select %}
         {% include '@bolt-components-form/form-select.twig' with {
           title: 'Country',
           options: [
+            {
+              type: 'option',
+              value: '',
+              label: '- Choose an option -',
+              attributes: {
+                disabled: true
+              }
+            },
             {
               type: 'option',
               value: 'most-viewed',
@@ -505,7 +509,6 @@
       {% endset %}
       {% include '@bolt-components-form/form-element.twig' with {
         label: label,
-        labelDisplay: 'before',
         children: select,
       } only %}
     {% endset %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-pegaworld.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-pegaworld.twig
@@ -543,7 +543,7 @@
             {
               type: 'option',
               value: '',
-              label: '- Choose an option -',
+              label: '- Choose sorting option -',
               attributes: {
                 disabled: true
               }

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-pegaworld.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-pegaworld.twig
@@ -362,7 +362,7 @@
             {
               type: 'option',
               value: '',
-              label: '- Choose option below -',
+              label: '- Choose a year -',
               attributes: {
                 disabled: true
               }
@@ -537,7 +537,7 @@
             {
               type: 'option',
               value: '',
-              label: '- Choose option below -',
+              label: '- Choose an option -',
               attributes: {
                 disabled: true
               }

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-pegaworld.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-pegaworld.twig
@@ -352,17 +352,21 @@
       {% set label %}
         {% include '@bolt-components-form/form-label.twig' with {
           title: 'Year',
-          displayType: 'block',
-          attributes: {
-            for: 'year-select',
-            class: 'u-bolt-visuallyhidden',
-          },
+          displayType: 'floating',
         } only %}
       {% endset %}
       {% set select %}
         {% include '@bolt-components-form/form-select.twig' with {
           title: 'Country',
           options: [
+            {
+              type: 'option',
+              value: '',
+              label: '- Choose option below -',
+              attributes: {
+                disabled: true
+              }
+            },
             {
               type: 'option',
               value: 'pegaworld-2020',
@@ -387,7 +391,6 @@
       {% endset %}
       {% include '@bolt-components-form/form-element.twig' with {
         label: label,
-        labelDisplay: 'before',
         children: select,
       } only %}
     {% endset %}
@@ -524,17 +527,21 @@
       {% set label %}
         {% include '@bolt-components-form/form-label.twig' with {
           title: 'Sort by',
-          displayType: 'block',
-          attributes: {
-            for: 'sort-select',
-            class: 'u-bolt-visuallyhidden',
-          },
+          displayType: 'floating',
         } only %}
       {% endset %}
       {% set select %}
         {% include '@bolt-components-form/form-select.twig' with {
           title: 'Country',
           options: [
+            {
+              type: 'option',
+              value: '',
+              label: '- Choose option below -',
+              attributes: {
+                disabled: true
+              }
+            },
             {
               type: 'option',
               value: 'most-viewed',
@@ -559,7 +566,6 @@
       {% endset %}
       {% include '@bolt-components-form/form-element.twig' with {
         label: label,
-        labelDisplay: 'before',
         children: select,
       } only %}
     {% endset %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-pegaworld.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-pegaworld.twig
@@ -353,6 +353,9 @@
         {% include '@bolt-components-form/form-label.twig' with {
           title: 'Year',
           displayType: 'floating',
+          attributes: {
+            for: 'year'
+          }
         } only %}
       {% endset %}
       {% set select %}
@@ -384,8 +387,8 @@
             },
           ],
           attributes: {
-            id: 'year-select',
-            name: 'year-select',
+            id: 'year',
+            name: 'year',
           },
         } only %}
       {% endset %}
@@ -528,6 +531,9 @@
         {% include '@bolt-components-form/form-label.twig' with {
           title: 'Sort by',
           displayType: 'floating',
+          attributes: {
+            for: 'sort-by'
+          }
         } only %}
       {% endset %}
       {% set select %}
@@ -559,8 +565,8 @@
             }
           ],
           attributes: {
-            id: 'sort-select',
-            name: 'sort-select',
+            id: 'sort-by',
+            name: 'sort by',
           },
         } only %}
       {% endset %}


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-680

## Summary

The chevrons in the select filters within the Best of Content pages were fixed.

## Details

On Best of Content pages, select chevron icons were overlaping the text :

 - [BoC - PegaWorld Replays](https://boltdesignsystem.com/pattern-lab/?p=pages-boc-listing-pegaworld-phase2)
 - [BoC - Customers](https://boltdesignsystem.com/pattern-lab/?p=pages-boc-listing-customers-phase2)
 
 Additionally, on the [Calculator - Results](https://boltdesignsystem.com/pattern-lab/?p=pages-d8-results) I found accidentally a bug related to color theming on those two colorful rectangles. I made a quick fix.

## How to test

Pull the branch. Check if the select fields on the BoC pages display correctly, without overlapping the text. Confirm there're no more broken selects with chevron icons overlapping the text.