### PR TITLE
DS-671 Add rel="noopener"

### DIFF
--- a/docs-site/src/components/docs-search/docs-search.js
+++ b/docs-site/src/components/docs-search/docs-search.js
@@ -49,7 +49,7 @@ class BoltDocsSearch extends withLitHtml {
           suggestion.url = suggestion.url.replace('#menu', '');
 
           if (self.shouldOpenInNewWindow) {
-            window.open(suggestion.url, '_blank');
+            window.open(suggestion.url, '_blank', 'noopener');
           } else {
             window.location = suggestion.url;
           }

--- a/docs-site/src/components/pattern-lab-utils/docs.twig
+++ b/docs-site/src/components/pattern-lab-utils/docs.twig
@@ -44,7 +44,7 @@
 {% set component_change_log %}
   {% if has_changelog %}
     <bolt-text font-size="xsmall">
-      <a target="_blank" href="{{ github_url(change_log_file) }}">Change log</a>
+      <a target="_blank" rel="noopener" href="{{ github_url(change_log_file) }}">Change log</a>
     </bolt-text>
   {% endif %}
 {% endset %}
@@ -52,14 +52,14 @@
 {% set component_github %}
   {% if has_readme %}
     <bolt-text font-size="xsmall">
-      <a target="_blank" href="{{ github_url(readme_file) | replace({'README.md':''}) }}">Github</a>
+      <a target="_blank" rel="noopener" href="{{ github_url(readme_file) | replace({'README.md':''}) }}">Github</a>
     </bolt-text>
   {% endif %}
 {% endset %}
 
 {% set component_npm %}
   <bolt-text font-size="xsmall">
-    <a target="_blank" href="https://www.npmjs.com/package/{{ component_title }}">NPM</a>
+    <a target="_blank" rel="noopener" href="https://www.npmjs.com/package/{{ component_title }}">NPM</a>
   </bolt-text>
 {% endset %}
 
@@ -147,7 +147,7 @@
           {% for key, value in pkg.dependencies %}
             <bolt-list-item>
               <bolt-text>
-                <a target="_blank" href="https://www.npmjs.com/package/{{ key }}">{{ key }}</a>
+                <a target="_blank" rel="noopener" href="https://www.npmjs.com/package/{{ key }}">{{ key }}</a>
               </bolt-text>
             </bolt-list-item>
           {% endfor %}

--- a/docs-site/src/components/pattern-lab-utils/md-embed.twig
+++ b/docs-site/src/components/pattern-lab-utils/md-embed.twig
@@ -1,6 +1,6 @@
 {# `file` - path to markdown content, like `@bolt-footer/readme.md` #}
 <div class="c-bds-md-embed">
-  <a href="{{ github_url(file) }}" class="c-bds-md-embed__edit" target="_blank">
+  <a href="{{ github_url(file) }}" class="c-bds-md-embed__edit" target="_blank" rel="noopener">
     {% include '@bolt-elements-icon/icon.twig' with { name: 'pencil' } only %}
     Edit this on GitHub
   </a>

--- a/docs-site/src/components/pattern-lab-utils/utilities.twig
+++ b/docs-site/src/components/pattern-lab-utils/utilities.twig
@@ -55,7 +55,7 @@
         <h5>SassDoc references</h5>
         <ul>
           {% for item in sassdoc_items %}
-            <li><a target="_blank" href="{{ item.anchor }}">{{ item.title }}</a></li>
+            <li><a target="_blank" rel="noopener" href="{{ item.anchor }}">{{ item.title }}</a></li>
           {% endfor %}
         </ul>
       </div>

--- a/docs-site/src/components/version-selector/version-selector.js
+++ b/docs-site/src/components/version-selector/version-selector.js
@@ -61,7 +61,7 @@ if (boltSelect) {
     if (url && window.location.href !== url) {
       // open Bolt version selected in a new tab (vs same tab) if the CMD / meta key is held
       if (shouldOpenInNewWindow) {
-        window.open(url, '_blank');
+        window.open(url, '_blank', 'noopener');
       } else {
         window.location = url;
       }

--- a/docs-site/src/pages/pattern-lab/_patterns/20-elements/button/15-button-attributes.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/20-elements/button/15-button-attributes.twig
@@ -4,10 +4,11 @@
 
 {% set demo %}
   {% include '@bolt-elements-button/button.twig' with {
-    content: 'This button has the "href", "target", and "id" attributes',
+    content: 'This button has the "href", "target", "rel", and "id" attributes',
     attributes: {
       href: 'https://google.com',
       target: '_blank',
+      rel:'noopener',
       id: 'js-bolt-some-unique-id'
     }
   } only %}
@@ -36,6 +37,7 @@
   attributes: {
     href: 'https://google.com',
     target: '_blank',
+    rel: 'noopener',
     id: 'js-bolt-some-unique-id'
   }
 } only %}
@@ -44,7 +46,7 @@
 
 {% set html_markup %}
 {% verbatim %}
-<a href="https://google.com" target="_blank" id="js-bolt-some-unique-id" class="e-bolt-button">This button has the "href", "target", and "id" attributes</a>
+<a href="https://google.com" target="_blank" rel="noopener" id="js-bolt-some-unique-id" class="e-bolt-button">This button has the "href", "target", "rel", and "id" attributes</a>
 {% endverbatim %}
 {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/20-elements/text-link/05-text-link.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/20-elements/text-link/05-text-link.twig
@@ -16,6 +16,7 @@
     attributes: {
       href: 'https://google.com',
       target: '_blank',
+      rel: 'noopener'
     }
   } only %}
 {% endset %}
@@ -27,6 +28,7 @@
   attributes: {
     href: 'https://google.com',
     target: '_blank',
+    rel: 'noopener'
   }
 } only %}
 {% endverbatim %}
@@ -34,7 +36,7 @@
 
 {% set html_markup %}
 {% verbatim %}
-<a href="https://google.com" target="_blank" class="e-bolt-text-link">Click me to go to google.com</a>
+<a href="https://google.com" target="_blank" rel="noopener" class="e-bolt-text-link">Click me to go to google.com</a>
 {% endverbatim %}
 {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/20-elements/text-link/15-text-link-attributes.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/20-elements/text-link/15-text-link-attributes.twig
@@ -23,10 +23,11 @@
 {% set twig_markup %}
 {% verbatim %}
 {% include '@bolt-elements-text-link/text-link.twig' with {
-  content: 'This text link has the "href", "target", and "id" attributes',
+  content: 'This text link has the "href", "target", "rel" and "id" attributes',
   attributes: {
     href: 'https://google.com',
     target: '_blank',
+    rel: 'noopener',
     id: 'js-bolt-some-unique-id'
   }
 } only %}
@@ -35,7 +36,7 @@
 
 {% set html_markup %}
 {% verbatim %}
-<a href="https://google.com" target="_blank" id="js-bolt-some-unique-id" class="e-bolt-text-link">This text link has the "href", "target", and "id" attributes</a>
+<a href="https://google.com" target="_blank" rel="noopener" id="js-bolt-some-unique-id" class="e-bolt-text-link">This text link has the "href", "target", "rel" and "id" attributes</a>
 {% endverbatim %}
 {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/card/999-card-replacement-with-web-component.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/card/999-card-replacement-with-web-component.twig
@@ -30,7 +30,7 @@
 
 {% macro body_with_link() %}
   <bolt-card-replacement-body>
-    This is a card-replacement with an overall link that makes the whole card-replacement clickable, while the body can still have <a target="_blank" href="https://boltdesignsystem.com/docs" class="e-bolt-text-link">text links</a> that would go somewhere else.
+    This is a card-replacement with an overall link that makes the whole card-replacement clickable, while the body can still have <a target="_blank" href="https://boltdesignsystem.com/docs" rel="noopener" class="e-bolt-text-link">text links</a> that would go somewhere else.
   </bolt-card-replacement-body>
 {% endmacro %}
 
@@ -62,7 +62,7 @@
 {% set advanced_link_demo %}
 <bolt-card-replacement>
   <bolt-card-replacement-link custom-attribute="foo" html-attribute="bar">
-    <a href="https://google.com" target="_blank">Go to google.com</a>
+    <a href="https://google.com" target="_blank" rel="noopener">Go to google.com</a>
   </bolt-card-replacement-link>
 {% include card_replacement_code.image() %}
 {% include card_replacement_code.body_clickable() %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/card/card-replacement-with-web-component.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/card/card-replacement-with-web-component.twig
@@ -38,7 +38,7 @@
 {% endmacro %}
 
 {% macro body_with_link() %}
-	<bolt-card-replacement-body>This is a card-replacement with an overall link that makes the whole card-replacement clickable, while the body can still have <a target="_blank" href="https://boltdesignsystem.com/docs" class="e-bolt-text-link">text links</a> that would go somewhere else.</bolt-card-replacement-body>
+	<bolt-card-replacement-body>This is a card-replacement with an overall link that makes the whole card-replacement clickable, while the body can still have <a target="_blank" rel="noopener" href="https://boltdesignsystem.com/docs" class="e-bolt-text-link">text links</a> that would go somewhere else.</bolt-card-replacement-body>
 {% endmacro %}
 
 {% macro actions() %}
@@ -73,7 +73,7 @@
 {% set advanced_link_demo %}
 <bolt-card-replacement>
 	<bolt-card-replacement-link custom-attribute="foo" html-attribute="bar">
-		<a href="https://google.com" target="_blank">Go to google.com</a>
+		<a href="https://google.com" target="_blank" rel="noopener">Go to google.com</a>
 	</bolt-card-replacement-link>
 	{% include card_replacement_demo.image() %}
 	{% include card_replacement_demo.body_clickable() %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/chip/10-chip-url-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/chip/10-chip-url-variations.twig
@@ -3,6 +3,7 @@
     text: 'This is a linked chip',
     url: 'https://google.com',
     target: '_blank',
+    rel: 'noopener'
   } only %}
 {% endset %}
 
@@ -12,13 +13,14 @@
   text: 'This is a linked chip',
   url: 'https://google.com',
   target: '_blank',
+  rel: 'noopener'
 } only %}
 {% endverbatim %}
 {% endset %}
 
 {% set html_markup %}
 {% verbatim %}
-<bolt-chip url="https://google.com" target="_blank">This is a linked chip</bolt-chip>
+<bolt-chip url="https://google.com" target="_blank" rel="noopener">This is a linked chip</bolt-chip>
 {% endverbatim %}
 {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/footer/_05-footer.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/footer/_05-footer.twig
@@ -54,7 +54,7 @@
                     <span class="o-bolt-inline-list__item">
                       <ul class="o-bolt-inline-list o-bolt-inline-list--small c-share__items">
                     <li class="o-bolt-inline-list__item c-share__item">
-                      <a href="https://twitter.com/" class="c-bolt-link u-bolt-color-info" target="_blank">
+                      <a href="https://twitter.com/" class="c-bolt-link u-bolt-color-info" target="_blank" rel="noopener">
                         <span class="u-bolt-visuallyhidden">Follow Us On Twitter</span>
                         {% include '@bolt-elements-icon/icon.twig' with {
                           name: 'twitter',
@@ -66,7 +66,7 @@
                       </a>
                     </li>
                     <li class="o-bolt-inline-list__item c-share__item">
-                      <a href="https://www.facebook.com/" class="c-bolt-link u-bolt-color-info" target="_blank">
+                      <a href="https://www.facebook.com/" class="c-bolt-link u-bolt-color-info" target="_blank" rel="noopener">
                         <span class="u-bolt-visuallyhidden">Follow Us On Facebook</span>
                         {% include '@bolt-elements-icon/icon.twig' with {
                           name: 'facebook',
@@ -78,7 +78,7 @@
                       </a>
                     </li>
                     <li class="o-bolt-inline-list__item c-share__item">
-                      <a href="https://www.linkedin.com/" class="c-bolt-link u-bolt-color-info" target="_blank">
+                      <a href="https://www.linkedin.com/" class="c-bolt-link u-bolt-color-info" target="_blank" rel="noopener">
                         <span class="u-bolt-visuallyhidden">Connect with us on LinkedIn</span>
                         {% include '@bolt-elements-icon/icon.twig' with {
                           name: 'linkedin-solid',
@@ -90,7 +90,7 @@
                       </a>
                     </li>
                     <li class="o-bolt-inline-list__item c-share__item">
-                      <a href="https://www.youtube.com/" class="c-bolt-link u-bolt-color-info" target="_blank">
+                      <a href="https://www.youtube.com/" class="c-bolt-link u-bolt-color-info" target="_blank" rel="noopener">
                         <span class="u-bolt-visuallyhidden">Check us out on YouTube</span>
                         {% include '@bolt-elements-icon/icon.twig' with {
                           name: 'youtube-solid',
@@ -193,7 +193,7 @@
                           </a>
                         </li>
                         <li class="o-bolt-ui-list__item">
-                          <a href="#!" target="_blank" rel="" class="c-link c-bolt-text c-bolt-text--xsmall">
+                          <a href="#!" target="_blank" rel="noopener" class="c-link c-bolt-text c-bolt-text--xsmall">
                             <span class="c-link__text">
                               Pega Product Design
                             </span>

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/link-deprecated/-30-link-with-web-component.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/link-deprecated/-30-link-with-web-component.twig
@@ -4,7 +4,7 @@
 
 {% set link_demo_advanced %}
 <bolt-link>
-  <a href="https://google.com" target="_blank">This is a link</a>
+  <a href="https://google.com" target="_blank" rel="noopener">This is a link</a>
 </bolt-link>
 {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/listing-teaser/55-listing-teaser-use-case-collaboration-center.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/listing-teaser/55-listing-teaser-use-case-collaboration-center.twig
@@ -228,7 +228,7 @@
   {% set listing_6 %}
     {% set reply %}
       <p><strong>Replied on Aug 21, 2021</strong></p>
-      <p>Hi <a href="/user/1622491" target="_blank">@ClayN538</a></p>
+      <p>Hi <a href="/user/1622491" target="_blank" rel="noopener">@ClayN538</a></p>
       <p>Here is the information for <a href="#!">Pega Patch 8.2.6</a>&nbsp;within the PCC and a direct link to our <a href="#!" target="_blank" rel="noopener">Digital Delivery Software</a>.</p>
       <p>Here is the <a href="#!">link</a> to all of our posts regarding Pega Patches.</p>
       <p>If you can't find the Patch for 8.2.6, please reach out to your Account Executive.</p>

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/menu/00-menu-docs.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/menu/00-menu-docs.twig
@@ -8,6 +8,7 @@
       content: 'Menu Item 2',
       attributes: {
         target: '_blank',
+        rel: 'noopener',
       },
     },
   ]

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/menu/20-menu-use-case-button-link-items.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/menu/20-menu-use-case-button-link-items.twig
@@ -13,6 +13,7 @@
       url: 'https://google.com',
       attributes: {
         target: '_blank',
+        rel: 'noopener',
       },
     },
   ]
@@ -31,6 +32,7 @@
       url: 'https://google.com',
       attributes: {
         target: '_blank',
+        rel: 'noopener',
       },
     },
   ]
@@ -44,7 +46,7 @@
   <bolt-menu-item>
     Menu item 1 is a button
   </bolt-menu-item>
-  <bolt-menu-item url="https://google.com" target="_blank">
+  <bolt-menu-item url="https://google.com" target="_blank" rel="noopener">
     Menu item 2 is a link with attributes
   </bolt-menu-item>
 </bolt-menu>

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/page-header/-page-header-example-main-site-with-subnav.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/page-header/-page-header-example-main-site-with-subnav.twig
@@ -1055,6 +1055,7 @@
     attributes: {
       href: 'https://google.com/',
       target: '_blank',
+      rel: 'noopener',
     }
   } only %}
 {% endset %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/page-header/_demo-main-site-page-header.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/page-header/_demo-main-site-page-header.twig
@@ -983,6 +983,7 @@
     attributes: {
       href: 'https://google.com/products/try-now',
       target: '_blank',
+      rel: 'noopener',
     }
   } only %}
 {% endset %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/profile/05-profile.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/profile/05-profile.twig
@@ -99,6 +99,7 @@
               url: 'https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse',
               attributes: {
                 target: '_blank',
+                rel: 'noopener',
               }
             },
             {
@@ -107,6 +108,7 @@
               url: 'https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!',
               attributes: {
                 target: '_blank',
+                rel: 'noopener',
               }
             },
             {
@@ -115,6 +117,7 @@
               url: 'https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com',
               attributes: {
                 target: '_blank',
+                rel: 'noopener',
               }
             },
             {
@@ -123,6 +126,7 @@
               url: 'mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com',
               attributes: {
                 target: '_blank',
+                rel: 'noopener'
               }
             },
           ]
@@ -325,6 +329,7 @@
           url: 'https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse',
           attributes: {
             target: '_blank',
+            rel: 'noopener'
           }
         },
         {
@@ -333,6 +338,7 @@
           url: 'https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!',
           attributes: {
             target: '_blank',
+            rel: 'noopener',
           }
         },
         {
@@ -341,6 +347,7 @@
           url: 'https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com',
           attributes: {
             target: '_blank',
+            rel: 'noopener',
           }
         },
         {
@@ -349,6 +356,7 @@
           url: 'mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com',
           attributes: {
             target: '_blank',
+            rel: 'noopener',
           }
         },
       ]

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/profile/10-profile-full-bleed.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/profile/10-profile-full-bleed.twig
@@ -70,6 +70,7 @@
             url: 'https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse',
             attributes: {
               target: '_blank',
+              rel: 'noopener',
             }
           },
           {
@@ -78,6 +79,7 @@
             url: 'https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!',
             attributes: {
               target: '_blank',
+              rel: 'noopener',
             }
           },
           {
@@ -86,6 +88,7 @@
             url: 'https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com',
             attributes: {
               target: '_blank',
+              rel: 'noopener',
             }
           },
           {
@@ -94,6 +97,7 @@
             url: 'mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com',
             attributes: {
               target: '_blank',
+              rel: 'noopener',
             }
           },
         ]
@@ -263,6 +267,7 @@
           url: 'https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse',
           attributes: {
             target: '_blank',
+            rel: 'noopener',
           }
         },
         {
@@ -271,6 +276,7 @@
           url: 'https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!',
           attributes: {
             target: '_blank',
+            rel: 'noopener',
           }
         },
         {
@@ -279,6 +285,7 @@
           url: 'https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com',
           attributes: {
             target: '_blank',
+            rel: 'noopener',
           }
         },
         {
@@ -287,6 +294,7 @@
           url: 'mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com',
           attributes: {
             target: '_blank',
+            rel: 'noopener',
           }
         },
       ]

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/00-teaser-docs.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/00-teaser-docs.twig
@@ -5,6 +5,8 @@
     text: 'Some awesome Title',
     link_attributes: {
       href: 'https://www.google.com',
+      target: '_blank',
+      rel: 'noopener'
     }
   },
 } %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/05-teaser.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/05-teaser.twig
@@ -28,6 +28,8 @@ A teaser is an interactive block element. Its main purpose is to display relevan
         text: 'This is the teaser headline',
         link_attributes: {
           href: 'https://www.google.com',
+          target: '_blank',
+          rel: 'noopener'
         }
       },
     } only %}
@@ -45,6 +47,8 @@ A teaser is an interactive block element. Its main purpose is to display relevan
     text: 'This is the teaser headline',
     link_attributes: {
       href: 'https://www.google.com',
+      target: '_blank',
+      rel: 'noopener'
     }
   },
 } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/10-teaser-layout.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/10-teaser-layout.twig
@@ -38,6 +38,8 @@
           text: 'This is vertical teaser',
           link_attributes: {
             href: 'https://www.google.com',
+            target: '_blank',
+            rel: 'noopener'
           }
         },
         description: {
@@ -53,6 +55,8 @@
           text: 'This is horizontal teaser',
           link_attributes: {
             href: 'https://www.google.com',
+            target: '_blank',
+            rel: 'noopener'
           }
         },
         description: {
@@ -69,6 +73,8 @@
           text: 'This is a responsive teaser',
           link_attributes: {
             href: 'https://www.google.com',
+            target: '_blank',
+            rel: 'noopener'
           }
         },
         description: {
@@ -88,6 +94,8 @@
     text: 'This is the teaser headline',
     link_attributes: {
       href: 'https://www.google.com',
+      target: '_blank',
+      rel: 'noopener'
     }
   },
 } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/15-teaser-gutter.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/15-teaser-gutter.twig
@@ -32,6 +32,8 @@
           text: 'This responsive teaser is using a large gutter',
           link_attributes: {
             href: 'https://www.google.com',
+            target: '_blank',
+            rel: 'noopener'
           }
         },
         description: {
@@ -49,6 +51,8 @@
           size: 'large',
           link_attributes: {
             href: 'https://www.google.com',
+            target: '_blank',
+            rel: 'noopener'
           }
         },
         description: {

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/20-teaser-chips.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/20-teaser-chips.twig
@@ -34,7 +34,9 @@
         tag: 'h2',
         size: 'xlarge',
         link_attributes: {
-          href: 'https://www.google.com'
+          href: 'https://www.google.com',
+          target: '_blank',
+          rel: 'noopener'
         },
       },
       description: {

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/30-teaser-status-and-actions.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/30-teaser-status-and-actions.twig
@@ -127,6 +127,8 @@
         size: 'xlarge',
         link_attributes: {
           href: 'https://www.google.com',
+          target: '_blank',
+          rel: 'noopener'
         }
       },
       description: {

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/35-teaser-text-options.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/35-teaser-text-options.twig
@@ -33,6 +33,8 @@
           size: 'xxlarge',
           link_attributes: {
             href: 'https://www.google.com',
+            target: '_blank',
+            rel: 'noopener'
           }
         },
         subheadline: {
@@ -58,6 +60,8 @@
     size: 'xxlarge',
     link_attributes: {
       href: 'https://www.google.com',
+      target: '_blank',
+      rel: 'noopener'
     }
   },
   subheadline: {

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/40-teaser-description-on-hover.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/teaser/40-teaser-description-on-hover.twig
@@ -25,6 +25,8 @@
           size: 'large',
           link_attributes: {
             href: 'https://google.com',
+            target: '_blank',
+            rel: 'noopener'
           },
         },
         description: {
@@ -45,6 +47,8 @@
           size: 'large',
           link_attributes: {
             href: 'https://google.com',
+            target: '_blank',
+            rel: 'noopener'
           },
         },
         description: {

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/trigger/10-trigger-tag-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/trigger/10-trigger-tag-variations.twig
@@ -12,6 +12,8 @@
     content: 'Trigger with <code>a</code> tag',
     url: 'https://www.google.com/',
     target: '_blank',
-    rel: 'noopener'
+    attributes: {
+      rel: 'noopener',
+    }
   } only %}
 </p>

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/trigger/10-trigger-tag-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/trigger/10-trigger-tag-variations.twig
@@ -11,6 +11,7 @@
   {% include '@bolt-components-trigger/trigger.twig' with {
     content: 'Trigger with <code>a</code> tag',
     url: 'https://www.google.com/',
-    target: '_blank'
+    target: '_blank',
+    rel: 'noopener'
   } only %}
 </p>

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/trigger/10-trigger-tag-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/trigger/10-trigger-tag-variations.twig
@@ -12,8 +12,6 @@
     content: 'Trigger with <code>a</code> tag',
     url: 'https://www.google.com/',
     target: '_blank',
-    attributes: {
-      rel: 'noopener',
-    }
+    rel: 'noopener'
   } only %}
 </p>

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/trigger/25-trigger-outline-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/trigger/25-trigger-outline-variations.twig
@@ -14,8 +14,6 @@
     no_outline: true,
     url: 'https://google.com',
     target: '_blank',
-    attributes: {
-      rel: 'noopener'
-    }
+    rel: 'noopener'
   } only %}
 </p>

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/trigger/25-trigger-outline-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/trigger/25-trigger-outline-variations.twig
@@ -13,6 +13,7 @@
     content: 'This &lt;a&gt; has no outline on focus',
     no_outline: true,
     url: 'https://google.com',
-    target: '_blank'
+    target: '_blank',
+    rel: 'noopener'
   } only %}
 </p>

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/trigger/25-trigger-outline-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/trigger/25-trigger-outline-variations.twig
@@ -14,6 +14,8 @@
     no_outline: true,
     url: 'https://google.com',
     target: '_blank',
-    rel: 'noopener'
+    attributes: {
+      rel: 'noopener'
+    }
   } only %}
 </p>

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/trigger/30-trigger-disabled-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/trigger/30-trigger-disabled-variations.twig
@@ -10,6 +10,7 @@
     content: 'This <code>&lt;a&gt;</code> is disabled',
     disabled: true,
     url: 'https://google.com',
-    target: '_blank'
+    target: '_blank',
+    rel: 'noopener'
   } only %}
 </p>

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/trigger/30-trigger-disabled-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/trigger/30-trigger-disabled-variations.twig
@@ -11,8 +11,6 @@
     disabled: true,
     url: 'https://google.com',
     target: '_blank',
-    attributes: {
-      rel: 'noopener'
-    }
+    rel: 'noopener'
   } only %}
 </p>

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/trigger/30-trigger-disabled-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/trigger/30-trigger-disabled-variations.twig
@@ -11,6 +11,8 @@
     disabled: true,
     url: 'https://google.com',
     target: '_blank',
-    rel: 'noopener'
+    attributes: {
+      rel: 'noopener'
+    }
   } only %}
 </p>

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/35-d8-events/00-event-landing.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/35-d8-events/00-event-landing.twig
@@ -264,7 +264,7 @@
           {% endfor %}
 
           {% include '@pl/_event-annotation.twig' with {
-            text: 'At mobile breakpoints, search facets should appear in an overlay. This page does not show that behavior. See <a target="_blank" href="http://5a8474d2be40f13bcfebaa78.bolt.netlify.com/patterns/50-pages-d8-partners-d8-partners-search/50-pages-d8-partners-d8-partners-search.html" class="e-bolt-text-link">this temporary page</a> for an example'
+            text: 'At mobile breakpoints, search facets should appear in an overlay. This page does not show that behavior. See <a target="_blank" rel="noopener" href="http://5a8474d2be40f13bcfebaa78.bolt.netlify.com/patterns/50-pages-d8-partners-d8-partners-search/50-pages-d8-partners-d8-partners-search.html" class="e-bolt-text-link">this temporary page</a> for an example'
           } only %}
 
           {% include '@pl/_event-annotation.twig' with {

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/85-user/-user-profile-empty-state.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/85-user/-user-profile-empty-state.twig
@@ -84,6 +84,7 @@
             url: 'https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse',
             attributes: {
               target: '_blank',
+              rel: 'noopener'
             }
           },
           {
@@ -92,6 +93,7 @@
             url: 'https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!',
             attributes: {
               target: '_blank',
+              rel: 'noopener'
             }
           },
           {
@@ -100,6 +102,7 @@
             url: 'https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com',
             attributes: {
               target: '_blank',
+              rel: 'noopener'
             }
           },
           {
@@ -108,6 +111,7 @@
             url: 'mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com',
             attributes: {
               target: '_blank',
+              rel: 'noopener'
             }
           },
         ]

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/85-user/-user-profile.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/85-user/-user-profile.twig
@@ -82,6 +82,7 @@
             url: 'https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse',
             attributes: {
               target: '_blank',
+              rel: 'noopener'
             }
           },
           {
@@ -90,6 +91,7 @@
             url: 'https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!',
             attributes: {
               target: '_blank',
+              rel: 'noopener'
             }
           },
           {
@@ -98,6 +100,7 @@
             url: 'https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com',
             attributes: {
               target: '_blank',
+              rel: 'noopener'
             }
           },
           {
@@ -106,6 +109,7 @@
             url: 'mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com',
             attributes: {
               target: '_blank',
+              rel: 'noopener'
             }
           },
         ]
@@ -422,6 +426,7 @@
                       url: 'https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;src=sdkpreparse',
                       attributes: {
                         target: '_blank',
+                        rel: 'noopener'
                       }
                     },
                     {
@@ -430,6 +435,7 @@
                       url: 'https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&text=Sample%20Share%20Text&via=pega&hashtags=boltDesignSystemRocks!',
                       attributes: {
                         target: '_blank',
+                        rel: 'noopener'
                       }
                     },
                     {
@@ -438,6 +444,7 @@
                       url: 'https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com',
                       attributes: {
                         target: '_blank',
+                        rel: 'noopener'
                       }
                     },
                     {
@@ -446,6 +453,7 @@
                       url: 'mailto:?&body=Sample%20Text%20--%20https%3A//boltdesignsystem.com',
                       attributes: {
                         target: '_blank',
+                        rel: 'noopener'
                       }
                     },
                   ]

--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/academy/03-organisms/search/_search-bar.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/academy/03-organisms/search/_search-bar.twig
@@ -15,6 +15,7 @@
         attributes: {
           action: "https://www.google.com/search",
           target: "_blank",
+          rel: 'noopener',
           method: "GET"
         }
       } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/navbar/00-navbar-with-links.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/navbar/00-navbar-with-links.twig
@@ -25,7 +25,8 @@
       content: 'External Link',
       attributes: {
         href: 'https://google.com/',
-        target: '_blank'
+        target: '_blank',
+        rel: 'noopener'
       }
     }
   },

--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/navbar/15-navbar-with-list.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/navbar/15-navbar-with-list.twig
@@ -36,7 +36,8 @@
         content: 'External Link',
         attributes: {
           href: 'https://google.com/',
-          target: '_blank'
+          target: '_blank',
+          rel: 'noopener'
         }
       }
     },

--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/navbar/20-navbar-no-title.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/navbar/20-navbar-no-title.twig
@@ -25,7 +25,8 @@
       content: 'External Link',
       attributes: {
         href: 'https://google.com/',
-        target: '_blank'
+        target: '_blank',
+        rel: 'noopener'
       }
     }
   },

--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/navbar/22-navbar-title-tags.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/navbar/22-navbar-title-tags.twig
@@ -25,7 +25,8 @@
       content: 'External Link',
       attributes: {
         href: 'https://google.com/',
-        target: '_blank'
+        target: '_blank',
+        rel: 'noopener'
       }
     }
   },

--- a/docs-site/src/templates/_page-header.twig
+++ b/docs-site/src/templates/_page-header.twig
@@ -19,6 +19,7 @@
       url: "https://github.com/boltdesignsystem/bolt/wiki",
       attributes: {
         target: "_blank",
+        rel: 'noopener'
       },
     },
     {
@@ -26,6 +27,7 @@
       url: "https://github.com/bolt-design-system/bolt",
       attributes: {
         target: "_blank",
+        rel: 'noopener'
       },
       icon: {
         name: "github",

--- a/docs-site/src/templates/homepage.twig
+++ b/docs-site/src/templates/homepage.twig
@@ -40,6 +40,7 @@
             attributes: {
               href: 'https://github.com/boltdesignsystem/bolt/wiki',
               target: '_blank',
+              rel: 'noopener'
             },
           }
         },
@@ -49,6 +50,7 @@
             attributes: {
               href: 'https://github.com/bolt-design-system/bolt',
               target: '_blank',
+              rel: 'noopener'
             },
             icon: {
               name: 'github',

--- a/packages/components/bolt-button/__tests__/__snapshots__/button.js.snap
+++ b/packages/components/bolt-button/__tests__/__snapshots__/button.js.snap
@@ -14,6 +14,7 @@ exports[`button Basic usage 1`] = `
 
 exports[`button Button adds target if passed via attributes 1`] = `
 <bolt-button target="_blank"
+             rel="noopener"
              url="https://google.com"
 >
   <a href="https://google.com"

--- a/packages/components/bolt-button/__tests__/button.js
+++ b/packages/components/bolt-button/__tests__/button.js
@@ -44,6 +44,7 @@ describe('button', () => {
       url: 'https://google.com',
       attributes: {
         target: '_blank',
+        rel: 'noopener',
       },
     });
     expect(results.ok).toBe(true);

--- a/packages/components/bolt-card-replacement/__tests__/__snapshots__/card-replacement.js.snap
+++ b/packages/components/bolt-card-replacement/__tests__/__snapshots__/card-replacement.js.snap
@@ -149,7 +149,6 @@ exports[`Bolt Card Props border_radius items: large 1`] = `
           >
             <a href="https://google.com"
                target="_self"
-               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--block"
             >
               This is a button
@@ -250,7 +249,6 @@ exports[`Bolt Card Props border_radius items: small 1`] = `
           >
             <a href="https://google.com"
                target="_self"
-               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--block"
             >
               This is a button
@@ -351,7 +349,6 @@ exports[`Bolt Card Props spacing items: medium 1`] = `
           >
             <a href="https://google.com"
                target="_self"
-               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--block"
             >
               This is a button
@@ -452,7 +449,6 @@ exports[`Bolt Card Props spacing items: small 1`] = `
           >
             <a href="https://google.com"
                target="_self"
-               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--small e-bolt-button--block"
             >
               This is a button
@@ -553,7 +549,6 @@ exports[`Bolt Card Props tag items: article 1`] = `
           >
             <a href="https://google.com"
                target="_self"
-               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--block"
             >
               This is a button
@@ -654,7 +649,6 @@ exports[`Bolt Card Props tag items: div 1`] = `
           >
             <a href="https://google.com"
                target="_self"
-               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--block"
             >
               This is a button
@@ -755,7 +749,6 @@ exports[`Bolt Card Props tag items: figure 1`] = `
           >
             <a href="https://google.com"
                target="_self"
-               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--block"
             >
               This is a button
@@ -856,7 +849,6 @@ exports[`Bolt Card Props theme items: dark 1`] = `
           >
             <a href="https://google.com"
                target="_self"
-               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--block"
             >
               This is a button
@@ -957,7 +949,6 @@ exports[`Bolt Card Props theme items: light 1`] = `
           >
             <a href="https://google.com"
                target="_self"
-               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--block"
             >
               This is a button
@@ -1058,7 +1049,6 @@ exports[`Bolt Card Props theme items: none 1`] = `
           >
             <a href="https://google.com"
                target="_self"
-               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--block"
             >
               This is a button
@@ -1159,7 +1149,6 @@ exports[`Bolt Card Props theme items: xdark 1`] = `
           >
             <a href="https://google.com"
                target="_self"
-               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--block"
             >
               This is a button
@@ -1260,7 +1249,6 @@ exports[`Bolt Card Props theme items: xlight 1`] = `
           >
             <a href="https://google.com"
                target="_self"
-               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--block"
             >
               This is a button
@@ -1359,7 +1347,6 @@ exports[`Bolt Card Two Actions 1`] = `
           >
             <a href="https://google.com"
                target="_self"
-               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--block"
             >
               This is a button
@@ -1388,7 +1375,6 @@ exports[`Bolt Card Two Actions 1`] = `
           >
             <a href="https://google.com"
                target="_self"
-               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--block"
             >
               This is a sceond button
@@ -1470,7 +1456,6 @@ exports[`Bolt Card Video Card 1`] = `
           >
             <a href="https://google.com"
                target="_self"
-               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--block"
             >
               This is a button
@@ -1657,7 +1642,6 @@ exports[`Bolt Card default 1`] = `
           >
             <a href="https://google.com"
                target="_self"
-               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--block"
             >
               This is a button

--- a/packages/components/bolt-card-replacement/__tests__/__snapshots__/card-replacement.js.snap
+++ b/packages/components/bolt-card-replacement/__tests__/__snapshots__/card-replacement.js.snap
@@ -149,6 +149,7 @@ exports[`Bolt Card Props border_radius items: large 1`] = `
           >
             <a href="https://google.com"
                target="_self"
+               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--block"
             >
               This is a button
@@ -249,6 +250,7 @@ exports[`Bolt Card Props border_radius items: small 1`] = `
           >
             <a href="https://google.com"
                target="_self"
+               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--block"
             >
               This is a button
@@ -349,6 +351,7 @@ exports[`Bolt Card Props spacing items: medium 1`] = `
           >
             <a href="https://google.com"
                target="_self"
+               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--block"
             >
               This is a button
@@ -449,6 +452,7 @@ exports[`Bolt Card Props spacing items: small 1`] = `
           >
             <a href="https://google.com"
                target="_self"
+               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--small e-bolt-button--block"
             >
               This is a button
@@ -549,6 +553,7 @@ exports[`Bolt Card Props tag items: article 1`] = `
           >
             <a href="https://google.com"
                target="_self"
+               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--block"
             >
               This is a button
@@ -649,6 +654,7 @@ exports[`Bolt Card Props tag items: div 1`] = `
           >
             <a href="https://google.com"
                target="_self"
+               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--block"
             >
               This is a button
@@ -749,6 +755,7 @@ exports[`Bolt Card Props tag items: figure 1`] = `
           >
             <a href="https://google.com"
                target="_self"
+               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--block"
             >
               This is a button
@@ -849,6 +856,7 @@ exports[`Bolt Card Props theme items: dark 1`] = `
           >
             <a href="https://google.com"
                target="_self"
+               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--block"
             >
               This is a button
@@ -949,6 +957,7 @@ exports[`Bolt Card Props theme items: light 1`] = `
           >
             <a href="https://google.com"
                target="_self"
+               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--block"
             >
               This is a button
@@ -1049,6 +1058,7 @@ exports[`Bolt Card Props theme items: none 1`] = `
           >
             <a href="https://google.com"
                target="_self"
+               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--block"
             >
               This is a button
@@ -1149,6 +1159,7 @@ exports[`Bolt Card Props theme items: xdark 1`] = `
           >
             <a href="https://google.com"
                target="_self"
+               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--block"
             >
               This is a button
@@ -1249,6 +1260,7 @@ exports[`Bolt Card Props theme items: xlight 1`] = `
           >
             <a href="https://google.com"
                target="_self"
+               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--block"
             >
               This is a button
@@ -1347,6 +1359,7 @@ exports[`Bolt Card Two Actions 1`] = `
           >
             <a href="https://google.com"
                target="_self"
+               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--block"
             >
               This is a button
@@ -1375,6 +1388,7 @@ exports[`Bolt Card Two Actions 1`] = `
           >
             <a href="https://google.com"
                target="_self"
+               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--block"
             >
               This is a sceond button
@@ -1456,6 +1470,7 @@ exports[`Bolt Card Video Card 1`] = `
           >
             <a href="https://google.com"
                target="_self"
+               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--block"
             >
               This is a button
@@ -1642,6 +1657,7 @@ exports[`Bolt Card default 1`] = `
           >
             <a href="https://google.com"
                target="_self"
+               rel
                class="e-bolt-button e-bolt-button--transparent e-bolt-button--block"
             >
               This is a button

--- a/packages/components/bolt-card-replacement/src/card-replacement-actions/_card-replacement-action.twig
+++ b/packages/components/bolt-card-replacement/src/card-replacement-actions/_card-replacement-action.twig
@@ -10,11 +10,16 @@
       {% if this.data.text.value %}
         {% set _button_attributes = attributes|default({}) %}
 
-        {% if this.data.url.value %}
+        {% if this.data.url.value and this.data.external.value %}
           {% set _button_attributes = _button_attributes|merge({
             href: this.data.url.value,
-            target: this.data.external.value == true ? '_blank' : '_self',
-            rel: this.data.external.value == true ? 'noopener',
+            target: '_blank',
+            rel: 'noopener',
+          }) %}
+        {% elseif this.data.url.value %}
+          {% set _button_attributes = _button_attributes|merge({
+            href: this.data.url.value,
+            target: '_self',
           }) %}
         {% else %}
           {% set _button_attributes = _button_attributes|merge({ type: 'button' }) %}

--- a/packages/components/bolt-card-replacement/src/card-replacement-actions/_card-replacement-action.twig
+++ b/packages/components/bolt-card-replacement/src/card-replacement-actions/_card-replacement-action.twig
@@ -13,7 +13,8 @@
         {% if this.data.url.value %}
           {% set _button_attributes = _button_attributes|merge({
             href: this.data.url.value,
-            target: this.data.external.value == true ? '_blank' : '_self'
+            target: this.data.external.value == true ? '_blank' : '_self',
+            rel: this.data.external.value == true ? 'noopener',
           }) %}
         {% else %}
           {% set _button_attributes = _button_attributes|merge({ type: 'button' }) %}

--- a/packages/components/bolt-card-replacement/src/card-replacement-actions/card-replacement-action.js
+++ b/packages/components/bolt-card-replacement/src/card-replacement-actions/card-replacement-action.js
@@ -81,9 +81,7 @@ class BoltCardReplacementAction extends withContext(BoltElement) {
                 target="${ifDefined(
                   this.url ? (this.external ? '_blank' : '_self') : undefined,
                 )}"
-                rel="${ifDefined(
-                  this.url ? (this.external ? 'noopener' : '') : undefined,
-                )}"
+                ${this.external ? 'rel="noopener"' : undefined}
               >
                 ${this.slotify('default')}${renderedIcon
                   ? // prettier-ignore

--- a/packages/components/bolt-card-replacement/src/card-replacement-actions/card-replacement-action.js
+++ b/packages/components/bolt-card-replacement/src/card-replacement-actions/card-replacement-action.js
@@ -81,6 +81,9 @@ class BoltCardReplacementAction extends withContext(BoltElement) {
                 target="${ifDefined(
                   this.url ? (this.external ? '_blank' : '_self') : undefined,
                 )}"
+                rel="${ifDefined(
+                  this.url ? (this.external ? 'noopener' : '') : undefined,
+                )}"
               >
                 ${this.slotify('default')}${renderedIcon
                   ? // prettier-ignore

--- a/packages/components/bolt-card-replacement/src/card-replacement-actions/card-replacement-action.js
+++ b/packages/components/bolt-card-replacement/src/card-replacement-actions/card-replacement-action.js
@@ -81,7 +81,7 @@ class BoltCardReplacementAction extends withContext(BoltElement) {
                 target="${ifDefined(
                   this.url ? (this.external ? '_blank' : '_self') : undefined,
                 )}"
-                ${this.external ? 'rel="noopener"' : undefined}
+                ${ifDefined(this.external ? 'rel="noopener"' : undefined)}
               >
                 ${this.slotify('default')}${renderedIcon
                   ? // prettier-ignore

--- a/packages/components/bolt-chip-list/__tests__/__snapshots__/chip-list.js.snap
+++ b/packages/components/bolt-chip-list/__tests__/__snapshots__/chip-list.js.snap
@@ -330,7 +330,7 @@ exports[`<bolt-chip-list> Component collapsible 1`] = `
 
 
 
-        
+          
 
 
 
@@ -364,7 +364,7 @@ exports[`<bolt-chip-list> Component collapsible 1`] = `
 
 
 
-        
+          
 
 
 
@@ -398,7 +398,7 @@ exports[`<bolt-chip-list> Component collapsible 1`] = `
 
 
 
-        
+          
 
 
 
@@ -434,7 +434,7 @@ exports[`<bolt-chip-list> Component collapsible 1`] = `
 
 
 
-        
+          
 
 
 
@@ -470,7 +470,7 @@ exports[`<bolt-chip-list> Component collapsible 1`] = `
 
 
 
-        
+          
 
 
 
@@ -819,7 +819,7 @@ exports[`<bolt-chip-list> Component truncate 1`] = `
 
 
 
-        
+          
 
 
 
@@ -874,7 +874,7 @@ exports[`<bolt-chip-list> Component truncate 1`] = `
 
 
 
-        
+          
 
 
 
@@ -929,7 +929,7 @@ exports[`<bolt-chip-list> Component truncate 1`] = `
 
 
 
-        
+          
 
 
 
@@ -986,7 +986,7 @@ exports[`<bolt-chip-list> Component truncate 1`] = `
 
 
 
-        
+          
 
 
 
@@ -1043,7 +1043,7 @@ exports[`<bolt-chip-list> Component truncate 1`] = `
 
 
 
-        
+          
 
 
 

--- a/packages/components/bolt-chip/__tests__/__snapshots__/chip.js.snap
+++ b/packages/components/bolt-chip/__tests__/__snapshots__/chip.js.snap
@@ -110,9 +110,11 @@ exports[`chip icon usage 1`] = `
 exports[`chip url usage 1`] = `
 <bolt-chip url="https://google.com"
            target="_blank"
+           rel="noopener"
 >
   <a href="https://google.com"
      target="_blank"
+     rel="noopener"
      class="c-bolt-chip c-bolt-chip--link c-bolt-chip--size-small"
   >
     <ssr-keep for="bolt-chip"

--- a/packages/components/bolt-chip/__tests__/chip.js
+++ b/packages/components/bolt-chip/__tests__/chip.js
@@ -16,6 +16,7 @@ describe('chip', () => {
       text: 'Has URL',
       url: 'https://google.com',
       target: '_blank',
+      rel: 'noopener',
     });
     expect(results.ok).toBe(true);
     expect(results.html).toMatchSnapshot();

--- a/packages/components/bolt-chip/chip.schema.js
+++ b/packages/components/bolt-chip/chip.schema.js
@@ -70,6 +70,10 @@ module.exports = {
       },
       ref: 'icon',
     },
+    rel: {
+      type: 'string',
+      description: 'Set to <code>noopener</code>, if a link is external.',
+    },
     tag: {
       description:
         '<mark>DEPRECATED</mark> - tag is automatically determined by URL.',

--- a/packages/components/bolt-chip/src/chip.twig
+++ b/packages/components/bolt-chip/src/chip.twig
@@ -25,6 +25,9 @@
   {% if target %}
     {% set inner_attributes = inner_attributes.setAttribute('target', target) %}
   {% endif %}
+  {% if rel %}
+    {% set inner_attributes = inner_attributes.setAttribute('rel', rel) %}
+  {% endif %}
 {% else %}
   {# Otherwise, it's a whatever tag is passed #}
   {% set tag = 'span' %}
@@ -61,6 +64,7 @@
   {% if url %}
     url="{{ url }}"
     {% if target %} target="{{ target }}" {% endif %}
+    {% if rel %} rel="{{ rel }}" {% endif %}
   {% endif %}
   {% if outer_classes %} class="{{ outer_classes|join(' ') }}" {% endif %}
   {{ this.props|without('text')|without('class') }}

--- a/packages/components/bolt-image/image.schema.js
+++ b/packages/components/bolt-image/image.schema.js
@@ -75,7 +75,7 @@ module.exports = {
     sizes: {
       type: 'string',
       description:
-        "A list of one or more strings separated by commas indicating a set of source sizes. Each source size consists of a media condition omitted for the last item), and a source size value. <a href='htt://mor10.com/experiments/ricg/'target='_blank'>Learn more</a>.",
+        "A list of one or more strings separated by commas indicating a set of source sizes. Each source size consists of a media condition omitted for the last item), and a source size value. <a href='http://mor10.com/experiments/ricg/'target='_blank' rel='noopener'>Learn more</a>.",
       default: 'auto',
     },
     useAspectRatio: {

--- a/packages/components/bolt-share/__tests__/__snapshots__/share.js.snap
+++ b/packages/components/bolt-share/__tests__/__snapshots__/share.js.snap
@@ -36,6 +36,7 @@ exports[`Bolt Share Props align items: center 1`] = `
             <a href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
                class="c-bolt-share__link js-bolt-share__link--facebook"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -61,6 +62,7 @@ exports[`Bolt Share Props align items: center 1`] = `
             <a href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
                class="c-bolt-share__link js-bolt-share__link--twitter"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -86,6 +88,7 @@ exports[`Bolt Share Props align items: center 1`] = `
             <a href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
                class="c-bolt-share__link js-bolt-share__link--linkedin"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -111,6 +114,7 @@ exports[`Bolt Share Props align items: center 1`] = `
             <a href="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
                class="c-bolt-share__link js-bolt-share__link--email"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -242,6 +246,7 @@ exports[`Bolt Share Props align items: end 1`] = `
             <a href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
                class="c-bolt-share__link js-bolt-share__link--facebook"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -267,6 +272,7 @@ exports[`Bolt Share Props align items: end 1`] = `
             <a href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
                class="c-bolt-share__link js-bolt-share__link--twitter"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -292,6 +298,7 @@ exports[`Bolt Share Props align items: end 1`] = `
             <a href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
                class="c-bolt-share__link js-bolt-share__link--linkedin"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -317,6 +324,7 @@ exports[`Bolt Share Props align items: end 1`] = `
             <a href="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
                class="c-bolt-share__link js-bolt-share__link--email"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -448,6 +456,7 @@ exports[`Bolt Share Props align items: start 1`] = `
             <a href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
                class="c-bolt-share__link js-bolt-share__link--facebook"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -473,6 +482,7 @@ exports[`Bolt Share Props align items: start 1`] = `
             <a href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
                class="c-bolt-share__link js-bolt-share__link--twitter"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -498,6 +508,7 @@ exports[`Bolt Share Props align items: start 1`] = `
             <a href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
                class="c-bolt-share__link js-bolt-share__link--linkedin"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -523,6 +534,7 @@ exports[`Bolt Share Props align items: start 1`] = `
             <a href="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
                class="c-bolt-share__link js-bolt-share__link--email"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -1184,6 +1196,7 @@ exports[`Bolt Share Props opacity items: 20 1`] = `
             <a href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
                class="c-bolt-share__link js-bolt-share__link--facebook"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -1209,6 +1222,7 @@ exports[`Bolt Share Props opacity items: 20 1`] = `
             <a href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
                class="c-bolt-share__link js-bolt-share__link--twitter"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -1234,6 +1248,7 @@ exports[`Bolt Share Props opacity items: 20 1`] = `
             <a href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
                class="c-bolt-share__link js-bolt-share__link--linkedin"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -1259,6 +1274,7 @@ exports[`Bolt Share Props opacity items: 20 1`] = `
             <a href="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
                class="c-bolt-share__link js-bolt-share__link--email"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -1390,6 +1406,7 @@ exports[`Bolt Share Props opacity items: 40 1`] = `
             <a href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
                class="c-bolt-share__link js-bolt-share__link--facebook"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -1415,6 +1432,7 @@ exports[`Bolt Share Props opacity items: 40 1`] = `
             <a href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
                class="c-bolt-share__link js-bolt-share__link--twitter"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -1440,6 +1458,7 @@ exports[`Bolt Share Props opacity items: 40 1`] = `
             <a href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
                class="c-bolt-share__link js-bolt-share__link--linkedin"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -1465,6 +1484,7 @@ exports[`Bolt Share Props opacity items: 40 1`] = `
             <a href="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
                class="c-bolt-share__link js-bolt-share__link--email"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -1596,6 +1616,7 @@ exports[`Bolt Share Props opacity items: 60 1`] = `
             <a href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
                class="c-bolt-share__link js-bolt-share__link--facebook"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -1621,6 +1642,7 @@ exports[`Bolt Share Props opacity items: 60 1`] = `
             <a href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
                class="c-bolt-share__link js-bolt-share__link--twitter"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -1646,6 +1668,7 @@ exports[`Bolt Share Props opacity items: 60 1`] = `
             <a href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
                class="c-bolt-share__link js-bolt-share__link--linkedin"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -1671,6 +1694,7 @@ exports[`Bolt Share Props opacity items: 60 1`] = `
             <a href="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
                class="c-bolt-share__link js-bolt-share__link--email"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -1802,6 +1826,7 @@ exports[`Bolt Share Props opacity items: 80 1`] = `
             <a href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
                class="c-bolt-share__link js-bolt-share__link--facebook"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -1827,6 +1852,7 @@ exports[`Bolt Share Props opacity items: 80 1`] = `
             <a href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
                class="c-bolt-share__link js-bolt-share__link--twitter"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -1852,6 +1878,7 @@ exports[`Bolt Share Props opacity items: 80 1`] = `
             <a href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
                class="c-bolt-share__link js-bolt-share__link--linkedin"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -1877,6 +1904,7 @@ exports[`Bolt Share Props opacity items: 80 1`] = `
             <a href="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
                class="c-bolt-share__link js-bolt-share__link--email"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -2008,6 +2036,7 @@ exports[`Bolt Share Props opacity items: 100 1`] = `
             <a href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
                class="c-bolt-share__link js-bolt-share__link--facebook"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -2033,6 +2062,7 @@ exports[`Bolt Share Props opacity items: 100 1`] = `
             <a href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
                class="c-bolt-share__link js-bolt-share__link--twitter"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -2058,6 +2088,7 @@ exports[`Bolt Share Props opacity items: 100 1`] = `
             <a href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
                class="c-bolt-share__link js-bolt-share__link--linkedin"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -2083,6 +2114,7 @@ exports[`Bolt Share Props opacity items: 100 1`] = `
             <a href="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
                class="c-bolt-share__link js-bolt-share__link--email"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -2214,6 +2246,7 @@ exports[`Bolt Share Props size items: medium 1`] = `
             <a href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
                class="c-bolt-share__link js-bolt-share__link--facebook"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -2239,6 +2272,7 @@ exports[`Bolt Share Props size items: medium 1`] = `
             <a href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
                class="c-bolt-share__link js-bolt-share__link--twitter"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -2264,6 +2298,7 @@ exports[`Bolt Share Props size items: medium 1`] = `
             <a href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
                class="c-bolt-share__link js-bolt-share__link--linkedin"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -2289,6 +2324,7 @@ exports[`Bolt Share Props size items: medium 1`] = `
             <a href="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
                class="c-bolt-share__link js-bolt-share__link--email"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -2420,6 +2456,7 @@ exports[`Bolt Share Props size items: small 1`] = `
             <a href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
                class="c-bolt-share__link js-bolt-share__link--facebook"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--small"
                    xmlns="http://www.w3.org/2000/svg"
@@ -2445,6 +2482,7 @@ exports[`Bolt Share Props size items: small 1`] = `
             <a href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
                class="c-bolt-share__link js-bolt-share__link--twitter"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--small"
                    xmlns="http://www.w3.org/2000/svg"
@@ -2470,6 +2508,7 @@ exports[`Bolt Share Props size items: small 1`] = `
             <a href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
                class="c-bolt-share__link js-bolt-share__link--linkedin"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--small"
                    xmlns="http://www.w3.org/2000/svg"
@@ -2495,6 +2534,7 @@ exports[`Bolt Share Props size items: small 1`] = `
             <a href="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
                class="c-bolt-share__link js-bolt-share__link--email"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--small"
                    xmlns="http://www.w3.org/2000/svg"
@@ -2626,6 +2666,7 @@ exports[`Bolt Share default 1`] = `
             <a href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
                class="c-bolt-share__link js-bolt-share__link--facebook"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -2651,6 +2692,7 @@ exports[`Bolt Share default 1`] = `
             <a href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
                class="c-bolt-share__link js-bolt-share__link--twitter"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -2676,6 +2718,7 @@ exports[`Bolt Share default 1`] = `
             <a href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
                class="c-bolt-share__link js-bolt-share__link--linkedin"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -2701,6 +2744,7 @@ exports[`Bolt Share default 1`] = `
             <a href="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
                class="c-bolt-share__link js-bolt-share__link--email"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -2832,6 +2876,7 @@ exports[`Bolt Share url deprecated test 1`] = `
             <a href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
                class="c-bolt-share__link js-bolt-share__link--facebook"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -2857,6 +2902,7 @@ exports[`Bolt Share url deprecated test 1`] = `
             <a href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
                class="c-bolt-share__link js-bolt-share__link--twitter"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -2882,6 +2928,7 @@ exports[`Bolt Share url deprecated test 1`] = `
             <a href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
                class="c-bolt-share__link js-bolt-share__link--linkedin"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"
@@ -2907,6 +2954,7 @@ exports[`Bolt Share url deprecated test 1`] = `
             <a href="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
                class="c-bolt-share__link js-bolt-share__link--email"
                target="_blank"
+               rel="noopener"
             >
               <svg class="e-bolt-icon e-bolt-icon--medium"
                    xmlns="http://www.w3.org/2000/svg"

--- a/packages/components/bolt-share/__tests__/__snapshots__/share.js.snap
+++ b/packages/components/bolt-share/__tests__/__snapshots__/share.js.snap
@@ -668,6 +668,7 @@ exports[`Bolt Share Props display menu test 1`] = `
             >
               <a href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
                  target="_blank"
+                 rel="noopener"
                  class="c-bolt-trigger c-bolt-trigger--display-block c-bolt-trigger--cursor-pointer c-bolt-trigger--outline-none"
                  is="shadow-root"
               >
@@ -711,6 +712,7 @@ exports[`Bolt Share Props display menu test 1`] = `
             >
               <a href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
                  target="_blank"
+                 rel="noopener"
                  class="c-bolt-trigger c-bolt-trigger--display-block c-bolt-trigger--cursor-pointer c-bolt-trigger--outline-none"
                  is="shadow-root"
               >
@@ -754,6 +756,7 @@ exports[`Bolt Share Props display menu test 1`] = `
             >
               <a href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
                  target="_blank"
+                 rel="noopener"
                  class="c-bolt-trigger c-bolt-trigger--display-block c-bolt-trigger--cursor-pointer c-bolt-trigger--outline-none"
                  is="shadow-root"
               >
@@ -797,6 +800,7 @@ exports[`Bolt Share Props display menu test 1`] = `
             >
               <a href="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
                  target="_blank"
+                 rel="noopener"
                  class="c-bolt-trigger c-bolt-trigger--display-block c-bolt-trigger--cursor-pointer c-bolt-trigger--outline-none"
                  is="shadow-root"
               >
@@ -941,6 +945,7 @@ exports[`Bolt Share Props display menu test 2`] = `
             >
               <a href="https://www.facebook.com/sharer/sharer.php?u=https://boltdesignsystem.com&amp;amp;src=sdkpreparse"
                  target="_blank"
+                 rel="noopener"
                  class="c-bolt-trigger c-bolt-trigger--display-block c-bolt-trigger--cursor-pointer c-bolt-trigger--outline-none"
                  is="shadow-root"
               >
@@ -984,6 +989,7 @@ exports[`Bolt Share Props display menu test 2`] = `
             >
               <a href="https://twitter.com/intent/tweet?url=https://boltdesignsystem.com&amp;text=Sample%20Share%20Text&amp;via=pega&amp;hashtags=boltDesignSystemRocks!"
                  target="_blank"
+                 rel="noopener"
                  class="c-bolt-trigger c-bolt-trigger--display-block c-bolt-trigger--cursor-pointer c-bolt-trigger--outline-none"
                  is="shadow-root"
               >
@@ -1027,6 +1033,7 @@ exports[`Bolt Share Props display menu test 2`] = `
             >
               <a href="https://www.linkedin.com/shareArticle?url=https://boltdesignsystem.com"
                  target="_blank"
+                 rel="noopener"
                  class="c-bolt-trigger c-bolt-trigger--display-block c-bolt-trigger--cursor-pointer c-bolt-trigger--outline-none"
                  is="shadow-root"
               >
@@ -1070,6 +1077,7 @@ exports[`Bolt Share Props display menu test 2`] = `
             >
               <a href="mailto:?&amp;body=Sample%20Text%20--%20https%3A//boltdesignsystem.com"
                  target="_blank"
+                 rel="noopener"
                  class="c-bolt-trigger c-bolt-trigger--display-block c-bolt-trigger--cursor-pointer c-bolt-trigger--outline-none"
                  is="shadow-root"
               >

--- a/packages/components/bolt-share/src/share.twig
+++ b/packages/components/bolt-share/src/share.twig
@@ -72,7 +72,7 @@
 
   {% if source_text %}
     {% set source_inline_items %}
-      <a {{ source_attributes.addClass(base_class ~ '__link js-bolt-share__link--' ~ source_name).setAttribute('target', '_blank') }}>
+      <a {{ source_attributes.addClass(base_class ~ '__link js-bolt-share__link--' ~ source_name).setAttribute('target', '_blank').setAttribute('rel', 'noopener') }}>
         {% include '@bolt-elements-icon/icon.twig' with {
           name: source_icon,
           size: size,

--- a/packages/components/bolt-teaser/__tests__/__snapshots__/teaser.js.snap
+++ b/packages/components/bolt-teaser/__tests__/__snapshots__/teaser.js.snap
@@ -253,6 +253,7 @@ exports[`Twig usage basic usage 1`] = `
                           >
                             <a href="https://www.facebook.com/"
                                target="_blank"
+                               rel="noopener"
                                class="c-bolt-trigger c-bolt-trigger--display-block c-bolt-trigger--cursor-pointer c-bolt-trigger--outline-none"
                                is="shadow-root"
                             >
@@ -296,6 +297,7 @@ exports[`Twig usage basic usage 1`] = `
                           >
                             <a href="https://twitter.com/"
                                target="_blank"
+                               rel="noopener"
                                class="c-bolt-trigger c-bolt-trigger--display-block c-bolt-trigger--cursor-pointer c-bolt-trigger--outline-none"
                                is="shadow-root"
                             >
@@ -339,6 +341,7 @@ exports[`Twig usage basic usage 1`] = `
                           >
                             <a href="https://www.linkedin.com/"
                                target="_blank"
+                               rel="noopener"
                                class="c-bolt-trigger c-bolt-trigger--display-block c-bolt-trigger--cursor-pointer c-bolt-trigger--outline-none"
                                is="shadow-root"
                             >
@@ -382,6 +385,7 @@ exports[`Twig usage basic usage 1`] = `
                           >
                             <a href="mailto:?&amp;body=Sample%20Text%20--%20https%3A//mail.com"
                                target="_blank"
+                               rel="noopener"
                                class="c-bolt-trigger c-bolt-trigger--display-block c-bolt-trigger--cursor-pointer c-bolt-trigger--outline-none"
                                is="shadow-root"
                             >

--- a/packages/components/bolt-trigger/__tests__/__snapshots__/trigger.js.snap
+++ b/packages/components/bolt-trigger/__tests__/__snapshots__/trigger.js.snap
@@ -47,6 +47,7 @@ exports[`trigger Trigger with "target" attribute renders same value on <bolt-tri
 >
   <a href="https://google.com"
      target="_blank"
+     rel="noopener"
      class="c-bolt-trigger c-bolt-trigger--display-inline c-bolt-trigger--cursor-pointer"
      is="shadow-root"
   >

--- a/packages/components/bolt-trigger/__tests__/__snapshots__/trigger.js.snap
+++ b/packages/components/bolt-trigger/__tests__/__snapshots__/trigger.js.snap
@@ -42,6 +42,7 @@ exports[`trigger Trigger with "no_outline" 1`] = `
 
 exports[`trigger Trigger with "target" attribute renders same value on <bolt-trigger> and inner <a> 1`] = `
 <bolt-trigger target="_blank"
+              rel="noopener"
               url="https://google.com"
 >
   <a href="https://google.com"

--- a/packages/components/bolt-trigger/__tests__/trigger.js
+++ b/packages/components/bolt-trigger/__tests__/trigger.js
@@ -60,6 +60,7 @@ describe('trigger', () => {
       url: 'https://google.com',
       attributes: {
         target: '_blank',
+        rel: 'noopener',
       },
     });
     expect(results.ok).toBe(true);

--- a/packages/components/bolt-trigger/src/trigger.js
+++ b/packages/components/bolt-trigger/src/trigger.js
@@ -93,6 +93,7 @@ class BoltTrigger extends BoltActionElement {
           href="${ifDefined(this.url && !this.disabled ? this.url : undefined)}"
           class="${classes}"
           target="${ifDefined(this.target ? this.target : undefined)}"
+          rel="${ifDefined(this.rel ? this.rel : undefined)}"
           aria-disabled=${ifDefined(this.disabled ? 'true' : undefined)}
           @focus="${e => this._handleFocus(e)}"
           @blur="${e => this._handleBlur(e)}"

--- a/packages/components/bolt-trigger/src/trigger.twig
+++ b/packages/components/bolt-trigger/src/trigger.twig
@@ -23,6 +23,7 @@
 {% set cursor = this.data.cursor.value %}
 {% set url = this.data.url.value %}
 {% set target = this.data.target.value %}
+{% set rel = this.data.rel.value %}
 {% set type = this.data.type.value %}
 {% set disabled = this.data.disabled.value %}
 
@@ -36,6 +37,9 @@
   {% endif %}
   {% if target %}
     {% set inner_attributes = inner_attributes.setAttribute("target", target) %}
+  {% endif %}
+  {% if rel %}
+    {% set inner_attributes = inner_attributes.setAttribute("rel", rel) %}
   {% endif %}
 {% else %}
   {# Otherwise, it's a button #}

--- a/packages/components/bolt-trigger/trigger.schema.js
+++ b/packages/components/bolt-trigger/trigger.schema.js
@@ -34,6 +34,10 @@ module.exports = {
       default: 'button',
       enum: ['button', 'submit', 'reset'],
     },
+    rel: {
+      description: 'Set to <code>noopener</code>, if a link is external.',
+      type: 'string',
+    },
     cursor: {
       description: 'Type of cursor shown on hover.',
       type: 'string',

--- a/packages/components/bolt-typeahead/__demos__/dynamically-fetch-data/typeahead.dynamically-fetch-data.js
+++ b/packages/components/bolt-typeahead/__demos__/dynamically-fetch-data/typeahead.dynamically-fetch-data.js
@@ -24,7 +24,7 @@ const setupEventHandlers = () => {
 
     function navigateTo(url) {
       if (window.location !== window.parent.location) {
-        const win = window.open(url, '_blank');
+        const win = window.open(url, '_blank', 'noopener');
         win.focus();
       } else {
         window.location = url;

--- a/packages/components/bolt-typeahead/__demos__/dynamically-fetch-data/typeahead.dynamically-fetch-data.twig
+++ b/packages/components/bolt-typeahead/__demos__/dynamically-fetch-data/typeahead.dynamically-fetch-data.twig
@@ -11,6 +11,7 @@
   attributes: {
     action: "https://www.pega.com/search",
     target: "_blank",
+    rel: "noopener",
     method: "GET"
   }
 } %}

--- a/packages/components/bolt-typeahead/__demos__/navigate-to-exact-result/typeahead.navigate-to-exact-result.js
+++ b/packages/components/bolt-typeahead/__demos__/navigate-to-exact-result/typeahead.navigate-to-exact-result.js
@@ -30,7 +30,7 @@ const setupEventHandlers = () => {
 
     function navigateTo(url) {
       if (window.location !== window.parent.location) {
-        const win = window.open(url, '_blank');
+        const win = window.open(url, '_blank', 'noopener');
         win.focus();
       } else {
         window.location = url;

--- a/packages/components/bolt-typeahead/__demos__/navigate-to-exact-result/typeahead.navigate-to-exact-result.twig
+++ b/packages/components/bolt-typeahead/__demos__/navigate-to-exact-result/typeahead.navigate-to-exact-result.twig
@@ -10,6 +10,7 @@
   attributes: {
     action: "https://www.pega.com/search",
     target: "_blank",
+    rel: "noopener",
     method: "GET"
   }
 } %}

--- a/packages/components/bolt-typeahead/__demos__/navigate-to-search-results/typeahead.navigate-to-search-results.js
+++ b/packages/components/bolt-typeahead/__demos__/navigate-to-search-results/typeahead.navigate-to-search-results.js
@@ -70,6 +70,7 @@ const setupEventHandlers = () => {
           const win = window.open(
             `https://www.pega.com/search?q=${itemSelected.label}`,
             '_blank',
+            'noopener',
           );
           win.focus();
         } else {

--- a/packages/components/bolt-typeahead/__demos__/navigate-to-search-results/typeahead.navigate-to-search-results.twig
+++ b/packages/components/bolt-typeahead/__demos__/navigate-to-search-results/typeahead.navigate-to-search-results.twig
@@ -10,6 +10,7 @@
   attributes: {
     action: "https://www.pega.com/search",
     target: "_blank",
+    rel: "noopener",
     method: "GET"
   }
 } %}

--- a/packages/components/bolt-typeahead/__demos__/typeahead.demo.twig
+++ b/packages/components/bolt-typeahead/__demos__/typeahead.demo.twig
@@ -54,7 +54,7 @@
 
         function navigateTo(url) {
           if (window.location !== window.parent.location) {
-            const win = window.open(url, '_blank');
+            const win = window.open(url, '_blank', 'noopener');
             win.focus();
           } else {
             window.location = url;

--- a/packages/components/bolt-typeahead/__tests__/__snapshots__/typeahead.js.snap
+++ b/packages/components/bolt-typeahead/__tests__/__snapshots__/typeahead.js.snap
@@ -3,6 +3,7 @@
 exports[`<bolt-typeahead> Component Typeahead Twig Template Renders 1`] = `
 <form action="https://www.pega.com/search"
       target="_blank"
+      rel="noopener"
       method="GET"
       class="c-bolt-form"
 >

--- a/packages/components/bolt-typeahead/__tests__/typeahead.js
+++ b/packages/components/bolt-typeahead/__tests__/typeahead.js
@@ -41,6 +41,7 @@ describe('<bolt-typeahead> Component', () => {
         attributes: {
           action: "https://www.pega.com/search",
           target: "_blank",
+          rel: "noopener",
           method: "GET"
         }
       } %}

--- a/packages/elements/bolt-text-link/__tests__/__snapshots__/text-link.js.snap
+++ b/packages/elements/bolt-text-link/__tests__/__snapshots__/text-link.js.snap
@@ -3,6 +3,7 @@
 exports[`Bolt text-link Props icon after 1`] = `
 <a href="https://google.com"
    target="_blank"
+   rel="noopener"
    class="e-bolt-text-link"
 >
   This is a text link
@@ -28,6 +29,7 @@ exports[`Bolt text-link Props icon after 1`] = `
 exports[`Bolt text-link Props reverse underline 1`] = `
 <a href="https://google.com"
    target="_blank"
+   rel="noopener"
    class="e-bolt-text-link e-bolt-text-link--reversed-underline"
 >
   This is a text link
@@ -37,6 +39,7 @@ exports[`Bolt text-link Props reverse underline 1`] = `
 exports[`Bolt text-link default 1`] = `
 <a href="https://google.com"
    target="_blank"
+   rel="noopener"
    class="e-bolt-text-link"
 >
   This is a text link

--- a/packages/elements/bolt-text-link/__tests__/text-link.js
+++ b/packages/elements/bolt-text-link/__tests__/text-link.js
@@ -23,6 +23,7 @@ beforeAll(async () => {
     attributes: {
       href: 'https://google.com',
       target: '_blank',
+      rel: 'noopener',
     },
   };
 

--- a/packages/website-ui/uikit-workshop/src/scripts/lit-components/pl-tools-menu/pl-tools-menu.js
+++ b/packages/website-ui/uikit-workshop/src/scripts/lit-components/pl-tools-menu/pl-tools-menu.js
@@ -165,6 +165,7 @@ class ToolsMenu extends BaseLitComponent {
                   <pl-button
                     href="${this.currentUrl}"
                     target="_blank"
+                    rel="noopener"
                     class="pl-js-open-new-window"
                   >
                     Open In New Tab
@@ -176,7 +177,11 @@ class ToolsMenu extends BaseLitComponent {
           ${!this.ishControlsHide['tools-docs']
             ? html`
                 <li class="pl-c-tools__item">
-                  <pl-button href="http://patternlab.io/docs/" target="_blank">
+                  <pl-button
+                    href="http://patternlab.io/docs/"
+                    target="_blank"
+                    rel="noopener"
+                  >
                     Pattern Lab Docs
                     <pl-icon name="help" slot="after"></pl-icon>
                   </pl-button>


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-671

## Summary

The attribute `rel="noopener"` was added to the `twig` demos and` js` files

## Details

The attribute `rel="noopener"` was added to:

- twig includes
- link demos
- js files
- test files


 :small_orange_diamond: `Bolt-trigger` and `bolt-chip` were updated due to adding `rel` prop to the schema and then updating the templates and demos. When we check the `bolt-trigger` and `bolt-chip` schemas we can see that they don't use `object attributes` to provide a `target` attribute but there is a custom prop target - so I follow the same way for the `rel` attr.

## How to test

Pull the branch. Check the codebase if `rel="noopener"` is added where should be
