### PR TITLE
SN-96 Skip JS validation on React form elements

### DIFF
--- a/packages/components/bolt-form/src/form.js
+++ b/packages/components/bolt-form/src/form.js
@@ -1,5 +1,7 @@
 // TODO: limit to a .js class
-const inputs = document.querySelectorAll('.c-bolt-input');
+const inputs = document.querySelectorAll(
+  '.c-bolt-input:not(.js-bolt-react-component)',
+);
 
 let thousandsDecimal = [',', '.'];
 
@@ -176,7 +178,9 @@ for (let i = 0, len = inputs.length; i < len; i++) {
   };
 }
 
-const customInputWrappers = document.querySelectorAll('.c-bolt-custom-input');
+const customInputWrappers = document.querySelectorAll(
+  '.c-bolt-custom-input:not(.js-bolt-react-component)',
+);
 
 for (let i = 0, len = customInputWrappers.length; i < len; i++) {
   const wrapper = customInputWrappers[i];


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/SN-96

## Summary

Updates the selector used to apply JS validation so that React form elements are skipped.

## Details

You can now add the class `js-bolt-react-component` to any React input which also uses the `c-bolt-input` class for styles and opt out of the default Bolt validation.

On Accounts this validation is handled via a separate React library.

## How to test

Review code and verify existing for JS works as expected. For example, blurring a required field triggers an error message.