### PR TITLE
DS-760 fix switch button label text

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/switch-button/05-switch-button.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/switch-button/05-switch-button.twig
@@ -1,7 +1,7 @@
 {% set notes %}
   <bolt-ol>
     <bolt-li>Switch Button should be used to handle changes that happen instantly. It should not be used in a form which requires a submit action. For rendering boolean options within a form, use a checkbox input instead.</bolt-li>
-    <bolt-li>The <code>label</code> prop can accept anything. For better control of text styling, pass the <a href="{{ link['viewall-components-headline'] }}" class="e-bolt-text-link">headline component</a> into the <code>label</code> prop.</bolt-li>
+    <bolt-li>The <code>label</code> prop can accept anything. For better control of text styling, pass the <a href="{{ link['viewall-components-headline'] }}" class="e-bolt-text-link">headline component</a> into the <code>label</code> prop. Set the headline&rsquo;s <code>tag</code> prop to <code>span</code> since headings are not allowed in a label.</bolt-li>
     <bolt-li>The component does not ship with JavaScript. Reference the sample code snippet below to see how to toggle on/off state with the <code>aria-checked</code> attribute.</bolt-li>
     <bolt-li>When writing HTML, make sure to follow the sample code snippet below and render all neccessary id, class, and attributes on the <code>&lt;label&gt;</code> and the <code>&lt;button&gt;</code> elements.</bolt-li>
   </bolt-ol>

--- a/packages/components/bolt-switch-button/__tests__/__snapshots__/switch-button.js.snap
+++ b/packages/components/bolt-switch-button/__tests__/__snapshots__/switch-button.js.snap
@@ -13,10 +13,14 @@ exports[`Bolt Switch Button Prop button_attributes 1`] = `
           role="switch"
           aria-checked="false"
   >
-    <span class="c-bolt-switch-button__button-text c-bolt-switch-button__button-text--checked">
+    <span class="c-bolt-switch-button__button-text c-bolt-switch-button__button-text--checked"
+          aria-hidden="true"
+    >
       on
     </span>
-    <span class="c-bolt-switch-button__button-text c-bolt-switch-button__button-text--unchecked ">
+    <span class="c-bolt-switch-button__button-text c-bolt-switch-button__button-text--unchecked"
+          aria-hidden="true"
+    >
       off
     </span>
   </button>
@@ -36,10 +40,14 @@ exports[`Bolt Switch Button Prop custom id 1`] = `
           role="switch"
           aria-checked="false"
   >
-    <span class="c-bolt-switch-button__button-text c-bolt-switch-button__button-text--checked">
+    <span class="c-bolt-switch-button__button-text c-bolt-switch-button__button-text--checked"
+          aria-hidden="true"
+    >
       on
     </span>
-    <span class="c-bolt-switch-button__button-text c-bolt-switch-button__button-text--unchecked ">
+    <span class="c-bolt-switch-button__button-text c-bolt-switch-button__button-text--unchecked"
+          aria-hidden="true"
+    >
       off
     </span>
   </button>
@@ -59,10 +67,14 @@ exports[`Bolt Switch Button Prop on 1`] = `
           role="switch"
           aria-checked="false"
   >
-    <span class="c-bolt-switch-button__button-text c-bolt-switch-button__button-text--checked">
+    <span class="c-bolt-switch-button__button-text c-bolt-switch-button__button-text--checked"
+          aria-hidden="true"
+    >
       on
     </span>
-    <span class="c-bolt-switch-button__button-text c-bolt-switch-button__button-text--unchecked ">
+    <span class="c-bolt-switch-button__button-text c-bolt-switch-button__button-text--unchecked"
+          aria-hidden="true"
+    >
       off
     </span>
   </button>
@@ -82,10 +94,14 @@ exports[`Bolt Switch Button default 1`] = `
           role="switch"
           aria-checked="false"
   >
-    <span class="c-bolt-switch-button__button-text c-bolt-switch-button__button-text--checked">
+    <span class="c-bolt-switch-button__button-text c-bolt-switch-button__button-text--checked"
+          aria-hidden="true"
+    >
       on
     </span>
-    <span class="c-bolt-switch-button__button-text c-bolt-switch-button__button-text--unchecked ">
+    <span class="c-bolt-switch-button__button-text c-bolt-switch-button__button-text--unchecked"
+          aria-hidden="true"
+    >
       off
     </span>
   </button>

--- a/packages/components/bolt-switch-button/src/switch-button.twig
+++ b/packages/components/bolt-switch-button/src/switch-button.twig
@@ -34,7 +34,7 @@
 <label {{ attributes.addClass(classes)|without('for') }} for="{{ _switch_button_id }}">
   <div class="c-bolt-switch-button__label">{% if label %}{{ label }}{% else %}{{ 'Switch'|t }}{% endif %}</div>
   <button {{ button_attributes.addClass('c-bolt-switch-button__button')|without('type')|without('id')|without('role')|without('aria-checked') }} type="button" id="{{ _switch_button_id }}" role="switch" aria-checked="{{ _checked }}">
-    <span class="c-bolt-switch-button__button-text c-bolt-switch-button__button-text--checked">{{ 'on'|t }}</span>
-    <span class="c-bolt-switch-button__button-text c-bolt-switch-button__button-text--unchecked ">{{ 'off'|t }}</span>
+    <span class="c-bolt-switch-button__button-text c-bolt-switch-button__button-text--checked" aria-hidden="true">{{ 'on'|t }}</span>
+    <span class="c-bolt-switch-button__button-text c-bolt-switch-button__button-text--unchecked" aria-hidden="true">{{ 'off'|t }}</span>
   </button>
 </label>


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-760

## Summary

Fixes a bug where the switch button's label text is announced twice.

## Details

1. Aria attributes added to prevent the redundant announcments
1. Doc page updated with better copy

## How to test

1. Run the branch locally
2. Go to the Switch Button doc
3. Use screen reader and tab to the switch button in the demo.
4. Press either enter or space
5. Listen to screen reader