### PR TITLE
DS-751: Add support for placeholders to Bolt-only version of |t filter

### DIFF
--- a/packages/twig-integration/twig-extensions-shared/src/TwigFilters.php
+++ b/packages/twig-integration/twig-extensions-shared/src/TwigFilters.php
@@ -50,8 +50,8 @@ class TwigFilters {
   }
 
   public static function t() {
-    return new Twig_SimpleFilter('t', function ($string) {
-      return $string;
+    return new Twig_SimpleFilter('t', function ($string, $args = []) {
+      return strtr($string, $args);
     });
   }
 


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-751

## Summary

Adds support for placeholders in translatable strings

## Details

Proper string translation requires the ability to use variables.  For example, if you wanted to translate the string "Tom's Profile", where "Tom" was a variable that corresponded to the user's name, you couldn't just expect a translator to convert "'s profile" into, say, Spanish.

Instead, you should ask the translator to translate "@user's profile".  A Spanish translator could then understand the context of what they were translating and rearrange the words to "Perfil de @user".

This PR adds support for  basic placeholders in translated strings in Bolt to match how the Drupal `|t` filter already works in Drupal.  See https://www.drupal.org/docs/theming-drupal/twig-in-drupal/filters-modifying-variables-in-twig-templates#s-translation-filters for more details

## How to test

To test, you could create a string that contains a placeholder variable and confirm that it's output correctly.  An example is shown in https://github.com/boltdesignsystem/bolt/pull/2451/commits/4c868ea5b9b1cd3e25baac06b1a99ba8992132d2, so you could confirm that it's working as expected on that PR.