### PR TITLE
DOCS-53 Remove whitespace around tooltip/popover trigger

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/tooltip/15-tooltip-link-whitespace.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/tooltip/15-tooltip-link-whitespace.twig
@@ -1,0 +1,34 @@
+{% set tooltip_link %}
+  {% include '@bolt-elements-text-link/text-link.twig' with {
+    content: 'tooltip',
+    attributes: {
+      href: 'https://google.com'
+    }
+  } only %}
+{% endset %}
+
+{% set tooltip %}{% spaceless %}
+  {% include "@bolt-components-tooltip/tooltip.twig" with {
+    trigger: tooltip_link,
+    content: "This is what we call a tooltip."
+  } only %}
+{% endspaceless %}{% endset %}
+
+{% set popover_link %}
+  {% include '@bolt-elements-text-link/text-link.twig' with {
+    content: 'popover',
+    attributes: {
+      type: 'button'
+    }
+  } only %}
+{% endset %}
+
+{% set popover %}{% spaceless %}
+  {% include '@bolt-components-popover/popover.twig' with {
+    trigger: popover_link,
+    content: "This is what we call a popover."
+  } only %}
+{% endspaceless %}{% endset %}
+
+<h2>Tooltip/Popover whitespace around trigger</h2>
+<p>When you use a link as the tooltip or popover trigger there should be no extra whitespace around the link. For example, this is a {{ tooltip }}. This is a {{ popover }}.</p>

--- a/packages/components/bolt-popover/src/popover.js
+++ b/packages/components/bolt-popover/src/popover.js
@@ -163,9 +163,9 @@ class BoltPopover extends BoltElement {
   }
 
   render() {
-    return html`
-      ${this.slotify('default')} ${this.slotify('content')}
-    `;
+    // Remove line breaks before and after lit-html template tags, causes unwanted space inside and around inline links
+    // prettier-ignore
+    return html`${this.slotify('default')}${this.slotify('content')}`;
   }
 }
 

--- a/packages/components/bolt-tooltip/src/tooltip.js
+++ b/packages/components/bolt-tooltip/src/tooltip.js
@@ -135,9 +135,9 @@ class BoltTooltip extends BoltElement {
   }
 
   render() {
-    return html`
-      ${this.slotify('default')} ${this.slotify('content')}
-    `;
+    // Remove line breaks before and after lit-html template tags, causes unwanted space inside and around inline links
+    // prettier-ignore
+    return html`${this.slotify('default')}${this.slotify('content')}`;
   }
 }
 


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DOCS-53

## Summary

Remove whitespace around tooltip/popover trigger.

## Details

When you pass a link as tooltip/popover trigger there is whitespace added by JS. This removes the whitespace.

This does not fix the whitespace added by Twig, which is still an issue on Tooltip.

## How to test

- Review code
- Checkout this branch locally and see new test page: `/pattern-lab/patterns/999-tests-tooltip-15-tooltip-link-whitespace/999-tests-tooltip-15-tooltip-link-whitespace.html`
- Verify there is not any whitespace after the tooltip or popover.