### PR TITLE
CC-843 remove fibers dependency

### DIFF
--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -120,7 +120,6 @@
     "yargs": "^15.1.0"
   },
   "optionalDependencies": {
-    "fibers": "^4.0.2",
     "sass": "^1.25.0"
   },
   "publishConfig": {

--- a/packages/website-ui/uikit-workshop/package.json
+++ b/packages/website-ui/uikit-workshop/package.json
@@ -128,7 +128,6 @@
     "yargs": "^15.1.0"
   },
   "optionalDependencies": {
-    "fibers": ">= 3.1.0",
     "preact": ">=10 || ^10.0.0-alpha.0",
     "react": "^16.8.0",
     "sass": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7908,12 +7908,6 @@ fg-loadjs@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fg-loadjs/-/fg-loadjs-1.1.0.tgz#a976f60eff5deb5a2479c863872ee2920bbedfdc"
 
-"fibers@>= 3.1.0":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/fibers/-/fibers-4.0.2.tgz#d04f9ccd0aba179588202202faeb4fed65d497f5"
-  dependencies:
-    detect-libc "^1.0.3"
-
 figgy-pudding@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7908,7 +7908,7 @@ fg-loadjs@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fg-loadjs/-/fg-loadjs-1.1.0.tgz#a976f60eff5deb5a2479c863872ee2920bbedfdc"
 
-"fibers@>= 3.1.0", fibers@^4.0.2:
+"fibers@>= 3.1.0":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/fibers/-/fibers-4.0.2.tgz#d04f9ccd0aba179588202202faeb4fed65d497f5"
   dependencies:


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/CC-843
https://pegadigitalit.atlassian.net/browse/DS-745

## Summary

Removes [fibers](https://www.npmjs.com/package/fibers) as an npm dependency

## Details

This project is resulting in an error in our Docksal container after upgrading to PHP 8.

That would be worth resolving if it weren't for the fact that it isn't actually used anywhere in our code and fibers explicitly says it's obsolete on its npm page.

How did it get introduced in the first place?  A giant sloppy PR from Salem (https://github.com/boltdesignsystem/bolt/pull/1725, https://github.com/boltdesignsystem/bolt/pull/1711), where he evidently just slammed in unused dependencies and couldn't be bothered to spend the time to clean up after himself, preferring instead to leave that work to his colleagues (we all knew this at the time, but could only do so much to contain the damage).  I'm relieved he's no longer at Pega creating more headaches for me and the team, and I hope he's matured to a point where he's more respectful and considerate of the developers who work with him.

## How to test

Confirm there are no more remaining usages of the fibers project and nothing is broken.