### PR TITLE
Fix: typeahead search button misalignment

### DIFF
--- a/packages/components/bolt-typeahead/__tests__/__snapshots__/typeahead.js.snap
+++ b/packages/components/bolt-typeahead/__tests__/__snapshots__/typeahead.js.snap
@@ -56,7 +56,7 @@ exports[`<bolt-typeahead> Component Typeahead Twig Template Renders 1`] = `
           <span class="e-bolt-button__icon-center"
                 aria-hidden="true"
           >
-            <svg class="c-bolt-typeahead__icon e-bolt-icon"
+            <svg class="e-bolt-icon"
                  xmlns="http://www.w3.org/2000/svg"
                  viewbox="0 0 32 32"
                  aria-hidden="true"

--- a/packages/components/bolt-typeahead/typeahead.js
+++ b/packages/components/bolt-typeahead/typeahead.js
@@ -127,7 +127,7 @@ class BoltTypeahead extends withLitEvents {
         disabled=${ifDefined(this.disabled === true ? true : undefined)}
       >
         <span class="e-bolt-button__icon-center" aria-hidden="true">
-          ${unsafeHTML(iconSearch({ attributes: { class: 'c-bolt-typeahead__icon' } }))}
+          ${unsafeHTML(iconSearch({ attributes: { } }))}
         </span>
       </button>
 
@@ -148,7 +148,7 @@ class BoltTypeahead extends withLitEvents {
         disabled=${ifDefined(this.disabled === true ? true : undefined)}
       >
         <span class="e-bolt-button__icon-center" aria-hidden="true">
-          ${unsafeHTML(iconCloseSolid({ attributes: { class: 'c-bolt-typeahead__icon' } }))}
+          ${unsafeHTML(iconCloseSolid({ attributes: { } }))}
         </span>
       </button>
     `;

--- a/packages/components/bolt-typeahead/typeahead.js
+++ b/packages/components/bolt-typeahead/typeahead.js
@@ -127,7 +127,7 @@ class BoltTypeahead extends withLitEvents {
         disabled=${ifDefined(this.disabled === true ? true : undefined)}
       >
         <span class="e-bolt-button__icon-center" aria-hidden="true">
-          ${unsafeHTML(iconSearch({ attributes: { } }))}
+          ${unsafeHTML(iconSearch())}
         </span>
       </button>
 
@@ -148,7 +148,7 @@ class BoltTypeahead extends withLitEvents {
         disabled=${ifDefined(this.disabled === true ? true : undefined)}
       >
         <span class="e-bolt-button__icon-center" aria-hidden="true">
-          ${unsafeHTML(iconCloseSolid({ attributes: { } }))}
+          ${unsafeHTML(iconCloseSolid())}
         </span>
       </button>
     `;

--- a/packages/components/bolt-typeahead/typeahead.scoped.scss
+++ b/packages/components/bolt-typeahead/typeahead.scoped.scss
@@ -211,7 +211,7 @@ bolt-autosuggest {
   left: 0;
 }
 
-.e-bolt-button--transparent {
+.c-bolt-typeahead .e-bolt-button--transparent {
   --e-bolt-button-text-color: var(--bolt-color-navy-light); // Typeahead is not compatible with color themes. This overrides the Button element to not change with parent's color theme.
 }
 

--- a/packages/components/bolt-typeahead/typeahead.scoped.scss
+++ b/packages/components/bolt-typeahead/typeahead.scoped.scss
@@ -211,7 +211,7 @@ bolt-autosuggest {
   left: 0;
 }
 
-.c-bolt-typeahead .e-bolt-button--transparent {
+.c-bolt-typeahead__button.e-bolt-button--transparent {
   --e-bolt-button-text-color: var(--bolt-color-navy-light); // Typeahead is not compatible with color themes. This overrides the Button element to not change with parent's color theme.
 }
 

--- a/packages/components/bolt-typeahead/typeahead.scoped.scss
+++ b/packages/components/bolt-typeahead/typeahead.scoped.scss
@@ -13,10 +13,6 @@ $bolt-typeahead-border-radius: 6px;
 $bolt-typeahead-placeholder-color: var(--bolt-color-gray);
 $bolt-typeahead-result-highlight-color: var(--bolt-color-gray-xlight);
 
-/**
- * 1. relative z-index so doesn't need to use bolt z-index mixin
- */
-
 bolt-typeahead {
   display: flex;
   align-self: stretch;
@@ -125,7 +121,7 @@ bolt-autosuggest {
   position: absolute;
   top: calc(100% + 2px);
   right: 0;
-  z-index: 10; /* [1] */
+  z-index: 1; // Raise stacking context above the input.
   width: 100%;
   min-width: 100%;
   max-height: 0;
@@ -203,24 +199,11 @@ bolt-autosuggest {
 
 .c-bolt-typeahead__button {
   position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  z-index: 1; /* [1] */
-  cursor: pointer;
-  border: 0;
-  transition: opacity 0.1s ease;
-
-  // overwrite .e-bolt-button--transparent hover and active transform
-  &:hover,
-  &:focus,
-  &:active:not(:disabled) {
-    transform: translateY(-50%);
-  }
+  top: 0;
 }
 
 .c-bolt-typeahead__button--clear {
   visibility: hidden;
-  opacity: 0;
   right: 0;
 }
 
@@ -228,29 +211,11 @@ bolt-autosuggest {
   left: 0;
 }
 
-.c-bolt-typeahead__icon {
-  color: var(--bolt-color-navy-light);
-  line-height: 1;
-}
-
-.c-bolt-typeahead__icon--clear {
-  fill: currentColor;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate3d(-50%, -50%, 0);
-  z-index: 1; /* [1] */
-  width: 1rem; // needed for icon SSR rendering
-  font-size: 1rem; // needed for icon SSR rendering
+.e-bolt-button--transparent {
+  --e-bolt-button-text-color: var(--bolt-color-navy-light); // Typeahead is not compatible with color themes. This overrides the Button element to not change with parent's color theme.
 }
 
 .c-bolt-typeahead__input[required]:valid ~ .c-bolt-typeahead__button--clear,
 .c-bolt-typeahead__button--clear.is-visible {
   visibility: visible;
-  opacity: 1;
-}
-
-.c-bolt-typeahead__input--with-clear-button
-  ~ .c-bolt-typeahead__button--submit {
-  opacity: 1;
 }

--- a/packages/components/bolt-typeahead/typeahead.twig
+++ b/packages/components/bolt-typeahead/typeahead.twig
@@ -4,28 +4,7 @@
   {{ validate_data_schema(schema, _self) | raw }}
 {% endif %}
 
-{# @todo: re-enable once CSS Modules ships %}
-{# {% set selectors = get_data("@bolt-components-typeahead/typeahead.scoped.json") %}
 {% set classNames = {
-  icon: selectors["c-bolt-typeahead__icon"],
-  clearIcon: selectors["c-bolt-typeahead__icon--clear"],
-  clearButton: [
-    selectors["c-bolt-typeahead__button"],
-    selectors["c-bolt-typeahead__button--clear"],
-  ],
-  submitButton: [
-    selectors["c-bolt-typeahead__button"],
-    selectors["c-bolt-typeahead__button--submit"],
-  ],
-  input: selectors["c-bolt-typeahead__input"],
-  inputWrapper: selectors["c-bolt-typeahead__input-wrapper"],
-  label: selectors["c-bolt-typeahead__label"],
-  typeahead: selectors["c-bolt-typeahead"],
-} %} #}
-
-{% set classNames = {
-  icon: "c-bolt-typeahead__icon",
-  clearIcon: "c-bolt-typeahead__icon--clear",
   clearButton: [
     "c-bolt-typeahead__button",
     "c-bolt-typeahead__button--clear",


### PR DESCRIPTION
## Summary

Fixes a visual regression where the typeahead's search button is misaligned.

## Details

1. Cleaned up Typeahead's HTML and CSS
2. Removed unnecessary  CSS that is prone to bugs

## How to test

Run the branch locally and check the typeadead docs with and without JS. When tabbing to the icon-only search button within the typeahead, it should not be misaligned.