### PR TITLE
WWW-1121 adjust chip icon alignment

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/chip/00-chip-and-icon.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/chip/00-chip-and-icon.twig
@@ -1,0 +1,25 @@
+{% set schema = bolt.data.components['@bolt-elements-icon'].schema %}
+{% set names = schema.properties.name.enum %}
+{% set colors = schema.properties.color.enum %}
+{% set sizes = schema.properties.size.enum %}
+
+{% for name in names %}
+  <p>
+    {# {% set text_and_icon %}
+      {% include "@bolt-elements-icon/icon.twig" with {
+        name: name,
+      } only %}
+      {{ name|capitalize }}
+    {% endset %}
+    {% include '@bolt-components-chip/chip.twig' with {
+      text: text_and_icon,
+    } only %} #}
+    {% include '@bolt-components-chip/chip.twig' with {
+      text: name|capitalize,
+      icon: {
+        name: name,
+        position: 'before',
+      },
+    } only %}
+  </p>
+{% endfor %}

--- a/packages/components/bolt-chip/src/chip.scss
+++ b/packages/components/bolt-chip/src/chip.scss
@@ -15,6 +15,7 @@
 // Base Chip Styles
 .c-bolt-chip {
   display: inline-flex;
+  align-items: center;
   gap: var(--bolt-spacing-x-xxsmall);
   font-family: var(--bolt-type-font-family-body);
   font-size: var(--bolt-type-font-size-xsmall);
@@ -223,8 +224,35 @@ $_bolt-chip-sizes: (xsmall, small, medium);
 }
 
 .c-bolt-chip__icon {
+  transform: translateY(
+    -10%
+  ); // All translateY values are for countering subpixel alignment issues, do not remove them or re-order them.
   width: 1em;
   height: 1em;
+  pointer-events: none;
+
+  @include bolt-mq(small) {
+    transform: translateY(-14%);
+  }
+
+  @include bolt-mq(medium) {
+    transform: translateY(-12%);
+  }
+}
+
+/* Safari 11+ */
+@media not all and (min-resolution: 0.001dpcm) {
+  @supports (-webkit-appearance: none) and (stroke-color: transparent) {
+    .c-bolt-chip__icon {
+      transform: translateY(-2%);
+    }
+  }
+}
+
+.c-bolt-chip__icon {
+  @include bolt-mq(xlarge) {
+    transform: translateY(-9%);
+  }
 }
 
 .c-bolt-chip--icon-only {


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/WWW-1121

## Summary

Fixes chip icon mis-alignment.

## Details

Breakpoint specific adjustments are added to CSS along with Safari specific adjustments. This is a subpixel issue and can't be fixed 100%, but the alignment should be fine most of the time now.

## How to test

Run the branch locally and check the chip and icon test page under Tests. Make sure the icon's vertical alignment is almost close to center at all breakpoints and across all browsers.