### PR TITLE
Fix: add proper navigation labels

### DIFF
--- a/packages/components/bolt-page-footer/src/page-footer.twig
+++ b/packages/components/bolt-page-footer/src/page-footer.twig
@@ -19,7 +19,7 @@
     </div>
     {{ primary_nav }}
   </nav>
-  <aside>
+  <aside aria-label="{{ 'More links'|t }}">
     <nav class="c-bolt-page-footer__nav c-bolt-page-footer__nav--aside" aria-label="{{ 'Utilities'|t }}">
       {{ secondary_nav }}
       <span class="c-bolt-page-footer__nav-item c-bolt-page-footer__nav-item--copyrights">&copy;{{ 'now'|date('Y') }} Pegasystems Inc.</span>

--- a/packages/components/bolt-page-footer/src/page-footer.twig
+++ b/packages/components/bolt-page-footer/src/page-footer.twig
@@ -13,13 +13,13 @@
 ] %}
 
 <footer {{ attributes.addClass(classes) }}>
-  <nav class="c-bolt-page-footer__nav c-bolt-page-footer__nav--main" aria-label="{{ 'About Pegasystems'|t }}">
+  <nav class="c-bolt-page-footer__nav c-bolt-page-footer__nav--main" aria-label="{{ 'Footer links'|t }}">
     <div class="c-bolt-page-footer__nav-item c-bolt-page-footer__nav-item--description">
       {{ description }}
     </div>
     {{ primary_nav }}
   </nav>
-  <aside aria-label="{{ 'More links'|t }}">
+  <aside aria-label="{{ 'More footer links'|t }}">
     <nav class="c-bolt-page-footer__nav c-bolt-page-footer__nav--aside" aria-label="{{ 'Utilities'|t }}">
       {{ secondary_nav }}
       <span class="c-bolt-page-footer__nav-item c-bolt-page-footer__nav-item--copyrights">&copy;{{ 'now'|date('Y') }} Pegasystems Inc.</span>

--- a/packages/components/bolt-page-header/src/page-header-primary-nav.twig
+++ b/packages/components/bolt-page-header/src/page-header-primary-nav.twig
@@ -29,7 +29,7 @@
     } only %}
   </span>
 </button>
-<nav {{ attributes.addClass(classes)|without('id')|without('aria-label') }} id="js-bolt-page-header-primary-nav" aria-label="Main Site Navigation">
+<nav {{ attributes.addClass(classes)|without('id')|without('aria-label') }} id="js-bolt-page-header-primary-nav" aria-label="{{ 'Main Site'|t }}">
   <div class="c-bolt-page-header__nav-list-group">
     {{ content }}
   </div>


### PR DESCRIPTION
## Summary

Updated navigation labels in page header and page footer to be more descriptive.

## How to test

Run the branch locally and view the page header and page footer docs. Turn on VO (`cmd` + `f5`), and enable rotor (`ctrl` + `opt` + `u`). Press left/right arrows to view all landmarks. Make sure each navigation has a descriptive name.