### PR TITLE
[6.x] Ds-602 Remove pattern template function

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/30-layouts/layout/-20-layout-background-and-theme.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/30-layouts/layout/-20-layout-background-and-theme.twig
@@ -1,5 +1,17 @@
 {% set demo %}
   <bolt-layout padding-top="xlarge" padding-bottom="xlarge" class="t-bolt-dark">
+    {% set image %}
+      {% include '@bolt-elements-image/image.twig' with {
+        background: true,
+        attributes: {
+          alt: 'Alt text.',
+          loading: 'lazy',
+          src: '/images/content/backgrounds/background-tall-4.jpg',
+          width: 3840,
+          height: 2160,
+        },
+      } only %}
+    {% endset %}
     {% include '@bolt-components-background/background.twig' with {
       opacity: 'heavy',
       fill: 'gradient',
@@ -8,9 +20,7 @@
         horizontal: 'center'
       },
       contentItems: [
-        {
-          src: '/images/content/backgrounds/background-tall-4.jpg'
-        }
+        image
       ]
     } only %}
     <bolt-layout-item>
@@ -23,6 +33,15 @@
 {% verbatim %}
 // Set a background
 {% set background %}
+  {% set image %}
+    {% include '@bolt-elements-image/image.twig' with {
+      background: true,
+      attributes: {
+        src: '/images/content/backgrounds/background-tall-4.jpg',
+        ...
+      },
+    } only %}
+  {% endset %}
   {% include '@bolt-components-background/background.twig' with {
     opacity: 'heavy',
     fill: 'gradient',
@@ -31,9 +50,7 @@
       horizontal: 'center'
     },
     contentItems: [
-      {
-        src: '/images/content/backgrounds/background-tall-4.jpg'
-      }
+      image
     ]
   } only %}
 {% endset %}

--- a/docs-site/src/pages/pattern-lab/_patterns/30-layouts/layout/-20-layout-background-and-theme.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/30-layouts/layout/-20-layout-background-and-theme.twig
@@ -9,7 +9,6 @@
       },
       contentItems: [
         {
-          pattern: 'image',
           src: '/images/content/backgrounds/background-tall-4.jpg'
         }
       ]
@@ -33,7 +32,6 @@
     },
     contentItems: [
       {
-        pattern: 'image',
         src: '/images/content/backgrounds/background-tall-4.jpg'
       }
     ]

--- a/docs-site/src/pages/pattern-lab/_patterns/30-layouts/layout/-99-layout-use-case-artificial-intelligence-hero.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/30-layouts/layout/-99-layout-use-case-artificial-intelligence-hero.twig
@@ -65,6 +65,14 @@
   {% endset %}
 
   {% set background %}
+    {% set image %}
+      {% include '@bolt-elements-image/image.twig' with {
+        background: true,
+        attributes: {
+          src: '/images/heros/live-assets/artificial-intelligence-hero.jpg',
+        },
+      } only %}
+    {% endset %}
     {% include '@bolt-components-background/background.twig' with {
       opacity: 'heavy',
       fill: 'gradient',
@@ -73,9 +81,7 @@
         horizontal: 'center'
       },
       contentItems: [
-        {
-          src: '/images/heros/live-assets/artificial-intelligence-hero.jpg'
-        }
+        image
       ]
     } only %}
   {% endset %}
@@ -140,6 +146,14 @@
 {% endset %}
 
 {% set background %}
+  {% set image %}
+    {% include '@bolt-elements-image/image.twig' with {
+      background: true,
+      attributes: {
+        src: '/images/heros/live-assets/artificial-intelligence-hero.jpg',
+      },
+    } only %}
+  {% endset %}
   {% include '@bolt-components-background/background.twig' with {
     opacity: 'heavy',
     fill: 'gradient',
@@ -148,9 +162,7 @@
       horizontal: 'center'
     },
     contentItems: [
-      {
-        src: '/images/heros/live-assets/artificial-intelligence-hero.jpg'
-      }
+      image
     ]
   } only %}
 {% endset %}

--- a/docs-site/src/pages/pattern-lab/_patterns/30-layouts/layout/-99-layout-use-case-artificial-intelligence-hero.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/30-layouts/layout/-99-layout-use-case-artificial-intelligence-hero.twig
@@ -74,7 +74,6 @@
       },
       contentItems: [
         {
-          pattern: 'image',
           src: '/images/heros/live-assets/artificial-intelligence-hero.jpg'
         }
       ]
@@ -150,7 +149,6 @@
     },
     contentItems: [
       {
-        pattern: 'image',
         src: '/images/heros/live-assets/artificial-intelligence-hero.jpg'
       }
     ]

--- a/docs-site/src/pages/pattern-lab/_patterns/30-layouts/layout/-99-layout-use-case-locations-france-hero.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/30-layouts/layout/-99-layout-use-case-locations-france-hero.twig
@@ -85,7 +85,6 @@
       },
       contentItems: [
         {
-          pattern: 'image',
           src: '/images/heros/live-assets/ces-paris-team.jpg'
         }
       ]
@@ -170,7 +169,6 @@
     },
     contentItems: [
       {
-        pattern: 'image',
         src: '/images/heros/live-assets/ces-paris-team.jpg'
       }
     ]

--- a/docs-site/src/pages/pattern-lab/_patterns/30-layouts/layout/-99-layout-use-case-locations-france-hero.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/30-layouts/layout/-99-layout-use-case-locations-france-hero.twig
@@ -76,6 +76,14 @@
   {% endset %}
 
   {% set background %}
+    {% set image %}
+      {% include '@bolt-elements-image/image.twig' with {
+        background: true,
+        attributes: {
+          src: '/images/heros/live-assets/ces-paris-team.jpg'
+        },
+      } only %}
+    {% endset %}
     {% include '@bolt-components-background/background.twig' with {
       opacity: 'heavy',
       fill_color: 'navy',
@@ -84,9 +92,7 @@
         horizontal: 'center'
       },
       contentItems: [
-        {
-          src: '/images/heros/live-assets/ces-paris-team.jpg'
-        }
+        image
       ]
     } only %}
   {% endset %}
@@ -160,6 +166,14 @@
 {% endset %}
 
 {% set background %}
+  {% set image %}
+    {% include '@bolt-elements-image/image.twig' with {
+      background: true,
+      attributes: {
+        src: '/images/heros/live-assets/ces-paris-team.jpg'
+      },
+    } only %}
+  {% endset %}
   {% include '@bolt-components-background/background.twig' with {
     opacity: 'heavy',
     fill_color: 'navy',
@@ -168,9 +182,7 @@
       horizontal: 'center'
     },
     contentItems: [
-      {
-        src: '/images/heros/live-assets/ces-paris-team.jpg'
-      }
+      image
     ]
   } only %}
 {% endset %}

--- a/docs-site/src/pages/pattern-lab/_patterns/30-layouts/layout/-999-layout-use-case-old-homepage.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/30-layouts/layout/-999-layout-use-case-old-homepage.twig
@@ -3,12 +3,18 @@
 {% endset %}
 
 <bolt-layout template="halves@from-small" valign-items="center" gutter="large" row-gutter="large" padding-top="large" padding-bottom="large" class="t-bolt-dark">
+  {% set image %}
+    {% include '@bolt-elements-image/image.twig' with {
+      background: true,
+      attributes: {
+        src: '/images/heros/hero-background-dark-shapes-1.jpg'
+      },
+    } only %}
+  {% endset %}
   {% include '@bolt-components-background/background.twig' with {
     overlay: 'disabled',
     contentItems: [
-      {
-        src: '/images/heros/hero-background-dark-shapes-1.jpg'
-      }
+      image
     ]
   } only %}
   <bolt-layout-item>
@@ -72,12 +78,18 @@
 </bolt-layout>
 
 <bolt-layout template="thirds@from-small" valign-items="start" gutter="large" padding-top="xlarge" padding-bottom="xlarge" valign-items="center" class="t-bolt-dark">
+  {% set image %}
+    {% include '@bolt-elements-image/image.twig' with {
+      background: true,
+      attributes: {
+        src: '/images/heros/hero-background-dark-shapes-2.jpg'
+      },
+    } only %}
+  {% endset %}
   {% include '@bolt-components-background/background.twig' with {
     overlay: 'disabled',
     contentItems: [
-      {
-        src: '/images/heros/hero-background-dark-shapes-2.jpg'
-      }
+      image
     ]
   } only %}
   <bolt-layout-item>

--- a/docs-site/src/pages/pattern-lab/_patterns/30-layouts/layout/-999-layout-use-case-old-homepage.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/30-layouts/layout/-999-layout-use-case-old-homepage.twig
@@ -7,7 +7,6 @@
     overlay: 'disabled',
     contentItems: [
       {
-        pattern: 'image',
         src: '/images/heros/hero-background-dark-shapes-1.jpg'
       }
     ]
@@ -77,7 +76,6 @@
     overlay: 'disabled',
     contentItems: [
       {
-        pattern: 'image',
         src: '/images/heros/hero-background-dark-shapes-2.jpg'
       }
     ]

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/background/00-background-docs.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/background/00-background-docs.twig
@@ -1,4 +1,15 @@
 {% set usage %}{% verbatim %}
+{% set image %}
+  {% include '@bolt-elements-image/image.twig' with {
+    background: true,
+    attributes: {
+      src: '/images/content/backgrounds/background-tall-4.jpg',
+      srcset: '/images/content/backgrounds/background-tall-4-50.jpg 50w, /images/content/backgrounds/background-tall-4-100.jpg 100w, /images/content/backgrounds/background-tall-4-200.jpg 200w, /images/content/backgrounds/background-tall-4-320.jpg 320w, /images/content/backgrounds/background-tall-4-480.jpg 480w, /images/content/backgrounds/background-tall-4-640.jpg 640w, /images/content/backgrounds/background-tall-4-800.jpg 800w, /images/content/backgrounds/background-tall-4-1024.jpg 1024w, /images/content/backgrounds/background-tall-4-1366.jpg 1366w, /images/content/backgrounds/background-tall-4-1536.jpg 1536w, /images/content/backgrounds/background-tall-4-1920.jpg 1920w, /images/content/backgrounds/background-tall-4-2560.jpg 2560w, /images/content/backgrounds/background-tall-4-2880.jpg 2880w, /images/content/backgrounds/background-tall-4.jpg 3840w',
+      width: 3840,
+      height: 2160
+    },
+  } only %}
+{% endset %}
 {% include '@bolt-components-background/background.twig' with {
   opacity: 'heavy',
   fill: 'gradient',
@@ -7,12 +18,7 @@
     horizontal: 'center'
   },
   content_items: [
-    {
-      src: '/images/content/backgrounds/background-tall-4.jpg',
-      srcset: '/images/content/backgrounds/background-tall-4-50.jpg 50w, /images/content/backgrounds/background-tall-4-100.jpg 100w, /images/content/backgrounds/background-tall-4-200.jpg 200w, /images/content/backgrounds/background-tall-4-320.jpg 320w, /images/content/backgrounds/background-tall-4-480.jpg 480w, /images/content/backgrounds/background-tall-4-640.jpg 640w, /images/content/backgrounds/background-tall-4-800.jpg 800w, /images/content/backgrounds/background-tall-4-1024.jpg 1024w, /images/content/backgrounds/background-tall-4-1366.jpg 1366w, /images/content/backgrounds/background-tall-4-1536.jpg 1536w, /images/content/backgrounds/background-tall-4-1920.jpg 1920w, /images/content/backgrounds/background-tall-4-2560.jpg 2560w, /images/content/backgrounds/background-tall-4-2880.jpg 2880w, /images/content/backgrounds/background-tall-4.jpg 3840w',
-      width: 3840,
-      height: 2160
-    }
+    image
   ]
 } only %}
 {% endverbatim %}{% endset %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/background/00-background-docs.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/background/00-background-docs.twig
@@ -8,7 +8,6 @@
   },
   content_items: [
     {
-      pattern: 'image',
       src: '/images/content/backgrounds/background-tall-4.jpg',
       srcset: '/images/content/backgrounds/background-tall-4-50.jpg 50w, /images/content/backgrounds/background-tall-4-100.jpg 100w, /images/content/backgrounds/background-tall-4-200.jpg 200w, /images/content/backgrounds/background-tall-4-320.jpg 320w, /images/content/backgrounds/background-tall-4-480.jpg 480w, /images/content/backgrounds/background-tall-4-640.jpg 640w, /images/content/backgrounds/background-tall-4-800.jpg 800w, /images/content/backgrounds/background-tall-4-1024.jpg 1024w, /images/content/backgrounds/background-tall-4-1366.jpg 1366w, /images/content/backgrounds/background-tall-4-1536.jpg 1536w, /images/content/backgrounds/background-tall-4-1920.jpg 1920w, /images/content/backgrounds/background-tall-4-2560.jpg 2560w, /images/content/backgrounds/background-tall-4-2880.jpg 2880w, /images/content/backgrounds/background-tall-4.jpg 3840w',
       width: 3840,

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/background/05-background.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/background/05-background.twig
@@ -1,4 +1,15 @@
 <div style="height: 400px; position: relative;">
+  {% set image %}
+    {% include '@bolt-elements-image/image.twig' with {
+      background: true,
+      attributes: {
+        src: '/images/content/backgrounds/background-tall-4.jpg',
+        srcset: '/images/content/backgrounds/background-tall-4-50.jpg 50w, /images/content/backgrounds/background-tall-4-100.jpg 100w, /images/content/backgrounds/background-tall-4-200.jpg 200w, /images/content/backgrounds/background-tall-4-320.jpg 320w, /images/content/backgrounds/background-tall-4-480.jpg 480w, /images/content/backgrounds/background-tall-4-640.jpg 640w, /images/content/backgrounds/background-tall-4-800.jpg 800w, /images/content/backgrounds/background-tall-4-1024.jpg 1024w, /images/content/backgrounds/background-tall-4-1366.jpg 1366w, /images/content/backgrounds/background-tall-4-1536.jpg 1536w, /images/content/backgrounds/background-tall-4-1920.jpg 1920w, /images/content/backgrounds/background-tall-4-2560.jpg 2560w, /images/content/backgrounds/background-tall-4-2880.jpg 2880w, /images/content/backgrounds/background-tall-4.jpg 3840w',
+        width: 3840,
+        height: 2160
+      },
+    } only %}
+  {% endset %}
   {% include '@bolt-components-background/background.twig' with {
     opacity: 'heavy',
     fill: 'gradient',
@@ -7,12 +18,7 @@
       horizontal: 'center'
     },
     content_items: [
-      {
-        src: '/images/content/backgrounds/background-tall-4.jpg',
-        srcset: '/images/content/backgrounds/background-tall-4-50.jpg 50w, /images/content/backgrounds/background-tall-4-100.jpg 100w, /images/content/backgrounds/background-tall-4-200.jpg 200w, /images/content/backgrounds/background-tall-4-320.jpg 320w, /images/content/backgrounds/background-tall-4-480.jpg 480w, /images/content/backgrounds/background-tall-4-640.jpg 640w, /images/content/backgrounds/background-tall-4-800.jpg 800w, /images/content/backgrounds/background-tall-4-1024.jpg 1024w, /images/content/backgrounds/background-tall-4-1366.jpg 1366w, /images/content/backgrounds/background-tall-4-1536.jpg 1536w, /images/content/backgrounds/background-tall-4-1920.jpg 1920w, /images/content/backgrounds/background-tall-4-2560.jpg 2560w, /images/content/backgrounds/background-tall-4-2880.jpg 2880w, /images/content/backgrounds/background-tall-4.jpg 3840w',
-        width: 3840,
-        height: 2160
-      }
+      image
     ]
 } only %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/background/05-background.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/background/05-background.twig
@@ -1,5 +1,4 @@
 <div style="height: 400px; position: relative;">
-
   {% include '@bolt-components-background/background.twig' with {
     opacity: 'heavy',
     fill: 'gradient',
@@ -9,7 +8,6 @@
     },
     content_items: [
       {
-        pattern: 'image',
         src: '/images/content/backgrounds/background-tall-4.jpg',
         srcset: '/images/content/backgrounds/background-tall-4-50.jpg 50w, /images/content/backgrounds/background-tall-4-100.jpg 100w, /images/content/backgrounds/background-tall-4-200.jpg 200w, /images/content/backgrounds/background-tall-4-320.jpg 320w, /images/content/backgrounds/background-tall-4-480.jpg 480w, /images/content/backgrounds/background-tall-4-640.jpg 640w, /images/content/backgrounds/background-tall-4-800.jpg 800w, /images/content/backgrounds/background-tall-4-1024.jpg 1024w, /images/content/backgrounds/background-tall-4-1366.jpg 1366w, /images/content/backgrounds/background-tall-4-1536.jpg 1536w, /images/content/backgrounds/background-tall-4-1920.jpg 1920w, /images/content/backgrounds/background-tall-4-2560.jpg 2560w, /images/content/backgrounds/background-tall-4-2880.jpg 2880w, /images/content/backgrounds/background-tall-4.jpg 3840w',
         width: 3840,

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/background/10-background-opacity-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/background/10-background-opacity-variations.twig
@@ -2,6 +2,17 @@
 
 {% for opacity in schema.properties.opacity.enum %}
 <p>Opacity: {{ opacity|capitalize }}</p>
+{% set image %}
+  {% include '@bolt-elements-image/image.twig' with {
+    background: true,
+    attributes: {
+      src: '/images/content/backgrounds/background-tall-2.jpg',
+      srcset: '/images/content/backgrounds/background-tall-2-50.jpg 50w, /images/content/backgrounds/background-tall-2-100.jpg 100w, /images/content/backgrounds/background-tall-2-200.jpg 200w, /images/content/backgrounds/background-tall-2-320.jpg 320w, /images/content/backgrounds/background-tall-2-480.jpg 480w, /images/content/backgrounds/background-tall-2-640.jpg 640w, /images/content/backgrounds/background-tall-2-800.jpg 800w, /images/content/backgrounds/background-tall-2-1024.jpg 1024w, /images/content/backgrounds/background-tall-2-1366.jpg 1366w, /images/content/backgrounds/background-tall-2-1536.jpg 1536w, /images/content/backgrounds/background-tall-2-1920.jpg 1920w, /images/content/backgrounds/background-tall-2-2560.jpg 2560w, /images/content/backgrounds/background-tall-2-2880.jpg 2880w, /images/content/backgrounds/background-tall-2.jpg 4320w',
+      width: 4320,
+      height: 2880
+    },
+  } only %}
+{% endset %}
 {% include './_00-background-band-demo.twig' with {
   background: {
     opacity: opacity,
@@ -10,12 +21,7 @@
       horizontal: 'center'
     },
     content_items: [
-      {
-        src: '/images/content/backgrounds/background-tall-2.jpg',
-        srcset: '/images/content/backgrounds/background-tall-2-50.jpg 50w, /images/content/backgrounds/background-tall-2-100.jpg 100w, /images/content/backgrounds/background-tall-2-200.jpg 200w, /images/content/backgrounds/background-tall-2-320.jpg 320w, /images/content/backgrounds/background-tall-2-480.jpg 480w, /images/content/backgrounds/background-tall-2-640.jpg 640w, /images/content/backgrounds/background-tall-2-800.jpg 800w, /images/content/backgrounds/background-tall-2-1024.jpg 1024w, /images/content/backgrounds/background-tall-2-1366.jpg 1366w, /images/content/backgrounds/background-tall-2-1536.jpg 1536w, /images/content/backgrounds/background-tall-2-1920.jpg 1920w, /images/content/backgrounds/background-tall-2-2560.jpg 2560w, /images/content/backgrounds/background-tall-2-2880.jpg 2880w, /images/content/backgrounds/background-tall-2.jpg 4320w',
-        width: 4320,
-        height: 2880
-      }
+      image
     ]
   }
 } %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/background/10-background-opacity-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/background/10-background-opacity-variations.twig
@@ -11,11 +11,10 @@
     },
     content_items: [
       {
-        pattern: 'image',
-          src: '/images/content/backgrounds/background-tall-2.jpg',
-          srcset: '/images/content/backgrounds/background-tall-2-50.jpg 50w, /images/content/backgrounds/background-tall-2-100.jpg 100w, /images/content/backgrounds/background-tall-2-200.jpg 200w, /images/content/backgrounds/background-tall-2-320.jpg 320w, /images/content/backgrounds/background-tall-2-480.jpg 480w, /images/content/backgrounds/background-tall-2-640.jpg 640w, /images/content/backgrounds/background-tall-2-800.jpg 800w, /images/content/backgrounds/background-tall-2-1024.jpg 1024w, /images/content/backgrounds/background-tall-2-1366.jpg 1366w, /images/content/backgrounds/background-tall-2-1536.jpg 1536w, /images/content/backgrounds/background-tall-2-1920.jpg 1920w, /images/content/backgrounds/background-tall-2-2560.jpg 2560w, /images/content/backgrounds/background-tall-2-2880.jpg 2880w, /images/content/backgrounds/background-tall-2.jpg 4320w',
-          width: 4320,
-          height: 2880
+        src: '/images/content/backgrounds/background-tall-2.jpg',
+        srcset: '/images/content/backgrounds/background-tall-2-50.jpg 50w, /images/content/backgrounds/background-tall-2-100.jpg 100w, /images/content/backgrounds/background-tall-2-200.jpg 200w, /images/content/backgrounds/background-tall-2-320.jpg 320w, /images/content/backgrounds/background-tall-2-480.jpg 480w, /images/content/backgrounds/background-tall-2-640.jpg 640w, /images/content/backgrounds/background-tall-2-800.jpg 800w, /images/content/backgrounds/background-tall-2-1024.jpg 1024w, /images/content/backgrounds/background-tall-2-1366.jpg 1366w, /images/content/backgrounds/background-tall-2-1536.jpg 1536w, /images/content/backgrounds/background-tall-2-1920.jpg 1920w, /images/content/backgrounds/background-tall-2-2560.jpg 2560w, /images/content/backgrounds/background-tall-2-2880.jpg 2880w, /images/content/backgrounds/background-tall-2.jpg 4320w',
+        width: 4320,
+        height: 2880
       }
     ]
   }

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/background/15-background-focal-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/background/15-background-focal-variations.twig
@@ -2,6 +2,17 @@
 
 {% for horz in schema.properties.focal_point.properties.horizontal.enum if horz != 'center' %}{# @todo: bolt background currently only reverses gradient on horz = 'left' #}
   <p>Heavy Opacity with {{  horz|capitalize }} Focal Point</p>
+  {% set image %}
+    {% include '@bolt-elements-image/image.twig' with {
+      background: true,
+      attributes: {
+        src: '/images/content/backgrounds/background-tall-4.jpg',
+        srcset: '/images/content/backgrounds/background-tall-4-50.jpg 50w, /images/content/backgrounds/background-tall-4-100.jpg 100w, /images/content/backgrounds/background-tall-4-200.jpg 200w, /images/content/backgrounds/background-tall-4-320.jpg 320w, /images/content/backgrounds/background-tall-4-480.jpg 480w, /images/content/backgrounds/background-tall-4-640.jpg 640w, /images/content/backgrounds/background-tall-4-800.jpg 800w, /images/content/backgrounds/background-tall-4-1024.jpg 1024w, /images/content/backgrounds/background-tall-4-1366.jpg 1366w, /images/content/backgrounds/background-tall-4-1536.jpg 1536w, /images/content/backgrounds/background-tall-4-1920.jpg 1920w, /images/content/backgrounds/background-tall-4-2560.jpg 2560w, /images/content/backgrounds/background-tall-4-2880.jpg 2880w, /images/content/backgrounds/background-tall-4.jpg 3840w',
+        width: 3840,
+        height: 2160
+      },
+    } only %}
+  {% endset %}
   {% include './_00-background-band-demo.twig' with {
     background: {
       opacity: 'heavy',
@@ -11,12 +22,7 @@
         horizontal: horz
       },
       content_items: [
-        {
-          src: '/images/content/backgrounds/background-tall-4.jpg',
-          srcset: '/images/content/backgrounds/background-tall-4-50.jpg 50w, /images/content/backgrounds/background-tall-4-100.jpg 100w, /images/content/backgrounds/background-tall-4-200.jpg 200w, /images/content/backgrounds/background-tall-4-320.jpg 320w, /images/content/backgrounds/background-tall-4-480.jpg 480w, /images/content/backgrounds/background-tall-4-640.jpg 640w, /images/content/backgrounds/background-tall-4-800.jpg 800w, /images/content/backgrounds/background-tall-4-1024.jpg 1024w, /images/content/backgrounds/background-tall-4-1366.jpg 1366w, /images/content/backgrounds/background-tall-4-1536.jpg 1536w, /images/content/backgrounds/background-tall-4-1920.jpg 1920w, /images/content/backgrounds/background-tall-4-2560.jpg 2560w, /images/content/backgrounds/background-tall-4-2880.jpg 2880w, /images/content/backgrounds/background-tall-4.jpg 3840w',
-          width: 3840,
-          height: 2160
-        }
+        image
       ]
     },
     teaserPosition: horz == 'left' ?? 'right'

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/background/15-background-focal-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/background/15-background-focal-variations.twig
@@ -12,7 +12,6 @@
       },
       content_items: [
         {
-          pattern: 'image',
           src: '/images/content/backgrounds/background-tall-4.jpg',
           srcset: '/images/content/backgrounds/background-tall-4-50.jpg 50w, /images/content/backgrounds/background-tall-4-100.jpg 100w, /images/content/backgrounds/background-tall-4-200.jpg 200w, /images/content/backgrounds/background-tall-4-320.jpg 320w, /images/content/backgrounds/background-tall-4-480.jpg 480w, /images/content/backgrounds/background-tall-4-640.jpg 640w, /images/content/backgrounds/background-tall-4-800.jpg 800w, /images/content/backgrounds/background-tall-4-1024.jpg 1024w, /images/content/backgrounds/background-tall-4-1366.jpg 1366w, /images/content/backgrounds/background-tall-4-1536.jpg 1536w, /images/content/backgrounds/background-tall-4-1920.jpg 1920w, /images/content/backgrounds/background-tall-4-2560.jpg 2560w, /images/content/backgrounds/background-tall-4-2880.jpg 2880w, /images/content/backgrounds/background-tall-4.jpg 3840w',
           width: 3840,

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/background/25-background-fill-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/background/25-background-fill-variations.twig
@@ -1,5 +1,16 @@
 {% for fill in ['color', 'gradient'] %}
 <p>Fill: {{ fill|capitalize }}</p>
+{% set image %}
+  {% include '@bolt-elements-image/image.twig' with {
+    background: true,
+    attributes: {
+      src: '/images/content/backgrounds/background-tall-2.jpg',
+      srcset: '/images/content/backgrounds/background-tall-2-50.jpg 50w, /images/content/backgrounds/background-tall-2-100.jpg 100w, /images/content/backgrounds/background-tall-2-200.jpg 200w, /images/content/backgrounds/background-tall-2-320.jpg 320w, /images/content/backgrounds/background-tall-2-480.jpg 480w, /images/content/backgrounds/background-tall-2-640.jpg 640w, /images/content/backgrounds/background-tall-2-800.jpg 800w, /images/content/backgrounds/background-tall-2-1024.jpg 1024w, /images/content/backgrounds/background-tall-2-1366.jpg 1366w, /images/content/backgrounds/background-tall-2-1536.jpg 1536w, /images/content/backgrounds/background-tall-2-1920.jpg 1920w, /images/content/backgrounds/background-tall-2-2560.jpg 2560w, /images/content/backgrounds/background-tall-2-2880.jpg 2880w, /images/content/backgrounds/background-tall-2.jpg 4320w',
+      width: 4320,
+      height: 2880
+    },
+  } only %}
+{% endset %}
 {% include './_00-background-band-demo.twig' with {
   background: {
     fill: fill,
@@ -9,12 +20,7 @@
       horizontal: 'center'
     },
     content_items: [
-      {
-        src: '/images/content/backgrounds/background-tall-2.jpg',
-        srcset: '/images/content/backgrounds/background-tall-2-50.jpg 50w, /images/content/backgrounds/background-tall-2-100.jpg 100w, /images/content/backgrounds/background-tall-2-200.jpg 200w, /images/content/backgrounds/background-tall-2-320.jpg 320w, /images/content/backgrounds/background-tall-2-480.jpg 480w, /images/content/backgrounds/background-tall-2-640.jpg 640w, /images/content/backgrounds/background-tall-2-800.jpg 800w, /images/content/backgrounds/background-tall-2-1024.jpg 1024w, /images/content/backgrounds/background-tall-2-1366.jpg 1366w, /images/content/backgrounds/background-tall-2-1536.jpg 1536w, /images/content/backgrounds/background-tall-2-1920.jpg 1920w, /images/content/backgrounds/background-tall-2-2560.jpg 2560w, /images/content/backgrounds/background-tall-2-2880.jpg 2880w, /images/content/backgrounds/background-tall-2.jpg 4320w',
-        width: 4320,
-        height: 2880
-      }
+      image
     ]
   }
 } %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/background/25-background-fill-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/background/25-background-fill-variations.twig
@@ -10,7 +10,6 @@
     },
     content_items: [
       {
-        pattern: 'image',
         src: '/images/content/backgrounds/background-tall-2.jpg',
         srcset: '/images/content/backgrounds/background-tall-2-50.jpg 50w, /images/content/backgrounds/background-tall-2-100.jpg 100w, /images/content/backgrounds/background-tall-2-200.jpg 200w, /images/content/backgrounds/background-tall-2-320.jpg 320w, /images/content/backgrounds/background-tall-2-480.jpg 480w, /images/content/backgrounds/background-tall-2-640.jpg 640w, /images/content/backgrounds/background-tall-2-800.jpg 800w, /images/content/backgrounds/background-tall-2-1024.jpg 1024w, /images/content/backgrounds/background-tall-2-1366.jpg 1366w, /images/content/backgrounds/background-tall-2-1536.jpg 1536w, /images/content/backgrounds/background-tall-2-1920.jpg 1920w, /images/content/backgrounds/background-tall-2-2560.jpg 2560w, /images/content/backgrounds/background-tall-2-2880.jpg 2880w, /images/content/backgrounds/background-tall-2.jpg 4320w',
         width: 4320,

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/background/35-background-valign-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/background/35-background-valign-variations.twig
@@ -1,9 +1,21 @@
 <p>
-  <mark>Note: <code>valign</code> is an Image component prop, not a Background component prop. Set <code>valign</code> on images passed in via <code>content_items</code> to control the vertical alignment.</mark>
+<mark>Note: <code>alignment</code> of an image can be achieved by <a href="{{ link['elements-image-use-case-background-fit-and-position'] }}" class="e-bolt-text-link">passing inline styles to the Image element's attributes objects</a>. Then you can pass the Image element to the Background component via <code>content_items</code>.</mark>
 </p>
 
-{% for image_valign in ['center', 'top', 'bottom', '25%'] %}
-  <p>valign: {{ image_valign }}</p>
+{% for valign in ['center', 'top', 'bottom', '25%'] %}
+  <p>valign: {{ valign }}</p>
+  {% set image %}
+    {% include '@bolt-elements-image/image.twig' with {
+      background: true,
+      attributes: {
+        src: '/images/content/backgrounds/background-tall-2.jpg',
+        srcset: '/images/content/backgrounds/background-tall-2-50.jpg 50w, /images/content/backgrounds/background-tall-2-100.jpg 100w, /images/content/backgrounds/background-tall-2-200.jpg 200w, /images/content/backgrounds/background-tall-2-320.jpg 320w, /images/content/backgrounds/background-tall-2-480.jpg 480w, /images/content/backgrounds/background-tall-2-640.jpg 640w, /images/content/backgrounds/background-tall-2-800.jpg 800w, /images/content/backgrounds/background-tall-2-1024.jpg 1024w, /images/content/backgrounds/background-tall-2-1366.jpg 1366w, /images/content/backgrounds/background-tall-2-1536.jpg 1536w, /images/content/backgrounds/background-tall-2-1920.jpg 1920w, /images/content/backgrounds/background-tall-2-2560.jpg 2560w, /images/content/backgrounds/background-tall-2-2880.jpg 2880w, /images/content/backgrounds/background-tall-2.jpg 4320w',
+        width: 4320,
+        height: 2880,
+        style: '--e-bolt-image-position: center ' ~ valign ~';',
+      },
+    } only %}
+  {% endset %}
   {% include './_00-background-band-demo.twig' with {
     background: {
       fill: 'color',
@@ -13,13 +25,7 @@
         horizontal: 'center'
       },
       content_items: [
-        {
-          src: '/images/content/backgrounds/background-tall-2.jpg',
-          srcset: '/images/content/backgrounds/background-tall-2-50.jpg 50w, /images/content/backgrounds/background-tall-2-100.jpg 100w, /images/content/backgrounds/background-tall-2-200.jpg 200w, /images/content/backgrounds/background-tall-2-320.jpg 320w, /images/content/backgrounds/background-tall-2-480.jpg 480w, /images/content/backgrounds/background-tall-2-640.jpg 640w, /images/content/backgrounds/background-tall-2-800.jpg 800w, /images/content/backgrounds/background-tall-2-1024.jpg 1024w, /images/content/backgrounds/background-tall-2-1366.jpg 1366w, /images/content/backgrounds/background-tall-2-1536.jpg 1536w, /images/content/backgrounds/background-tall-2-1920.jpg 1920w, /images/content/backgrounds/background-tall-2-2560.jpg 2560w, /images/content/backgrounds/background-tall-2-2880.jpg 2880w, /images/content/backgrounds/background-tall-2.jpg 4320w',
-          width: 4320,
-          height: 2880,
-          valign: image_valign
-        }
+        image
       ]
     }
   } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/background/35-background-valign-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/background/35-background-valign-variations.twig
@@ -14,7 +14,6 @@
       },
       content_items: [
         {
-          pattern: 'image',
           src: '/images/content/backgrounds/background-tall-2.jpg',
           srcset: '/images/content/backgrounds/background-tall-2-50.jpg 50w, /images/content/backgrounds/background-tall-2-100.jpg 100w, /images/content/backgrounds/background-tall-2-200.jpg 200w, /images/content/backgrounds/background-tall-2-320.jpg 320w, /images/content/backgrounds/background-tall-2-480.jpg 480w, /images/content/backgrounds/background-tall-2-640.jpg 640w, /images/content/backgrounds/background-tall-2-800.jpg 800w, /images/content/backgrounds/background-tall-2-1024.jpg 1024w, /images/content/backgrounds/background-tall-2-1366.jpg 1366w, /images/content/backgrounds/background-tall-2-1536.jpg 1536w, /images/content/backgrounds/background-tall-2-1920.jpg 1920w, /images/content/backgrounds/background-tall-2-2560.jpg 2560w, /images/content/backgrounds/background-tall-2-2880.jpg 2880w, /images/content/backgrounds/background-tall-2.jpg 4320w',
           width: 4320,

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/band/35-band-with-background.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/band/35-band-with-background.twig
@@ -24,7 +24,6 @@
       },
       content_items: [
         {
-          pattern: 'image',
           src: '/images/content/backgrounds/background-short-1.jpg',
           lazyload: false,
           width: 2320,

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/band/35-band-with-background.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/band/35-band-with-background.twig
@@ -13,6 +13,17 @@
     } only %}
   {% endset %}
 
+  {% set image %}
+    {% include '@bolt-elements-image/image.twig' with {
+      background: true,
+      attributes: {
+        src: '/images/content/backgrounds/background-short-1.jpg',
+        width: 2320,
+        height: 800
+      },
+    } only %}
+  {% endset %}
+
   {% include '@bolt-components-band/band.twig' with {
     size: 'large',
     background: {
@@ -23,12 +34,7 @@
         horizontal: 'center'
       },
       content_items: [
-        {
-          src: '/images/content/backgrounds/background-short-1.jpg',
-          lazyload: false,
-          width: 2320,
-          height: 800
-        },
+        image
       ]
     },
     content: content_image

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/band/40-band-nested.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/band/40-band-nested.twig
@@ -17,6 +17,16 @@
   } only %}
 {% endset %}
 
+{% set image %}
+  {% include '@bolt-elements-image/image.twig' with {
+    background: true,
+    attributes: {
+      src: '/images/content/backgrounds/background-short-1.jpg',
+      width: 2320,
+      height: 800
+    },
+  } only %}
+{% endset %}
 
 {% include '@bolt-components-band/band.twig' with {
   theme: 'xdark',
@@ -28,12 +38,7 @@
       horizontal: 'center'
     },
     content_items: [
-      {
-        src: '/images/content/backgrounds/background-short-1.jpg',
-        lazyload: false,
-        width: 2320,
-        height: 800
-      },
+      image
     ]
   },
   content: parent_band_content,

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/band/40-band-nested.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/band/40-band-nested.twig
@@ -29,7 +29,6 @@
     },
     content_items: [
       {
-        pattern: 'image',
         src: '/images/content/backgrounds/background-short-1.jpg',
         lazyload: false,
         width: 2320,

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/band/_variations/_band--collection.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/band/_variations/_band--collection.twig
@@ -7,7 +7,7 @@
       {% cell 'u-bolt-width-1/1 u-bolt-width-1/3@small' %}
       {# TODO: get length of items to divide into cells #}
         {% block collection_content %}
-          {% include pattern_template(pattern ?? item.pattern) with item only %}
+          {{ item }}
         {% endblock %}
       {% endcell %}
     {% endfor %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/band/_variations/_band--feature.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/band/_variations/_band--feature.twig
@@ -6,7 +6,7 @@
     {% cell 'u-bolt-width-1/1 u-bolt-width-2/3@small' %}
       {% if primaryTeaser %}
         {% block primary_teaser %}
-          {% include pattern_template('teaser') with primaryTeaser only %}
+          {{ primaryTeaser }}
         {% endblock primary_teaser %}
       {% endif %}
     {% endcell %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/breadcrumb/15-breadcrumb-use-case-band.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/breadcrumb/15-breadcrumb-use-case-band.twig
@@ -146,41 +146,9 @@
     'content': breadcrumb
   } only %}
   {% include '@pl/_band--feature.twig' with {
-    'size': 'large',
-    'theme': 'none',
-    'primaryTeaser': {
-      'headlines': [
-        {
-          'type': 'eyebrow',
-          'text': 'Digital Transformation',
-          'tag': 'span'
-        },
-        {
-          'type': 'headline',
-          'text': 'Be Future Empowered',
-          'size': 'xxxlarge',
-          'tag': 'h1'
-        },
-        {
-          'type': 'subheadline',
-          'text': 'Start with the outcomes you want.',
-          'size': 'xxlarge',
-          'tag': 'h2'
-        },
-        {
-          'type': 'text',
-          'text': 'Digital transformation is more than a slick new mobile app. It demands the hard work of designing for customer outcomes. Pega software gives you the power to truly transform.',
-          'tag': 'p'
-        }
-      ],
-      'buttons': [
-        {
-          'text': 'Get Smart',
-          'hierarchy': 'primary',
-          'url': 'https://www.google.com'
-        }
-      ]
-    }
+    size: 'large',
+    theme: 'none',
+    primaryTeaser: headings_stack,
   } only %}
 {% endset %}
 
@@ -231,45 +199,13 @@
 {% set stacked_bands %}
   {% include '@bolt-components-band/band.twig' with {
     'size': 'xsmall',
-    'theme': 'dark',
+    'theme': 'xdark',
     'content': breadcrumb
   } only %}
   {% include '@pl/_band--feature.twig' with {
-    'size': 'large',
-    'theme': 'xdark',
-    'primaryTeaser': {
-      'headlines': [
-        {
-          'type': 'eyebrow',
-          'text': 'Digital Transformation',
-          'tag': 'span'
-        },
-        {
-          'type': 'headline',
-          'text': 'Be Future Empowered',
-          'size': 'xxxlarge',
-          'tag': 'h1'
-        },
-        {
-          'type': 'subheadline',
-          'text': 'Start with the outcomes you want.',
-          'size': 'xxlarge',
-          'tag': 'h2'
-        },
-        {
-          'type': 'text',
-          'text': 'Digital transformation is more than a slick new mobile app. It demands the hard work of designing for customer outcomes. Pega software gives you the power to truly transform.',
-          'tag': 'p'
-        }
-      ],
-      'buttons': [
-        {
-          'text': 'Get Smart',
-          'hierarchy': 'primary',
-          'url': 'https://www.google.com'
-        }
-      ]
-    }
+    size: 'large',
+    theme: 'xdark',
+    primaryTeaser: headings_stack,
   } only %}
 {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/breadcrumb/15-breadcrumb-use-case-band.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/breadcrumb/15-breadcrumb-use-case-band.twig
@@ -77,42 +77,35 @@
     'theme': 'none',
     'content': breadcrumb
   } only %}
+  {% set headings_stack %}
+    {% include '@bolt-components-headline/eyebrow.twig' with {
+      text: 'Eyebrow',
+    } only %}
+
+    {% include '@bolt-components-headline/headline.twig' with {
+      text: 'Headline',
+      size: 'xxxlarge',
+    } only %}
+
+    {% include '@bolt-components-headline/subheadline.twig' with {
+      text: 'Subheadline',
+    } only %}
+
+    {% include '@bolt-components-headline/text.twig' with {
+      text: 'Body text',
+    } only %}
+
+    {% include '@bolt-elements-button/button.twig' with {
+      content: 'This is a button',
+      attributes: {
+        type: 'button'
+      }
+    } only %}
+  {% endset %}
   {% include '@pl/_band--feature.twig' with {
-    'size': 'large',
-    'theme': 'none',
-    'primaryTeaser': {
-      'headlines': [
-        {
-          'type': 'eyebrow',
-          'text': 'Eyebrow',
-          'tag': 'span'
-        },
-        {
-          'type': 'headline',
-          'text': 'Headline',
-          'size': 'xxxlarge',
-          'tag': 'h1'
-        },
-        {
-          'type': 'subheadline',
-          'text': 'Subheadline',
-          'size': 'xxlarge',
-          'tag': 'h2'
-        },
-        {
-          'type': 'text',
-          'text': 'Body text.',
-          'tag': 'p'
-        }
-      ],
-      'buttons': [
-        {
-          'text': 'Call to Action',
-          'hierarchy': 'primary',
-          'url': 'https://www.google.com'
-        }
-      ]
-    }
+    size: 'large',
+    theme: 'none',
+    primaryTeaser: headings_stack,
   } only %}
 {% endset %}
 

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/breadcrumb/15-breadcrumb-use-case-band.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/breadcrumb/15-breadcrumb-use-case-band.twig
@@ -165,7 +165,6 @@
       'horizontal': 'right'
     },
     'content_items': [{
-      'pattern': 'image',
       'src': '/images/content/backgrounds/background-tall-3.jpg'
     }]
   },

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/card/20-card-replacement-theme-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/card/20-card-replacement-theme-variations.twig
@@ -30,6 +30,14 @@
 
   <h3>Inside {{ container_theme|upper }} Parent Container</h3>
   <div class="u-bolt-margin-bottom-medium">
+    {% set image %}
+      {% include '@bolt-elements-image/image.twig' with {
+        background: true,
+        attributes: {
+          src: '/images/content/backgrounds/background-tall-2.jpg',
+        },
+      } only %}
+    {% endset %}
     {% embed '@bolt-components-band/band.twig' with {
       theme: container_theme,
     } %}
@@ -43,10 +51,7 @@
         opacity: 'heavy',
         fill: 'color',
         content_items: [
-          {
-            src: '/images/content/backgrounds/background-tall-2.jpg',
-            lazyload: false
-          }
+          image
         ]
       }
     } %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/card/20-card-replacement-theme-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/card/20-card-replacement-theme-variations.twig
@@ -44,7 +44,6 @@
         fill: 'color',
         content_items: [
           {
-            pattern: 'image',
             src: '/images/content/backgrounds/background-tall-2.jpg',
             lazyload: false
           }

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/carousel/30-carousel-advanced-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/carousel/30-carousel-advanced-variations.twig
@@ -165,6 +165,14 @@
       </div>
     {% endset %}
     {% set band_slide_1 %}
+      {% set image %}
+        {% include '@bolt-elements-image/image.twig' with {
+          background: true,
+          attributes: {
+            src: '/images/backgrounds/pw19-hp-bg2.jpg',
+          },
+        } only %}
+      {% endset %}
       {% include '@bolt-components-band/band.twig' with {
         size: 'large',
         full_bleed: false,
@@ -176,10 +184,7 @@
             horizontal: 'center'
           },
           content_items: [
-            {
-              src: '/images/backgrounds/pw19-hp-bg2.jpg',
-              lazyload: false
-            },
+            image
           ]
         },
         content: content_image
@@ -215,6 +220,14 @@
       </div>
     {% endset %}
     {% set band_slide_2 %}
+      {% set image %}
+        {% include '@bolt-elements-image/image.twig' with {
+          background: true,
+          attributes: {
+            src: '/images/backgrounds/pw19-hero-banner.png',
+          },
+        } only %}
+      {% endset %}
       {% include '@bolt-components-band/band.twig' with {
         size: 'large',
         full_bleed: false,
@@ -226,10 +239,7 @@
             horizontal: 'center'
           },
           content_items: [
-            {
-              src: '/images/backgrounds/pw19-hero-banner.png',
-              lazyload: false
-            },
+            image
           ]
         },
         content: content_image

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/carousel/30-carousel-advanced-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/carousel/30-carousel-advanced-variations.twig
@@ -177,7 +177,6 @@
           },
           content_items: [
             {
-              pattern: 'image',
               src: '/images/backgrounds/pw19-hp-bg2.jpg',
               lazyload: false
             },
@@ -228,7 +227,6 @@
           },
           content_items: [
             {
-              pattern: 'image',
               src: '/images/backgrounds/pw19-hero-banner.png',
               lazyload: false
             },

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/carousel/_archive/example-content/_band-carousel--slide-1.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/carousel/_archive/example-content/_band-carousel--slide-1.twig
@@ -4,18 +4,23 @@
   <bolt-wrapper bolt-object="" full="true" size="xxlarge">
     <div class="o-bolt-wrapper o-bolt-wrapper--xxlarge o-bolt-wrapper--full">
 
-
-        {% include "@bolt-components-background/background.twig" with {
-          opacity: "heavy",
-          fill: "gradient",
+        {% set image %}
+          {% include '@bolt-elements-image/image.twig' with {
+            background: true,
+            attributes: {
+              src: '/images/backgrounds/pw19-hero-banner.png',
+            },
+          } only %}
+        {% endset %}
+        {% include '@bolt-components-background/background.twig' with {
+          opacity: 'heavy',
+          fill: 'gradient',
           focalPoint: {
-            vertical: "center",
-            horizontal: "center"
+            vertical: 'center',
+            horizontal: 'center'
           },
           contentItems: [
-            {
-              src: "/images/backgrounds/pw19-hero-banner.png"
-            }
+            image
           ]
       } only %}
       <div class="c-bolt-band__content">

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/carousel/_archive/example-content/_band-carousel--slide-1.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/carousel/_archive/example-content/_band-carousel--slide-1.twig
@@ -14,7 +14,6 @@
           },
           contentItems: [
             {
-              pattern: "image",
               src: "/images/backgrounds/pw19-hero-banner.png"
             }
           ]

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/carousel/_archive/example-content/_band-carousel--slide-2.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/carousel/_archive/example-content/_band-carousel--slide-2.twig
@@ -4,18 +4,23 @@
   <bolt-wrapper bolt-object="" full="true" size="xxlarge">
     <div class="o-bolt-wrapper o-bolt-wrapper--xxlarge o-bolt-wrapper--full">
 
-
-      {% include "@bolt-components-background/background.twig" with {
-          opacity: "heavy",
-          fill: "gradient",
+      {% set image %}
+        {% include '@bolt-elements-image/image.twig' with {
+          background: true,
+          attributes: {
+            src: '/images/backgrounds/pw19-hp-bg2.jpg',
+          },
+        } only %}
+      {% endset %}
+      {% include '@bolt-components-background/background.twig' with {
+          opacity: 'heavy',
+          fill: 'gradient',
           focalPoint: {
-            vertical: "center",
-            horizontal: "center"
+            vertical: 'center',
+            horizontal: 'center'
           },
           contentItems: [
-            {
-              src: "/images/backgrounds/pw19-hp-bg2.jpg"
-            }
+            image
           ]
       } only %}
       <div class="c-bolt-band__content">

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/carousel/_archive/example-content/_band-carousel--slide-2.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/carousel/_archive/example-content/_band-carousel--slide-2.twig
@@ -14,7 +14,6 @@
           },
           contentItems: [
             {
-              pattern: "image",
               src: "/images/backgrounds/pw19-hp-bg2.jpg"
             }
           ]

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/carousel/_archive/example-content/_carousel-slide-content.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/carousel/_archive/example-content/_carousel-slide-content.twig
@@ -1,33 +1,3 @@
-{# {% include "@bolt-components-card/card.twig" with {
-  contentItems: [
-    {
-      pattern: "image",
-      src: "/images/placeholders/landscape-16x9-mountains.jpg",
-      lazyload: false,
-      alt: "Anthem Video"
-    },
-    {
-      pattern: "eyebrow",
-      text: "Video"
-    },
-    {
-      pattern: "headline",
-      tag: "h3",
-      size: "large",
-      text: "Anthem: Service Desktop"
-    },
-    {
-      pattern: "text",
-      text: "Example card text.",
-    },
-    {
-      pattern: "button",
-      text: "Get the report",
-      url: "https://google.com",
-    }
-  ]
-} only %} #}
-
 {% include '@bolt-components-card-replacement/card-replacement.twig' with {
   media: {
     image: {

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/carousel/_archive/examples/_120-image-carousel-card.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/carousel/_archive/examples/_120-image-carousel-card.twig
@@ -1,26 +1,16 @@
 <div class="o-bolt-wrapper">
-  {% embed "@bolt-components-card/card.twig" with {
-    contentItems: [
+  {% embed "@bolt-components-card-replacement/card-replacement.twig" with {
+    body: {
+      eyebrow: 'Video',
+      headline: 'Anthem: Service Desktop',
+      paragraph: 'Anthem debuts its next-generation service desktop, driving frictionless customer experiences.',
+    },
+    actions: [
       {
-        pattern: "eyebrow",
-        text: "Video"
+        text: 'Get the report',
+        url: 'https://google.com',
       },
-      {
-        pattern: "headline",
-        tag: "h3",
-        size: "large",
-        text: "Anthem: Service Desktop"
-      },
-      {
-        pattern: "text",
-        text: "Anthem debuts its next-generation service desktop, driving frictionless customer experiences."
-      },
-      {
-        pattern: "button",
-        text: "Get the report",
-        url: "https://google.com",
-      }
-    ]
+    ],
   } only %}
     {% block card_media %}
       {% include "@bolt-components-carousel/carousel.twig" with {
@@ -32,10 +22,10 @@
         '<bolt-ratio ratio="16/9" style="--aspect-ratio: 16/9; background-size: cover; background-image:url(/images/content/backgrounds/background-tall-1.jpg)"></bolt-ratio>',
           '<bolt-ratio ratio="16/9" style="--aspect-ratio: 16/9; background-size: cover; background-image:url(/images/content/backgrounds/background-tall-2.jpg)"></bolt-ratio>',
         ],
-        slidesPerView: 1,
-        spaceBetween: "small",
-        noPagination: true,
-        navButtonPosition: "inside",
+        slides_per_view: 1,
+        space_between: "small",
+        no_pagination: true,
+        nav_button_position: "inside",
       } only %}
     {% endblock %}
   {% endembed %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/carousel/_archive/examples/_carousel-slide-background.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/carousel/_archive/examples/_carousel-slide-background.twig
@@ -7,7 +7,6 @@
   },
   contentItems: [
     {
-      pattern: "image",
       src: "/images/content/backgrounds/background-tall-2.jpg"
     }
   ]

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/carousel/_archive/examples/_carousel-slide-background.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/carousel/_archive/examples/_carousel-slide-background.twig
@@ -1,13 +1,19 @@
-{% include "@bolt-components-background/background.twig" with {
-  opacity: "heavy",
-  fill: "gradient",
+{% set image %}
+  {% include '@bolt-elements-image/image.twig' with {
+    background: true,
+    attributes: {
+      src: '/images/content/backgrounds/background-tall-2.jpg',
+    },
+  } only %}
+{% endset %}
+{% include '@bolt-components-background/background.twig' with {
+  opacity: 'heavy',
+  fill: 'gradient',
   focalPoint: {
-    vertical: "center",
-    horizontal: "center"
+    vertical: 'center',
+    horizontal: 'center'
   },
   contentItems: [
-    {
-      src: "/images/content/backgrounds/background-tall-2.jpg"
-    }
+    image
   ]
 } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/modal/wip-modal-content-variations.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/modal/wip-modal-content-variations.twig
@@ -121,72 +121,63 @@
   {% set card_band_content %}
     {% grid 'o-bolt-grid--flex o-bolt-grid--matrix' %}
       {% cell 'u-bolt-width-1/1 u-bolt-width-1/3@small' %}
-        {% include '@bolt-components-card/card.twig' with {
-          contentItems: [
-            {
-              pattern: 'image',
+        {% include '@bolt-components-card-replacement/card-replacement.twig' with {
+          media: {
+            image: {
               src: '/images/placeholders/landscape-16x9-mountains.jpg',
+              alt: 'Image alt.',
               lazyload: false,
-              alt: 'Image description'
             },
+          },
+          body: {
+            headline: 'Collection 1',
+          },
+          actions: [
             {
-              pattern: 'headline',
-              tag: 'h3',
-              size: 'large',
-              text: 'Collection 1'
-            },
-            {
-              pattern: 'button',
               text: 'This is a button',
               url: 'https://google.com',
-            }
-          ]
+            },
+          ],
         } only %}
       {% endcell %}
       {% cell 'u-bolt-width-1/1 u-bolt-width-1/3@small' %}
-        {% include '@bolt-components-card/card.twig' with {
-          contentItems: [
-            {
-              pattern: 'image',
+        {% include '@bolt-components-card-replacement/card-replacement.twig' with {
+          media: {
+            image: {
               src: '/images/placeholders/landscape-16x9-mountains.jpg',
+              alt: 'Image alt.',
               lazyload: false,
-              alt: 'Image description'
             },
+          },
+          body: {
+            headline: 'Collection 2',
+          },
+          actions: [
             {
-              pattern: 'headline',
-              tag: 'h3',
-              size: 'large',
-              text: 'Collection 2'
-            },
-            {
-              pattern: 'button',
               text: 'This is a button',
               url: 'https://google.com',
-            }
-          ]
+            },
+          ],
         } only %}
       {% endcell %}
       {% cell 'u-bolt-width-1/1 u-bolt-width-1/3@small' %}
-        {% include '@bolt-components-card/card.twig' with {
-          contentItems: [
-            {
-              pattern: 'image',
+        {% include '@bolt-components-card-replacement/card-replacement.twig' with {
+          media: {
+            image: {
               src: '/images/placeholders/landscape-16x9-mountains.jpg',
+              alt: 'Image alt.',
               lazyload: false,
-              alt: 'Image description'
             },
+          },
+          body: {
+            headline: 'Collection 3',
+          },
+          actions: [
             {
-              pattern: 'headline',
-              tag: 'h3',
-              size: 'large',
-              text: 'Collection 3'
-            },
-            {
-              pattern: 'button',
               text: 'This is a button',
               url: 'https://google.com',
-            }
-          ]
+            },
+          ],
         } only %}
       {% endcell %}
     {% endgrid %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/sticky/_15-sticky-with-content-example.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/sticky/_15-sticky-with-content-example.twig
@@ -56,7 +56,6 @@
       'fill': 'color',
       'content_items': [
         {
-          'pattern': 'image',
           'src': '/images/content/backgrounds/background-tall-1.jpg'
         }
       ]

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/sticky/_15-sticky-with-content-example.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/sticky/_15-sticky-with-content-example.twig
@@ -51,13 +51,19 @@
   }
 } %}
   {% block band_background %}
+    {% set image %}
+      {% include '@bolt-elements-image/image.twig' with {
+        background: true,
+        attributes: {
+          src: '/images/content/backgrounds/background-tall-1.jpg'
+        },
+      } only %}
+    {% endset %}
     {% include '@bolt-components-background/background.twig' with {
       'opacity': 'medium',
       'fill': 'color',
       'content_items': [
-        {
-          'src': '/images/content/backgrounds/background-tall-1.jpg'
-        }
+        image
       ]
     } only %}
   {% endblock band_background %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-gallery.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-gallery.twig
@@ -358,16 +358,22 @@
     </div>
   {% endset %}
 
+  {% set image %}
+    {% include '@bolt-elements-image/image.twig' with {
+      background: true,
+      attributes: {
+        src: '/images/backgrounds/teal-shapes.png',
+        loading: 'lazy',
+      },
+    } only %}
+  {% endset %}
   {% include '@bolt-components-band/band.twig' with {
     content: band_content,
     theme: 'light',
     background: {
       opacity: 'none',
       content_items: [
-        {
-          src: '/images/backgrounds/teal-shapes.png',
-          lazyload: true,
-        },
+        image
       ]
     },
   } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-gallery.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-gallery.twig
@@ -365,7 +365,6 @@
       opacity: 'none',
       content_items: [
         {
-          pattern: 'image',
           src: '/images/backgrounds/teal-shapes.png',
           lazyload: true,
         },

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-homepage.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-homepage.twig
@@ -306,17 +306,22 @@
     </div>
   </div>
 {% endset %}
-
+{% set image %}
+  {% include '@bolt-elements-image/image.twig' with {
+    background: true,
+    attributes: {
+      src: '/images/backgrounds/teal-stripes.png',
+      loading: 'lazy',
+    },
+  } only %}
+{% endset %}
 {% include '@bolt-components-band/band.twig' with {
   content: band_content,
   theme: 'xlight',
   background: {
     opacity: 'none',
     content_items: [
-      {
-        src: '/images/backgrounds/teal-stripes.png',
-        lazyload: true,
-      },
+      image,
     ]
   },
 } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-homepage.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-homepage.twig
@@ -314,7 +314,6 @@
     opacity: 'none',
     content_items: [
       {
-        pattern: 'image',
         src: '/images/backgrounds/teal-stripes.png',
         lazyload: true,
       },

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-pegaworld.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-pegaworld.twig
@@ -331,17 +331,22 @@
       </div>
     </div>
   {% endset %}
-
+  {% set image %}
+    {% include '@bolt-elements-image/image.twig' with {
+      background: true,
+      attributes: {
+        src: '/images/backgrounds/navy-light-circles.jpg',
+        loading: 'lazy',
+      },
+    } only %}
+  {% endset %}
   {% include '@bolt-components-band/band.twig' with {
     content: band_content,
     theme: 'dark',
     background: {
       opacity: 'none',
       content_items: [
-        {
-          src: '/images/backgrounds/navy-light-circles.jpg',
-          lazyload: true,
-        },
+        image
       ]
     },
   } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-pegaworld.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/50-pages/65-best-of-content/_boc-listing-pegaworld.twig
@@ -339,7 +339,6 @@
       opacity: 'none',
       content_items: [
         {
-          pattern: 'image',
           src: '/images/backgrounds/navy-light-circles.jpg',
           lazyload: true,
         },

--- a/docs-site/src/pages/pattern-lab/_patterns/60-experiments/micro-journeys/combos/-95-in-page-example.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/60-experiments/micro-journeys/combos/-95-in-page-example.twig
@@ -12,6 +12,30 @@
   {% include '@pl/_demo-main-site-page-header.twig' %}
 {% endblock %}
 
+{% set headings_set %}
+  {% include '@bolt-components-headline/headline.twig' with {
+    text: 'CRM Applications',
+    tag: 'span',
+    url: '#!',
+    size: 'small',
+    icon: {
+      name: 'arrow-left',
+      position: 'before'
+    }
+  } only %}
+  {% include '@bolt-components-headline/headline.twig' with {
+    text: 'Dynamically recommend next-best-actions for your customers.',
+    tag: 'h1',
+    size: 'xxxlarge',
+  } only %}
+  {% include '@bolt-elements-button/button.twig' with {
+    content: 'Call to action',
+    attributes: {
+      type: 'button'
+    }
+  } only %}
+{% endset %}
+
 {% block main_content %}
   {% embed "@pl/_band--feature.twig" with {
     teaserPosition: "left",
@@ -32,34 +56,7 @@
         lazyload: false
       }]
     },
-    primaryTeaser: {
-      headlines: [
-        {
-          type: "headline",
-          text: "CRM Applications",
-          size: "xsmall",
-          tag: "span",
-          url: "https://google.com",
-          icon: {
-          name: "arrow-left",
-          position: "before"
-        }
-        },
-        {
-          type: "headline",
-          text: "Dynamically recommend next-best-actions for your customers.",
-          size: "xxxlarge",
-          tag: "h1"
-        }
-      ],
-      buttons: [
-        {
-          text: "Call to Action",
-          hierarchy: "primary",
-          url: "#!"
-        }
-      ]
-    }
+    primaryTeaser: headings_set,
   } only %}
 
   {% endembed %}
@@ -104,7 +101,7 @@
           } only %}
         {% endset %}
 
-        {% set icon_shape_1 %}
+        {% set shape_1 %}
           {% include "@bolt-elements-shape/shape.twig" with {
             content: icon_1,
             size: "xlarge",
@@ -114,7 +111,7 @@
           } only %}
         {% endset %}
 
-        {% set icon_shape_2 %}
+        {% set shape_2 %}
           {% include "@bolt-elements-shape/shape.twig" with {
             content: icon_2,
             size: "xlarge",
@@ -124,7 +121,7 @@
           } only %}
         {% endset %}
 
-        {% set icon_shape_3 %}
+        {% set shape_3 %}
           {% include "@bolt-elements-shape/shape.twig" with {
             content: icon_3,
             size: "xlarge",
@@ -136,69 +133,63 @@
 
         {% cell "u-bolt-width-1/1 u-bolt-width-1/2@small" %}
           {% set flag_item_1 %}
-            {# flag is an object, it’s a legacy thing we didn’t deprecate yet #}
-            {% include "@bolt/flag.twig" with {
-              valign: "middle",
-              url: "#!",
-              figure: {
-                content: icon_shape_1
-              },
-              items: [
-                {
-                  pattern: "headline",
-                  size: "small",
-                  text: "Download the data Sheet",
-                  url: "https://www.google.com",
-                  icon: {
-                  name: "chevron-right"
-                },
-                  tag: "h3"
-                }
-              ]
+          {% set headline %}
+            {% include '@bolt-components-headline/headline.twig' with {
+              text: 'Download the data Sheet',
+              size: 'small',
+              url: 'https://www.google.com',
+              icon: 'chevron-right'
             } only %}
           {% endset %}
-          {% set flag_item_2 %}
           {# flag is an object, it’s a legacy thing we didn’t deprecate yet #}
-            {% include "@bolt/flag.twig" with {
-              valign: "middle",
-              url: "#!",
-              figure: {
-                content: icon_shape_2
-              },
-              items: [
-                {
-                  pattern: "headline",
-                  size: "small",
-                  text: "Download the Overview document",
-                  url: "https://www.google.com",
-                  icon: {
-                  name: "chevron-right"
-                }
-                }
-              ]
+          {% include '@bolt/flag.twig' with {
+            valign: 'middle',
+            url: '#!',
+            figure: {
+              content: shape_1
+            },
+            content: headline,
+          } only %}
+        {% endset %}
+        {% set flag_item_2 %}
+          {% set headline %}
+            {% include '@bolt-components-headline/headline.twig' with {
+              text: 'Download the Overview document',
+              size: 'small',
+              url: 'https://www.google.com',
+              icon: 'chevron-right'
             } only %}
           {% endset %}
-          {% set flag_item_3 %}
-            {# flag is an object, it’s a legacy thing we didn’t deprecate yet #}
-            {% include "@bolt/flag.twig" with {
-              valign: "middle",
-              url: "#!",
-              figure: {
-                content: icon_shape_3
-              },
-              items: [
-                {
-                  pattern: "headline",
-                  size: "small",
-                  text: "View Pricing for Pega Marketing",
-                  url: "https://www.google.com",
-                  icon: {
-                  name: "chevron-right"
-                }
-                }
-              ]
+          {# flag is an object, it’s a legacy thing we didn’t deprecate yet #}
+          {% include '@bolt/flag.twig' with {
+            valign: 'middle',
+            url: '#!',
+            figure: {
+              content: shape_2
+            },
+            content: headline,
+          } only %}
+        {% endset %}
+        {% set flag_item_3 %}
+          {% set headline %}
+            {% include '@bolt-components-headline/headline.twig' with {
+              text: 'View Pricing for Pega Marketing',
+              size: 'small',
+              url: 'https://www.google.com',
+              icon: 'chevron-right'
             } only %}
           {% endset %}
+          {# flag is an object, it’s a legacy thing we didn’t deprecate yet #}
+          {% include '@bolt/flag.twig' with {
+            valign: 'middle',
+            url: '#!',
+            figure: {
+              content: shape_3
+            },
+            content: headline
+          } only %}
+        {% endset %}
+
 
           {% include "@bolt-components-headline/headline.twig" with {
             text: "Get to know Pega Marketing",

--- a/docs-site/src/pages/pattern-lab/_patterns/60-experiments/micro-journeys/combos/-95-in-page-example.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/60-experiments/micro-journeys/combos/-95-in-page-example.twig
@@ -37,6 +37,14 @@
 {% endset %}
 
 {% block main_content %}
+  {% set image %}
+    {% include '@bolt-elements-image/image.twig' with {
+      background: true,
+      attributes: {
+        src: "/images/content/backgrounds/background-tall-3.jpg",
+      },
+    } only %}
+  {% endset %}
   {% embed "@pl/_band--feature.twig" with {
     teaserPosition: "left",
     teaserWidth: "2/3",
@@ -50,10 +58,9 @@
         vertical: "center",
         horizontal: "right"
       },
-      content_items: [{
-        src: "/images/content/backgrounds/background-tall-3.jpg",
-        lazyload: false
-      }]
+      content_items: [
+        image
+      ]
     },
     primaryTeaser: headings_set,
   } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/60-experiments/micro-journeys/combos/-95-in-page-example.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/60-experiments/micro-journeys/combos/-95-in-page-example.twig
@@ -51,7 +51,6 @@
         horizontal: "right"
       },
       content_items: [{
-        pattern: "image",
         src: "/images/content/backgrounds/background-tall-3.jpg",
         lazyload: false
       }]
@@ -220,99 +219,34 @@
     theme: 'light'
   } only %}
 
+  {% set card %}
+    {% include '@bolt-components-card-replacement/card-replacement.twig' with {
+      media: {
+        image: {
+          src: '/images/content/promos/promo-16x9-anthem.jpg'
+        },
+      },
+      body: {
+        eyebrow: 'Article',
+        headline: 'Gartner Magic Quadrant for the CRM Customer Engagement Center',
+        paragraph: 'Simplify and automate to reduce costs and improve agility.',
+      },
+      actions: [
+        {
+          text: 'Learn More',
+          url: 'https://www.google.com/pega7',
+        }
+      ]
+    } only %}
+  {% endset %}
 
   {% embed "@pl/_band--collection.twig" with {
     "theme": "dark",
     "size": "medium",
     "contentItems": [
-      {
-        "pattern": "card",
-        "image": {
-        "src": "/images/content/promos/promo-16x9-anthem.jpg",
-        "lazyload": false
-      },
-        "teaser": {
-        "eyebrow": {
-          text: "Article"
-        },
-        "logo": {
-          src: "/images/content/logos/logo-paypal.svg",
-          "lazyload": false
-        },
-        "headlines": [
-          {
-            "type": "headline",
-            "text": "Gartner Magic Quadrant for the CRM Customer Engagement Center",
-            "size": "large"
-          }
-        ],
-        "content": "Simplify and automate to reduce costs and improve agility.",
-        "buttons": [
-          {
-            "text": "Learn More",
-            "hierarchy": "secondary",
-            "url": "https://www.google.com/pega7",
-            "width": "full"
-          }
-        ]
-      }
-      },
-      {
-        "pattern": "card",
-        "image": {
-        "src": "/images/content/promos/promo-16x9-anthem.jpg",
-        "lazyload": false
-      },
-        "teaser": {
-        "eyebrow": {
-          text: "Article"
-        },
-        "headlines": [
-          {
-            "type": "headline",
-            "text": "Gartner Magic Quadrant for the CRM Customer Engagement Center",
-            "size": "large"
-          }
-        ],
-        "content": "Simplify and automate to reduce costs and improve agility.",
-        "buttons": [
-          {
-            "text": "Learn More",
-            "hierarchy": "secondary",
-            "url": "https://www.google.com/pega7",
-            "width": "full"
-          }
-        ]
-      }
-      },
-      {
-        "pattern": "card",
-        "image": {
-        "src": "/images/content/promos/promo-16x9-anthem.jpg",
-        "lazyload": false
-      },
-        "teaser": {
-        "eyebrow": {
-          text: "Article"
-        },
-        "headlines": [
-          {
-            "type": "headline",
-            "text": "Gartner Magic Quadrant for the CRM Customer Engagement Center",
-            "size": "large"
-          }
-        ],
-        "content": "Simplify and automate to reduce costs and improve agility.",
-        "buttons": [
-          {
-            "text": "Learn More",
-            "hierarchy": "secondary",
-            "url": "https://www.google.com/pega7",
-            "width": "full"
-          }
-        ]
-      }
-      }
+      card,
+      card,
+      card,
     ]
   } %}
     {% block band_content %}
@@ -603,7 +537,6 @@
       },
       "content_items": [
         {
-          "pattern": "image",
           "src": "/images/content/backgrounds/background-tall-4.jpg",
           "lazyload": false
         }

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/academy/03-organisms/band/_band--instructor-led-training.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/academy/03-organisms/band/_band--instructor-led-training.twig
@@ -21,7 +21,14 @@
     {% endcell %}
   {% endgrid %}
 {% endset %}
-
+{% set image %}
+  {% include '@bolt-elements-image/image.twig' with {
+    background: true,
+    attributes: {
+      src: "/images/content/backgrounds/background-night-sky.jpg",
+    },
+  } only %}
+{% endset %}
 {% include "@bolt-components-band/band.twig" with {
   theme: "xdark",
   content: content,
@@ -29,9 +36,7 @@
     opacity: "light",
     fill: "gradient",
     content_items: [
-      {
-        src: "/images/content/backgrounds/background-night-sky.jpg",
-      },
+      image
     ]
   },
 } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/academy/03-organisms/band/_band--instructor-led-training.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/academy/03-organisms/band/_band--instructor-led-training.twig
@@ -30,7 +30,6 @@
     fill: "gradient",
     content_items: [
       {
-        pattern: "image",
         src: "/images/content/backgrounds/background-night-sky.jpg",
       },
     ]

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/academy/03-organisms/heros/dashboard-page-hero/_dashboard-page-hero.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/academy/03-organisms/heros/dashboard-page-hero/_dashboard-page-hero.twig
@@ -3,7 +3,14 @@
     {{ block('heroButtonRow') }}
   {% endset %}
 {% endif %}
-
+{% set image %}
+  {% include '@bolt-elements-image/image.twig' with {
+    background: true,
+    attributes: {
+      src: "/images/dashboard-hero.jpg",
+    },
+  } only %}
+{% endset %}
 {% embed "@bolt-components-band/band.twig" with {
   theme: "xdark",
   size: "medium",
@@ -11,10 +18,7 @@
     opacity: "light",
     fill: "gradient",
     content_items: [
-      {
-        src: "/images/dashboard-hero.jpg",
-        placeholder_color: "#000000"
-      },
+      image
     ]
   },
   heroSubTitle: heroSubTitle,

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/academy/03-organisms/heros/dashboard-page-hero/_dashboard-page-hero.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/academy/03-organisms/heros/dashboard-page-hero/_dashboard-page-hero.twig
@@ -12,7 +12,6 @@
     fill: "gradient",
     content_items: [
       {
-        pattern: "image",
         src: "/images/dashboard-hero.jpg",
         placeholder_color: "#000000"
       },

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/academy/03-organisms/heros/search/_search-results-hero.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/academy/03-organisms/heros/search/_search-results-hero.twig
@@ -43,6 +43,15 @@
 {% endset %}
 
 {# Note: `valign` prop of this band is tied to this particular image, subject to change with the image #}
+{% set image %}
+  {% include '@bolt-elements-image/image.twig' with {
+    background: true,
+    attributes: {
+      src: "/images/background-satellite-dish.jpg",
+      style: '--e-bolt-image-position: center 42%;',
+    },
+  } only %}
+{% endset %}
 {% include "@bolt-components-band/band.twig" with {
   theme: "xdark",
   size: size|default("small"),
@@ -51,10 +60,7 @@
     opacity: "light",
     fill: "gradient",
     content_items: [
-      {
-        src: "/images/background-satellite-dish.jpg",
-        valign: "42%"
-      },
+      image
     ]
   })
 } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/academy/03-organisms/heros/search/_search-results-hero.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/academy/03-organisms/heros/search/_search-results-hero.twig
@@ -52,7 +52,6 @@
     fill: "gradient",
     content_items: [
       {
-        pattern: "image",
         src: "/images/background-satellite-dish.jpg",
         valign: "42%"
       },

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/academy/03-organisms/landing-page/_landing-page-inner-layout.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/academy/03-organisms/landing-page/_landing-page-inner-layout.twig
@@ -27,7 +27,6 @@
     overlay: "disabled",
     content_items: mainBackgroundImage ? [
       {
-        pattern: "image",
         src: mainBackgroundImage,
         lazyload: false,
         align: "75%",

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/academy/03-organisms/modals/_test-completed-modal--after-submit.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/academy/03-organisms/modals/_test-completed-modal--after-submit.twig
@@ -121,17 +121,22 @@
   {% set modal_return_to_mission %}
     {{ macros.include("@bolt-academy/_test-completed-modal--return-to-mission.twig") }}
   {% endset %}
+  {% set image %}
+    {% include '@bolt-elements-image/image.twig' with {
+      background: true,
+      attributes: {
+        src: "/images/orion-nebula.jpg",
+        style: '--e-bolt-image-position: center 90%;',
+      },
+    } only %}
+  {% endset %}
   {% include "@bolt-components-card-replacement/card-replacement.twig" with {
     theme: "dark",
     border_radius: "large",
     overlay: "disabled",
     background: {
       content_items: [
-        {
-          src: "/images/orion-nebula.jpg",
-          lazyload: false,
-          valign: "90%"
-        }
+        image
       ]
     },
     content: [

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/academy/03-organisms/modals/_test-completed-modal--after-submit.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/academy/03-organisms/modals/_test-completed-modal--after-submit.twig
@@ -128,7 +128,6 @@
     background: {
       content_items: [
         {
-          pattern: "image",
           src: "/images/orion-nebula.jpg",
           lazyload: false,
           valign: "90%"

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/academy/03-organisms/modals/_test-completed-modal--before-submit.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/academy/03-organisms/modals/_test-completed-modal--before-submit.twig
@@ -80,17 +80,22 @@
   {% set modal_rating %}
     {{ macros.include("@bolt-academy/_test-completed-modal--rating.twig") }}
   {% endset %}
+  {% set image %}
+    {% include '@bolt-elements-image/image.twig' with {
+      background: true,
+      attributes: {
+        src: "/images/orion-nebula.jpg",
+        style: '--e-bolt-image-position: center -22rem;',
+      },
+    } only %}
+  {% endset %}
   {% include "@bolt-components-card-replacement/card-replacement.twig" with {
     theme: "dark",
     border_radius: "large",
     overlay: "disabled",
     background: {
       contentItems: [
-        {
-          src: "/images/orion-nebula.jpg",
-          lazyload: false,
-          valign: "-22rem",
-        }
+        image
       ]
     },
     content: [

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/academy/03-organisms/modals/_test-completed-modal--before-submit.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/academy/03-organisms/modals/_test-completed-modal--before-submit.twig
@@ -87,7 +87,6 @@
     background: {
       contentItems: [
         {
-          pattern: "image",
           src: "/images/orion-nebula.jpg",
           lazyload: false,
           valign: "-22rem",

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/academy/05-pages/dashboard/dashboard--my-missions/acd-dashboard--my-missions.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/academy/05-pages/dashboard/dashboard--my-missions/acd-dashboard--my-missions.twig
@@ -1,6 +1,14 @@
 {% extends "@bolt-academy/_academy-default-page-template.twig" %}
 
 {% block page_content %}
+  {% set image %}
+    {% include '@bolt-elements-image/image.twig' with {
+      background: true,
+      attributes: {
+        src: "/images/dashboard-hero.jpg",
+      },
+    } only %}
+  {% endset %}
   {% embed "@bolt-components-band/band.twig" with {
     theme: "xdark",
     size: "small",
@@ -8,10 +16,7 @@
       opacity: "light",
       fill: "gradient",
       content_items: [
-        {
-          src: "/images/dashboard-hero.jpg",
-          placeholder_color: "#000000"
-        },
+        image,
       ]
     }
   } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/academy/05-pages/dashboard/dashboard--my-missions/acd-dashboard--my-missions.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/academy/05-pages/dashboard/dashboard--my-missions/acd-dashboard--my-missions.twig
@@ -9,7 +9,6 @@
       fill: "gradient",
       content_items: [
         {
-          pattern: "image",
           src: "/images/dashboard-hero.jpg",
           placeholder_color: "#000000"
         },

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/content-hub/sticky-navbar.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/content-hub/sticky-navbar.twig
@@ -20,7 +20,6 @@
       },
       'content_items': [
         {
-          'pattern': 'image',
           'src': '/images/content/backgrounds/background-robotics-customer-service.jpg',
           'lazyload': true
         }

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/events/event-detail.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/events/event-detail.twig
@@ -529,71 +529,80 @@
   {% endembed %}
 {# End Speakers section #}
 
+{% set card_1 %}
+  {% include '@bolt-components-card-replacement/card-replacement.twig' with {
+    media: {
+      image: {
+          src: '/images/placeholders/1200x660.jpg'
+        },
+    },
+    body: {
+      eyebrow: 'Article',
+      headline: 'Headline #1',
+      paragraph: 'Simplify and automate to reduce costs and improve agility.',
+    },
+    actions: [
+      {
+        text: 'Call to action',
+        hierarchy: 'secondary',
+        url: '#',
+      }
+    ]
+  } only %}
+{% endset %}
+
+{% set card_2 %}
+  {% include '@bolt-components-card-replacement/card-replacement.twig' with {
+    media: {
+      image: {
+        src: '/images/content/promos/promo-16x9-anthem.jpg'
+      },
+    },
+    body: {
+      eyebrow: 'Article',
+      headline:  'Headline #2',
+      paragraph: 'Simplify and automate to reduce costs and improve agility.',
+    },
+    actions: [
+      {
+        text: 'Call to action',
+        hierarchy: 'secondary',
+        url: '#',
+      }
+    ]
+  } only %}
+{% endset %}
+
+{% set card_3 %}
+  {% include '@bolt-components-card-replacement/card-replacement.twig' with {
+    media: {
+      image: {
+        src: '/images/content/promos/promo-16x9-ai.jpg'
+      },
+    },
+    body: {
+      eyebrow: 'Article',
+      headline: 'Headline #3',
+      paragraph: 'Simplify and automate to reduce costs and improve agility.',
+    },
+    actions: [
+      {
+        text: 'Call to action',
+        hierarchy: 'text',
+        url: '#',
+      }
+    ]
+  } only %}
+{% endset %}
+
 {# Start 2017 Highlights section #}
   {% embed '@pl/_band--collection.twig' with {
   theme: 'xlight',
   size: 'large',
   contentItems: [
-    {
-      pattern: 'card',
-      media: {
-        image: {
-            src: '/images/placeholders/1200x660.jpg'
-          },
-      },
-      body: {
-        eyebrow: 'Article',
-        headline: 'Headline #2',
-        paragraph: 'Simplify and automate to reduce costs and improve agility.',
-      },
-      actions: [
-        {
-          text: 'Call to action',
-          hierarchy: 'secondary',
-          url: '#',
-        }
-      ]
-    },
-    {
-      pattern: 'card',
-      media: {
-        image: {
-          src: '/images/content/promos/promo-16x9-anthem.jpg'
-        },
-      },
-      body: {
-        eyebrow: 'Article',
-        headline:  'Headline #2',
-        paragraph: 'Simplify and automate to reduce costs and improve agility.',
-      },
-      actions: [
-        {
-          text: 'Call to action',
-          hierarchy: 'secondary',
-          url: '#',
-        }
-      ]
-    },
-    {
-      pattern: 'card',
-      media: {
-        image: {
-          src: '/images/content/promos/promo-16x9-ai.jpg'
-        },
-      },
-      body: {
-        eyebrow: 'Article',
-        headline: 'Headline #3',
-        paragraph: 'Simplify and automate to reduce costs and improve agility.',
-      },
-      actions: [
-        {
-          text: 'Call to action',
-          hierarchy: 'text',
-          url: '#',
-        }
-      ]
-    }
+    card_1,
+    card_2,
+    card_3,
   ]
 } %}
   {% block band_content %}
@@ -656,72 +665,80 @@
   {% endembed %}
 {# End Event Sponsors section #}
 
+{% set card_1 %}
+  {% include '@bolt-components-card-replacement/card-replacement.twig' with {
+    media: {
+      image: {
+          src: '/images/placeholders/1200x660.jpg'
+        },
+    },
+    body: {
+      eyebrow: 'Article',
+      headline: 'Headline #1',
+      paragraph: 'Simplify and automate to reduce costs and improve agility.',
+    },
+    actions: [
+      {
+        text: 'Call to action',
+        hierarchy: 'secondary',
+        url: '#',
+      }
+    ]
+  } only %}
+{% endset %}
+
+{% set card_2 %}
+  {% include '@bolt-components-card-replacement/card-replacement.twig' with {
+    media: {
+      image: {
+        src: '/images/content/promos/promo-16x9-anthem.jpg'
+      },
+    },
+    body: {
+      eyebrow: 'Article',
+      headline: 'Headline #2',
+      paragraph: 'Simplify and automate to reduce costs and improve agility.',
+    },
+    actions: [
+      {
+        text: 'Call to action',
+        hierarchy: 'secondary',
+        url: '#',
+      }
+    ]
+  } only %}
+{% endset %}
+
+{% set card_3 %}
+  {% include '@bolt-components-card-replacement/card-replacement.twig' with {
+    media: {
+      image: {
+        src: '/images/content/promos/promo-16x9-ai.jpg'
+      },
+    },
+    body: {
+      eyebrow: 'Article',
+      headline: 'Headline #3',
+      paragraph: 'Simplify and automate to reduce costs and improve agility.',
+    },
+    actions: [
+      {
+        text: 'Call to action',
+        hierarchy: 'text',
+        url: '#',
+      }
+    ]
+  } only %}
+{% endset %}
 
 {# Start Related Resources section #}
   {% embed '@pl/_band--collection.twig' with {
   theme: 'dark',
   size: 'large',
   contentItems: [
-    {
-      pattern: 'card',
-      media: {
-        image: {
-            src: '/images/placeholders/1200x660.jpg'
-          },
-      },
-      body: {
-        eyebrow: 'Article',
-        headline: 'Headline #2',
-        paragraph: 'Simplify and automate to reduce costs and improve agility.',
-      },
-      actions: [
-        {
-          text: 'Call to action',
-          hierarchy: 'secondary',
-          url: '#',
-        }
-      ]
-    },
-    {
-      pattern: 'card',
-      media: {
-        image: {
-          src: '/images/content/promos/promo-16x9-anthem.jpg'
-        },
-      },
-      body: {
-        eyebrow: 'Article',
-        headline: 'Headline #2',
-        paragraph: 'Simplify and automate to reduce costs and improve agility.',
-      },
-      actions: [
-        {
-          text: 'Call to action',
-          hierarchy: 'secondary',
-          url: '#',
-        }
-      ]
-    },
-    {
-      pattern: 'card',
-      media: {
-        image: {
-          src: '/images/content/promos/promo-16x9-ai.jpg'
-        },
-      },
-      body: {
-        eyebrow: 'Article',
-        headline: 'Headline #3',
-        paragraph: 'Simplify and automate to reduce costs and improve agility.',
-      },
-      actions: [
-        {
-          text: 'Call to action',
-          hierarchy: 'text',
-          url: '#',
-        }
-      ]
-    }
+    card_1,
+    card_2,
+    card_3,
   ]
   } %}
   {% block band_content %}

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/events/event-landing.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/events/event-landing.twig
@@ -15,7 +15,6 @@
       },
       'content_items': [
         {
-          'pattern': 'image',
           'src': '/images/content/backgrounds/events-landing.png',
           'lazyload': true
         }

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/homepage/homepage-japanese.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/homepage/homepage-japanese.twig
@@ -59,41 +59,39 @@
     content: feature_band_content
   }) %}
 
+  {% set text_set %}
+    {% include '@bolt-components-headline/eyebrow.twig' with {
+      text: '営業効率',
+    } only %}
+    {% include '@bolt-components-headline/headline.twig' with {
+      text: '「ペガは管理者が、すぐ目の前にあるかもしれないオポチュニティーについて代理店と話せるようにします。」',
+      tag: 'h1',
+      size: 'xxxlarge',
+    } only %}
+    {% include '@bolt-components-headline/text.twig' with {
+      text: '最高販売配信責任者Larik Hall',
+    } only %}
+    {% set icon_chevron_right %}
+    {% include '@bolt-elements-icon/icon.twig' with {
+        name: 'chevron-right',
+      } only %}
+    {% endset %}
+    {% include '@bolt-elements-button/button.twig' with {
+      content: '今すぐ営業目標を上げる',
+      attributes: {
+        type: 'button'
+      },
+      url: 'https://www.google.com',
+      icon_after: icon_chevron_right ,
+    } only %}
+  {% endset %}
 
   {% embed '@pl/_band--feature.twig' with {
     size: 'large',
     theme: 'dark',
     teaserPosition: 'left',
     teaserWidth: '2/3',
-    primaryTeaser: {
-      eyebrow: {
-        text: '営業効率'
-      },
-      headlines: [
-        {
-          type: 'headline',
-          text: '「ペガは管理者が、すぐ目の前にあるかもしれないオポチュニティーについて代理店と話せるようにします。」',
-          size: 'xxxlarge',
-          tag: 'h1'
-        }
-      ],
-      logo: {
-        src: '/images/content/logos/logo-paypal.svg',
-        invert: true,
-        lazyload: false
-      },
-      content: '最高販売配信責任者Larik Hall',
-      buttons: [
-        {
-          text: '今すぐ営業目標を上げる',
-          hierarchy: 'primary',
-          url: 'https://www.google.com',
-          icon: {
-            name: 'chevron-right'
-          }
-        }
-      ]
-    },
+    primaryTeaser: text_set,
     content: feature_band.content | default(content),
     background: {
       opacity: 'heavy',
@@ -263,68 +261,76 @@
     {% endblock %}
   {% endembed %}
 
+  {% set card_1 %}
+    {% include '@bolt-components-card-replacement/card-replacement.twig' with {
+      media: {
+        image: {
+          src: '/images/content/promos/promo-16x9-forrester.jpg'
+        },
+      },
+      body: {
+        headline: 'iBPMSでの2017MAGIC QUADRANT',
+        paragraph: 'Gartnerは、最新のiBPMSレポートにおいてペガがトップであることを認めています。',
+      },
+      actions: [
+        {
+          text: 'レポートを読む',
+          hierarchy: 'secondary',
+          url: '#!',
+        },
+      ]
+    } only %}
+  {% endset %}
+
+  {% set card_2 %}
+    {% include '@bolt-components-card-replacement/card-replacement.twig' with {
+      media: {
+        image: {
+          src: '/images/content/promos/promo-16x9-anthem.jpg'
+        },
+      },
+      body: {
+        headline: 'Robotics and AI Are Changing the World of Work',
+        paragraph: 'Marketforce の最近の調査によると、上級管理者の 69% が労働力の一環として知能機械の導入を考えていることがわかりました。',
+      },
+      actions: [
+        {
+          text: '発見を探索',
+          hierarchy: 'secondary',
+          url: '#!',
+        },
+      ]
+    } only %}
+  {% endset %}
+
+  {% set card_3 %}
+    {% include '@bolt-components-card-replacement/card-replacement.twig' with {
+      media: {
+        image: {
+          src: '/images/content/promos/promo-16x9-ai.jpg'
+        },
+      },
+      body: {
+        headline: 'トランサヴィア：エンドツーエンドのカスタマージャーニー',
+        paragraph: 'Marketforce の最近の調査によると、上級管理者の 69% が労働力の一環として知能機械の導入を考えていることがわかりました。',
+      },
+      actions: [
+        {
+          text: '事例を見る',
+          hierarchy: 'secondary',
+          url: '#!',
+        },
+      ]
+    } only %}
+  {% endset %}
 
   {% embed '@pl/_band--collection.twig' with {
     theme: 'xlight',
     size: 'large',
     contentItems: [
-      {
-        pattern: 'card',
-        media: {
-          image: {
-            src: '/images/content/promos/promo-16x9-forrester.jpg'
-          },
-        },
-        body: {
-          headline: 'iBPMSでの2017MAGIC QUADRANT',
-          paragraph: 'Gartnerは、最新のiBPMSレポートにおいてペガがトップであることを認めています。',
-        },
-        actions: [
-          {
-            text: 'レポートを読む',
-            hierarchy: 'secondary',
-            url: '#!',
-          },
-        ]
-      },
-      {
-        pattern: 'card',
-        media: {
-          image: {
-            src: '/images/content/promos/promo-16x9-anthem.jpg'
-          },
-        },
-        body: {
-          headline: 'Robotics and AI Are Changing the World of Work',
-          paragraph: 'Marketforce の最近の調査によると、上級管理者の 69% が労働力の一環として知能機械の導入を考えていることがわかりました。',
-        },
-        actions: [
-          {
-            text: '発見を探索',
-            hierarchy: 'secondary',
-            url: '#!',
-          },
-        ]
-      },
-      {
-        pattern: 'card',
-        media: {
-          image: {
-            src: '/images/content/promos/promo-16x9-ai.jpg'
-          },
-        },
-        body: {
-          headline: 'トランサヴィア：エンドツーエンドのカスタマージャーニー',
-          paragraph: 'Marketforce の最近の調査によると、上級管理者の 69% が労働力の一環として知能機械の導入を考えていることがわかりました。',
-        },
-        actions: [
-          {
-            text: '事例を見る',
-            hierarchy: 'secondary',
-            url: '#!',
-          },
-        ]
-      },
+      card_1,
+      card_2,
+      card_3,
     ]
   } %}
     {% block band_content %}

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/homepage/homepage-japanese.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/homepage/homepage-japanese.twig
@@ -101,7 +101,6 @@
       },
       content_items: [
         {
-          pattern: 'image',
           src: '/images/backgrounds/pw19-hp-bg2.jpg',
           lazyload: false
         }

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/homepage/homepage-japanese.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/homepage/homepage-japanese.twig
@@ -85,7 +85,14 @@
       icon_after: icon_chevron_right ,
     } only %}
   {% endset %}
-
+  {% set image %}
+    {% include '@bolt-elements-image/image.twig' with {
+      background: true,
+      attributes: {
+        src: '/images/backgrounds/pw19-hp-bg2.jpg',
+      },
+    } only %}
+  {% endset %}
   {% embed '@pl/_band--feature.twig' with {
     size: 'large',
     theme: 'dark',
@@ -100,10 +107,7 @@
         vertical: 'center'
       },
       content_items: [
-        {
-          src: '/images/backgrounds/pw19-hp-bg2.jpg',
-          lazyload: false
-        }
+        image
       ]
     }
   } only %}{% endembed %}

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/homepage/homepage.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/homepage/homepage.twig
@@ -99,7 +99,6 @@
       },
       content_items: [
         {
-          pattern: 'image',
           src: '/images/backgrounds/pw19-hp-bg2.jpg',
           lazyload: false
         }

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/homepage/homepage.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/homepage/homepage.twig
@@ -83,7 +83,14 @@
       icon_after: icon_chevron_right ,
     } only %}
   {% endset %}
-
+  {% set image %}
+    {% include '@bolt-elements-image/image.twig' with {
+      background: true,
+      attributes: {
+        src: '/images/backgrounds/pw19-hp-bg2.jpg',
+      },
+    } only %}
+  {% endset %}
   {% embed '@pl/_band--feature.twig' with {
     size: 'large',
     theme: 'dark',
@@ -98,10 +105,7 @@
         vertical: 'center'
       },
       content_items: [
-        {
-          src: '/images/backgrounds/pw19-hp-bg2.jpg',
-          lazyload: false
-        }
+        image
       ]
     }
   } only %}{% endembed %}

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/homepage/homepage.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/homepage/homepage.twig
@@ -58,41 +58,38 @@
     content: feature_band_content
   }) %}
 
+  {% set text_set %}
+    {% include '@bolt-components-headline/eyebrow.twig' with {
+      text: 'Customer service',
+    } only %}
+    {% include '@bolt-components-headline/headline.twig' with {
+      text: 'Dynamically recommend next-best-actions for your customers.',
+      tag: 'h1',
+      size: 'xxxlarge',
+    } only %}
+    {% include '@bolt-components-headline/text.twig' with {
+      text: 'We\'re able to predict that you\'re going to call before you need to actually contact us.',
+    } only %}
+    {% set icon_chevron_right %}
+    {% include '@bolt-elements-icon/icon.twig' with {
+        name: 'chevron-right',
+      } only %}
+    {% endset %}
+    {% include '@bolt-elements-button/button.twig' with {
+      content: 'Get real',
+      attributes: {
+        type: 'button'
+      },
+      icon_after: icon_chevron_right ,
+    } only %}
+  {% endset %}
 
   {% embed '@pl/_band--feature.twig' with {
     size: 'large',
     theme: 'dark',
     teaserPosition: 'left',
     teaserWidth: '2/3',
-    primaryTeaser: {
-      eyebrow: {
-        text: 'Customer Service'
-      },
-      headlines: [
-        {
-          type: 'headline',
-          text: 'We\'re able to predict that you\'re going to call before you need to actually contact us.',
-          size: 'xxxlarge',
-          tag: 'h1'
-        }
-      ],
-      logo: {
-        src: '/images/content/logos/logo-paypal.svg',
-        invert: true,
-        lazyload: false
-      },
-      content: 'Powered by real AI, Pega Customer Service delivers game-changing results for enterprises.',
-      buttons: [
-        {
-          text: 'Get Real',
-          hierarchy: 'primary',
-          url: '#!',
-          icon: {
-            name: 'chevron-right'
-          }
-        }
-      ]
-    },
+    primaryTeaser: text_set,
     content: feature_band.content | default(content),
     background: {
       opacity: 'heavy',
@@ -148,76 +145,83 @@
     {% endblock %}
   {% endembed %}
 
+  {% set card_1 %}
+    {% include '@bolt-components-card-replacement/card-replacement.twig' with {
+      media: {
+        image: {
+          src: '/images/content/promos/promo-16x9-forrester.jpg'
+        },
+      },
+      body: {
+        eyebrow:  'Article',
+        headline: 'Headline #1',
+        paragraph: 'Pega cited as a Leader in The Forrester Wave™: Digital Process Automation Software, Q3 2017.',
+      },
+      actions: [
+        {
+          text: 'Learn More',
+          hierarchy: 'secondary',
+          url: '#!',
+        },
+      ]
+    } only %}
+  {% endset %}
 
+  {% set card_2 %}
+    {% include '@bolt-components-card-replacement/card-replacement.twig' with {
+      media: {
+        image: {
+          src: '/images/content/promos/promo-16x9-anthem.jpg'
+        },
+      },
+      body: {
+        eyebrow: 'Article',
+        headline: 'Headline #2',
+        paragraph: 'Simplify and automate to reduce costs and improve agility.',
+      },
+      actions: [
+        {
+          text: 'Learn More',
+          url: '#!',
+          width: 'full'
+        },
+        {
+          text: 'About Pega',
+          url: '#!',
+          width: 'full'
+        }
+      ]
+    } only %}
+  {% endset %}
+
+  {% set card_3 %}
+    {% include '@bolt-components-card-replacement/card-replacement.twig' with {
+      media: {
+        image: {
+          src: '/images/content/promos/promo-16x9-ai.jpg'
+        },
+      },
+      body: {
+        eyebrow: 'Article',
+        headline: 'Headline #3',
+        paragraph: 'Sed auctor neque eu tellus rhoncus ut eleifend nibh porttitor. Ut in nulla enim.',
+      },
+      actions: [
+        {
+          text: "Learn More About Pega 7",
+          url: "#!",
+        },
+      ]
+    } only %}
+  {% endset %}
 
   {% embed '@pl/_band--collection.twig' with {
     theme: 'light',
     size: 'medium',
     contentItems: [
-      {
-        pattern: 'card',
-        media: {
-          image: {
-            src: '/images/content/promos/promo-16x9-forrester.jpg'
-          },
-        },
-        body: {
-          eyebrow:  'Article',
-          headline: 'Headline #1',
-          paragraph: 'Pega cited as a Leader in The Forrester Wave™: Digital Process Automation Software, Q3 2017.',
-        },
-        actions: [
-          {
-            text: 'Learn More',
-            hierarchy: 'secondary',
-            url: '#!',
-          },
-        ]
-      },
-      {
-        pattern: 'card',
-        media: {
-          image: {
-            src: '/images/content/promos/promo-16x9-anthem.jpg'
-          },
-        },
-        body: {
-          eyebrow: 'Article',
-          headline: 'Headline #2',
-          paragraph: 'Simplify and automate to reduce costs and improve agility.',
-        },
-        actions: [
-          {
-            text: 'Learn More',
-            url: '#!',
-            width: 'full'
-          },
-          {
-            text: 'About Pega',
-            url: '#!',
-            width: 'full'
-          }
-        ]
-      },
-      {
-        pattern: 'card',
-        media: {
-          image: {
-            src: '/images/content/promos/promo-16x9-ai.jpg'
-          },
-        },
-        body: {
-          eyebrow: 'Article',
-          headline: 'Headline #3',
-          paragraph: 'Sed auctor neque eu tellus rhoncus ut eleifend nibh porttitor. Ut in nulla enim.',
-        },
-        actions: [
-          {
-            text: "Learn More About Pega 7",
-            url: "#!",
-          },
-        ]
-      }
+      card_1,
+      card_2,
+      card_3,
     ]
   } %}
     {% block band_content %}

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/partners/partners-search.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/partners/partners-search.twig
@@ -31,7 +31,6 @@
         horizontal: 'right'
       },
       content_items: [{
-        pattern: 'image',
         src: '/images/placeholders/landscape-16x9-mountains.jpeg'
       }]
 

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/partners/partners-search.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/partners/partners-search.twig
@@ -1,5 +1,21 @@
 {% extends '@pl/_default-page-template.twig' %}
 
+{% set headings_set %}
+  {% include '@bolt-components-headline/eyebrow.twig' with {
+    text: 'Partner overview',
+    url: '#!',
+    icon: {
+      name: 'arrow-left',
+      position: 'before'
+    }
+  } only %}
+  {% include '@bolt-components-headline/headline.twig' with {
+    text: 'Find a Partner',
+    tag: 'h1',
+    size: 'xxxlarge',
+  } only %}
+{% endset %}
+
 {% block main_content %}
   {% embed '@pl/_band--feature.twig' with {
     teaserPosition: 'left',
@@ -21,25 +37,7 @@
 
 
     },
-    primaryTeaser: {
-      headlines: [
-        {
-          type: 'eyebrow',
-          text: 'Partner Overview',
-          url: 'https://google.com',
-          icon: {
-            name: 'arrow-left',
-            position: 'before'
-          }
-        },
-        {
-          type: 'headline',
-          text: 'Find a Partner',
-          size: 'xxxlarge',
-          tag: 'h1'
-        }
-      ]
-    }
+    primaryTeaser: headings_set,
   } only %}{% endembed %}
 
 

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/partners/partners-search.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/partners/partners-search.twig
@@ -17,6 +17,14 @@
 {% endset %}
 
 {% block main_content %}
+  {% set image %}
+    {% include '@bolt-elements-image/image.twig' with {
+      background: true,
+      attributes: {
+        src: '/images/placeholders/landscape-16x9-mountains.jpeg'
+      },
+    } only %}
+  {% endset %}
   {% embed '@pl/_band--feature.twig' with {
     teaserPosition: 'left',
     teaserWidth: '2/3',
@@ -30,11 +38,9 @@
         vertical: 'center',
         horizontal: 'right'
       },
-      content_items: [{
-        src: '/images/placeholders/landscape-16x9-mountains.jpeg'
-      }]
-
-
+      content_items: [
+        image
+      ]
     },
     primaryTeaser: headings_set,
   } only %}{% endembed %}

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/press-and-media/news-landing.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/press-and-media/news-landing.twig
@@ -147,52 +147,61 @@
     } only %}
 </div>
 
+  {% set card_1 %}
+    {% include '@bolt-components-card-replacement/card-replacement.twig' with {
+      body: {
+        eyebrow: 'Jan 18 2018',
+        headline: 'Pegasystems to Present at the Needham Growth Conference',
+        paragraph: 'CAMBRIDGE, Mass. – January 11, 2018 – Pegasystems Inc. (NASDAQ: PEGA), the software company empowering customer engagement at the world’s leading enterprises, today announced that its chief financial officer, chief...',
+      },
+      actions: [
+        {
+          text: 'Read more',
+          url: 'https://www.google.com',
+        }
+      ]
+    } only %}
+  {% endset %}
+
+  {% set card_2 %}
+    {% include '@bolt-components-card-replacement/card-replacement.twig' with {
+      body: {
+        eyebrow: 'Jan 18 2018',
+        headline: 'Pega Receives Highest Scores in Two Use Cases in Gartner’s Critical Capabilities for the CRM Customer Engagement Center",
+        paragraph: "CAMBRIDGE, Mass. – December 26, 2017 – Pegasystems Inc. (NASDAQ: PEGA), the software company empowering customer engagement at the world’s leading enterprises, today announced it received the highest scores in the business-...',
+      },
+      actions: [
+        {
+          text: 'Read more',
+          url: 'https://www.google.com',
+        }
+      ]
+    } only %}
+  {% endset %}
+
+  {% set card_3 %}
+    {% include '@bolt-components-card-replacement/card-replacement.twig' with {
+      body: {
+        eyebrow: 'Jan 04 2018',
+        headline: 'Pegasystems Announces Quarterly Cash Dividend',
+        paragraph: 'CAMBRIDGE, Mass. – December 15, 2017 – Pegasystems Inc. (NASDAQ: PEGA), the software company empowering customer engagement at the world’s leading enterprises, today announced a quarterly cash dividend of $0.03 per share,...',
+      },
+      actions: [
+        {
+          text: 'Read more',
+          url: 'https://www.google.com',
+        }
+      ]
+    } only %}
+  {% endset %}
+
   {% embed '@pl/_band--collection.twig' with {
     theme: 'xlight',
     size: 'medium',
     contentItems: [
-      {
-        pattern: 'card',
-        body: {
-          eyebrow: 'Jan 18 2018',
-          headline: 'Pegasystems to Present at the Needham Growth Conference',
-          paragraph: 'CAMBRIDGE, Mass. – January 11, 2018 – Pegasystems Inc. (NASDAQ: PEGA), the software company empowering customer engagement at the world’s leading enterprises, today announced that its chief financial officer, chief...',
-        },
-        actions: [
-          {
-            text: 'Read more',
-            url: 'https://www.google.com',
-          }
-        ]
-      },
-      {
-        pattern: 'card',
-        body: {
-          eyebrow: 'Jan 18 2018',
-          headline: 'Pega Receives Highest Scores in Two Use Cases in Gartner’s Critical Capabilities for the CRM Customer Engagement Center",
-          paragraph: "CAMBRIDGE, Mass. – December 26, 2017 – Pegasystems Inc. (NASDAQ: PEGA), the software company empowering customer engagement at the world’s leading enterprises, today announced it received the highest scores in the business-...',
-        },
-        actions: [
-          {
-            text: 'Read more',
-            url: 'https://www.google.com',
-          }
-        ]
-      },
-      {
-        pattern: 'card',
-        body: {
-          eyebrow: 'Jan 04 2018',
-          headline: 'Pegasystems Announces Quarterly Cash Dividend',
-          paragraph: 'CAMBRIDGE, Mass. – December 15, 2017 – Pegasystems Inc. (NASDAQ: PEGA), the software company empowering customer engagement at the world’s leading enterprises, today announced a quarterly cash dividend of $0.03 per share,...',
-        },
-        actions: [
-          {
-            text: 'Read more',
-            url: 'https://www.google.com',
-          }
-        ]
-      }
+      card_1,
+      card_2,
+      card_3,
     ]
   } %}
     {% block band_content %}
@@ -227,52 +236,61 @@
     {% endblock band_content %}
   {% endembed %}
 
+  {% set card_1 %}
+    {% include '@bolt-components-card-replacement/card-replacement.twig' with {
+      body: {
+        eyebrow: 'Jan 22 2018',
+        headline: 'A New CRM Bill of Rights for the Future Empowered Enterprise',
+        paragraph: 'Jeff Nicholson of Pega provides insight into what companies should expect from CRM vendors.',
+      },
+      actions: [
+        {
+          text: 'MARTECH ADVISOR',
+          url: 'https://www.google.com',
+        }
+      ]
+    } only %}
+  {% endset %}
+
+  {% set card_2 %}
+    {% include '@bolt-components-card-replacement/card-replacement.twig' with {
+      body: {
+        eyebrow: 'Jan 11 2018',
+        headline: '6 Customer Experience Trends to Watch in 2018',
+        paragraph: 'Pega\'s Don Schuerman previews customer experience questions and trends for the New Year.',
+      },
+      actions: [
+        {
+          text: 'CMS WIRE',
+          url: 'https://www.google.com',
+        }
+      ]
+    } only %}
+  {% endset %}
+
+  {% set card_3 %}
+    {% include '@bolt-components-card-replacement/card-replacement.twig' with {
+      body: {
+        eyebrow:  'Dec 26 2017',
+        headline: '3 Reasons Your AI-Driven Customer Experiences are Falling Short',
+        paragraph: 'Pega\'s Jeff Nicholson examines the state of AI in today\'s customer experiences.',
+      },
+      actions: [
+        {
+          text: 'CIO AUSTRALIA',
+          url: 'https://www.google.com',
+        }
+      ]
+    } only %}
+  {% endset %}
+
   {% embed '@pl/_band--collection.twig' with {
     theme: 'light',
     size: 'medium',
     contentItems: [
-      {
-        pattern: 'card',
-        body: {
-          eyebrow: 'Jan 22 2018',
-          headline: 'A New CRM Bill of Rights for the Future Empowered Enterprise',
-          paragraph: 'Jeff Nicholson of Pega provides insight into what companies should expect from CRM vendors.',
-        },
-        actions: [
-          {
-            text: 'MARTECH ADVISOR',
-            url: 'https://www.google.com',
-          }
-        ]
-      },
-      {
-        pattern: 'card',
-        body: {
-          eyebrow: 'Jan 11 2018',
-          headline: '6 Customer Experience Trends to Watch in 2018',
-          paragraph: 'Pega\'s Don Schuerman previews customer experience questions and trends for the New Year.',
-        },
-        actions: [
-          {
-            text: 'CMS WIRE',
-            url: 'https://www.google.com',
-          }
-        ]
-      },
-      {
-        pattern: 'card',
-        body: {
-          eyebrow:  'Dec 26 2017',
-          headline: '3 Reasons Your AI-Driven Customer Experiences are Falling Short',
-          paragraph: 'Pega\'s Jeff Nicholson examines the state of AI in today\'s customer experiences.',
-        },
-        actions: [
-          {
-            text: 'CIO AUSTRALIA',
-            url: 'https://www.google.com',
-          }
-        ]
-      }
+      card_1,
+      card_2,
+      card_3,
     ]
   } %}
     {% block band_content %}
@@ -307,13 +325,8 @@
     {% endblock band_content %}
   {% endembed %}
 
-  {# Featured Resources #}
-  {% embed '@pl/_band--collection.twig' with {
-  theme: 'dark',
-  size: 'medium',
-  contentItems: [
-    {
-      pattern: 'card',
+  {% set card_1 %}
+    {% include '@bolt-components-card-replacement/card-replacement.twig' with {
       media: {
         image: {
           src: '/images/placeholders/1200x660.jpg'
@@ -329,9 +342,11 @@
           hierarchy: 'text',
         },
       ]
-    },
-    {
-      pattern: 'card',
+    } only %}
+  {% endset %}
+
+  {% set card_2 %}
+    {% include '@bolt-components-card-replacement/card-replacement.twig' with {
       media: {
         image: {
           src: '/images/content/promos/promo-16x9-anthem.jpg'
@@ -354,9 +369,11 @@
           url: 'www.google.com/pega7',
         }
       ]
-    },
-    {
-      pattern: 'card',
+    } only %}
+  {% endset %}
+
+  {% set card_3 %}
+    {% include '@bolt-components-card-replacement/card-replacement.twig' with {
       media: {
         image: {
           src: '/images/content/promos/promo-16x9-ai.jpg'
@@ -373,7 +390,17 @@
           url: 'www.google.com/pega7',
         }
       ]
-    }
+    } only %}
+  {% endset %}
+
+  {# Featured Resources #}
+  {% embed '@pl/_band--collection.twig' with {
+  theme: 'dark',
+  size: 'medium',
+  contentItems: [
+    card_1,
+    card_2,
+    card_3,
   ]
 } %}
   {% block band_content %}

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/_product-t3-extra-videos.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/_product-t3-extra-videos.twig
@@ -645,96 +645,35 @@
   {% endblock %}
 {% endembed %}
 
-
+{% set card %}
+  {% include '@bolt-components-card-replacement/card-replacement.twig' with {
+    media: {
+      image: {
+        src: '/images/placeholders/landscape-16x9-mountains.jpg',
+        alt: 'Image alt.',
+      },
+    },
+    body: {
+      eyebrow: 'Article',
+      headline: 'Gartner Magic Quadrant for the CRM Customer Engagement Center',
+      paragraph: 'Simplify and automate to reduce costs and improve agility.',
+    },
+    actions: [
+      {
+        text: 'Learn More',
+        url: 'https://google.com',
+      },
+    ],
+  } only %}
+{% endset %}
 
 {% embed '@pl/_band--collection.twig' with {
   'theme': 'xlight',
   'size': 'medium',
   'contentItems': [
-    {
-      'pattern': 'card',
-      'image': {
-        'src': '/images/content/promos/promo-16x9-anthem.jpg'
-      },
-      'teaser': {
-        'eyebrow': {
-          text: 'Article'
-        },
-        'logo': {
-          src: '/images/content/logos/logo-paypal.svg'
-        },
-        'headlines': [
-          {
-            'type': 'headline',
-            'text': 'Gartner Magic Quadrant for the CRM Customer Engagement Center',
-            'size': 'large'
-          }
-        ],
-        'content': 'Simplify and automate to reduce costs and improve agility.',
-        'buttons': [
-          {
-            'text': 'Learn More',
-            'hierarchy': 'secondary',
-            'url': 'https://www.google.com/pega7',
-            'width': 'full'
-          }
-        ]
-      }
-    },
-    {
-      'pattern': 'card',
-      'image': {
-        'src': '/images/content/promos/promo-16x9-anthem.jpg'
-      },
-      'teaser': {
-        'eyebrow': {
-          text: 'Article'
-        },
-        'headlines': [
-          {
-            'type': 'headline',
-            'text': 'Gartner Magic Quadrant for the CRM Customer Engagement Center',
-            'size': 'large'
-          }
-        ],
-        'content': 'Simplify and automate to reduce costs and improve agility.',
-        'buttons': [
-          {
-            'text': 'Learn More',
-            'hierarchy': 'secondary',
-            'url': 'https://www.google.com/pega7',
-            'width': 'full'
-          }
-        ]
-      }
-    },
-    {
-      'pattern': 'card',
-      'image': {
-        'src': '/images/content/promos/promo-16x9-anthem.jpg'
-      },
-      'teaser': {
-        'eyebrow': {
-          text: 'Article'
-        },
-        'headlines': [
-          {
-            'type': 'headline',
-            'text': 'Gartner Magic Quadrant for the CRM Customer Engagement Center',
-            'size': 'large'
-          }
-        ],
-        'content': 'Simplify and automate to reduce costs and improve agility.',
-        'buttons': [
-          {
-            'text': 'Learn More',
-            'hierarchy': 'secondary',
-            'url': 'https://www.google.com/pega7',
-            'width': 'full'
-          }
-        ]
-      }
-    }
+    card,
+    card,
+    card,
   ]
 } %}
   {% block band_content %}

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/_product-t3-extra-videos.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/_product-t3-extra-videos.twig
@@ -39,7 +39,6 @@
         horizontal: 'right'
       },
       content_items: [{
-        pattern: 'image',
         src: '/images/content/backgrounds/background-tall-3.jpg'
       }]
     },
@@ -732,7 +731,6 @@
     },
     'content_items': [
       {
-        'pattern': 'image',
         'src': '/images/content/backgrounds/background-tall-3.jpg'
       }
     ]

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/_product-t3-extra-videos.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/_product-t3-extra-videos.twig
@@ -25,6 +25,14 @@
 {% endset %}
 
 {% block main_content %}
+  {% set image %}
+    {% include '@bolt-elements-image/image.twig' with {
+      background: true,
+      attributes: {
+        src: '/images/content/backgrounds/background-tall-3.jpg'
+      },
+    } only %}
+  {% endset %}
   {% embed '@pl/_band--feature.twig' with {
     teaserPosition: 'left',
     teaserWidth: '2/3',
@@ -38,9 +46,9 @@
         vertical: 'center',
         horizontal: 'right'
       },
-      content_items: [{
-        src: '/images/content/backgrounds/background-tall-3.jpg'
-      }]
+      content_items: [
+        image
+      ]
     },
     primaryTeaser: headings_set,
   } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/_product-t3-extra-videos.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/_product-t3-extra-videos.twig
@@ -1,5 +1,29 @@
 {% extends '@pl/_default-page-template.twig' %}
 
+{% set headings_set %}
+  {% include '@bolt-components-headline/headline.twig' with {
+    text: 'CRM Applications',
+    tag: 'span',
+    url: '#!',
+    size: 'small',
+    icon: {
+      name: 'arrow-left',
+      position: 'before'
+    }
+  } only %}
+  {% include '@bolt-components-headline/headline.twig' with {
+    text: 'Dynamically recommend next-best-actions for your customers.',
+    tag: 'h1',
+    size: 'xxxlarge',
+  } only %}
+  {% include '@bolt-elements-button/button.twig' with {
+    content: 'Call to action',
+    attributes: {
+      type: 'button'
+    }
+  } only %}
+{% endset %}
+
 {% block main_content %}
   {% embed '@pl/_band--feature.twig' with {
     teaserPosition: 'left',
@@ -19,34 +43,7 @@
         src: '/images/content/backgrounds/background-tall-3.jpg'
       }]
     },
-    primaryTeaser: {
-      headlines: [
-        {
-          type: 'headline',
-          text: 'CRM Applications',
-          size: 'xsmall',
-          tag: 'span',
-          url: 'https://google.com',
-          icon: {
-            name: 'arrow-left',
-            position: 'before'
-          }
-        },
-        {
-          type: 'headline',
-          text: 'Dynamically recommend next-best-actions for your customers.',
-          size: 'xxxlarge',
-          tag: 'h1'
-        }
-      ],
-      buttons: [
-        {
-          text: 'Call to Action',
-          hierarchy: 'primary',
-          url: '#!'
-        }
-      ]
-    }
+    primaryTeaser: headings_set,
   } only %}
 
   {% endembed %}
@@ -143,69 +140,63 @@
         {% endset %}
 
         {% set flag_item_1 %}
+          {% set headline %}
+            {% include '@bolt-components-headline/headline.twig' with {
+              text: 'Download the data Sheet',
+              size: 'small',
+              url: 'https://www.google.com',
+              icon: 'chevron-right'
+            } only %}
+          {% endset %}
           {# flag is an object, it’s a legacy thing we didn’t deprecate yet #}
-          {% include "@bolt/flag.twig" with {
-            valign: "middle",
-            url: "#!",
+          {% include '@bolt/flag.twig' with {
+            valign: 'middle',
+            url: '#!',
             figure: {
               content: shape_1
             },
-            items: [
-              {
-                pattern: "headline",
-                size: "small",
-                text: "Download the data Sheet",
-                url: "https://www.google.com",
-                icon: {
-                  name: "chevron-right"
-                },
-                tag: "h3"
-              }
-            ]
+            content: headline,
           } only %}
         {% endset %}
         {% set flag_item_2 %}
+          {% set headline %}
+            {% include '@bolt-components-headline/headline.twig' with {
+              text: 'Download the Overview document',
+              size: 'small',
+              url: 'https://www.google.com',
+              icon: 'chevron-right'
+            } only %}
+          {% endset %}
           {# flag is an object, it’s a legacy thing we didn’t deprecate yet #}
-          {% include "@bolt/flag.twig" with {
-            valign: "middle",
-            url: "#!",
+          {% include '@bolt/flag.twig' with {
+            valign: 'middle',
+            url: '#!',
             figure: {
               content: shape_2
             },
-            items: [
-              {
-                pattern: "headline",
-                size: "small",
-                text: "Download the Overview document",
-                url: "https://www.google.com",
-                icon: {
-                  name: "chevron-right"
-                }
-              }
-            ]
+            content: headline,
           } only %}
         {% endset %}
         {% set flag_item_3 %}
+          {% set headline %}
+            {% include '@bolt-components-headline/headline.twig' with {
+              text: 'View Pricing for Pega Marketing',
+              size: 'small',
+              url: 'https://www.google.com',
+              icon: 'chevron-right'
+            } only %}
+          {% endset %}
           {# flag is an object, it’s a legacy thing we didn’t deprecate yet #}
-          {% include "@bolt/flag.twig" with {
-            valign: "middle",
-            url: "#!",
+          {% include '@bolt/flag.twig' with {
+            valign: 'middle',
+            url: '#!',
             figure: {
               content: shape_3
             },
-            items: [
-              {
-                pattern: "headline",
-                size: "small",
-                text: "View Pricing for Pega Marketing",
-                url: "https://www.google.com",
-                icon: {
-                  name: "chevron-right"
-                }
-              }
-            ]
+            content: headline
           } only %}
         {% endset %}
+
 
         {% include "@bolt-components-list/list.twig" with {
           display: "block",

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/_product-t3.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/_product-t3.twig
@@ -25,6 +25,14 @@
 {% endset %}
 
 {% block main_content %}
+  {% set image %}
+    {% include '@bolt-elements-image/image.twig' with {
+      background: true,
+      attributes: {
+        src: '/images/content/backgrounds/background-tall-3.jpg'
+      },
+    } only %}
+  {% endset %}
   {% embed '@pl/_band--feature.twig' with {
     teaserPosition: 'left',
     teaserWidth: '2/3',
@@ -38,9 +46,9 @@
         vertical: 'top',
         horizontal: 'right'
       },
-      content_items: [{
-        src: '/images/content/backgrounds/background-tall-3.jpg'
-      }]
+      content_items: [
+        image
+      ]
     },
     primaryTeaser: headings_set,
   } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/_product-t3.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/_product-t3.twig
@@ -1,5 +1,29 @@
 {% extends '@pl/_default-page-template.twig' %}
 
+{% set headings_set %}
+  {% include '@bolt-components-headline/headline.twig' with {
+    text: 'CRM Applications',
+    tag: 'span',
+    url: '#!',
+    size: 'small',
+    icon: {
+      name: 'arrow-left',
+      position: 'before'
+    }
+  } only %}
+  {% include '@bolt-components-headline/headline.twig' with {
+    text: 'Dynamically recommend next-best-actions for your customers.',
+    tag: 'h1',
+    size: 'xxxlarge',
+  } only %}
+  {% include '@bolt-elements-button/button.twig' with {
+    content: 'Call to action',
+    attributes: {
+      type: 'button'
+    }
+  } only %}
+{% endset %}
+
 {% block main_content %}
   {% embed '@pl/_band--feature.twig' with {
     teaserPosition: 'left',
@@ -11,7 +35,7 @@
       opacity: 'medium',
       fill: 'gradient',
       focal_point: {
-        vertical: 'center',
+        vertical: 'top',
         horizontal: 'right'
       },
       content_items: [{
@@ -19,34 +43,7 @@
         src: '/images/content/backgrounds/background-tall-3.jpg'
       }]
     },
-    primaryTeaser: {
-      headlines: [
-        {
-          type: 'headline',
-          text: 'CRM Applications',
-          size: 'xsmall',
-          tag: 'span',
-          url: 'https://google.com',
-          icon: {
-            name: 'arrow-left',
-            position: 'before'
-          }
-        },
-        {
-          type: 'headline',
-          text: 'Dynamically recommend next-best-actions for your customers.',
-          size: 'xxxlarge',
-          tag: 'h1'
-        }
-      ],
-      buttons: [
-        {
-          text: 'Call to Action',
-          hierarchy: 'primary',
-          url: '#!'
-        }
-      ]
-    }
+    primaryTeaser: headings_set,
   } only %}
 
   {% endembed %}
@@ -145,6 +142,14 @@
         {% endset %}
 
         {% set flag_item_1 %}
+          {% set headline %}
+            {% include '@bolt-components-headline/headline.twig' with {
+              text: 'Download the data Sheet',
+              size: 'small',
+              url: 'https://www.google.com',
+              icon: 'chevron-right'
+            } only %}
+          {% endset %}
           {# flag is an object, it’s a legacy thing we didn’t deprecate yet #}
           {% include '@bolt/flag.twig' with {
             valign: 'middle',
@@ -152,21 +157,18 @@
             figure: {
               content: shape_1
             },
-            items: [
-              {
-                pattern: 'headline',
-                size: 'small',
-                text: 'Download the data Sheet',
-                url: 'https://www.google.com',
-                icon: {
-                  name: 'chevron-right'
-                },
-                tag: 'h3'
-              }
-            ]
+            content: headline,
           } only %}
         {% endset %}
         {% set flag_item_2 %}
+          {% set headline %}
+            {% include '@bolt-components-headline/headline.twig' with {
+              text: 'Download the Overview document',
+              size: 'small',
+              url: 'https://www.google.com',
+              icon: 'chevron-right'
+            } only %}
+          {% endset %}
           {# flag is an object, it’s a legacy thing we didn’t deprecate yet #}
           {% include '@bolt/flag.twig' with {
             valign: 'middle',
@@ -174,20 +176,18 @@
             figure: {
               content: shape_2
             },
-            items: [
-              {
-                pattern: 'headline',
-                size: 'small',
-                text: 'Download the Overview document',
-                url: 'https://www.google.com',
-                icon: {
-                  name: 'chevron-right'
-                }
-              }
-            ]
+            content: headline,
           } only %}
         {% endset %}
         {% set flag_item_3 %}
+          {% set headline %}
+            {% include '@bolt-components-headline/headline.twig' with {
+              text: 'View Pricing for Pega Marketing',
+              size: 'small',
+              url: 'https://www.google.com',
+              icon: 'chevron-right'
+            } only %}
+          {% endset %}
           {# flag is an object, it’s a legacy thing we didn’t deprecate yet #}
           {% include '@bolt/flag.twig' with {
             valign: 'middle',
@@ -195,17 +195,7 @@
             figure: {
               content: shape_3
             },
-            items: [
-              {
-                pattern: 'headline',
-                size: 'small',
-                text: 'View Pricing for Pega Marketing',
-                url: 'https://www.google.com',
-                icon: {
-                  name: 'chevron-right'
-                }
-              }
-            ]
+            content: headline
           } only %}
         {% endset %}
 
@@ -667,96 +657,35 @@
   {% endblock %}
 {% endembed %}
 
-
+{% set card %}
+  {% include '@bolt-components-card-replacement/card-replacement.twig' with {
+    media: {
+        image: {
+          src: '/images/content/promos/promo-16x9-anthem.jpg'
+        },
+      },
+      body: {
+        eyebrow: 'Article',
+        headline: 'Gartner Magic Quadrant for the CRM Customer Engagement Center',
+        paragraph: 'Simplify and automate to reduce costs and improve agility.',
+      },
+      actions: [
+        {
+          text: 'Learn More',
+          hierarchy: 'secondary',
+          url: 'https://www.google.com/pega7',
+        }
+      ]
+  } only %}
+{% endset %}
 
 {% embed '@pl/_band--collection.twig' with {
-  'theme': 'xlight',
-  'size': 'medium',
-  'contentItems': [
-    {
-      'pattern': 'card',
-      'image': {
-        'src': '/images/content/promos/promo-16x9-anthem.jpg'
-      },
-      'teaser': {
-        'eyebrow': {
-          text: 'Article'
-        },
-        'logo': {
-          src: '/images/content/logos/logo-paypal.svg'
-        },
-        'headlines': [
-          {
-            'type': 'headline',
-            'text': 'Gartner Magic Quadrant for the CRM Customer Engagement Center',
-            'size': 'large'
-          }
-        ],
-        'content': 'Simplify and automate to reduce costs and improve agility.',
-        'buttons': [
-          {
-            'text': 'Learn More',
-            'hierarchy': 'secondary',
-            'url': 'https://www.google.com/pega7',
-            'width': 'full'
-          }
-        ]
-      }
-    },
-    {
-      'pattern': 'card',
-      'image': {
-        'src': '/images/content/promos/promo-16x9-anthem.jpg'
-      },
-      'teaser': {
-        'eyebrow': {
-          text: 'Article'
-        },
-        'headlines': [
-          {
-            'type': 'headline',
-            'text': 'Gartner Magic Quadrant for the CRM Customer Engagement Center',
-            'size': 'large'
-          }
-        ],
-        'content': 'Simplify and automate to reduce costs and improve agility.',
-        'buttons': [
-          {
-            'text': 'Learn More',
-            'hierarchy': 'secondary',
-            'url': 'https://www.google.com/pega7',
-            'width': 'full'
-          }
-        ]
-      }
-    },
-    {
-      'pattern': 'card',
-      'image': {
-        'src': '/images/content/promos/promo-16x9-anthem.jpg'
-      },
-      'teaser': {
-        'eyebrow': {
-          text: 'Article'
-        },
-        'headlines': [
-          {
-            'type': 'headline',
-            'text': 'Gartner Magic Quadrant for the CRM Customer Engagement Center',
-            'size': 'large'
-          }
-        ],
-        'content': 'Simplify and automate to reduce costs and improve agility.',
-        'buttons': [
-          {
-            'text': 'Learn More',
-            'hierarchy': 'secondary',
-            'url': 'https://www.google.com/pega7',
-            'width': 'full'
-          }
-        ]
-      }
-    }
+  theme: 'xlight',
+  size: 'medium',
+  contentItems: [
+    card,
+    card,
+    card,
   ]
 } %}
   {% block band_content %}

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/_product-t3.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/_product-t3.twig
@@ -39,7 +39,6 @@
         horizontal: 'right'
       },
       content_items: [{
-        pattern: 'image',
         src: '/images/content/backgrounds/background-tall-3.jpg'
       }]
     },
@@ -744,7 +743,6 @@
     },
     'content_items': [
       {
-        'pattern': 'image',
         'src': '/images/content/backgrounds/background-tall-1.jpg'
       }
     ]

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/product-landing.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/product-landing.twig
@@ -43,7 +43,6 @@
         horizontal: 'right'
       },
       content_items: [{
-        pattern: 'image',
         src: '/images/content/backgrounds/background-short-1.jpg',
         alt: 'Background banner of conference keynote',
         lazyload: true
@@ -348,7 +347,6 @@
     },
     'content_items': [
       {
-        'pattern': 'image',
         'src': '/images/content/backgrounds/background-tall-4.jpg',
         'lazyload': true
       }

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/product-landing.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/product-landing.twig
@@ -29,6 +29,16 @@
 {% endset %}
 
 {% block main_content %}
+  {% set image %}
+    {% include '@bolt-elements-image/image.twig' with {
+      background: true,
+      attributes: {
+        src: '/images/content/backgrounds/background-short-1.jpg',
+        alt: 'Background banner of conference keynote',
+        loading: 'lazy'
+      },
+    } only %}
+  {% endset %}
   {% embed '@pl/_band--feature.twig' with {
     teaserPosition: 'left',
     teaserWidth: '2/3',
@@ -42,11 +52,9 @@
         vertical: 'center',
         horizontal: 'right'
       },
-      content_items: [{
-        src: '/images/content/backgrounds/background-short-1.jpg',
-        alt: 'Background banner of conference keynote',
-        lazyload: true
-      }]
+      content_items: [
+        image
+      ]
     },
     primaryTeaser: text_set,
   } only %}{% endembed %}

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/product-landing.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/product-landing.twig
@@ -1,5 +1,33 @@
 {% extends '@pl/_default-page-template.twig' %}
 
+{% set text_set %}
+  {% include '@bolt-components-headline/headline.twig' with {
+    text: 'Products',
+    tag: 'span',
+    url: '#!',
+    size: 'small',
+    icon: {
+      name: 'arrow-left',
+      position: 'before'
+    }
+  } only %}
+  {% include '@bolt-components-headline/headline.twig' with {
+    text: 'Dynamically recommend next-best-actions for your customers.',
+    tag: 'h1',
+    size: 'xxxlarge',
+  } only %}
+  {% include '@bolt-components-headline/text.twig' with {
+    text: 'Pega’s AI powered CRM Suite is transforming the way enterprises drive greater engagement across the entire customer journey.',
+    size: 'xxlarge',
+  } only %}
+  {% include '@bolt-elements-button/button.twig' with {
+    content: 'Call to action',
+    attributes: {
+      type: 'button'
+    }
+  } only %}
+{% endset %}
+
 {% block main_content %}
   {% embed '@pl/_band--feature.twig' with {
     teaserPosition: 'left',
@@ -21,40 +49,7 @@
         lazyload: true
       }]
     },
-    primaryTeaser: {
-      headlines: [
-        {
-          type: 'headline',
-          text: 'Products',
-          size: 'xsmall',
-          tag: 'span',
-          url: 'https://google.com',
-          icon: {
-            name: 'arrow-left',
-            position: 'before'
-          }
-        },
-        {
-          type: 'headline',
-          text: 'CRM Applications for Real-Time Engagement',
-          size: 'xxxlarge',
-          tag: 'h1'
-        },
-        {
-          type: 'subheadline',
-          text: 'Pega’s AI powered CRM Suite is transforming the way enterprises drive greater engagement across the entire customer journey.',
-          size: 'xlarge',
-          tag: 'p'
-        }
-      ],
-      buttons: [
-        {
-          text: 'Call to Action',
-          hierarchy: 'primary',
-          url: '#!'
-        }
-      ]
-    }
+    primaryTeaser: text_set,
   } only %}{% endembed %}
 
 
@@ -129,6 +124,18 @@
 
       {% cell 'u-bolt-width-1/1 u-bolt-width-1/2@small' %}
         {% set flag_item_1 %}
+          {% set info %}
+            {% include '@bolt-components-headline/headline.twig' with {
+              text: 'Marketing',
+              size: 'large',
+              url: 'https://www.google.com',
+              icon: 'chevron-right'
+            } only %}
+            {% include '@bolt-components-headline/text.twig' with {
+              text: 'Engage customers with real-time 1:1 marketing on any channel.',
+              size: 'medium',
+            } only %}
+          {% endset %}
           {# flag is an object, it’s a legacy thing we didn’t deprecate yet #}
           {% include "@bolt/flag.twig" with {
             valign: "middle",
@@ -136,25 +143,22 @@
             figure: {
               content: shape_1
             },
-            items: [
-              {
-                'pattern': 'headline',
-                'size': 'large',
-                'text': 'Marketing',
-                'url': 'https://www.google.com',
-                'icon': {
-                  name: 'chevron-right'
-                }
-              },
-              {
-                'pattern': 'text',
-                'text': 'Engage customers with real-time 1:1 marketing on any channel.',
-                'size': 'medium',
-              }
-            ]
+            content: info,
           } only %}
         {% endset %}
         {% set flag_item_2 %}
+          {% set info %}
+            {% include '@bolt-components-headline/headline.twig' with {
+              text: 'Sales Automation',
+              size: 'large',
+              url: 'https://www.google.com',
+              icon: 'chevron-right'
+            } only %}
+            {% include '@bolt-components-headline/text.twig' with {
+              text: 'Intelligently guide sales professionals and automate the sales process.',
+              size: 'medium',
+            } only %}
+          {% endset %}
           {# flag is an object, it’s a legacy thing we didn’t deprecate yet #}
           {% include "@bolt/flag.twig" with {
             valign: "middle",
@@ -162,25 +166,22 @@
             figure: {
               content: shape_2
             },
-            items: [
-              {
-                'pattern': 'headline',
-                'size': 'large',
-                'text': 'Sales Automation',
-                'url': 'https://www.google.com',
-                'icon': {
-                  name: 'chevron-right'
-                }
-              },
-              {
-                'pattern': 'text',
-                'text': 'Intelligently guide sales professionals and automate the sales process.',
-                'size': 'medium',
-              }
-            ]
+            content: info,
           } only %}
         {% endset %}
         {% set flag_item_3 %}
+        {% set info %}
+          {% include '@bolt-components-headline/headline.twig' with {
+              text: 'Customer Service',
+              size: 'large',
+              url: 'https://www.google.com',
+              icon: 'chevron-right'
+            } only %}
+            {% include '@bolt-components-headline/text.twig' with {
+              text: 'Serve, satisfy and engage every customer with digital customer service.',
+              size: 'medium',
+            } only %}
+          {% endset %}
           {# flag is an object, it’s a legacy thing we didn’t deprecate yet #}
           {% include "@bolt/flag.twig" with {
             valign: "middle",
@@ -188,22 +189,7 @@
             figure: {
               content: shape_3
             },
-            items: [
-              {
-                'pattern': 'headline',
-                'size': 'large',
-                'text': 'Customer Service',
-                'url': 'https://www.google.com',
-                'icon': {
-                  name: 'chevron-right'
-                }
-              },
-              {
-                'pattern': 'text',
-                'text': 'Serve, satisfy and engage every customer with digital customer service.',
-                'size': 'medium',
-              }
-            ]
+            content: info,
           } only %}
         {% endset %}
 
@@ -275,79 +261,35 @@
   {% endblock %}
 {% endembed %}
 
-
+{% set card %}
+  {% include '@bolt-components-card-replacement/card-replacement.twig' with {
+    media: {
+        image: {
+          src: '/images/content/promos/promo-16x9-anthem.jpg'
+        },
+      },
+      body: {
+        eyebrow: 'Article',
+        headline: 'Gartner Magic Quadrant for the CRM Customer Engagement Center',
+        paragraph: 'Simplify and automate to reduce costs and improve agility.',
+      },
+      actions: [
+        {
+          text: 'Learn More',
+          hierarchy: 'secondary',
+          url: 'https://www.google.com/pega7',
+        }
+      ]
+  } only %}
+{% endset %}
 
 {% embed '@pl/_band--collection.twig' with {
   theme: 'light',
   size: 'medium',
   contentItems: [
-    {
-      pattern: 'card',
-      media: {
-        image: {
-          src: '/images/content/promos/promo-16x9-anthem.jpg',
-          lazyload: true
-        },
-      },
-      body: {
-        eyebrow: 'Article',
-        logo: {
-          src: '/images/content/logos/logo-paypal.svg',
-          lazyload: true
-        },
-        headline: 'Gartner Magic Quadrant for the CRM Customer Engagement Center',
-        paragraph: 'Simplify and automate to reduce costs and improve agility.',
-      },
-      actions: [
-        {
-          text: 'Learn More',
-          hierarchy: 'secondary',
-          url: 'https://www.google.com/pega7',
-        }
-      ]
-    },
-    {
-      pattern: 'card',
-      media: {
-        image: {
-          src: '/images/content/promos/promo-16x9-anthem.jpg',
-          lazyload: true
-        },
-      },
-      body: {
-        eyebrow: 'Article',
-        headline: 'Gartner Magic Quadrant for the CRM Customer Engagement Center',
-        paragraph: 'Simplify and automate to reduce costs and improve agility.',
-      },
-      actions: [
-        {
-          text: 'Learn More',
-          hierarchy: 'secondary',
-          url: 'https://www.google.com/pega7',
-        }
-      ]
-    },
-    {
-      pattern: 'card',
-      media: {
-        image: {
-          src: '/images/content/promos/promo-16x9-anthem.jpg',
-          lazyload: true
-        },
-      },
-      body: {
-        eyebrow: 'Article',
-        headline: 'Gartner Magic Quadrant for the CRM Customer Engagement Center',
-        paragraph: 'Simplify and automate to reduce costs and improve agility.',
-      },
-      actions: [
-        {
-          text: 'Learn More',
-          hierarchy: 'secondary',
-          url: 'https://www.google.com/pega7',
-        }
-      ]
-    }
+    card,
+    card,
+    card,
   ]
 } %}
   {% block band_content %}

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/product-t2.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/product-t2.twig
@@ -25,6 +25,16 @@
 {% endset %}
 
 {% block main_content %}
+  {% set image %}
+    {% include '@bolt-elements-image/image.twig' with {
+      background: true,
+      attributes: {
+        src: '/images/content/backgrounds/background-tall-3.jpg',
+        sizes: '100vw',
+        style: '--e-bolt-image-position: center 30%;',
+      },
+    } only %}
+  {% endset %}
   {% embed '@pl/_band--feature.twig' with {
     teaserPosition: 'left',
     teaserWidth: '2/3',
@@ -38,13 +48,9 @@
         vertical: 'top',
         horizontal: 'right'
       },
-      content_items: [{
-        src: '/images/content/backgrounds/background-tall-3.jpg',
-        lazyload: false,
-        placeholder_color: 'hsl(10, 14%, 8%)',
-        valign: '30%',
-        sizes: '100vw'
-      }]
+      content_items: [
+        image
+      ]
     },
     primaryTeaser: headings_set,
   } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/product-t2.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/product-t2.twig
@@ -39,7 +39,6 @@
         horizontal: 'right'
       },
       content_items: [{
-        pattern: 'image',
         src: '/images/content/backgrounds/background-tall-3.jpg',
         lazyload: false,
         placeholder_color: 'hsl(10, 14%, 8%)',
@@ -591,7 +590,6 @@
     },
     'content_items': [
       {
-        'pattern': 'image',
         'src': '/images/content/backgrounds/background-tall-4.jpg',
       }
     ]

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/product-t2.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/product-t2.twig
@@ -1,5 +1,29 @@
 {% extends '@pl/_default-page-template.twig' %}
 
+{% set headings_set %}
+  {% include '@bolt-components-headline/headline.twig' with {
+    text: 'CRM Applications',
+    tag: 'span',
+    url: '#!',
+    size: 'small',
+    icon: {
+      name: 'arrow-left',
+      position: 'before'
+    }
+  } only %}
+  {% include '@bolt-components-headline/headline.twig' with {
+    text: 'Dynamically recommend next-best-actions for your customers.',
+    tag: 'h1',
+    size: 'xxxlarge',
+  } only %}
+  {% include '@bolt-elements-button/button.twig' with {
+    content: 'Call to action',
+    attributes: {
+      type: 'button'
+    }
+  } only %}
+{% endset %}
+
 {% block main_content %}
   {% embed '@pl/_band--feature.twig' with {
     teaserPosition: 'left',
@@ -11,7 +35,7 @@
       opacity: 'medium',
       fill: 'gradient',
       focal_point: {
-        vertical: 'center',
+        vertical: 'top',
         horizontal: 'right'
       },
       content_items: [{
@@ -23,34 +47,7 @@
         sizes: '100vw'
       }]
     },
-    primaryTeaser: {
-      headlines: [
-        {
-          type: 'headline',
-          text: 'CRM Applications',
-          size: 'xsmall',
-          tag: 'span',
-          url: 'https://google.com',
-          icon: {
-            name: 'arrow-left',
-            position: 'before'
-          }
-        },
-        {
-          type: 'headline',
-          text: 'Dynamically recommend next-best-actions for your customers.',
-          size: 'xxxlarge',
-          tag: 'h1'
-        }
-      ],
-      buttons: [
-        {
-          text: 'Call to Action',
-          hierarchy: 'primary',
-          url: '#!'
-        }
-      ]
-    }
+    primaryTeaser: headings_set,
   } only %}
 
   {% endembed %}
@@ -127,6 +124,14 @@
 
       {% cell 'u-bolt-width-1/1 u-bolt-width-1/2@small' %}
         {% set flag_item_1 %}
+          {% set headline %}
+            {% include '@bolt-components-headline/headline.twig' with {
+              text: 'Download the data Sheet',
+              size: 'small',
+              url: 'https://www.google.com',
+              icon: 'chevron-right'
+            } only %}
+          {% endset %}
           {# flag is an object, it’s a legacy thing we didn’t deprecate yet #}
           {% include '@bolt/flag.twig' with {
             valign: 'middle',
@@ -134,21 +139,18 @@
             figure: {
               content: shape_1
             },
-            items: [
-              {
-                pattern: 'headline',
-                size: 'small',
-                text: 'Download the data Sheet',
-                url: 'https://www.google.com',
-                icon: {
-                  name: 'chevron-right'
-                },
-                tag: 'h3'
-              }
-            ]
+            content: headline,
           } only %}
         {% endset %}
         {% set flag_item_2 %}
+          {% set headline %}
+            {% include '@bolt-components-headline/headline.twig' with {
+              text: 'Download the Overview document',
+              size: 'small',
+              url: 'https://www.google.com',
+              icon: 'chevron-right'
+            } only %}
+          {% endset %}
           {# flag is an object, it’s a legacy thing we didn’t deprecate yet #}
           {% include '@bolt/flag.twig' with {
             valign: 'middle',
@@ -156,20 +158,18 @@
             figure: {
               content: shape_2
             },
-            items: [
-              {
-                pattern: 'headline',
-                size: 'small',
-                text: 'Download the Overview document',
-                url: 'https://www.google.com',
-                icon: {
-                  name: 'chevron-right'
-                }
-              }
-            ]
+            content: headline,
           } only %}
         {% endset %}
         {% set flag_item_3 %}
+          {% set headline %}
+            {% include '@bolt-components-headline/headline.twig' with {
+              text: 'View Pricing for Pega Marketing',
+              size: 'small',
+              url: 'https://www.google.com',
+              icon: 'chevron-right'
+            } only %}
+          {% endset %}
           {# flag is an object, it’s a legacy thing we didn’t deprecate yet #}
           {% include '@bolt/flag.twig' with {
             valign: 'middle',
@@ -177,17 +177,7 @@
             figure: {
               content: shape_3
             },
-            items: [
-              {
-                pattern: 'headline',
-                size: 'small',
-                text: 'View Pricing for Pega Marketing',
-                url: 'https://www.google.com',
-                icon: {
-                  name: 'chevron-right'
-                }
-              }
-            ]
+            content: headline
           } only %}
         {% endset %}
 
@@ -513,80 +503,38 @@
   {% endblock %}
 {% endembed %}
 
-
+{% set card %}
+  {% include '@bolt-components-card-replacement/card-replacement.twig' with {
+    media: {
+        image: {
+          src: '/images/content/promos/promo-16x9-anthem.jpg'
+        },
+      },
+      body: {
+        eyebrow: 'Article',
+        headline: 'Gartner Magic Quadrant for the CRM Customer Engagement Center',
+        paragraph: 'Simplify and automate to reduce costs and improve agility.',
+      },
+      actions: [
+        {
+          text: 'Learn More',
+          hierarchy: 'secondary',
+          url: 'https://www.google.com/pega7',
+        }
+      ]
+  } only %}
+{% endset %}
 
 {% embed '@pl/_band--collection.twig' with {
-  theme: 'xlight',
-  size: 'medium',
-  contentItems: [
-    {
-      pattern: 'card',
-      media: {
-        image: {
-          src: '/images/content/promos/promo-16x9-anthem.jpg',
-          placeholder_color: '#8d9598'
-        },
-      },
-      body: {
-        eyebrow: 'Article',
-        logo: {
-          src: '/images/content/logos/logo-paypal.svg',
-        },
-        headline: 'Gartner Magic Quadrant for the CRM Customer Engagement Center',
-        paragraph: 'Simplify and automate to reduce costs and improve agility.',
-      },
-      actions: [
-        {
-          text: 'Learn More',
-          hierarchy: 'secondary',
-          url: 'https://www.google.com/pega7',
-        }
-      ]
-    },
-    {
-      pattern: 'card',
-      media: {
-        image: {
-          src: '/images/content/promos/promo-16x9-anthem.jpg',
-          placeholder_color: '#8d9598'
-        },
-      },
-      body: {
-        eyebrow: 'Article',
-        headline: 'Gartner Magic Quadrant for the CRM Customer Engagement Center',
-        paragraph: 'Simplify and automate to reduce costs and improve agility.',
-      },
-      actions: [
-        {
-          text: 'Learn More',
-          hierarchy: 'secondary',
-          url: 'https://www.google.com/pega7',
-        }
-      ]
-    },
-    {
-      pattern: 'card',
-      media: {
-        image: {
-          src: '/images/content/promos/promo-16x9-anthem.jpg',
-          placeholder_color: '#8d9598'
-        },
-      },
-      body: {
-        eyebrow: 'Article',
-        headline: 'Gartner Magic Quadrant for the CRM Customer Engagement Center',
-        paragraph: 'Simplify and automate to reduce costs and improve agility.',
-      },
-      actions: [
-        {
-          text: "Learn More",
-          hierarchy: "secondary",
-          url: "https://www.google.com/pega7",
-        }
-      ]
-    }
-  ]
-} %}
+    theme: 'xlight',
+    size: 'medium',
+    contentItems: [
+      card,
+      card,
+      card
+    ]
+  } %}
+  
   {% block band_content %}
 
 

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/product-t4.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/product-t4.twig
@@ -1,6 +1,41 @@
 {% extends '@pl/_default-page-template.twig' %}
 
+{% set test %}
+{% include '@bolt-components-teaser/teaser.twig' with {
+  headline: {
+    text: 'Some awesome Title',
+    link_attributes: {
+      href: 'https://www.google.com',
+      target: '_blank',
+      rel: 'noopener'
+    }
+  },
+} %}
+{% endset %}
 
+{% set headings_set %}
+  {% include '@bolt-components-headline/headline.twig' with {
+    text: 'CRM Applications',
+    tag: 'span',
+    url: '#!',
+    size: 'small',
+    icon: {
+      name: 'arrow-left',
+      position: 'before'
+    }
+  } only %}
+  {% include '@bolt-components-headline/headline.twig' with {
+    text: 'Dynamically recommend next-best-actions for your customers.',
+    tag: 'h1',
+    size: 'xxxlarge',
+  } only %}
+  {% include '@bolt-elements-button/button.twig' with {
+    content: 'Call to action',
+    attributes: {
+      type: 'button'
+    }
+  } only %}
+{% endset %}
 
 {% block main_content %}
   {% embed '@pl/_band--feature.twig' with {
@@ -17,38 +52,10 @@
         horizontal: 'right'
       },
       content_items: [{
-        pattern: 'image',
         src: '/images/content/backgrounds/background-tall-3.jpg'
       }]
     },
-    primaryTeaser: {
-      headlines: [
-        {
-          type: 'headline',
-          text: 'CRM Applications',
-          size: 'xsmall',
-          tag: 'span',
-          url: 'https://google.com',
-          icon: {
-            name: 'arrow-left',
-            position: 'before'
-          }
-        },
-        {
-          type: 'headline',
-          text: 'Dynamically recommend next-best-actions for your customers.',
-          size: 'xxxlarge',
-          tag: 'h1'
-        }
-      ],
-      buttons: [
-        {
-          text: 'Call to Action',
-          hierarchy: 'primary',
-          url: '#!'
-        }
-      ]
-    }
+    primaryTeaser: headings_set
   } only %}
 
   {% endembed %}
@@ -146,6 +153,14 @@
         {% endset %}
 
         {% set flag_item_1 %}
+          {% set headline %}
+            {% include '@bolt-components-headline/headline.twig' with {
+              text: 'Download the data Sheet',
+              size: 'small',
+              url: 'https://www.google.com',
+              icon: 'chevron-right'
+            } only %}
+          {% endset %}
           {# flag is an object, it’s a legacy thing we didn’t deprecate yet #}
           {% include '@bolt/flag.twig' with {
             valign: 'middle',
@@ -153,21 +168,18 @@
             figure: {
               content: shape_1
             },
-            items: [
-              {
-                pattern: 'headline',
-                size: 'small',
-                text: 'Download the data Sheet',
-                url: 'https://www.google.com',
-                icon: {
-                  name: 'chevron-right'
-                },
-                tag: 'h3'
-              }
-            ]
+            content: headline,
           } only %}
         {% endset %}
         {% set flag_item_2 %}
+          {% set headline %}
+            {% include '@bolt-components-headline/headline.twig' with {
+              text: 'Download the Overview document',
+              size: 'small',
+              url: 'https://www.google.com',
+              icon: 'chevron-right'
+            } only %}
+          {% endset %}
           {# flag is an object, it’s a legacy thing we didn’t deprecate yet #}
           {% include '@bolt/flag.twig' with {
             valign: 'middle',
@@ -175,20 +187,18 @@
             figure: {
               content: shape_2
             },
-            items: [
-              {
-                pattern: 'headline',
-                size: 'small',
-                text: 'Download the Overview document',
-                url: 'https://www.google.com',
-                icon: {
-                  name: 'chevron-right'
-                }
-              }
-            ]
+            content: headline,
           } only %}
         {% endset %}
         {% set flag_item_3 %}
+          {% set headline %}
+            {% include '@bolt-components-headline/headline.twig' with {
+              text: 'View Pricing for Pega Marketing',
+              size: 'small',
+              url: 'https://www.google.com',
+              icon: 'chevron-right'
+            } only %}
+          {% endset %}
           {# flag is an object, it’s a legacy thing we didn’t deprecate yet #}
           {% include '@bolt/flag.twig' with {
             valign: 'middle',
@@ -196,17 +206,7 @@
             figure: {
               content: shape_3
             },
-            items: [
-              {
-                pattern: 'headline',
-                size: 'small',
-                text: 'View Pricing for Pega Marketing',
-                url: 'https://www.google.com',
-                icon: {
-                  name: 'chevron-right'
-                }
-              }
-            ]
+            content: headline
           } only %}
         {% endset %}
 
@@ -892,75 +892,35 @@
   {% endblock %}
 {% endembed %}
 
-
+{% set card %}
+  {% include '@bolt-components-card-replacement/card-replacement.twig' with {
+    media: {
+        image: {
+          src: '/images/content/promos/promo-16x9-anthem.jpg'
+        },
+      },
+      body: {
+        eyebrow: 'Article',
+        headline: 'Gartner Magic Quadrant for the CRM Customer Engagement Center',
+        paragraph: 'Simplify and automate to reduce costs and improve agility.',
+      },
+      actions: [
+        {
+          text: 'Learn More',
+          hierarchy: 'secondary',
+          url: 'https://www.google.com/pega7',
+        }
+      ]
+  } only %}
+{% endset %}
 
 {% embed '@pl/_band--collection.twig' with {
   theme: 'xlight',
   size: 'medium',
   contentItems: [
-    {
-      pattern: 'card',
-      media: {
-        image: {
-          src: '/images/content/promos/promo-16x9-anthem.jpg'
-        },
-      },
-      body: {
-        eyebrow: 'Article',
-        logo: {
-          src: '/images/content/logos/logo-paypal.svg'
-        },
-        headline: 'Gartner Magic Quadrant for the CRM Customer Engagement Center',
-        paragraph: 'Simplify and automate to reduce costs and improve agility.',
-      },
-      actions: [
-        {
-          text: 'Learn More',
-          hierarchy: 'secondary',
-          url: 'https://www.google.com/pega7',
-        }
-      ]
-    },
-    {
-      pattern: 'card',
-      media: {
-        image: {
-          src: '/images/content/promos/promo-16x9-anthem.jpg'
-        },
-      },
-      body: {
-        eyebrow: 'Article',
-        headline: 'Gartner Magic Quadrant for the CRM Customer Engagement Center',
-        paragraph: 'Simplify and automate to reduce costs and improve agility.',
-      },
-      actions: [
-        {
-          text: 'Learn More',
-          hierarchy: 'secondary',
-          url: 'https://www.google.com/pega7',
-        }
-      ]
-    },
-    {
-      pattern: 'card',
-      media: {
-        image: {
-          src: '/images/content/promos/promo-16x9-anthem.jpg'
-        },
-      },
-      body: {
-        eyebrow: 'Article',
-        headline: 'Gartner Magic Quadrant for the CRM Customer Engagement Center',
-        paragraph: 'Simplify and automate to reduce costs and improve agility.',
-      },
-      actions: [
-        {
-          text: 'Learn More',
-          hierarchy: 'secondary',
-          url: 'https://www.google.com/pega7',
-        }
-      ]
-    }
+    card,
+    card,
+    card
   ]
 } %}
   {% block band_content %}

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/product-t4.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/product-t4.twig
@@ -52,7 +52,6 @@
         horizontal: 'right'
       },
       content_items: [{
-        pattern: 'image',
         src: '/images/content/backgrounds/background-tall-3.jpg'
       }]
     },
@@ -980,7 +979,6 @@
     },
     'content_items': [
       {
-        'pattern': 'image',
         'src': '/images/content/backgrounds/background-tall-3.jpg'
       }
     ]

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/product-t4.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/product-t4.twig
@@ -38,6 +38,14 @@
 {% endset %}
 
 {% block main_content %}
+  {% set image %}
+    {% include '@bolt-elements-image/image.twig' with {
+      background: true,
+      attributes: {
+        src: '/images/content/backgrounds/background-tall-3.jpg'
+      },
+    } only %}
+  {% endset %}
   {% embed '@pl/_band--feature.twig' with {
     teaserPosition: 'left',
     teaserWidth: '2/3',
@@ -51,9 +59,9 @@
         vertical: 'center',
         horizontal: 'right'
       },
-      content_items: [{
-        src: '/images/content/backgrounds/background-tall-3.jpg'
-      }]
+      content_items: [
+        image
+      ]
     },
     primaryTeaser: headings_set
   } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/product-t4.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/product-pages/product-t4.twig
@@ -52,6 +52,7 @@
         horizontal: 'right'
       },
       content_items: [{
+        pattern: 'image',
         src: '/images/content/backgrounds/background-tall-3.jpg'
       }]
     },

--- a/docs-site/src/pages/pattern-lab/_patterns/999-archive/resource-details-pages/resource-details-page.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-archive/resource-details-pages/resource-details-page.twig
@@ -150,74 +150,58 @@
 
     {% grid 'o-bolt-grid--flex o-bolt-grid--matrix' %}
       {% cell 'u-bolt-width-1/1 u-bolt-width-1/2@medium' %}
+        {% set item %}
+          {% include '@bolt-components-headline/eyebrow.twig' with {
+            text: 'Asset type',
+          } only %}
 
+          {% include '@bolt-components-headline/headline.twig' with {
+            text: 'Asset Title comes From ECM Enterprise Content...',
+            url: 'https://www.google.com',
+            icon: 'chevron-right',
+            size: 'large'
+          } only %}
+        {% endset %}
 
-        {% include '@bolt-components-card-w-teaser/card-w-teaser-list.twig' with {
-          teasers: [
-            {
-              eyebrow: {
-                text: 'Asset type'
-              },
-              headlines: [
-                {
-                  'type': 'headline',
-                  'text': 'Asset Title comes From ECM Enterprise Content...',
-                  'size': 'large',
-                  'url': 'https://google.com'
-                }
-              ]
-            },
-            {
-              eyebrow: {
-                text: 'Asset type'
-              },
-              headlines: [
-                {
-                  'type': 'headline',
-                  'text': 'Asset Title comes From ECM Enterprise Content...',
-                  'size': 'large'
-                }
-              ]
-            },
-            {
-              eyebrow: {
-                text: 'Asset type'
-              },
-              headlines: [
-                {
-                  'type': 'headline',
-                  'text': 'Asset Title comes From ECM Enterprise Content...',
-                  'size': 'large'
-                }
-              ]
-            }
-          ]
+        {% set list %}
+          {% include '@bolt-components-list/list.twig' with {
+            display: 'block',
+            separator: 'solid',
+            spacing: 'large',
+            items: [
+              item,
+              item,
+              item,
+            ]
+          } only %}
+        {% endset %}
+
+        {% include '@bolt-components-card-replacement/card-replacement.twig' with {
+          body: {
+            content: list
+          }
         } only %}
 
       {% endcell %}
 
       {% cell 'u-bolt-width-1/1 u-bolt-width-1/2@medium' %}
-         {% include '@bolt-components-card-w-teaser/card-w-teaser.twig' with {
-            'image': {
-              'src': '/images/placeholders/1200x660.jpg',
+        {% include '@bolt-components-card-replacement/card-replacement.twig' with {
+          media: {
+            image: {
+              src: '/images/placeholders/1200x660.jpg',
+              alt: 'Image alt.',
             },
-            'teaser': {
-              'headlines': [
-                {
-                  'type': 'headline',
-                  'text': 'Pega 7 for Operations',
-                  'size': 'large'
-                }
-              ],
-              'content': 'Simplify and automate to reduce costs and improve agility.',
-              'buttons': [
-                {
-                  'text': 'Learn More About Pega 7',
-                  'hierarchy': 'secondary',
-                  'url': 'www.google.com/pega7'
-                }
-              ]
-            }
+          },
+          body: {
+            headline: 'Pega 7 for Operations',
+            paragraph: 'Simplify and automate to reduce costs and improve agility.',
+          },
+          actions: [
+            {
+              text: 'Learn More About Pega 7',
+              url: 'https://google.com',
+            },
+          ],
         } only %}
 
       {% endcell %}

--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/background/background-image.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/background/background-image.twig
@@ -1,0 +1,49 @@
+<h2>Image attributes passed to <code>content_items</code> array as an object.</h2>
+
+<div style="height: 400px; position: relative;" class="u-bolt-margin-bottom-large">
+  {% include '@bolt-components-background/background.twig' with {
+    opacity: 'heavy',
+    fill: 'gradient',
+    focal_point: {
+      vertical: 'center',
+      horizontal: 'center'
+    },
+    content_items: [
+      {
+        src: '/images/content/backgrounds/background-tall-4.jpg',
+        srcset: '/images/content/backgrounds/background-tall-4-50.jpg 50w, /images/content/backgrounds/background-tall-4-100.jpg 100w, /images/content/backgrounds/background-tall-4-200.jpg 200w, /images/content/backgrounds/background-tall-4-320.jpg 320w, /images/content/backgrounds/background-tall-4-480.jpg 480w, /images/content/backgrounds/background-tall-4-640.jpg 640w, /images/content/backgrounds/background-tall-4-800.jpg 800w, /images/content/backgrounds/background-tall-4-1024.jpg 1024w, /images/content/backgrounds/background-tall-4-1366.jpg 1366w, /images/content/backgrounds/background-tall-4-1536.jpg 1536w, /images/content/backgrounds/background-tall-4-1920.jpg 1920w, /images/content/backgrounds/background-tall-4-2560.jpg 2560w, /images/content/backgrounds/background-tall-4-2880.jpg 2880w, /images/content/backgrounds/background-tall-4.jpg 3840w',
+        width: 3840,
+        height: 2160
+      },
+    ]
+} only %}
+</div>
+
+<h2>Image passed to <code>content_items</code> as a twig variable with specific image attributes.</h2>
+<div style="height: 400px; position: relative;">
+{% set image %}
+  {% include '@bolt-elements-image/image.twig' with {
+    background: true,
+    attributes: {
+      alt: 'Alt text.',
+      loading: 'lazy',
+      sizes: '100vw',
+      src: '/images/content/backgrounds/background-tall-4.jpg',
+      srcset: '/images/content/backgrounds/background-tall-4-50.jpg 50w, /images/content/backgrounds/background-tall-4-100.jpg 100w, /images/content/backgrounds/background-tall-4-200.jpg 200w, /images/content/backgrounds/background-tall-4-320.jpg 320w, /images/content/backgrounds/background-tall-4-480.jpg 480w, /images/content/backgrounds/background-tall-4-640.jpg 640w, /images/content/backgrounds/background-tall-4-800.jpg 800w, /images/content/backgrounds/background-tall-4-1024.jpg 1024w, /images/content/backgrounds/background-tall-4-1366.jpg 1366w, /images/content/backgrounds/background-tall-4-1536.jpg 1536w, /images/content/backgrounds/background-tall-4-1920.jpg 1920w, /images/content/backgrounds/background-tall-4-2560.jpg 2560w, /images/content/backgrounds/background-tall-4-2880.jpg 2880w, /images/content/backgrounds/background-tall-4.jpg 3840w',
+      width: 3840,
+      height: 2160
+    },
+  } only %}
+{% endset %}
+{% include '@bolt-components-background/background.twig' with {
+  opacity: 'heavy',
+  fill: 'gradient',
+  focal_point: {
+    vertical: 'center',
+    horizontal: 'center'
+  },
+  content_items: [
+    image
+  ]
+} only %}
+</div>

--- a/packages/components/bolt-background/src/background-item.twig
+++ b/packages/components/bolt-background/src/background-item.twig
@@ -55,12 +55,6 @@
           loading: _loading,
         })
       } only %}
-    {% else %}
-      {% include pattern_template(item.pattern) with item|merge({
-        ratio: _ratio_value,
-        lazyload: item.lazyload ?? true,
-        cover: item.cover ?? true
-      }) only %}
     {% endif %}
   </div>
 {% elseif (item is iterable) %}

--- a/packages/components/bolt-background/src/background-item.twig
+++ b/packages/components/bolt-background/src/background-item.twig
@@ -2,60 +2,43 @@
 
 {# Variables #}
 {% set this = init(schema) %}
-{% set item_attributes = item.pattern ~ 'Attributes' %}
 
-{# Image expects 'ratio' to be passed as string, Video expects boolean #}
-{# todo: in v4.0 remove reference to Video, no longer supported #}
-{% set _ratio_value = item.pattern == 'image' ? 'none' : false %}
-
-{% if item.pattern and item.pattern != 'image' %}
-  {% set item = item|merge({
-    (item_attributes): {
-      class: ['c-bolt-background__#{item.pattern}']
-    }
-  }) %}
-{% endif %}
-
-
-{# todo: in v4.0 nix the pattern_template pattern #}
-{% if item.pattern %}
+{% if item.src or item.srcset %}
   <div class="{{ 'c-bolt-background__item' }}">
-    {% if item.pattern == 'image' %}
-      {% set attributes = {} %}
+    {% set attributes = {} %}
 
-      {% if item.srcset %}
-        {% set attributes = attributes|merge({ srcset: item.srcset }) %}
-      {% endif %}
-
-      {% if item.width %}
-        {% set attributes = attributes|merge({ width: item.width }) %}
-      {% endif %}
-
-      {% if item.height %}
-        {% set attributes = attributes|merge({ height: item.height }) %}
-      {% endif %}
-
-      {% if item.align or item.valign %}
-        {% set _align = item.align ? item.align : 'center' %}
-        {% set _valign = item.valign ? item.valign : 'center' %}
-        {% set _alignment = _align ~ ' ' ~ _valign %}
-        {% set attributes = attributes|merge({ style:  '--e-bolt-image-position: ' ~ _alignment ~ ';' }) %}
-      {% endif %}
-
-      {% set _sizes = item.sizes ? item.sizes : '100vw' %}
-
-      {# Found both of these spellings, expanding the conditional to catch both #}
-      {% set _loading = (item.lazyLoad is same as false) or (item.lazyload is same as false) ? 'eager' : 'lazy' %}
-
-      {% include '@bolt-elements-image/image.twig' with {
-        background: true,
-        attributes: attributes|merge({
-          src: item.src,
-          sizes: _sizes,
-          loading: _loading,
-        })
-      } only %}
+    {% if item.srcset %}
+      {% set attributes = attributes|merge({ srcset: item.srcset }) %}
     {% endif %}
+
+    {% if item.width %}
+      {% set attributes = attributes|merge({ width: item.width }) %}
+    {% endif %}
+
+    {% if item.height %}
+      {% set attributes = attributes|merge({ height: item.height }) %}
+    {% endif %}
+
+    {% if item.align or item.valign %}
+      {% set _align = item.align ? item.align : 'center' %}
+      {% set _valign = item.valign ? item.valign : 'center' %}
+      {% set _alignment = _align ~ ' ' ~ _valign %}
+      {% set attributes = attributes|merge({ style:  '--e-bolt-image-position: ' ~ _alignment ~ ';' }) %}
+    {% endif %}
+
+    {% set _sizes = item.sizes ? item.sizes : '100vw' %}
+
+    {# Found both of these spellings, expanding the conditional to catch both #}
+    {% set _loading = (item.lazyLoad is same as false) or (item.lazyload is same as false) ? 'eager' : 'lazy' %}
+
+    {% include '@bolt-elements-image/image.twig' with {
+      background: true,
+      attributes: attributes|merge({
+        src: item.src,
+        sizes: _sizes,
+        loading: _loading,
+      })
+    } only %}
   </div>
 {% elseif (item is iterable) %}
   <div class="{{ 'c-bolt-background__item' }}">

--- a/packages/components/bolt-hero/hero.twig
+++ b/packages/components/bolt-hero/hero.twig
@@ -92,7 +92,6 @@
 {% else %}
   {% set background_content = [
     {
-      pattern: "image",
       lazyload: false,
       src: this.data["background"].value | default('data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=='),
     },

--- a/packages/global/styles/05-objects/objects-flag/src/flag.twig
+++ b/packages/global/styles/05-objects/objects-flag/src/flag.twig
@@ -61,7 +61,7 @@
 
         {% if url %}
           {% include "@bolt-components-link/link.twig" with {
-            display: "block",
+            display: "flex",
             url: url,
             text: figureContent
           } only %}
@@ -74,16 +74,7 @@
 
   <div class="o-bolt-flag__body">
     {% block body %}
-      {% for item in items %}
-        {% if item.pattern %}
-          {% include pattern_template(item.pattern) with item only %}
-        {% elseif item.text %}
-          {{ item.text }}
-        {% endif %}
-      {% endfor %}
-
       {{ content }}
-
     {% endblock %}
   </div>
 </div>

--- a/packages/global/styles/05-objects/objects-ui-list/src/ui-list.twig
+++ b/packages/global/styles/05-objects/objects-ui-list/src/ui-list.twig
@@ -35,7 +35,7 @@
             {{ item.text }}
           {% elseif item.contentItems %}
             {% for item in item.contentItems %}
-              {% include pattern_template(item.pattern) with item only %}
+              {{ item }}
             {% endfor %}
           {% endif %}
         </li>

--- a/packages/twig-integration/twig-extensions-shared/src/TwigExtensions/BoltCoreCompat.php
+++ b/packages/twig-integration/twig-extensions-shared/src/TwigExtensions/BoltCoreCompat.php
@@ -13,6 +13,7 @@ class BoltCoreCompat extends Twig_Extension implements Twig_ExtensionInterface {
   public function getFunctions() {
     return [
       Bolt\TwigFunctions::create_attribute(),
+      Bolt\TwigFunctions::pattern_template(),
       Bolt\TwigFunctions::link(),
     ];
   }

--- a/packages/twig-integration/twig-extensions-shared/src/TwigExtensions/BoltCoreCompat.php
+++ b/packages/twig-integration/twig-extensions-shared/src/TwigExtensions/BoltCoreCompat.php
@@ -13,7 +13,6 @@ class BoltCoreCompat extends Twig_Extension implements Twig_ExtensionInterface {
   public function getFunctions() {
     return [
       Bolt\TwigFunctions::create_attribute(),
-      Bolt\TwigFunctions::pattern_template(),
       Bolt\TwigFunctions::link(),
     ];
   }

--- a/packages/twig-integration/twig-extensions-shared/src/TwigFunctions.php
+++ b/packages/twig-integration/twig-extensions-shared/src/TwigFunctions.php
@@ -176,51 +176,6 @@ class TwigFunctions {
     });
   }
 
-  // @todo Deprecate & remove this whole `pattern_template` function
-  public static function pattern_template() {
-    return new Twig_SimpleFunction('pattern_template', function($patternName) {
-
-      switch ($patternName) {
-        case 'button_group':
-          return '@bolt-components-button-group/button-group.twig';
-        case 'button':
-          return '@bolt-components-button/button.twig';
-        case 'card':
-          return '@bolt-components-card-replacement/card-replacement.twig';
-        case 'card-w-teaser':
-          return '@bolt-components-card-w-teaser/card-w-teaser.twig';
-        case 'eyebrow':
-          return '@bolt-components-headline/eyebrow.twig';
-        case 'flag':
-          return '@bolt/flag.twig';
-        case 'headline':
-          return '@bolt-components-headline/headline.twig';
-        case 'image':
-          return '@bolt-components-image/image.twig';
-        case 'link':
-          return '@bolt-components-link/link.twig';
-        case 'teaser':
-          return '@bolt-components-teaser/teaser.twig';
-        case 'text':
-          return '@bolt-components-text/text.twig';
-        default:
-          return 'ERROR: Template not found: '. $patternName;
-      }
-
-      // the full list of `$patternName` that uses this is:
-      //button - @bolt-components-button/button.twig
-      //button_group - @bolt-button-group/button-group.twig
-      //card - @bolt-card/card.twig
-      //eyebrow - @bolt-headline/eyebrow.twig
-      //flag - @bolt-global/flag.twig
-      //headline - @bolt-headline/headline.twig
-      //image - @bolt-global/image.twig
-      //teaser - @bolt-teaser/teaser.twig
-      //text - @bolt-headline/text.twig
-    });
-  }
-
-
   // returns an array with the results of the color contrast analysis
   // it returns akey for each level (AA and AAA, both for normal and large or bold text)
   // it also returns the calculated contrast ratio

--- a/packages/twig-integration/twig-extensions-shared/src/TwigFunctions.php
+++ b/packages/twig-integration/twig-extensions-shared/src/TwigFunctions.php
@@ -176,6 +176,50 @@ class TwigFunctions {
     });
   }
 
+  // @todo Deprecate & remove this whole `pattern_template` function
+  public static function pattern_template() {
+    return new Twig_SimpleFunction('pattern_template', function($patternName) {
+
+      switch ($patternName) {
+        case 'button_group':
+          return '@bolt-components-button-group/button-group.twig';
+        case 'button':
+          return '@bolt-components-button/button.twig';
+        case 'card':
+          return '@bolt-components-card-replacement/card-replacement.twig';
+        case 'card-w-teaser':
+          return '@bolt-components-card-w-teaser/card-w-teaser.twig';
+        case 'eyebrow':
+          return '@bolt-components-headline/eyebrow.twig';
+        case 'flag':
+          return '@bolt/flag.twig';
+        case 'headline':
+          return '@bolt-components-headline/headline.twig';
+        case 'image':
+          return '@bolt-components-image/image.twig';
+        case 'link':
+          return '@bolt-components-link/link.twig';
+        case 'teaser':
+          return '@bolt-components-teaser/teaser.twig';
+        case 'text':
+          return '@bolt-components-text/text.twig';
+        default:
+          return 'ERROR: Template not found: '. $patternName;
+      }
+
+      // the full list of `$patternName` that uses this is:
+      //button - @bolt-components-button/button.twig
+      //button_group - @bolt-button-group/button-group.twig
+      //card - @bolt-card/card.twig
+      //eyebrow - @bolt-headline/eyebrow.twig
+      //flag - @bolt-global/flag.twig
+      //headline - @bolt-headline/headline.twig
+      //image - @bolt-global/image.twig
+      //teaser - @bolt-teaser/teaser.twig
+      //text - @bolt-headline/text.twig
+    });
+  }
+
   // returns an array with the results of the color contrast analysis
   // it returns akey for each level (AA and AAA, both for normal and large or bold text)
   // it also returns the calculated contrast ratio


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-602

## Summary

Pattern_template function usage was rewritten in the Bolt repository.

## Details

All the examples of the `pattern_template` function (for example pattern: 'image' )used in the Bolt repository (components and pattern lab) are rewritten.

## How to test

Pull the branch.  Search for examples of `pattern_template` usage, and confirm that there is no regression due to updating it.

## Release notes

Pattern_template function is deprecated.

A list of where `pattern_template()` function will be no longer in use in the future:

- buton-group (`@bolt-components-button-group/button-group.twig`)
- button (`@bolt-components-button/button.twig`)
- card (`@bolt-components-card-replacement/card-replacement.twig`)
- card-w-teaser (`@bolt-components-card-w-teaser/card-w-teaser.twig`)
- eyebrow (`@bolt-components-headline/eyebrow.twig`)
- flag (`@bolt/flag.twig`) (this is an object)
- headline (`@bolt-components-headline/headline.twig`)
- image (`@bolt-components-image/image.twig`)
- link (`@bolt-components-link/link.twig`)
- teaser (`@bolt-components-teaser/teaser.twig`)
- text (`@bolt-components-text/text.twig`)

`pattern` prop (`pattern: $name`) will no longer be used. Please use the bolt-components whenever you want to utilize card, headline, image, etc.

There is no need to use the `pattern: image` when utilizing `bolt-background` component.