### PR TITLE
WWW-1289 fix page footer button's chevron placement in iOS 14

### DIFF
--- a/packages/components/bolt-page-footer/src/page-footer.scss
+++ b/packages/components/bolt-page-footer/src/page-footer.scss
@@ -216,8 +216,10 @@
   }
 
   @include bolt-mq($until: medium) {
-    display: grid;
-    grid-template-columns: 1fr auto;
+    display: flex;
+    flex-wrap: nowrap;
+    justify-content: space-between;
+    gap: var(--bolt-spacing-x-small);
     width: 100%;
     padding: var(--bolt-spacing-y-small) var(--bolt-spacing-x-xsmall);
 


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/WWW-1289

## Summary

Fixes an issue where the Page Footer button's chevron icon is out of place.

## Details

Updated CSS to use flex instead of grid.

## How to test

Run the branch locally and check the page footer doc with viewport set to 480px or smaller. Make sure the chevron icon that  is in each section heading is displayed on the same line as the text and to the right edge.