### PR TITLE
DS-695 Comment-out content-visibility rule

### DIFF
--- a/packages/elements/bolt-image/src/image.scss
+++ b/packages/elements/bolt-image/src/image.scss
@@ -2,6 +2,9 @@
 
 /**
  * Image Element
+ *
+ * Dev notes:
+ * 1. `content-visibility` conflicts with how we track scroll position in TOC and smooth-scroll components, @see https://pegadigitalit.atlassian.net/browse/DS-696
  */
 
 .e-bolt-image {
@@ -9,7 +12,7 @@
   height: auto;
   object-fit: var(--e-bolt-image-fit, cover);
   object-position: var(--e-bolt-image-position, center);
-  content-visibility: auto;
+  // content-visibility: auto; /* [1] */
 }
 
 .e-bolt-image--fill {


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-695

## Summary

`content-visibility: auto;` is conflicting with our JS that calculates scroll position. Comment-out to avoid bugs until we can fix the root issue.

## Details
When an image is far enough outside of the viewport, `content-visibility: auto;` will hide the image and the height thereafter is determined by the `height` attribute of the image. If there is no `height` attribute, the height is `0`. Either way, this change in height can happen while the TOC is in mid-scroll toward a target section. Upon arrival at that section, the page has shifted and it arrives at the wrong spot. Until we can figure out how to work with this new property, I am commenting-out this rule.

## How to test

Review files changed. Nothing else to review.