### PR TITLE
WWW-1072 Fix chip component's gray color option

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/chip/30-chip-color-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/chip/30-chip-color-variations.twig
@@ -2,8 +2,9 @@
 
 {% set notes %}
   <bolt-ol>
+    <bolt-li>When <code>color</code> is null or set to <code>auto</code>, the default design has a semi-transparent background that works across all color themes; when <code>color</code> is set to a specific color, the chip will always render in that color.</bolt-li>
     <bolt-li>When using status chips, it is recommended to append an appropriate icon in front of the text.</bolt-li>
-    <bolt-li>When using branded chips, always make sure a chip has good contrast with the page background. For example, do not use navy colored chip on a navy background.</bolt-li>
+    <bolt-li>When using branded chips, always make sure a chip has good contrast with the page background. For example, do not use a navy colored chip against a navy background.</bolt-li>
   </bolt-ol>
 {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/chip/30-chip-color-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/chip/30-chip-color-variations.twig
@@ -9,8 +9,10 @@
 {% endset %}
 
 {% set demo %}
-  <bolt-text headline font-size="xxsmall" text-transform="uppercase" letter-spacing="wide">Status Colors</bolt-text>
   <bolt-list display="inline">
+    <bolt-list-item>
+      <bolt-text headline font-size="xsmall" font-weight="semibold" letter-spacing="wide" tag="p">Status Colors</bolt-text>
+    </bolt-list-item>
     {% for color in schema.properties.color.enum %}
       {% if color == 'error' or color == 'warning' or color == 'success' %}
         {% if color == 'error' %}
@@ -35,8 +37,10 @@
       {% endif %}
     {% endfor %}
   </bolt-list>
-  <bolt-text headline font-size="xxsmall" text-transform="uppercase" letter-spacing="wide">Selective Brand Colors</bolt-text>
   <bolt-list display="inline">
+    <bolt-list-item>
+      <bolt-text headline font-size="xsmall" font-weight="semibold" letter-spacing="wide" tag="p">Selective Brand Colors</bolt-text>
+    </bolt-list-item>
     {% for color in schema.properties.color.enum %}
       {% if color != 'error' and color != 'warning' and color != 'success' %}
         <bolt-list-item>

--- a/packages/components/bolt-chip/chip.schema.js
+++ b/packages/components/bolt-chip/chip.schema.js
@@ -38,8 +38,9 @@ module.exports = {
     color: {
       type: 'string',
       description: 'Controls the color of the chip.',
-      default: 'gray',
+      default: 'auto',
       enum: [
+        'auto',
         'error',
         'warning',
         'success',

--- a/packages/components/bolt-chip/src/chip.js
+++ b/packages/components/bolt-chip/src/chip.js
@@ -35,7 +35,7 @@ class BoltChip extends BoltActionElement {
       [`c-bolt-chip--link`]: this.url,
       [`c-bolt-chip--size-${this.size}`]: this.size,
       [`c-bolt-chip--border-radius-${this.borderRadius}`]: this.borderRadius,
-      [`c-bolt-chip--color-${this.color}`]: this.color,
+      [`c-bolt-chip--color-${this.color}`]: this.color && this.color !== 'auto',
       [`c-bolt-chip--icon-only`]: this.iconOnly,
     });
 

--- a/packages/components/bolt-chip/src/chip.scss
+++ b/packages/components/bolt-chip/src/chip.scss
@@ -5,11 +5,10 @@
 \* ------------------------------------ */
 
 // Custom element styles
-bolt-chip {
-  display: inline-block;
-}
-
 @include bolt-repeat-rule(('bolt-chip', ':host')) {
+  --c-bolt-chip-text-color: var(--m-bolt-text);
+  --c-bolt-chip-bg-color: #{rgba(bolt-color(gray), 0.16)};
+  display: inline-block;
   outline: none;
 }
 
@@ -20,7 +19,7 @@ bolt-chip {
   font-family: var(--bolt-type-font-family-body);
   font-size: var(--bolt-type-font-size-xsmall);
   font-weight: var(--bolt-type-font-weight-regular);
-  color: var(--m-bolt-text);
+  color: var(--c-bolt-chip-text-color);
   line-height: calc(
     var(--bolt-type-line-height-xsmall) *
       var(--bolt-type-line-height-multiplier-tight)
@@ -28,7 +27,7 @@ bolt-chip {
   text-decoration: none;
   border-radius: bolt-border-radius(full);
   box-shadow: 0 0 0 1px rgba(bolt-color(gray, light), 0.2);
-  background-color: rgba(bolt-color(gray), 0.16);
+  background-color: var(--c-bolt-chip-bg-color);
   transition: color var(--bolt-transition),
     background-color var(--bolt-transition),
     text-decoration var(--bolt-transition);
@@ -56,153 +55,165 @@ $_bolt-chip-sizes: (xsmall, small, medium);
 }
 
 .c-bolt-chip--link {
-  color: var(--m-bolt-link);
+  --c-bolt-chip-text-color: var(--m-bolt-link);
 
   &:hover,
   &:focus {
-    color: var(--m-bolt-headline);
+    --c-bolt-chip-text-color: var(--m-bolt-headline);
+    --c-bolt-chip-bg-color: #{rgba(bolt-color(gray), 0.08)};
     text-decoration: underline;
-    background-color: rgba(bolt-color(gray), 0.08);
   }
 
   &:active,
   &:focus:active {
-    color: var(--m-bolt-headline);
+    --c-bolt-chip-text-color: var(--m-bolt-headline);
     text-decoration: none;
   }
 }
 
 .c-bolt-chip--color-error {
-  color: var(--bolt-color-error-dark) !important;
+  --c-bolt-chip-text-color: var(--bolt-color-error-dark);
+  --c-bolt-chip-bg-color: var(--bolt-color-error-light);
   box-shadow: 0 0 0 1px currentColor;
-  background-color: var(--bolt-color-error-light);
 
   &.c-bolt-chip--link {
     &:hover,
     &:focus {
-      background-color: var(--bolt-color-error-light);
+      --c-bolt-chip-bg-color: var(--bolt-color-error-light);
     }
   }
 }
 
 .c-bolt-chip--color-warning {
-  color: var(--bolt-color-black) !important;
+  --c-bolt-chip-text-color: var(--bolt-color-black);
+  --c-bolt-chip-bg-color: var(--bolt-color-warning-light);
   box-shadow: 0 0 0 1px var(--bolt-color-warning-dark);
-  background-color: var(--bolt-color-warning-light);
 
   &.c-bolt-chip--link {
     &:hover,
     &:focus {
-      background-color: var(--bolt-color-warning-light);
+      --c-bolt-chip-bg-color: var(--bolt-color-warning-light);
     }
   }
 }
 
 .c-bolt-chip--color-success {
-  color: var(--bolt-color-success-dark) !important;
+  --c-bolt-chip-text-color: var(--bolt-color-success-dark);
+  --c-bolt-chip-bg-color: var(--bolt-color-success-light);
   box-shadow: 0 0 0 1px currentColor;
-  background-color: var(--bolt-color-success-light);
 
   &.c-bolt-chip--link {
     &:hover,
     &:focus {
-      background-color: var(--bolt-color-success-light);
+      --c-bolt-chip-bg-color: var(--bolt-color-success-light);
     }
   }
 }
 
 .c-bolt-chip--color-navy {
-  color: var(--bolt-color-white) !important;
-  background-color: var(--bolt-color-navy);
+  --c-bolt-chip-text-color: var(--bolt-color-white);
+  --c-bolt-chip-bg-color: var(--bolt-color-navy);
 
   &.c-bolt-chip--link {
     &:hover,
     &:focus {
-      background-color: var(--bolt-color-navy-light);
+      --c-bolt-chip-bg-color: var(--bolt-color-navy-light);
     }
   }
 }
 
 .c-bolt-chip--color-teal {
-  color: var(--bolt-color-white) !important;
-  background-color: var(--bolt-color-teal-dark);
+  --c-bolt-chip-text-color: var(--bolt-color-white);
+  --c-bolt-chip-bg-color: var(--bolt-color-teal-dark);
 
   &.c-bolt-chip--link {
     &:hover,
     &:focus {
-      background-color: var(--bolt-color-teal);
+      --c-bolt-chip-bg-color: var(--bolt-color-teal);
     }
   }
 }
 
 .c-bolt-chip--color-orange {
-  color: var(--bolt-color-white) !important;
-  background-color: var(--bolt-color-orange-dark);
+  --c-bolt-chip-text-color: var(--bolt-color-white);
+  --c-bolt-chip-bg-color: var(--bolt-color-orange-dark);
 
   &.c-bolt-chip--link {
     &:hover,
     &:focus {
-      background-color: var(--bolt-color-orange);
+      --c-bolt-chip-bg-color: var(--bolt-color-orange);
     }
   }
 }
 
 .c-bolt-chip--color-yellow {
-  color: var(--bolt-color-black) !important;
-  background-color: var(--bolt-color-yellow);
+  --c-bolt-chip-text-color: var(--bolt-color-black);
+  --c-bolt-chip-bg-color: var(--bolt-color-yellow);
 
   &.c-bolt-chip--link {
     &:hover,
     &:focus {
-      background-color: var(--bolt-color-yellow-light);
+      --c-bolt-chip-bg-color: var(--bolt-color-yellow-light);
     }
   }
 }
 
 .c-bolt-chip--color-wine {
-  color: var(--bolt-color-white) !important;
-  background-color: var(--bolt-color-wine);
+  --c-bolt-chip-text-color: var(--bolt-color-white);
+  --c-bolt-chip-bg-color: var(--bolt-color-wine);
 
   &.c-bolt-chip--link {
     &:hover,
     &:focus {
-      background-color: var(--bolt-color-wine);
+      --c-bolt-chip-bg-color: var(--bolt-color-wine);
     }
   }
 }
 
 .c-bolt-chip--color-pink {
-  color: var(--bolt-color-white) !important;
-  background-color: var(--bolt-color-pink);
+  --c-bolt-chip-text-color: var(--bolt-color-white);
+  --c-bolt-chip-bg-color: var(--bolt-color-pink);
 
   &.c-bolt-chip--link {
     &:hover,
     &:focus {
-      background-color: var(--bolt-color-pink);
+      --c-bolt-chip-bg-color: var(--bolt-color-pink);
     }
   }
 }
 
 .c-bolt-chip--color-berry {
-  color: var(--bolt-color-white) !important;
-  background-color: var(--bolt-color-berry);
+  --c-bolt-chip-text-color: var(--bolt-color-white);
+  --c-bolt-chip-bg-color: var(--bolt-color-berry);
 
   &.c-bolt-chip--link {
     &:hover,
     &:focus {
-      background-color: var(--bolt-color-berry);
+      --c-bolt-chip-bg-color: var(--bolt-color-berry);
     }
   }
 }
 
 .c-bolt-chip--color-violet {
-  color: var(--bolt-color-white) !important;
-  background-color: var(--bolt-color-violet);
+  --c-bolt-chip-text-color: var(--bolt-color-white);
+  --c-bolt-chip-bg-color: var(--bolt-color-violet);
 
   &.c-bolt-chip--link {
     &:hover,
     &:focus {
-      background-color: var(--bolt-color-violet);
+      --c-bolt-chip-bg-color: var(--bolt-color-violet);
+    }
+  }
+}
+
+.c-bolt-chip--color-gray {
+  --c-bolt-chip-text-color: var(--bolt-color-black);
+  --c-bolt-chip-bg-color: var(--bolt-color-gray-light);
+
+  &.c-bolt-chip--link {
+    &:hover,
+    &:focus {
+      --c-bolt-chip-bg-color: var(--bolt-color-gray-light);
     }
   }
 }

--- a/packages/components/bolt-chip/src/chip.scss
+++ b/packages/components/bolt-chip/src/chip.scss
@@ -8,14 +8,14 @@
 @include bolt-repeat-rule(('bolt-chip', ':host')) {
   --c-bolt-chip-text-color: var(--m-bolt-text);
   --c-bolt-chip-bg-color: #{rgba(bolt-color(gray), 0.16)};
-  display: inline-block;
+  display: inline;
   outline: none;
 }
 
 // Base Chip Styles
 .c-bolt-chip {
-  display: flex;
-  align-items: center;
+  display: inline-flex;
+  gap: var(--bolt-spacing-x-xxsmall);
   font-family: var(--bolt-type-font-family-body);
   font-size: var(--bolt-type-font-size-xsmall);
   font-weight: var(--bolt-type-font-weight-regular);
@@ -218,10 +218,13 @@ $_bolt-chip-sizes: (xsmall, small, medium);
   }
 }
 
-.c-bolt-chip__text,
-.c-bolt-chip__icon {
+.c-bolt-chip__text {
   display: inline;
-  padding: 0 calc(var(--bolt-spacing-x-xxsmall) / 2);
+}
+
+.c-bolt-chip__icon {
+  width: 1em;
+  height: 1em;
 }
 
 .c-bolt-chip--icon-only {

--- a/packages/components/bolt-chip/src/chip.twig
+++ b/packages/components/bolt-chip/src/chip.twig
@@ -36,7 +36,7 @@
   url ? 'c-bolt-chip--link' : '',
   size ? 'c-bolt-chip--size-' ~ size : '',
   border_radius ? 'c-bolt-chip--border-radius-' ~ border_radius : '',
-  color != "auto" ? 'c-bolt-chip--color-' ~ color : '',
+  color and color != 'auto' ? 'c-bolt-chip--color-' ~ color : '',
   iconOnly ? 'c-bolt-chip--icon-only' : '',
 ] %}
 

--- a/packages/components/bolt-chip/src/chip.twig
+++ b/packages/components/bolt-chip/src/chip.twig
@@ -36,7 +36,7 @@
   url ? 'c-bolt-chip--link' : '',
   size ? 'c-bolt-chip--size-' ~ size : '',
   border_radius ? 'c-bolt-chip--border-radius-' ~ border_radius : '',
-  color ? 'c-bolt-chip--color-' ~ color : '',
+  color != "auto" ? 'c-bolt-chip--color-' ~ color : '',
   iconOnly ? 'c-bolt-chip--icon-only' : '',
 ] %}
 


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/WWW-1072

## Summary

Fixes a bug where the gray color option for the chip component is not rendering any CSS.

## Details

1. Fixed the relevant modifier class in CSS.
2. Updated the twig and js files to reflect the default color.
3. Fixed an height issue where chips with icon is taller than chips without icon.

## How to test

Run the branch locally and check the chip docs. Make sure all color variations are rendering the correct color in all color themes. 