### PR TITLE
Brightcove Playback Rates update

### DIFF
--- a/packages/website-ui/styleguidekit-twig-default/views/partials/general-footer.twig
+++ b/packages/website-ui/styleguidekit-twig-default/views/partials/general-footer.twig
@@ -37,6 +37,7 @@
       this.customError(this.getAttribute('data-custom-error-message'))
     })
     thisPlayer.ready(function() {
+      
       // OPTIONS
       // data-playback-rates (optional) [array]: Sets the playback rates on the player controls
       if(this.el().dataset.playbackRates){

--- a/packages/website-ui/styleguidekit-twig-default/views/partials/general-footer.twig
+++ b/packages/website-ui/styleguidekit-twig-default/views/partials/general-footer.twig
@@ -42,9 +42,17 @@
       if(this.el().dataset.playbackRates){
         var playbackRateOptions = this.getAttribute('data-playback-rates').replace(/(\[*\]*)/g, '')
         playbackRateOptions = playbackRateOptions.split(',')
-        thisPlayer.controlBar.playbackRateMenuButton = thisPlayer.controlBar.addChild('PlaybackRateMenuButton', {
-          playbackRates: playbackRateOptions
-        }, 10)
+        if(typeof thisPlayer.playbackRates === "function"){
+          var playbackRateOptionsClean = []
+          for (var o = 0; o < playbackRateOptions.length; o++) {
+            playbackRateOptionsClean.push(parseFloat(playbackRateOptions[o], 10))
+            } 
+            thisPlayer.playbackRates(playbackRateOptionsClean);
+        } else {
+          thisPlayer.controlBar.playbackRateMenuButton = thisPlayer.controlBar.addChild('PlaybackRateMenuButton', {
+            playbackRates: playbackRateOptions
+          }, 10)
+        }
       }
       // OPTIONS
       // data-default-resolution (optional) [string]: Adjusts the default resolution for the videos (ex. 720p)


### PR DESCRIPTION
## Summary

Brightcove Playback rates logic update to support video.js v7.13+ and provide a fallback to previous versions
(This PR is to maintain consistency between BC, Drupal and Bolt, this code is being tested and merged [here](https://gitlab.com/pegadigital/bolt/pega_bolt/-/merge_requests/287))
