### PR TITLE
Fix: namespace Page Footer component code

### DIFF
--- a/packages/components/bolt-page-footer/src/page-footer-nav-li.twig
+++ b/packages/components/bolt-page-footer/src/page-footer-nav-li.twig
@@ -10,14 +10,14 @@
 {% set _link_tag = link_attributes.type ? 'button' : link_attributes.href ? 'a' : 'span' %}
 
 {% set classes = [
-  'c-page-footer__nav-list-item',
+  'c-bolt-page-footer__nav-list-item',
 ] %}
 
 <li {{ attributes.addClass(classes) }}>
-  <{{ _link_tag }} {{ link_attributes.addClass('c-page-footer__nav-link')|without('aria-describedby') }} {% if link_attributes.target == '_blank' %}aria-describedby="page-footer-new-window"{% endif %}>
-    <span class="c-page-footer__nav-link__text">{{ link.content }}</span>
+  <{{ _link_tag }} {{ link_attributes.addClass('c-bolt-page-footer__nav-link')|without('aria-describedby') }} {% if link_attributes.target == '_blank' %}aria-describedby="page-footer-new-window"{% endif %}>
+    <span class="c-bolt-page-footer__nav-link__text">{{ link.content }}</span>
     {% if link.icon_before %}
-      <span class="c-page-footer__nav-link__icon">{{ link.icon_before }}</span>
+      <span class="c-bolt-page-footer__nav-link__icon">{{ link.icon_before }}</span>
     {% endif %}
   </{{ _link_tag }}>
 </li>

--- a/packages/components/bolt-page-footer/src/page-footer-nav-ul.twig
+++ b/packages/components/bolt-page-footer/src/page-footer-nav-ul.twig
@@ -9,23 +9,23 @@
 {% set headline_attributes = create_attribute(headline.attributes|default({})) %}
 
 {% set classes = [
-  'c-page-footer__nav-item',
-  this.data.category.value ? 'c-page-footer__nav-item--' ~ this.data.category.value,
+  'c-bolt-page-footer__nav-item',
+  this.data.category.value ? 'c-bolt-page-footer__nav-item--' ~ this.data.category.value,
 ] %}
 
 <div {{ attributes.addClass(classes) }}>
-  <{{ headline.tag }} {{ headline_attributes.addClass('c-page-footer__nav-headline') }}>
+  <{{ headline.tag }} {{ headline_attributes.addClass('c-bolt-page-footer__nav-headline') }}>
     {{ headline.content }}
   </{{ headline.tag }}>
-  <button class="c-page-footer__nav-headline c-page-footer__nav-headline--trigger js-bolt-page-footer-toggle-trigger" type="button" aria-expanded="{{ this.data.open.value is same as(true) ? 'true' : 'false' }}">
+  <button class="c-bolt-page-footer__nav-headline c-bolt-page-footer__nav-headline--trigger js-bolt-page-footer-toggle-trigger" type="button" aria-expanded="{{ this.data.open.value is same as(true) ? 'true' : 'false' }}">
     {{ headline.content }}
-    <span class="c-page-footer__nav-headline--trigger__icon" aria-hidden="true">
+    <span class="c-bolt-page-footer__nav-headline--trigger__icon" aria-hidden="true">
       {% include '@bolt-elements-icon/icon.twig' with {
         name: 'chevron-down',
       } only %}
     </span>
   </button>
-  <ul class="c-page-footer__nav-list">
+  <ul class="c-bolt-page-footer__nav-list">
     {{ content }}
   </ul>
 </div>

--- a/packages/components/bolt-page-footer/src/page-footer.scss
+++ b/packages/components/bolt-page-footer/src/page-footer.scss
@@ -4,7 +4,7 @@
 
 @import '@bolt/core-v3.x';
 
-.c-page-footer {
+.c-bolt-page-footer {
   @include bolt-full-bleed;
 
   padding: var(--bolt-spacing-y-medium) var(--bolt-page-padding-x);
@@ -23,11 +23,11 @@
   }
 }
 
-.c-page-footer__nav {
+.c-bolt-page-footer__nav {
   display: grid;
 }
 
-.c-page-footer__nav--main {
+.c-bolt-page-footer__nav--main {
   @include bolt-mq(medium) {
     grid-gap: var(--bolt-spacing-x-medium);
     grid-row-gap: var(--bolt-spacing-y-medium);
@@ -38,24 +38,24 @@
       'social . . .';
     padding: var(--bolt-spacing-y-medium) var(--bolt-page-padding-x);
 
-    .c-page-footer__nav-item {
+    .c-bolt-page-footer__nav-item {
       grid-row: span 2;
     }
 
-    .c-page-footer__nav-item--description {
+    .c-bolt-page-footer__nav-item--description {
       grid-row: unset;
       grid-area: description;
       max-width: 55ch;
     }
 
-    .c-page-footer__nav-item--social {
+    .c-bolt-page-footer__nav-item--social {
       grid-row: unset;
       grid-area: social;
     }
   }
 }
 
-.c-page-footer__nav--aside {
+.c-bolt-page-footer__nav--aside {
   @include bolt-mq(medium) {
     display: flex;
     flex-wrap: wrap;
@@ -76,7 +76,7 @@
       background-color: var(--bolt-color-gray);
     }
 
-    .c-page-footer__nav-item {
+    .c-bolt-page-footer__nav-item {
       margin-right: var(--bolt-spacing-x-medium);
 
       &:last-child {
@@ -86,7 +86,7 @@
   }
 }
 
-.c-page-footer__nav-item {
+.c-bolt-page-footer__nav-item {
   display: block;
 
   @include bolt-mq($until: medium) {
@@ -94,7 +94,7 @@
   }
 }
 
-.c-page-footer__nav-item--description {
+.c-bolt-page-footer__nav-item--description {
   @include bolt-mq($until: medium) {
     padding-bottom: var(--bolt-spacing-y-medium);
   }
@@ -104,54 +104,54 @@
   }
 }
 
-.c-page-footer__nav-item--social {
+.c-bolt-page-footer__nav-item--social {
   @include bolt-mq(medium) {
     display: grid;
     grid-template-columns: auto 1fr;
     align-items: baseline;
 
-    .c-page-footer__nav-headline {
+    .c-bolt-page-footer__nav-headline {
       font-size: inherit;
       font-weight: var(--bolt-type-font-weight-semibold);
       line-height: inherit;
     }
 
-    .c-page-footer__nav-list {
+    .c-bolt-page-footer__nav-list {
       display: flex;
       padding: 0 var(--bolt-spacing-x-small);
       font-size: var(--bolt-type-font-size-large);
     }
 
-    .c-page-footer__nav-link__text {
+    .c-bolt-page-footer__nav-link__text {
       @include bolt-visuallyhidden;
     }
   }
 }
 
-.c-page-footer__nav-item--copyrights {
+.c-bolt-page-footer__nav-item--copyrights {
   @include bolt-mq($until: medium) {
     padding: var(--bolt-spacing-y-small) var(--bolt-spacing-x-xsmall);
     border-bottom: 0;
   }
 }
 
-.c-page-footer__nav-item--language,
-.c-page-footer__nav-item--legal {
+.c-bolt-page-footer__nav-item--language,
+.c-bolt-page-footer__nav-item--legal {
   @include bolt-mq(medium) {
-    .c-page-footer__nav-list {
+    .c-bolt-page-footer__nav-list {
       display: flex;
       gap: var(--bolt-spacing-x-xsmall);
       white-space: nowrap;
     }
 
-    .c-page-footer__nav-headline:not(.c-page-footer__nav-headline--trigger) {
+    .c-bolt-page-footer__nav-headline:not(.c-bolt-page-footer__nav-headline--trigger) {
       @include bolt-visuallyhidden;
     }
   }
 }
 
-.c-page-footer__nav-item--language {
-  .c-page-footer__nav-link {
+.c-bolt-page-footer__nav-item--language {
+  .c-bolt-page-footer__nav-link {
     color: var(--m-bolt-link);
 
     &:hover {
@@ -160,11 +160,11 @@
   }
 }
 
-.c-page-footer__nav-headline--trigger {
+.c-bolt-page-footer__nav-headline--trigger {
   @include bolt-button-native-styles-reset; // Button styles must be reset first before applying other styles.
 }
 
-.c-page-footer__nav-headline {
+.c-bolt-page-footer__nav-headline {
   display: none;
   margin-bottom: var(--bolt-spacing-y-small);
   font-family: var(--bolt-type-font-family-headline);
@@ -178,7 +178,7 @@
   }
 }
 
-.c-page-footer__nav-headline--trigger {
+.c-bolt-page-footer__nav-headline--trigger {
   position: relative;
   margin-bottom: 0;
 
@@ -226,11 +226,11 @@
         opacity: 0.05;
       }
 
-      .c-page-footer__nav-headline--trigger__icon {
+      .c-bolt-page-footer__nav-headline--trigger__icon {
         transform: rotate(180deg);
       }
 
-      & ~ .c-page-footer__nav-list {
+      & ~ .c-bolt-page-footer__nav-list {
         visibility: visible;
         opacity: 1;
         max-height: 100vh;
@@ -240,7 +240,7 @@
       }
     }
 
-    &[aria-expanded='false'] ~ .c-page-footer__nav-list {
+    &[aria-expanded='false'] ~ .c-bolt-page-footer__nav-list {
       visibility: hidden;
       opacity: 0;
       max-height: 0;
@@ -256,11 +256,11 @@
   }
 }
 
-.c-page-footer__nav-headline--trigger__icon {
+.c-bolt-page-footer__nav-headline--trigger__icon {
   transition: transform var(--bolt-transition);
 }
 
-.c-page-footer__nav-list {
+.c-bolt-page-footer__nav-list {
   margin: 0;
   padding: 0;
   list-style-type: none;
@@ -270,7 +270,7 @@
   }
 }
 
-.c-page-footer__nav-list-item {
+.c-bolt-page-footer__nav-list-item {
   margin: 0 0 var(--bolt-spacing-y-small) 0;
   padding: 0;
   color: var(--m-bolt-text);
@@ -280,7 +280,7 @@
   }
 }
 
-.c-page-footer__nav-link {
+.c-bolt-page-footer__nav-link {
   display: inline-grid;
   grid-template-columns: auto 1fr;
   grid-gap: var(--bolt-spacing-x-xsmall);
@@ -293,7 +293,7 @@
     color: var(--m-bolt-headline);
     text-decoration: underline;
 
-    .c-page-footer__nav-link__icon {
+    .c-bolt-page-footer__nav-link__icon {
       color: var(--m-bolt-headline);
     }
   }
@@ -312,14 +312,14 @@
   }
 }
 
-.c-page-footer__nav-link__icon {
+.c-bolt-page-footer__nav-link__icon {
   color: var(--m-bolt-link);
   transition: color var(--bolt-transition);
 }
 
 @media (prefers-reduced-motion) {
-  .c-page-footer__nav-list,
-  .c-page-footer__nav-headline--trigger__icon {
+  .c-bolt-page-footer__nav-list,
+  .c-bolt-page-footer__nav-headline--trigger__icon {
     transition: none !important; // Remove transitions that would cause motion sickness.
   }
 }

--- a/packages/components/bolt-page-footer/src/page-footer.twig
+++ b/packages/components/bolt-page-footer/src/page-footer.twig
@@ -8,21 +8,21 @@
 {% set attributes = create_attribute(attributes|default({})) %}
 
 {% set classes = [
-  'c-page-footer',
+  'c-bolt-page-footer',
   'js-bolt-page-footer',
 ] %}
 
 <footer {{ attributes.addClass(classes) }}>
-  <nav class="c-page-footer__nav c-page-footer__nav--main" aria-label="{{ 'About Pegasystems'|t }}">
-    <div class="c-page-footer__nav-item c-page-footer__nav-item--description">
+  <nav class="c-bolt-page-footer__nav c-bolt-page-footer__nav--main" aria-label="{{ 'About Pegasystems'|t }}">
+    <div class="c-bolt-page-footer__nav-item c-bolt-page-footer__nav-item--description">
       {{ description }}
     </div>
     {{ primary_nav }}
   </nav>
   <aside>
-    <nav class="c-page-footer__nav c-page-footer__nav--aside" aria-label="{{ 'Utilities'|t }}">
+    <nav class="c-bolt-page-footer__nav c-bolt-page-footer__nav--aside" aria-label="{{ 'Utilities'|t }}">
       {{ secondary_nav }}
-      <span class="c-page-footer__nav-item c-page-footer__nav-item--copyrights">&copy;{{ 'now'|date('Y') }} Pegasystems Inc.</span>
+      <span class="c-bolt-page-footer__nav-item c-bolt-page-footer__nav-item--copyrights">&copy;{{ 'now'|date('Y') }} Pegasystems Inc.</span>
     </nav>
   </aside>
   <span id="page-footer-new-window" hidden>{{ 'Open in new window'|t }}</span>


### PR DESCRIPTION
## Summary

Fixes the naming convention within the Page Footer component.

## Details

1. All changes are within the templates and CSS
2. Make sure if raw HTML was used before, update class names `c-page-footer*` to `c-bolt-page-footer*`

## How to test

Run the branch locally and check out the page footer docs. Make sure everything works exactly as before.