### PR TITLE
DS-756 Fix css animation selector

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/animations/banner-test-fade-ins.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/animations/banner-test-fade-ins.twig
@@ -8,6 +8,7 @@
       content: 'This is the banner content fade' ~ fade,
       attributes: {
         class: [
+          'a-bolt-base',
           'a-bolt' ~ fade,
           'a-bolt-cascade-fast'
         ],
@@ -18,7 +19,7 @@
 
 <script>
 
-  const fadeEl = document.querySelectorAll('[class*="a-bolt-"]');
+  const fadeEl = document.querySelectorAll('.a-bolt-base');
 
   // Repeat single specific fade on click
   function triggerThisEl({ target }) {

--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/animations/banner-test-fade-ins.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/animations/banner-test-fade-ins.twig
@@ -9,6 +9,7 @@
       attributes: {
         class: [
           'a-bolt-base',
+          'a-bolt-in',
           'a-bolt' ~ fade,
           'a-bolt-cascade-fast'
         ],

--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/animations/gallery-test-fade-ins.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/animations/gallery-test-fade-ins.twig
@@ -301,7 +301,7 @@
         content: item_video,
         attributes: {
           class: [
-            
+            'a-bolt-base',
             'a-bolt-in--fade-up',
             'a-bolt-cascade-slow'
           ]
@@ -313,7 +313,7 @@
         content: item_external_link,
         attributes: {
           class: [
-            
+            'a-bolt-base',
             'a-bolt-in--fade-up',
             'a-bolt-cascade-slow'
           ]
@@ -325,7 +325,7 @@
         content: item_locked,
         attributes: {
           class: [
-            
+            'a-bolt-base',
             'a-bolt-in--fade-up',
             'a-bolt-cascade-slow'
           ]
@@ -337,7 +337,79 @@
         content: item_video,
         attributes: {
           class: [
-            
+            'a-bolt-base',
+            'a-bolt-in--fade-up',
+            'a-bolt-cascade-slow'
+          ]
+        }
+      },
+      {
+        column_start: '1 5@small',
+        column_span: '6 4@small',
+        content: item_pdf,
+        attributes: {
+          class: [
+            'a-bolt-base',
+            'a-bolt-in--fade-up',
+            'a-bolt-cascade-slow'
+          ]
+        }
+      },
+      {
+        column_start: '7 9@small',
+        column_span: '6 4@small',
+        content: item_locked,
+        attributes: {
+          class: [
+            'a-bolt-base',
+            'a-bolt-in--fade-up',
+            'a-bolt-cascade-slow'
+          ]
+        }
+      },
+              {
+        column_start: '1 1@small',
+        column_span: '6 4@small',
+        content: item_video,
+        attributes: {
+          class: [
+            'a-bolt-base',
+            'a-bolt-in--fade-up',
+            'a-bolt-cascade-slow'
+          ]
+        }
+      },
+      {
+        column_start: '7 5@small',
+        column_span: '6 4@small',
+        content: item_external_link,
+        attributes: {
+          class: [
+            'a-bolt-base',
+            'a-bolt-in--fade-up',
+            'a-bolt-cascade-slow'
+          ]
+        }
+      },
+      {
+        column_start: '1 9@small',
+        column_span: '6 4@small',
+        content: item_locked,
+        attributes: {
+          class: [
+            'a-bolt-base',
+            'a-bolt-in--fade-up',
+            'a-bolt-cascade-slow'
+          ]
+        }
+      },
+              {
+        column_start: '7 1@small',
+        column_span: '6 4@small',
+        content: item_video,
+        attributes: {
+          class: [
+            'a-bolt-base',
             'a-bolt-in--fade-up',
             'a-bolt-cascade-slow'
           ]
@@ -361,7 +433,7 @@
         content: item_locked,
         attributes: {
           class: [
-            
+            'a-bolt-base',
             'a-bolt-in--fade-up',
             'a-bolt-cascade-slow'
           ]
@@ -373,7 +445,7 @@
         content: item_video,
         attributes: {
           class: [
-            
+            'a-bolt-base',
             'a-bolt-in--fade-up',
             'a-bolt-cascade-slow'
           ]
@@ -397,7 +469,7 @@
         content: item_locked,
         attributes: {
           class: [
-            
+            'a-bolt-base',
             'a-bolt-in--fade-up',
             'a-bolt-cascade-slow'
           ]
@@ -409,79 +481,7 @@
         content: item_video,
         attributes: {
           class: [
-            
-            'a-bolt-in--fade-up',
-            'a-bolt-cascade-slow'
-          ]
-        }
-      },
-      {
-        column_start: '1 5@small',
-        column_span: '6 4@small',
-        content: item_pdf,
-        attributes: {
-          class: [
-            
-            'a-bolt-in--fade-up',
-            'a-bolt-cascade-slow'
-          ]
-        }
-      },
-      {
-        column_start: '7 9@small',
-        column_span: '6 4@small',
-        content: item_locked,
-        attributes: {
-          class: [
-            
-            'a-bolt-in--fade-up',
-            'a-bolt-cascade-slow'
-          ]
-        }
-      },
-              {
-        column_start: '1 1@small',
-        column_span: '6 4@small',
-        content: item_video,
-        attributes: {
-          class: [
-            
-            'a-bolt-in--fade-up',
-            'a-bolt-cascade-slow'
-          ]
-        }
-      },
-      {
-        column_start: '7 5@small',
-        column_span: '6 4@small',
-        content: item_external_link,
-        attributes: {
-          class: [
-            
-            'a-bolt-in--fade-up',
-            'a-bolt-cascade-slow'
-          ]
-        }
-      },
-      {
-        column_start: '1 9@small',
-        column_span: '6 4@small',
-        content: item_locked,
-        attributes: {
-          class: [
-            
-            'a-bolt-in--fade-up',
-            'a-bolt-cascade-slow'
-          ]
-        }
-      },
-              {
-        column_start: '7 1@small',
-        column_span: '6 4@small',
-        content: item_video,
-        attributes: {
-          class: [
-            
+            'a-bolt-base',
             'a-bolt-in--fade-up',
             'a-bolt-cascade-slow'
           ]
@@ -505,7 +505,7 @@
         content: item_locked,
         attributes: {
           class: [
-            
+            'a-bolt-base',
             'a-bolt-in--fade-up',
             'a-bolt-cascade-slow'
           ]
@@ -529,7 +529,7 @@
         content: item_pdf,
         attributes: {
           class: [
-            
+            'a-bolt-base',
             'a-bolt-in--fade-up',
             'a-bolt-cascade-slow'
           ]
@@ -541,7 +541,7 @@
         content: item_locked,
         attributes: {
           class: [
-            
+            'a-bolt-base',
             'a-bolt-in--fade-up',
             'a-bolt-cascade-slow'
           ]

--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/animations/gallery-test-fade-ins.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/animations/gallery-test-fade-ins.twig
@@ -302,6 +302,7 @@
         attributes: {
           class: [
             'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--fade-up',
             'a-bolt-cascade-slow'
           ]
@@ -314,6 +315,7 @@
         attributes: {
           class: [
             'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--fade-up',
             'a-bolt-cascade-slow'
           ]
@@ -326,6 +328,7 @@
         attributes: {
           class: [
             'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--fade-up',
             'a-bolt-cascade-slow'
           ]
@@ -338,6 +341,7 @@
         attributes: {
           class: [
             'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--fade-up',
             'a-bolt-cascade-slow'
           ]
@@ -350,6 +354,7 @@
         attributes: {
           class: [
             'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--fade-up',
             'a-bolt-cascade-slow'
           ]
@@ -362,6 +367,7 @@
         attributes: {
           class: [
             'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--fade-up',
             'a-bolt-cascade-slow'
           ]
@@ -374,6 +380,7 @@
         attributes: {
           class: [
             'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--fade-up',
             'a-bolt-cascade-slow'
           ]
@@ -386,6 +393,7 @@
         attributes: {
           class: [
             'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--fade-up',
             'a-bolt-cascade-slow'
           ]
@@ -410,6 +418,7 @@
         attributes: {
           class: [
             'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--fade-up',
             'a-bolt-cascade-slow'
           ]
@@ -421,7 +430,8 @@
         content: item_pdf,
         attributes: {
           class: [
-            
+            'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--fade-up',
             'a-bolt-cascade-slow'
           ]
@@ -434,6 +444,7 @@
         attributes: {
           class: [
             'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--fade-up',
             'a-bolt-cascade-slow'
           ]
@@ -446,6 +457,7 @@
         attributes: {
           class: [
             'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--fade-up',
             'a-bolt-cascade-slow'
           ]
@@ -457,7 +469,8 @@
         content: item_external_link,
         attributes: {
           class: [
-            
+            'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--fade-up',
             'a-bolt-cascade-slow'
           ]
@@ -470,6 +483,7 @@
         attributes: {
           class: [
             'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--fade-up',
             'a-bolt-cascade-slow'
           ]
@@ -482,6 +496,7 @@
         attributes: {
           class: [
             'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--fade-up',
             'a-bolt-cascade-slow'
           ]
@@ -493,7 +508,8 @@
         content: item_external_link,
         attributes: {
           class: [
-            
+            'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--fade-up',
             'a-bolt-cascade-slow'
           ]
@@ -506,6 +522,7 @@
         attributes: {
           class: [
             'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--fade-up',
             'a-bolt-cascade-slow'
           ]
@@ -517,7 +534,8 @@
         content: item_video,
         attributes: {
           class: [
-            
+            'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--fade-up',
             'a-bolt-cascade-slow'
           ]
@@ -530,6 +548,7 @@
         attributes: {
           class: [
             'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--fade-up',
             'a-bolt-cascade-slow'
           ]
@@ -542,6 +561,7 @@
         attributes: {
           class: [
             'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--fade-up',
             'a-bolt-cascade-slow'
           ]

--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/animations/icon-test-fade-ins.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/animations/icon-test-fade-ins.twig
@@ -8,6 +8,7 @@
     attributes: {
       class: [
         'a-bolt-base',
+        'a-bolt-in',
         'a-bolt-in--fade-up',
         'a-bolt-duration-short',
         'a-bolt-cascade-fast',

--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/animations/icon-test-fade-ins.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/animations/icon-test-fade-ins.twig
@@ -7,6 +7,7 @@
     size: 'xlarge',
     attributes: {
       class: [
+        'a-bolt-base',
         'a-bolt-in--fade-up',
         'a-bolt-duration-short',
         'a-bolt-cascade-fast',

--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/animations/video-test-bounce-ins.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/animations/video-test-bounce-ins.twig
@@ -173,6 +173,7 @@
         attributes: {
           class: [
             'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -185,6 +186,7 @@
         attributes: {
           class: [
             'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -197,6 +199,7 @@
         attributes: {
           class: [
             'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -209,6 +212,7 @@
         attributes: {
           class: [
             'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -221,6 +225,7 @@
         attributes: {
           class: [
             'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -233,6 +238,7 @@
         attributes: {
           class: [
             'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -245,6 +251,7 @@
         attributes: {
           class: [
             'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -257,6 +264,7 @@
         attributes: {
           class: [
             'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -329,6 +337,7 @@
         attributes: {
           class: [
             'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -341,6 +350,7 @@
         attributes: {
           class: [
             'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -353,6 +363,7 @@
         attributes: {
           class: [
             'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -365,6 +376,7 @@
         attributes: {
           class: [
             'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -377,6 +389,7 @@
         attributes: {
           class: [
             'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -389,6 +402,7 @@
         attributes: {
           class: [
             'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -401,6 +415,7 @@
         attributes: {
           class: [
             'a-bolt-base',
+            'a-bolt-in',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]

--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/animations/video-test-bounce-ins.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/animations/video-test-bounce-ins.twig
@@ -172,7 +172,7 @@
         content: item,
         attributes: {
           class: [
-            
+            'a-bolt-base',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -184,7 +184,7 @@
         content: item_1,
         attributes: {
           class: [
-            
+            'a-bolt-base',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -196,7 +196,7 @@
         content: item_2,
         attributes: {
           class: [
-            
+            'a-bolt-base',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -208,7 +208,7 @@
         content: item_3,
         attributes: {
           class: [
-            
+            'a-bolt-base',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -220,7 +220,7 @@
         content: item_4,
         attributes: {
           class: [
-            
+            'a-bolt-base',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -232,7 +232,7 @@
         content: item_5,
         attributes: {
           class: [
-            
+            'a-bolt-base',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -244,7 +244,7 @@
         content: item_6,
         attributes: {
           class: [
-            
+            'a-bolt-base',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -256,7 +256,7 @@
         content: item_7,
         attributes: {
           class: [
-            
+            'a-bolt-base',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -268,7 +268,7 @@
         content: item,
         attributes: {
           class: [
-            
+            'a-bolt-base',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -280,7 +280,7 @@
         content: item_1,
         attributes: {
           class: [
-            
+            'a-bolt-base',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -292,7 +292,7 @@
         content: item_2,
         attributes: {
           class: [
-            
+            'a-bolt-base',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -304,7 +304,7 @@
         content: item_3,
         attributes: {
           class: [
-            
+            'a-bolt-base',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -316,7 +316,7 @@
         content: item_4,
         attributes: {
           class: [
-            
+            'a-bolt-base',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -328,7 +328,7 @@
         content: item_5,
         attributes: {
           class: [
-            
+            'a-bolt-base',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -340,7 +340,7 @@
         content: item_6,
         attributes: {
           class: [
-            
+            'a-bolt-base',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -352,7 +352,7 @@
         content: item_7,
         attributes: {
           class: [
-            
+            'a-bolt-base',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -364,7 +364,7 @@
         content: item,
         attributes: {
           class: [
-            
+            'a-bolt-base',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -376,7 +376,7 @@
         content: item_1,
         attributes: {
           class: [
-            
+            'a-bolt-base',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -388,7 +388,7 @@
         content: item_2,
         attributes: {
           class: [
-            
+            'a-bolt-base',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]
@@ -400,7 +400,7 @@
         content: item_3,
         attributes: {
           class: [
-            
+            'a-bolt-base',
             'a-bolt-in--bounce-up',
             'a-bolt-cascade-fast'
           ]

--- a/packages/global/styles/06-animations/_999-animations-on-load-test.js
+++ b/packages/global/styles/06-animations/_999-animations-on-load-test.js
@@ -1,7 +1,7 @@
 function playStateRunningOnLoad() {
   const cascadeAnimations = { slow: [], fast: [] };
   const onLoadAnimations = [
-    ...document.querySelectorAll('[class*="a-bolt-"]'),
+    ...document.querySelectorAll('.a-bolt-base'),
   ].filter(el => {
     if (el.classList.contains('a-bolt-cascade-fast')) {
       cascadeAnimations.fast.push(el);

--- a/packages/global/styles/06-animations/_animations.scss
+++ b/packages/global/styles/06-animations/_animations.scss
@@ -20,13 +20,11 @@
   }
 }
 
-[class^='a-bolt-in-'],
-[class*=' a-bolt-in-'] {
+.a-bolt-in {
   animation-timing-function: ease-out;
 }
 
-[class^='a-bolt-out-'],
-[class*=' a-bolt-out-'] {
+.a-bolt-out {
   animation-timing-function: ease-in;
   @media print, (prefers-reduced-motion: reduce) {
     opacity: 0;

--- a/packages/global/styles/06-animations/_animations.scss
+++ b/packages/global/styles/06-animations/_animations.scss
@@ -8,8 +8,7 @@
  * 2. Start animation one after another.
  */
 
-[class^='a-bolt-'],
-[class*=' a-bolt-'] {
+.a-bolt-base {
   visibility: hidden; /* [1] */
   animation-delay: var(--bolt-animation-delay);
   animation-duration: var(--bolt-animation-duration);
@@ -21,11 +20,13 @@
   }
 }
 
-[class*='a-bolt-in'] {
+[class^='a-bolt-in-'],
+[class*=' a-bolt-in-'] {
   animation-timing-function: ease-out;
 }
 
-[class*='a-bolt-out'] {
+[class^='a-bolt-out-'],
+[class*=' a-bolt-out-'] {
   animation-timing-function: ease-in;
   @media print, (prefers-reduced-motion: reduce) {
     opacity: 0;

--- a/packages/global/styles/06-animations/_animations.scss
+++ b/packages/global/styles/06-animations/_animations.scss
@@ -8,7 +8,8 @@
  * 2. Start animation one after another.
  */
 
-[class*='a-bolt-'] {
+[class^='a-bolt-'],
+[class*=' a-bolt-'] {
   visibility: hidden; /* [1] */
   animation-delay: var(--bolt-animation-delay);
   animation-duration: var(--bolt-animation-duration);


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-756

## Summary

Attributes selectors were replaced with specific classes.

## Details

- `[class*='a-bolt-']` replaced with `.a-bolt-base`
- `[class*='a-bolt-in']` replaced with `.a-bolt-in`
- `[class*='a-bolt-out']` replaced with `.a-bolt-out`

- JS file was updated with the new class
- Animation test pages were updated with the new classes in the Tests folder.

## How to test

Pull the branch. Check if new classes are specific enough to avoid targeting other random classes. Go to test pages and confirm that animations work as previously.