### PR TITLE
WWW-1217 add open prop to page footer nav list

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/page-footer/05-page-footer.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/page-footer/05-page-footer.twig
@@ -418,7 +418,7 @@
         tag: 'h3',
       },
       category: 'language',
-      content: language_list_items
+      content: language_list_items,
     } only %}
     {% include '@bolt-components-page-footer/page-footer-nav-ul.twig' with {
       headline: {

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/page-footer/05-page-footer.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/page-footer/05-page-footer.twig
@@ -426,7 +426,8 @@
         tag: 'h3',
       },
       category: 'legal',
-      content: legal_list_items
+      content: legal_list_items,
+      open: true,
     } only %}
   {% endset %}
 
@@ -463,6 +464,7 @@
   },
   content: content, // Use page-footer-nav-li.twig to render each link
   category: category, // Set the category for a particular list of navigation
+  open: true, // Set to true if a nav list needs to be expanded by default in mobile view
 } only %}
 
 // Nav list item template

--- a/packages/components/bolt-page-footer/page-footer-nav-ul.schema.js
+++ b/packages/components/bolt-page-footer/page-footer-nav-ul.schema.js
@@ -42,5 +42,11 @@ module.exports = {
         },
       },
     },
+    open: {
+      type: 'boolean',
+      description:
+        'Set to true if a nav list needs to be expanded by default in mobile view.',
+      default: false,
+    },
   },
 };

--- a/packages/components/bolt-page-footer/src/page-footer-nav-ul.twig
+++ b/packages/components/bolt-page-footer/src/page-footer-nav-ul.twig
@@ -17,7 +17,7 @@
   <{{ headline.tag }} {{ headline_attributes.addClass('c-page-footer__nav-headline') }}>
     {{ headline.content }}
   </{{ headline.tag }}>
-  <button class="c-page-footer__nav-headline c-page-footer__nav-headline--trigger js-bolt-page-footer-toggle-trigger" type="button" aria-expanded="false">
+  <button class="c-page-footer__nav-headline c-page-footer__nav-headline--trigger js-bolt-page-footer-toggle-trigger" type="button" {% if this.data.open.value == true %}aria-expanded="true"{% else %}aria-expanded="false"{% endif %}>
     {{ headline.content }}
     <span class="c-page-footer__nav-headline--trigger__icon" aria-hidden="true">
       {% include '@bolt-elements-icon/icon.twig' with {

--- a/packages/components/bolt-page-footer/src/page-footer-nav-ul.twig
+++ b/packages/components/bolt-page-footer/src/page-footer-nav-ul.twig
@@ -17,7 +17,7 @@
   <{{ headline.tag }} {{ headline_attributes.addClass('c-page-footer__nav-headline') }}>
     {{ headline.content }}
   </{{ headline.tag }}>
-  <button class="c-page-footer__nav-headline c-page-footer__nav-headline--trigger js-bolt-page-footer-toggle-trigger" type="button" {% if this.data.open.value == true %}aria-expanded="true"{% else %}aria-expanded="false"{% endif %}>
+  <button class="c-page-footer__nav-headline c-page-footer__nav-headline--trigger js-bolt-page-footer-toggle-trigger" type="button" aria-expanded="{{ this.data.open.value is same as(true) ? 'true' : 'false' }}">
     {{ headline.content }}
     <span class="c-page-footer__nav-headline--trigger__icon" aria-hidden="true">
       {% include '@bolt-elements-icon/icon.twig' with {


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/WWW-1215
https://pegadigitalit.atlassian.net/browse/WWW-1217

## Summary

Adds a `open` prop to Page Footer's nav list template.

## Details

1. Updated twig and schema.
2. The prop will make a nav list expand by default in mobile view.

## How to test

Run the branch locally and check the Page Footer docs, make sure the `open` prop works as expected.