### PR TITLE
Fix: add max width to regular modal

### DIFF
--- a/packages/components/bolt-modal/src/modal.scss
+++ b/packages/components/bolt-modal/src/modal.scss
@@ -274,7 +274,7 @@ bolt-modal:not([ready]) {
 // Content width options
 @include bolt-mq($bolt-modal-breakpoint) {
   .c-bolt-modal__content--width-regular {
-    width: 100% / 12 * 10;
+    width: clamp(200px, calc(100% / 12 * 10), #{bolt-breakpoint(xxlarge)});
   }
 
   .c-bolt-modal__content--width-optimal {


### PR DESCRIPTION
## Summary

Adds a max-width to regular modals.

## Details

1. Updated CSS for the `regular` option for Modal component's width prop
2. The max width is set to be exactly the same as the overall site max width (1400px)

## How to test

Run the branch locally and check the modal docs. Modals with width set to `regular` should be no wider than 1400px.

## Release notes

### Visual changes

Any modal that has `width` set to `regular` now has a max-width of 1400px. This means the modal width will not get wider than 1400px. For modals that require going beyond that max-width, use `width: full` instead. 
