### PR TITLE
Remove async attr on global JS script tag

### DIFF
--- a/docs-site/src/templates/_site-head.twig
+++ b/docs-site/src/templates/_site-head.twig
@@ -60,7 +60,7 @@
       window.bolt.data.fullManifest.version = window.bolt.data.fullManifest.version || {{ bolt.data.fullManifest.version|json_encode|raw }};
     </script>
 
-    <script type="module" src="{{ assets["bolt-global.js"] | default("/build/bolt-global.js") }}" async></script>
+    <script type="module" src="{{ assets["bolt-global.js"] | default("/build/bolt-global.js") }}"></script>
 
     <noscript>
       <link href="/pattern-lab/styleguide/css/pattern-lab.css" rel="stylesheet">


### PR DESCRIPTION
## Jira

n/a

## Summary

Fixes race condition caused by loading global JS file asynchronously.

## Details

While reviewing https://github.com/boltdesignsystem/bolt/pull/2423 I noticed sometimes the Floating Action Buttons JS would not load at all. This was because the JS was executing _before_ the DOM was ready, and the document query we were using to conditionally load the JS was returning empty.

At one point in time, when we were all in on web components it might've made sense to load our JS asynchronously, as our JS would work whether it loaded before or after an HTML element was added to the DOM. But `[async]` doesn't make sense for anything not a web component that needs to query the DOM (most other components).

We also do not use `[async]` in production on any of our sites. So, I'm removing it from PL. This change only affects PL.

## How to test

- Review the code changes
- Optionally, run locally and verify JS loads as expected