### PR TITLE
DS 748 update ordered list formats in article element

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/20-elements/article/05-article.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/20-elements/article/05-article.twig
@@ -142,6 +142,52 @@
         First level ordered item
       </li>
     </ol>
+    <ol>
+      <li>
+        First level ordered item 1
+      </li>
+      <li>
+        First level ordered item 2
+        <ol>
+          <li>Second level ordered item 1</li>
+          <li>
+            Second level ordered item 2
+            <ol>
+              <li>
+                Third level ordered item 1
+              </li>
+              <li>
+                Third level ordered item 2
+                <ol>
+                  <li>Fourth level ordered item 1</li>
+                  <li>Fourth level ordered item 2
+                    <ol>
+                      <li>Fifth level ordered item 1</li>
+                      <li>Fifth level ordered item 2
+                        <ol>
+                          <li>Sixth level ordered item 1</li>
+                          <li>Sixth level ordered item 2</li>
+                          <li>Sixth level ordered item 3</li>
+                        </ol>
+                      </li>
+                      <li>Fifth level ordered item 3</li>
+                    </ol>
+                  </li>
+                  <li>Fourth level ordered item 3</li>
+                </ol>
+              </li>
+              <li>Third level ordered item 3</li>
+            </ol>
+          </li>
+          <li>
+            Second level ordered item 3
+          </li>
+        </ol>
+      </li>
+      <li>
+        First level ordered item 3
+      </li>
+    </ol>
     <details>
       <summary>Summary sums up the details</summary>
       <p>

--- a/packages/elements/bolt-article/src/article.scss
+++ b/packages/elements/bolt-article/src/article.scss
@@ -122,17 +122,17 @@ $_bolt-article-element-spacing: var(--bolt-spacing-y-medium);
   }
 
   ol,
-  ol ol ol ol {
+  ol > li > ol > li > ol > li > ol {
     list-style-type: decimal;
   }
 
-  ol ol,
-  ol ol ol ol ol {
+  ol > li > ol,
+  ol > li > ol > li > ol > li > ol > li > ol {
     list-style-type: lower-alpha;
   }
 
-  ol ol ol,
-  ol ol ol ol ol ol {
+  ol > li > ol > li > ol,
+  ol > li > ol > li > ol > li > ol > li > ol > li > ol {
     list-style-type: upper-roman;
   }
 

--- a/packages/elements/bolt-article/src/article.scss
+++ b/packages/elements/bolt-article/src/article.scss
@@ -121,6 +121,21 @@ $_bolt-article-element-spacing: var(--bolt-spacing-y-medium);
     }
   }
 
+  ol,
+  ol ol ol ol {
+    list-style-type: decimal;
+  }
+
+  ol ol,
+  ol ol ol ol ol {
+    list-style-type: lower-alpha;
+  }
+
+  ol ol ol,
+  ol ol ol ol ol ol {
+    list-style-type: upper-roman;
+  }
+
   header,
   section {
     margin: 0 0 calc(#{$_bolt-article-element-spacing} * 1.5) 0;


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-748

## Summary

The ordered list can be rendered as [the example here](https://pegadigitalit.atlassian.net/browse/DS-748) for any free-form content areas.

## Details

Styles were updated that `<ol>` uses `list-style-type`s:

- decimal (first and fourth level)
- alphabetical (second and fifth level),
- roman numbers (third, sixth, and larger than the sixth level)

## How to test

Pull the branch. Create an ordered list using HTML `<ol>` tag and check if is rendered correctly with the Jira example.

## Release notes

The ordered (`<ol>`) list has new level indicators for nested items.

### Visual changes

The ordered list uses decimal, alphabetical and roman numbers for the nested items for any free-form content areas.
