### PR TITLE
Ds 729 Scope button state styles to a and button elements

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/button/00-button-without-states.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/button/00-button-without-states.twig
@@ -1,0 +1,15 @@
+<div class="u-bolt-padding t-bolt-{{ theme }}">
+  <h3>This elements look like button beacuse of a class <code>e-bolt-button</code> and its variations. They don't have any states like <code>:hover</code> or <code>:active</code> which belongs to <code>a</code> and <code>button</code> semantic elements.</h3>
+  <span class="e-bolt-button">This is not a button nor a link</span>
+  <span class="e-bolt-button e-bolt-button--secondary">This is not a button nor a link</span>
+  <span class="e-bolt-button e-bolt-button--tertiary">This is not a button nor a link</span>
+  <span class="e-bolt-button e-bolt-button--transparent">This is not a button nor a link</span>
+  <span class="e-bolt-button e-bolt-button--icon-only">
+    <span class="e-bolt-button__icon-center"><svg enable-background="new 0 0 32 32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path clip-rule="evenodd" d="m18 13.9v-11.8c0-1.2-.9-2.1-2-2.1s-2 .9-2 2.1v11.8h-11.1c-1.1 0-2 .9-2 2.1s.9 2.1 2 2.1h11.1v11.8c0 1.2.9 2.1 2 2.1s2-.9 2-2.1v-11.8h11.1c1.1 0 2-.9 2-2.1s-.9-2.1-2-2.1z" fill="white" fill-rule="evenodd"/></svg></span>
+  </span>
+
+  <hr>
+
+  <a href="#" class="e-bolt-button">This is a true href with states clsses</a>
+  <button type="button" class="e-bolt-button">This is a true button withstates classes</button>
+</div>

--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/button/00-button-without-states.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/button/00-button-without-states.twig
@@ -1,4 +1,4 @@
-<div class="u-bolt-padding t-bolt-{{ theme }}">
+<div class="u-bolt-padding">
   <p>This  <code>&lt;span&gt;</code> elements look like button beacuse of a class <code>e-bolt-button</code> and its variations. They don't have any interactive features like <code>:hover</code> or <code>:active</code> which belongs to an <code>&lt;a&gt;</code> and a <code>&lt;button&gt;</code> semantic elements.</p>
   <span class="e-bolt-button u-bolt-margin-bottom-small">This is not a button nor a link</span>
   <span class="e-bolt-button e-bolt-button--secondary u-bolt-margin-bottom-small">This is not a button nor a link</span>
@@ -10,7 +10,7 @@
 
   <hr>
 
-  <p>These are a true <code>link</code> and a true <code>button</code> with their states.</p>
+  <p>These are examples of semantic <code>link</code> and a semantic <code>button</code> with their interactive states.</p>
   <a href="https://www.google.com/" target="_blank" rel="noopener" class="e-bolt-button u-bolt-margin-bottom-small">This is a true href with states clsses</a>
-  <button type="button" class="e-bolt-button u-bolt-margin-bottom-small">This is a true button withstates classes</button>
+  <button type="button" class="e-bolt-button u-bolt-margin-bottom-small">This is a true button with states classes</button>
 </div>

--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/button/00-button-without-states.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/button/00-button-without-states.twig
@@ -10,7 +10,22 @@
 
   <hr>
 
-  <p>These are examples of semantic <code>link</code> and a semantic <code>button</code> with their interactive states.</p>
+  <p>These are examples of semantic <code>link</code> with their interactive states.</p>
   <a href="https://www.google.com/" target="_blank" rel="noopener" class="e-bolt-button u-bolt-margin-bottom-small">This is a true href with states classes</a>
+  <a href="https://www.google.com/" target="_blank" rel="noopener" class="e-bolt-button e-bolt-button--secondary u-bolt-margin-bottom-small">This is a true href with states classes</a>
+  <a href="https://www.google.com/" target="_blank" rel="noopener" class="e-bolt-button e-bolt-button--tertiary u-bolt-margin-bottom-small">This is a true href with states classes</a>
+  <a href="https://www.google.com/" target="_blank" rel="noopener" class="e-bolt-button e-bolt-button--transparent u-bolt-margin-bottom-small">This is a true href with states classes</a>
+  <a href="https://www.google.com/" target="_blank" rel="noopener" class="e-bolt-button e-bolt-button--icon-only u-bolt-margin-bottom-small">
+    <span class="e-bolt-button__icon-center"><svg enable-background="new 0 0 32 32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path clip-rule="evenodd" d="m18 13.9v-11.8c0-1.2-.9-2.1-2-2.1s-2 .9-2 2.1v11.8h-11.1c-1.1 0-2 .9-2 2.1s.9 2.1 2 2.1h11.1v11.8c0 1.2.9 2.1 2 2.1s2-.9 2-2.1v-11.8h11.1c1.1 0 2-.9 2-2.1s-.9-2.1-2-2.1z" fill="white" fill-rule="evenodd"/></svg></span>
+  </a>
+  <br />
+  <hr>
+  <p>These are examples of semantic <code>button</code> with their interactive states.</p>
   <button type="button" class="e-bolt-button u-bolt-margin-bottom-small">This is a true button with states classes</button>
+  <button type="button" class="e-bolt-button e-bolt-button--secondary u-bolt-margin-bottom-small">This is a true button with states classes</button>
+  <button type="button" class="e-bolt-button e-bolt-button--tertiary u-bolt-margin-bottom-small">This is a true button with states classes</button>
+  <button type="button" class="e-bolt-button e-bolt-button--transparent u-bolt-margin-bottom-small">This is a true button with states classes</button>
+  <button type="button" class="e-bolt-button e-bolt-button--icon-only u-bolt-margin-bottom-small">
+    <span class="e-bolt-button__icon-center"><svg enable-background="new 0 0 32 32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path clip-rule="evenodd" d="m18 13.9v-11.8c0-1.2-.9-2.1-2-2.1s-2 .9-2 2.1v11.8h-11.1c-1.1 0-2 .9-2 2.1s.9 2.1 2 2.1h11.1v11.8c0 1.2.9 2.1 2 2.1s2-.9 2-2.1v-11.8h11.1c1.1 0 2-.9 2-2.1s-.9-2.1-2-2.1z" fill="white" fill-rule="evenodd"/></svg></span>
+  </button>
 </div>

--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/button/00-button-without-states.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/button/00-button-without-states.twig
@@ -11,6 +11,6 @@
   <hr>
 
   <p>These are examples of semantic <code>link</code> and a semantic <code>button</code> with their interactive states.</p>
-  <a href="https://www.google.com/" target="_blank" rel="noopener" class="e-bolt-button u-bolt-margin-bottom-small">This is a true href with states clsses</a>
+  <a href="https://www.google.com/" target="_blank" rel="noopener" class="e-bolt-button u-bolt-margin-bottom-small">This is a true href with states classes</a>
   <button type="button" class="e-bolt-button u-bolt-margin-bottom-small">This is a true button with states classes</button>
 </div>

--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/button/00-button-without-states.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/button/00-button-without-states.twig
@@ -1,15 +1,16 @@
 <div class="u-bolt-padding t-bolt-{{ theme }}">
-  <h3>This elements look like button beacuse of a class <code>e-bolt-button</code> and its variations. They don't have any states like <code>:hover</code> or <code>:active</code> which belongs to <code>a</code> and <code>button</code> semantic elements.</h3>
-  <span class="e-bolt-button">This is not a button nor a link</span>
-  <span class="e-bolt-button e-bolt-button--secondary">This is not a button nor a link</span>
-  <span class="e-bolt-button e-bolt-button--tertiary">This is not a button nor a link</span>
-  <span class="e-bolt-button e-bolt-button--transparent">This is not a button nor a link</span>
-  <span class="e-bolt-button e-bolt-button--icon-only">
+  <p>This  <code>&lt;span&gt;</code> elements look like button beacuse of a class <code>e-bolt-button</code> and its variations. They don't have any interactive features like <code>:hover</code> or <code>:active</code> which belongs to an <code>&lt;a&gt;</code> and a <code>&lt;button&gt;</code> semantic elements.</p>
+  <span class="e-bolt-button u-bolt-margin-bottom-small">This is not a button nor a link</span>
+  <span class="e-bolt-button e-bolt-button--secondary u-bolt-margin-bottom-small">This is not a button nor a link</span>
+  <span disabled class="e-bolt-button e-bolt-button--tertiary u-bolt-margin-bottom-small">This is not a button nor a link</span>
+  <span class="e-bolt-button e-bolt-button--transparent u-bolt-margin-bottom-small">This is not a button nor a link</span>
+  <span class="e-bolt-button e-bolt-button--icon-only u-bolt-margin-bottom-small">
     <span class="e-bolt-button__icon-center"><svg enable-background="new 0 0 32 32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path clip-rule="evenodd" d="m18 13.9v-11.8c0-1.2-.9-2.1-2-2.1s-2 .9-2 2.1v11.8h-11.1c-1.1 0-2 .9-2 2.1s.9 2.1 2 2.1h11.1v11.8c0 1.2.9 2.1 2 2.1s2-.9 2-2.1v-11.8h11.1c1.1 0 2-.9 2-2.1s-.9-2.1-2-2.1z" fill="white" fill-rule="evenodd"/></svg></span>
   </span>
 
   <hr>
 
-  <a href="#" class="e-bolt-button">This is a true href with states clsses</a>
-  <button type="button" class="e-bolt-button">This is a true button withstates classes</button>
+  <p>These are a true <code>link</code> and a true <code>button</code> with their states.</p>
+  <a href="https://www.google.com/" target="_blank" rel="noopener" class="e-bolt-button u-bolt-margin-bottom-small">This is a true href with states clsses</a>
+  <button type="button" class="e-bolt-button u-bolt-margin-bottom-small">This is a true button withstates classes</button>
 </div>

--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/button/00-button-without-states.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/button/00-button-without-states.twig
@@ -1,5 +1,5 @@
 <div class="u-bolt-padding">
-  <p>This  <code>&lt;span&gt;</code> elements look like button beacuse of a class <code>e-bolt-button</code> and its variations. They don't have any interactive features like <code>:hover</code> or <code>:active</code> which belongs to an <code>&lt;a&gt;</code> and a <code>&lt;button&gt;</code> semantic elements.</p>
+  <p>This  <code>&lt;span&gt;</code> elements look like a button beacuse of a class <code>e-bolt-button</code> and its modifiers. They don't have any interactive features like <code>:hover</code> or <code>:active</code> which belongs to an <code>&lt;a&gt;</code> and a <code>&lt;button&gt;</code> semantic tags.</p>
   <span class="e-bolt-button u-bolt-margin-bottom-small">This is not a button nor a link</span>
   <span class="e-bolt-button e-bolt-button--secondary u-bolt-margin-bottom-small">This is not a button nor a link</span>
   <span disabled class="e-bolt-button e-bolt-button--tertiary u-bolt-margin-bottom-small">This is not a button nor a link</span>

--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/button/00-button-without-states.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/button/00-button-without-states.twig
@@ -28,4 +28,8 @@
   <button type="button" class="e-bolt-button e-bolt-button--icon-only u-bolt-margin-bottom-small">
     <span class="e-bolt-button__icon-center"><svg enable-background="new 0 0 32 32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path clip-rule="evenodd" d="m18 13.9v-11.8c0-1.2-.9-2.1-2-2.1s-2 .9-2 2.1v11.8h-11.1c-1.1 0-2 .9-2 2.1s.9 2.1 2 2.1h11.1v11.8c0 1.2.9 2.1 2 2.1s2-.9 2-2.1v-11.8h11.1c1.1 0 2-.9 2-2.1s-.9-2.1-2-2.1z" fill="white" fill-rule="evenodd"/></svg></span>
   </button>
+  <br />
+  <hr>
+  <p>This is an example of semantic <code>input</code> with <code>type=[file]</code> and its interactive states.</p>
+  <input id="unique-file-id" type="file" class="e-bolt-button e-bolt-button--small e-bolt-button--tertiary u-bolt-margin-bottom-small">
 </div>

--- a/packages/elements/bolt-button/src/button.scss
+++ b/packages/elements/bolt-button/src/button.scss
@@ -104,23 +104,8 @@ a.e-bolt-button {
 $_bolt-button-hierarchy: primary, secondary, tertiary, transparent;
 
 @each $hierarchy-name in $_bolt-button-hierarchy {
-  .e-bolt-button--#{$hierarchy-name} {
-    @if $hierarchy-name == tertiary or $hierarchy-name == transparent {
-      button.e-bolt-button,
-      a.e-bolt-button {
-        &:hover {
-          transform: translate3d(0, 0, 0);
-
-          &:after {
-            opacity: 0.2;
-            box-shadow: none;
-            background-color: var(--bolt-color-gray);
-          }
-        }
-      }
-    }
-
-    @if $hierarchy-name != transparent {
+  @if $hierarchy-name != transparent {
+    .e-bolt-button--#{$hierarchy-name} {
       --e-bolt-button-text-color: var(--m-bolt-text-on-#{$hierarchy-name});
       --e-bolt-button-bg-color: var(--m-bolt-#{$hierarchy-name});
 
@@ -141,7 +126,9 @@ $_bolt-button-hierarchy: primary, secondary, tertiary, transparent;
           box-shadow: 0 0 0 2px var(--m-bolt-primary);
         }
       }
-    } @else {
+    }
+  } @else {
+    .e-bolt-button--#{$hierarchy-name} {
       --e-bolt-button-text-color: var(--m-bolt-link);
       --e-bolt-button-bg-color: transparent;
 
@@ -149,14 +136,31 @@ $_bolt-button-hierarchy: primary, secondary, tertiary, transparent;
       &:after {
         display: none;
       }
+    }
+  }
 
-      button.e-bolt-button,
-      a.e-bolt-button {
-        &:hover {
-          text-decoration: underline;
-          text-decoration-thickness: 2px;
-          text-underline-offset: 3px;
+  @if $hierarchy-name == tertiary or $hierarchy-name == transparent {
+    button.e-bolt-button--#{$hierarchy-name},
+    a.e-bolt-button--#{$hierarchy-name} {
+      &:hover {
+        transform: translate3d(0, 0, 0);
+
+        &:after {
+          opacity: 0.2;
+          box-shadow: none;
+          background-color: var(--bolt-color-gray);
         }
+      }
+    }
+  }
+
+  @if $hierarchy-name == transparent {
+    button.e-bolt-button--#{$hierarchy-name},
+    a.e-bolt-button--#{$hierarchy-name} {
+      &:hover {
+        text-decoration: underline;
+        text-decoration-thickness: 2px;
+        text-underline-offset: 3px;
       }
     }
   }

--- a/packages/elements/bolt-button/src/button.scss
+++ b/packages/elements/bolt-button/src/button.scss
@@ -87,7 +87,8 @@ a.e-bolt-button {
 }
 
 button.e-bolt-button,
-a.e-bolt-button {
+a.e-bolt-button,
+input[type='file'].e-bolt-button {
   &:focus,
   &:active:not(:disabled) {
     transform: translate3d(0, 0, 0);
@@ -97,7 +98,8 @@ a.e-bolt-button {
 }
 
 button.e-bolt-button,
-a.e-bolt-button {
+a.e-bolt-button,
+input[type='file'].e-bolt-button {
   cursor: pointer;
 }
 
@@ -141,7 +143,8 @@ $_bolt-button-hierarchy: primary, secondary, tertiary, transparent;
 
   @if $hierarchy-name == tertiary or $hierarchy-name == transparent {
     button.e-bolt-button--#{$hierarchy-name},
-    a.e-bolt-button--#{$hierarchy-name} {
+    a.e-bolt-button--#{$hierarchy-name},
+    input[type='file'].e-bolt-button--#{$hierarchy-name} {
       &:hover {
         transform: translate3d(0, 0, 0);
 

--- a/packages/elements/bolt-button/src/button.scss
+++ b/packages/elements/bolt-button/src/button.scss
@@ -61,28 +61,6 @@
     opacity: 0;
   }
 
-  &[type='button'],
-  &[href] {
-    &:hover {
-      transform: translate3d(0, -2px, 0);
-
-      &:after {
-        opacity: 0.4;
-        box-shadow: 0 0.4em 1.5em var(--m-bolt-primary);
-      }
-    }
-  }
-
-  &[type='button'],
-  &[href] {
-    &:focus,
-    &:active:not(:disabled) {
-      transform: translate3d(0, 0, 0);
-      outline: var(--bolt-focus-ring);
-      outline-offset: 2px;
-    }
-  }
-
   &:disabled {
     --e-bolt-button-text-color: var(--m-bolt-text-on-disabled);
     --e-bolt-button-bg-color: var(--m-bolt-disabled);
@@ -94,11 +72,33 @@
       display: none;
     }
   }
+}
 
-  &[type='button'],
-  &[href] {
-    cursor: pointer;
+button.e-bolt-button,
+a.e-bolt-button {
+  &:hover {
+    transform: translate3d(0, -2px, 0);
+
+    &:after {
+      opacity: 0.4;
+      box-shadow: 0 0.4em 1.5em var(--m-bolt-primary);
+    }
   }
+}
+
+button.e-bolt-button,
+a.e-bolt-button {
+  &:focus,
+  &:active:not(:disabled) {
+    transform: translate3d(0, 0, 0);
+    outline: var(--bolt-focus-ring);
+    outline-offset: 2px;
+  }
+}
+
+button.e-bolt-button,
+a.e-bolt-button {
+  cursor: pointer;
 }
 
 $_bolt-button-hierarchy: primary, secondary, tertiary, transparent;
@@ -106,8 +106,8 @@ $_bolt-button-hierarchy: primary, secondary, tertiary, transparent;
 @each $hierarchy-name in $_bolt-button-hierarchy {
   .e-bolt-button--#{$hierarchy-name} {
     @if $hierarchy-name == tertiary or $hierarchy-name == transparent {
-      &[type='button'],
-      &[href] {
+      button.e-bolt-button,
+      a.e-bolt-button {
         &:hover {
           transform: translate3d(0, 0, 0);
 
@@ -150,8 +150,8 @@ $_bolt-button-hierarchy: primary, secondary, tertiary, transparent;
         display: none;
       }
 
-      &[type='button'],
-      &[href] {
+      button.e-bolt-button,
+      a.e-bolt-button {
         &:hover {
           text-decoration: underline;
           text-decoration-thickness: 2px;

--- a/packages/elements/bolt-button/src/button.scss
+++ b/packages/elements/bolt-button/src/button.scss
@@ -12,7 +12,6 @@
 
 .e-bolt-button {
   @include bolt-button-native-styles-reset;
-
   --e-bolt-button-padding-y: calc(var(--bolt-spacing-y-medium) * 0.5);
   --e-bolt-button-padding-x: var(--bolt-spacing-x-medium);
   --e-bolt-button-font-size: var(--bolt-type-font-size-small);
@@ -34,6 +33,7 @@
   text-align: center;
   text-decoration: none;
   vertical-align: middle;
+  cursor: default;
   border-radius: var(--e-bolt-button-border-radius);
   background-color: var(--e-bolt-button-bg-color);
   transition: transform var(--bolt-transition);
@@ -93,6 +93,11 @@
     &:after {
       display: none;
     }
+  }
+
+  &[type='button'],
+  &[href] {
+    cursor: pointer;
   }
 }
 

--- a/packages/elements/bolt-button/src/button.scss
+++ b/packages/elements/bolt-button/src/button.scss
@@ -61,20 +61,26 @@
     opacity: 0;
   }
 
-  &:hover {
-    transform: translate3d(0, -2px, 0);
+  &[type='button'],
+  &[href] {
+    &:hover {
+      transform: translate3d(0, -2px, 0);
 
-    &:after {
-      opacity: 0.4;
-      box-shadow: 0 0.4em 1.5em var(--m-bolt-primary);
+      &:after {
+        opacity: 0.4;
+        box-shadow: 0 0.4em 1.5em var(--m-bolt-primary);
+      }
     }
   }
 
-  &:focus,
-  &:active:not(:disabled) {
-    transform: translate3d(0, 0, 0);
-    outline: var(--bolt-focus-ring);
-    outline-offset: 2px;
+  &[type='button'],
+  &[href] {
+    &:focus,
+    &:active:not(:disabled) {
+      transform: translate3d(0, 0, 0);
+      outline: var(--bolt-focus-ring);
+      outline-offset: 2px;
+    }
   }
 
   &:disabled {
@@ -95,13 +101,16 @@ $_bolt-button-hierarchy: primary, secondary, tertiary, transparent;
 @each $hierarchy-name in $_bolt-button-hierarchy {
   .e-bolt-button--#{$hierarchy-name} {
     @if $hierarchy-name == tertiary or $hierarchy-name == transparent {
-      &:hover {
-        transform: translate3d(0, 0, 0);
+      &[type='button'],
+      &[href] {
+        &:hover {
+          transform: translate3d(0, 0, 0);
 
-        &:after {
-          opacity: 0.2;
-          box-shadow: none;
-          background-color: var(--bolt-color-gray);
+          &:after {
+            opacity: 0.2;
+            box-shadow: none;
+            background-color: var(--bolt-color-gray);
+          }
         }
       }
     }
@@ -136,10 +145,13 @@ $_bolt-button-hierarchy: primary, secondary, tertiary, transparent;
         display: none;
       }
 
-      &:hover {
-        text-decoration: underline;
-        text-decoration-thickness: 2px;
-        text-underline-offset: 3px;
+      &[type='button'],
+      &[href] {
+        &:hover {
+          text-decoration: underline;
+          text-decoration-thickness: 2px;
+          text-underline-offset: 3px;
+        }
       }
     }
   }


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-729

## Summary

HTML elements different than `<a>` and `<button>` can look like the bolt button element but without the interactive features.

## Details

Interactive features of `<button>` like:

- hover
- active
- cursor pointer

were scoped only to semantic HTML `<button>` and `<a>` tags.

A test page of the examples was added to the Tests folder.

## How to test

Pull the branch. Try to add `e-bolt-button`  class to different HTML tags than `<a>` and `<button>`. For example `<span>` or `<div>`.

### Visual changes

If an HTML tag with an `e-bolt-button` class is not a semantic `<button>` or `<a>`, the element will only look like the button (shape, color, etc), without the interactive features of the button.
