### PR TITLE
DS-697 Prevent Listing teaser from outputting empty div

### DIFF
--- a/packages/components/bolt-listing-teaser/src/listing-teaser.twig
+++ b/packages/components/bolt-listing-teaser/src/listing-teaser.twig
@@ -53,37 +53,39 @@
         {% spaceless %}<ul class="c-bolt-listing-teaser__meta">{% for item in eyebrow_items %}<li class="c-bolt-listing-teaser__meta__item">{{ item }}</li>{% endfor %}</ul>{% endspaceless %}
       </div>
     {% endif %}
-    <div class="c-bolt-listing-teaser__flag-content">
-      {% if meta_items %}
-        {% spaceless %}<ul class="c-bolt-listing-teaser__meta">{% for item in meta_items %}<li class="c-bolt-listing-teaser__meta__item">{{ item }}</li>{% endfor %}</ul>{% endspaceless %}
-      {% endif %}
-      {% if description %}
-        <div class="c-bolt-listing-teaser__flag-content__item">
-          {{ description }}
-        </div>
-      {% endif %}
-      {% if warning %}
-        <div class="c-bolt-listing-teaser__flag-content__item c-bolt-listing-teaser__flag-content__item--warning">
-          {% include '@bolt-elements-icon/icon.twig' with {
-            name: 'warning',
-            color: 'yellow',
-          } only %}
-          <div>
-            {{ warning }}
+    {% if meta_items or description or warning or chip_list or reply %}
+      <div class="c-bolt-listing-teaser__flag-content">
+        {% if meta_items %}
+          {% spaceless %}<ul class="c-bolt-listing-teaser__meta">{% for item in meta_items %}<li class="c-bolt-listing-teaser__meta__item">{{ item }}</li>{% endfor %}</ul>{% endspaceless %}
+        {% endif %}
+        {% if description %}
+          <div class="c-bolt-listing-teaser__flag-content__item">
+            {{ description }}
           </div>
-        </div>
-      {% endif %}
-      {% if chip_list %}
-        <div class="c-bolt-listing-teaser__flag-content__item c-bolt-listing-teaser__flag-content__item--chips">
-          {{ chip_list }}
-        </div>
-      {% endif %}
-      {% if reply %}
-        <div class="c-bolt-listing-teaser__flag-content__item c-bolt-listing-teaser__flag-content__item--reply">
-          {{ reply }}
-        </div>
-      {% endif %}
-    </div>
+        {% endif %}
+        {% if warning %}
+          <div class="c-bolt-listing-teaser__flag-content__item c-bolt-listing-teaser__flag-content__item--warning">
+            {% include '@bolt-elements-icon/icon.twig' with {
+              name: 'warning',
+              color: 'yellow',
+            } only %}
+            <div>
+              {{ warning }}
+            </div>
+          </div>
+        {% endif %}
+        {% if chip_list %}
+          <div class="c-bolt-listing-teaser__flag-content__item c-bolt-listing-teaser__flag-content__item--chips">
+            {{ chip_list }}
+          </div>
+        {% endif %}
+        {% if reply %}
+          <div class="c-bolt-listing-teaser__flag-content__item c-bolt-listing-teaser__flag-content__item--reply">
+            {{ reply }}
+          </div>
+        {% endif %}
+      </div>
+    {% endif %}
     {% if status %}
       <ul class="c-bolt-listing-teaser__flag-status">
         {% if status.solved %}


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-697

## Summary

The if conditional was added to prevent rendering empty div - `c-bolt-listing-teaser__flag-content`

## Details

`c-bolt-listing-teaser__flag-content` is rendered if one of the following properties is added: 

- `meta_items`
- `description`
- `warning`
- `chip_list`
- `reply`

## How to test

Check if div with the class `c-bolt-listing-teaser__flag-content` is rendered only when one or more properties are added