### PR TITLE
DS-732 Mobile | IOS Search icon is not visible in the search bar

### DIFF
--- a/packages/components/bolt-form/src/form.scss
+++ b/packages/components/bolt-form/src/form.scss
@@ -439,6 +439,7 @@ $bolt-input-transition: var(--bolt-transition);
 
 .c-bolt-input-icon--link {
   padding: 0;
+  color: var(--bolt-color-navy-light);
   text-decoration: none;
   cursor: pointer;
   pointer-events: auto;


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-732

## Summary

The search icon should be visible on mobile IOS.

## Details

The search icon should be visible inside the search input.

<img width="361" alt="ios search icon" src="https://user-images.githubusercontent.com/85670248/162444088-d49e0882-5d1f-4a29-9fe7-58c874870e5d.png">

## How to test

Pull the branch. Go to `pattern-lab/?p=components-form-search` on mobile ios and check if the search icon is rendered.
