### PR TITLE
DS-734: Tooltip aria_type Prop

### DIFF
--- a/packages/components/bolt-tooltip/src/tooltip.js
+++ b/packages/components/bolt-tooltip/src/tooltip.js
@@ -73,6 +73,10 @@ class BoltTooltip extends BoltElement {
       offset: [0, 0],
       plugins: [hideOnEsc],
       zIndex: this.zIndex,
+      aria: {
+        expanded: false,
+        content: this.ariaType,
+      },
       popperOptions: {
         modifiers: [
           {

--- a/packages/components/bolt-tooltip/tooltip.schema.js
+++ b/packages/components/bolt-tooltip/tooltip.schema.js
@@ -80,7 +80,7 @@ module.exports = {
     aria_type: {
       type: 'string',
       description:
-        '`labelledby` should reference brief text that provides the element with an accessible name. `describedby` is used to reference longer content that provides a description.',
+        "This sets the specific aria attribute for rendering the tooltip, the 2 available options do different things. 'labelledby' sets the tooltip text as the accessible name for the trigger, while 'describedby' keeps the trigger's accessible name (it must have one in such case) and provides additional description.",
       enum: ['labelledby', 'describedby'],
       default: 'labelledby',
     },

--- a/packages/components/bolt-tooltip/tooltip.schema.js
+++ b/packages/components/bolt-tooltip/tooltip.schema.js
@@ -77,6 +77,13 @@ module.exports = {
       description:
         "An array of different placement options that Popper.js should try if there isn't enough space for the ideal placement. Normally this defaults to all placement options however this lets you limit the options to pick from in certain situations.",
     },
+    aria_type: {
+      type: 'string',
+      description:
+        '`labelledby` should reference brief text that provides the element with an accessible name. `describedby` is used to reference longer content that provides a description.',
+      enum: ['labelledby', 'describedby'],
+      default: 'labelledby',
+    },
     direction: {
       type: 'any',
       title: 'DEPRECATED',


### PR DESCRIPTION
## Jira

[https://pegadigitalit.atlassian.net/browse/DS-734](https://pegadigitalit.atlassian.net/browse/DS-734)

## Summary

`aria_type` property on `bolt-tooltip`. remove `aria-expanded` use on `bolt-tooltip`.

## Details

Add a new property to `bolt-tooltip` that allows users to choose `labelledby` or `describedby`. Remove the dependency on `aria-expanded` to prevent conflicts with other components.

## How to test

Pull the branch and set some demos to use `describedby` instead.

## Release notes

new `aria_type` property on `bolt-tooltip`
