### PR TITLE
Background Component LazyLoad Update

### DIFF
--- a/packages/components/bolt-background/src/background-item.twig
+++ b/packages/components/bolt-background/src/background-item.twig
@@ -45,7 +45,7 @@
       {% set _sizes = item.sizes ? item.sizes : '100vw' %}
 
       {# Found both of these spellings, expanding the conditional to catch both #}
-      {% set _loading = item.lazyLoad or item.lazyload ? 'lazy' : 'eager' %}
+      {% set _loading = (item.lazyLoad is same as false) or (item.lazyload is same as false) ? 'eager' : 'lazy' %}
 
       {% include '@bolt-elements-image/image.twig' with {
         background: true,


### PR DESCRIPTION
## Summary

Updated the Bolt Background lazy load conditional to default to lazy

## How to test

1. Pull down the branch locally
2. Navigate to http://localhost:3000/pattern-lab/?p=pages-d8-homepage
3. Inspect the Bolt Background image and confirm that **loading="eager"** is present
4. Change the twig value on line 107 in "docs-site/src/pages/pattern-lab/_patterns/50-pages/05-d8-homepage/00-d8-homepage.twig" to "true"
5. Reload the page http://localhost:3000/pattern-lab/?p=pages-d8-homepage
6. Inspect the Bolt Background image and confirm that **loading="lazy"** is present
