### PR TITLE
WWW-1284: Remove reference to undefined `themes` variable

### DIFF
--- a/packages/experimental/micro-journeys/src/interactive-pathways.js
+++ b/packages/experimental/micro-journeys/src/interactive-pathways.js
@@ -295,7 +295,7 @@ class BoltInteractivePathways extends withLitContext {
     `;
 
     return html`
-      ${this.addStyles([styles, themes])}
+      ${this.addStyles([styles])}
       <div class="${classes}">
         <div class="c-bolt-interactive-pathways__header">
           ${props.hidePathwaysImage


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/WWW-1284

## Summary

Restores microjourneys, which have been broken as of 5.0.0

## Details

This appears to have originally broken with
https://github.com/boltdesignsystem/bolt/commit/3a8a24ca83c3e2fd44bafb4290decc250638c5b9.  By removing the reference to an undefined variable, micro journeys work again and themes are still supported.

## How to test

On this branch, go to /pattern-lab/?p=experiments-micro-journeys and confirm that the micro journey loads.  Optionally, add a `t-bolt-dark` class to confirm all parts still work with a dark theme.
