### PR TITLE
DOCS-232 Fix holy grail layout content width

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/30-layouts/holy-grail/10-holy-grail-use-case-navigation.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/30-layouts/holy-grail/10-holy-grail-use-case-navigation.twig
@@ -113,6 +113,61 @@
       <p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. Corporis harum placeat magni voluptas maiores iure explicabo magnam delectus et molestias tempore, dolore sed voluptate voluptatibus! Voluptas pariatur rerum quidem blanditiis! Lorem ipsum dolor sit amet consectetur adipisicing elit. Recusandae atque molestias esse iusto laboriosam, repellendus voluptate adipisci consequatur consectetur? Fuga recusandae excepturi deleniti quo natus voluptas sequi, optio nemo aspernatur.</p>
       <h2 id="section-two">Section Two</h2>
       <p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. Corporis harum placeat magni voluptas maiores iure explicabo magnam delectus et molestias tempore, dolore sed voluptate voluptatibus! Voluptas pariatur rerum quidem blanditiis! Lorem ipsum dolor sit amet consectetur adipisicing elit. Recusandae atque molestias esse iusto laboriosam, repellendus voluptate adipisci consequatur consectetur? Fuga recusandae excepturi deleniti quo natus voluptas sequi, optio nemo aspernatur.</p>
+      {% include '@bolt-components-table/table.twig' with {
+        first_col_fixed_width: true,
+        headers: {
+          top: {
+            cells: [
+              'Item number',
+              'Description',
+              'Assemblies',
+            ]
+          },
+          side: {
+            cells: [
+              'Build 2.0.1.0 — SR-49969',
+              {
+                content: 'Build 1.1.360 — SR-44891',
+                attributes: {
+                  rowspan: 2,
+                }
+              },
+              {},
+              'Build 1.1.354 — SR-44889',
+            ]
+          }
+        },
+        rows: [
+          {
+            cells: [
+              'SR-49941',
+              'This hotfix changes Updater requirements for .NET. If you are using Updater with 7.1 or 8.0 Robotic Automation Runtime clients, you now need to have both .NET 4.0 and .NET 3.5 installed.',
+              'OpenSpan.UpdaterService.Remoting.dll<br>OpenSpan.Updater.ServerClientInterface.dll<br>OpenSpan.Updater.ScheduledTasks.dll<br>OpenSpan.Updater.PrePostOperation.dll<br>OpenSpan.Updater.Git.dll<br>OpenSpan.VersionFinder.exe<br>OpenSpan.UpdaterService.exe<br>OpenSpan.Updater.X509tool.exe<br>OpenSpan.Updater.UserHelper.exe<br>OpenSpan.Updater.UninstallHelper.exe<br>OpenSpan.Updater.RuntimeLauncher.exe<br>OpenSpan.Updater.InstallHelper.exe<br>OpenSpan.Updater.Initializer.exe',
+            ]
+          },
+          {
+            cells: [
+              'SR-44869',
+              'This hotfix changes the system to better handle long file names. It also enhances VersionFinder to sort the list of branches, making it easier to find a specific branch.',
+              'OpenSpan.Updater.Git.dll',
+            ]
+          },
+          {
+            cells: [
+              'SR-43163',
+              'This hotfix adds a list of post-update tasks to the <span>RuntimeConfig.xml </span>file. These tasks are run after files that match a pattern you specify are updated.',
+              'OpenSpan.Updater.Git.dll<br>OpenSpan.Updater.Initializer.exe<br>OpenSpan.Updater.InstallHelper.exe<br>OpenSpan.Updater.PrePostOperation.dll<br>OpenSpan.Updater.PreReqCheck.dll<br>OpenSpan.Updater.RuntimeLauncher.exe<br>OpenSpan.Updater.ScheduledTasks.dll<br>OpenSpan.Updater.ServerClientInterface.dll<br>OpenSpan.Updater.ServerClientInterface.Tester.exe<br>OpenSpan.Updater.UninstallHelper.exe<br>OpenSpan.Updater.UserHelper.exe<br>OpenSpan.Updater.X509tool.exe<br>OpenSpan.UpdaterService.Remoting.dll<br>OpenSpan.UpdaterService.exe',
+            ]
+          },
+          {
+            cells: [
+              'SR-44850',
+              'This hotfix changes Updater to avoid an exception that could prevent it from correctly populating branches.',
+              'ManagedOpenSsl.dll',
+            ]
+          },
+        ],
+      } only %}
     </article>
   {% endset %}
 

--- a/packages/layouts/bolt-holy-grail/src/holy-grail.scss
+++ b/packages/layouts/bolt-holy-grail/src/holy-grail.scss
@@ -11,7 +11,7 @@ $_bolt-holy-grail-sidebar-overflow-offset: 2rem;
   @include bolt-full-bleed;
 
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   min-height: 100%;
 
   @include bolt-mq($until: medium) {
@@ -19,16 +19,15 @@ $_bolt-holy-grail-sidebar-overflow-offset: 2rem;
       'sidebar'
       'article';
     grid-template-rows: auto 1fr;
-    grid-template-columns: 1fr auto;
+    grid-template-columns: minmax(0, 1fr) auto;
     grid-gap: var(--bolt-spacing-x-xxsmall);
     grid-row-gap: var(--bolt-spacing-y-medium);
   }
 
   @include bolt-mq(xxxlarge) {
-    grid-template-columns: minmax(18vw, var(--bolt-page-padding-x)) 1fr minmax(
-        20.2vw,
-        var(--bolt-page-padding-x)
-      );
+    grid-template-columns:
+      minmax(18vw, var(--bolt-page-padding-x)) minmax(0, 1fr)
+      minmax(20.2vw, var(--bolt-page-padding-x));
   }
 }
 

--- a/packages/layouts/bolt-holy-grail/src/holy-grail.scss
+++ b/packages/layouts/bolt-holy-grail/src/holy-grail.scss
@@ -4,6 +4,9 @@
  * Holy Grail Layout
  */
 
+// Dev Notes
+// 1. Using 1fr in CSS grid template causes certain components to miscalculate the width of its parent container. It has been changed to minmax(0, 1fr) as a fix. 0 min-width straightens out the issue.
+
 $_bolt-holy-grail-sidebar-trigger-click-target: 44px;
 $_bolt-holy-grail-sidebar-overflow-offset: 2rem;
 
@@ -11,7 +14,7 @@ $_bolt-holy-grail-sidebar-overflow-offset: 2rem;
   @include bolt-full-bleed;
 
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-columns: auto minmax(0, 1fr) auto; // [1]
   min-height: 100%;
 
   @include bolt-mq($until: medium) {
@@ -19,7 +22,7 @@ $_bolt-holy-grail-sidebar-overflow-offset: 2rem;
       'sidebar'
       'article';
     grid-template-rows: auto 1fr;
-    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-columns: minmax(0, 1fr) auto; // [1]
     grid-gap: var(--bolt-spacing-x-xxsmall);
     grid-row-gap: var(--bolt-spacing-y-medium);
   }
@@ -27,7 +30,7 @@ $_bolt-holy-grail-sidebar-overflow-offset: 2rem;
   @include bolt-mq(xxxlarge) {
     grid-template-columns:
       minmax(18vw, var(--bolt-page-padding-x)) minmax(0, 1fr)
-      minmax(20.2vw, var(--bolt-page-padding-x));
+      minmax(20.2vw, var(--bolt-page-padding-x)); // [1]
   }
 }
 


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DOCS-232

## Summary

Fixes a grid width issue with the Holy Grail Layout that causes responsive tables to not render correctly.

## Details

Use `1fr` in CSS grid template is causing certain components miscalculate the width of its parent container. It has been changed to `minmax(0, 1fr)` as a fix. 0 min-width straightens out the issue.

## How to test

Run the branch locally and check the Holy Grail Layout docs. The table in the use case demo should be able to horizontally scroll when the viewport is smaller than ~1000px.