### PR TITLE
DS-630: Screenreader Keypress Navigation in Page Header

### DIFF
--- a/packages/components/bolt-page-header/src/page-header-nav.js
+++ b/packages/components/bolt-page-header/src/page-header-nav.js
@@ -94,6 +94,7 @@ export class BoltPageHeaderNav {
   setupDesktopMenu() {
     this.addHoverHandler(this.menu);
     this.addKeypressHandler(this.menu);
+    this.addClickHandler(this.menu);
     this.state.desktopIsSetup = true;
   }
 
@@ -101,6 +102,7 @@ export class BoltPageHeaderNav {
     this.resetActiveMenus();
     this.hoverListeners.forEach(listener => listener.remove());
     this.removeKeypressHandler(this.menu);
+    this.removeClickHandler(this.menu);
     this.state.desktopIsSetup = false;
   }
 

--- a/packages/components/bolt-page-header/src/page-header-nav.js
+++ b/packages/components/bolt-page-header/src/page-header-nav.js
@@ -45,6 +45,7 @@ export class BoltPageHeaderNav {
   }
 
   init() {
+    this.handleKeypress = this.handleKeypress.bind(this);
     this.handleEscapeKeypress = this.handleEscapeKeypress.bind(this);
     this.clickHandler = this.clickHandler.bind(this);
     this.handleExternalClick = this.handleExternalClick.bind(this);
@@ -92,14 +93,14 @@ export class BoltPageHeaderNav {
 
   setupDesktopMenu() {
     this.addHoverHandler(this.menu);
-    this.addClickHandler(this.menu);
+    this.addKeypressHandler(this.menu);
     this.state.desktopIsSetup = true;
   }
 
   resetDesktopMenu() {
     this.resetActiveMenus();
     this.hoverListeners.forEach(listener => listener.remove());
-    this.removeClickHandler(this.menu);
+    this.removeKeypressHandler(this.menu);
     this.state.desktopIsSetup = false;
   }
 
@@ -128,11 +129,37 @@ export class BoltPageHeaderNav {
     this.toggleMenu(el);
   }
 
+  addKeypressHandler(menus = []) {
+    menus.forEach(menu => {
+      menu.trigger.addEventListener('keydown', this.handleKeypress);
+    });
+  }
+
+  removeKeypressHandler(menus = []) {
+    menus.forEach(menu => {
+      menu.trigger.removeEventListener('keydown', this.handleKeypress);
+    });
+  }
+
   getKey(e) {
     if (e.key !== undefined) {
       return e.key;
     } else if (e.keyCode !== undefined) {
       return e.keyCode;
+    }
+  }
+
+  handleKeypress(e) {
+    switch (this.getKey(e)) {
+      case 'Enter' || 13: // enter key
+        this.toggleMenu(e.target);
+        break;
+      case ' ' || 32: // space key
+        this.toggleMenu(e.target);
+        break;
+      case 'Escape' || 27: // escape key
+        this.hideMenu(e.target);
+        break;
     }
   }
 

--- a/packages/components/bolt-page-header/src/page-header-nav.js
+++ b/packages/components/bolt-page-header/src/page-header-nav.js
@@ -9,7 +9,6 @@ export class BoltPageHeaderNav {
       desktop: true,
       isNested: false,
       onNestedNavToggle: null,
-      closeOnEscape: false,
       ...options,
     };
 
@@ -45,7 +44,6 @@ export class BoltPageHeaderNav {
   }
 
   init() {
-    this.handleKeypress = this.handleKeypress.bind(this);
     this.handleEscapeKeypress = this.handleEscapeKeypress.bind(this);
     this.clickHandler = this.clickHandler.bind(this);
     this.handleExternalClick = this.handleExternalClick.bind(this);
@@ -93,7 +91,6 @@ export class BoltPageHeaderNav {
 
   setupDesktopMenu() {
     this.addHoverHandler(this.menu);
-    this.addKeypressHandler(this.menu);
     this.addClickHandler(this.menu);
     this.state.desktopIsSetup = true;
   }
@@ -101,7 +98,6 @@ export class BoltPageHeaderNav {
   resetDesktopMenu() {
     this.resetActiveMenus();
     this.hoverListeners.forEach(listener => listener.remove());
-    this.removeKeypressHandler(this.menu);
     this.removeClickHandler(this.menu);
     this.state.desktopIsSetup = false;
   }
@@ -131,18 +127,6 @@ export class BoltPageHeaderNav {
     this.toggleMenu(el);
   }
 
-  addKeypressHandler(menus = []) {
-    menus.forEach(menu => {
-      menu.trigger.addEventListener('keydown', this.handleKeypress);
-    });
-  }
-
-  removeKeypressHandler(menus = []) {
-    menus.forEach(menu => {
-      menu.trigger.removeEventListener('keydown', this.handleKeypress);
-    });
-  }
-
   getKey(e) {
     if (e.key !== undefined) {
       return e.key;
@@ -151,19 +135,10 @@ export class BoltPageHeaderNav {
     }
   }
 
-  handleKeypress(e) {
-    if (this.getKey(e) === 'Escape' || this.getKey(e) === 27) {
-      this.hideMenu(e.target);
-    }
-  }
-
   handleEscapeKeypress(e) {
     if (this.getKey(e) === 'Escape' || this.getKey(e) === 27) {
       this.state.activeMenu.trigger.focus();
       this.hideMenu(this.state.activeMenu.trigger);
-      if (!this.state.activeTrail.length) {
-        document.removeEventListener('keyup', this.handleEscapeKeypress);
-      }
     }
   }
 
@@ -220,9 +195,7 @@ export class BoltPageHeaderNav {
       document.addEventListener('click', this.handleExternalClick);
     }
 
-    if (this.options.closeOnEscape) {
-      document.addEventListener('keyup', this.handleEscapeKeypress);
-    }
+    document.addEventListener('keyup', this.handleEscapeKeypress);
   }
 
   hideMenu(el) {
@@ -232,6 +205,10 @@ export class BoltPageHeaderNav {
 
     if (!this.state.isMobile) {
       document.removeEventListener('click', this.handleExternalClick);
+    }
+
+    if (!this.state.activeTrail.length) {
+      document.removeEventListener('keyup', this.handleEscapeKeypress);
     }
   }
 

--- a/packages/components/bolt-page-header/src/page-header-nav.js
+++ b/packages/components/bolt-page-header/src/page-header-nav.js
@@ -150,16 +150,8 @@ export class BoltPageHeaderNav {
   }
 
   handleKeypress(e) {
-    switch (this.getKey(e)) {
-      case 'Enter' || 13: // enter key
-        this.toggleMenu(e.target);
-        break;
-      case ' ' || 32: // space key
-        this.toggleMenu(e.target);
-        break;
-      case 'Escape' || 27: // escape key
-        this.hideMenu(e.target);
-        break;
+    if (this.getKey(e) === 'Escape' || this.getKey(e) === 27) {
+      this.hideMenu(e.target);
     }
   }
 

--- a/packages/components/bolt-page-header/src/page-header-nav.js
+++ b/packages/components/bolt-page-header/src/page-header-nav.js
@@ -45,7 +45,6 @@ export class BoltPageHeaderNav {
   }
 
   init() {
-    this.handleKeypress = this.handleKeypress.bind(this);
     this.handleEscapeKeypress = this.handleEscapeKeypress.bind(this);
     this.clickHandler = this.clickHandler.bind(this);
     this.handleExternalClick = this.handleExternalClick.bind(this);
@@ -93,14 +92,14 @@ export class BoltPageHeaderNav {
 
   setupDesktopMenu() {
     this.addHoverHandler(this.menu);
-    this.addKeypressHandler(this.menu);
+    this.addClickHandler(this.menu);
     this.state.desktopIsSetup = true;
   }
 
   resetDesktopMenu() {
     this.resetActiveMenus();
     this.hoverListeners.forEach(listener => listener.remove());
-    this.removeKeypressHandler(this.menu);
+    this.removeClickHandler(this.menu);
     this.state.desktopIsSetup = false;
   }
 
@@ -129,37 +128,11 @@ export class BoltPageHeaderNav {
     this.toggleMenu(el);
   }
 
-  addKeypressHandler(menus = []) {
-    menus.forEach(menu => {
-      menu.trigger.addEventListener('keydown', this.handleKeypress);
-    });
-  }
-
-  removeKeypressHandler(menus = []) {
-    menus.forEach(menu => {
-      menu.trigger.removeEventListener('keydown', this.handleKeypress);
-    });
-  }
-
   getKey(e) {
     if (e.key !== undefined) {
       return e.key;
     } else if (e.keyCode !== undefined) {
       return e.keyCode;
-    }
-  }
-
-  handleKeypress(e) {
-    switch (this.getKey(e)) {
-      case 'Enter' || 13: // enter key
-        this.toggleMenu(e.target);
-        break;
-      case ' ' || 32: // space key
-        this.toggleMenu(e.target);
-        break;
-      case 'Escape' || 27: // escape key
-        this.hideMenu(e.target);
-        break;
     }
   }
 

--- a/packages/components/bolt-page-header/src/page-header.js
+++ b/packages/components/bolt-page-header/src/page-header.js
@@ -43,7 +43,6 @@ export class BoltPageHeader {
       ...opts,
       desktop: false,
       isNested: true,
-      closeOnEscape: true,
       onNestedNavToggle: open => {
         const primaryNav = this.el.querySelector(
           '#js-bolt-page-header-primary-nav',
@@ -65,7 +64,6 @@ export class BoltPageHeader {
     // Action Nav
     this.actionMenu = new BoltPageHeaderActionNav(actionMenuArray, {
       ...opts,
-      closeOnEscape: true,
     });
   }
 


### PR DESCRIPTION
## Jira
[https://pegadigitalit.atlassian.net/browse/DS-630](https://pegadigitalit.atlassian.net/browse/DS-630)

## Summary

`Enter` and `Space` key interaction not working with screen readers active.

## Details

The screen readers are sending `click` events instead of `keypress` events when using `Enter` or `Space`. This ticket is to add the click `click` events and allow users to navigate the page header while using a screen reader.

## How to test

Test in BrowserStack with NVDA on, or otherwise use PAWS and NVDA, then make sure you can navigate the pege header.

## Release notes
Modify page-header keypress interaction.
