### PR TITLE
DS-540: scroll to top demo warning

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/floating-action-buttons/-05a-floating-action-buttons-demo.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/floating-action-buttons/-05a-floating-action-buttons-demo.twig
@@ -4,7 +4,7 @@
   {% set layout_items %}
     {% set banner %}
       {% include '@bolt-components-banner/banner.twig' with {
-        content: 'This demo shows the usage of basic floating action buttons. In this particular case, a scroll to top button is utilized. Please note that this button will not animate properly unless the demo is opened in a new page (outside the pattern-lab wrapper).',
+        content: 'This demo shows the usage of basic floating action buttons. In this particular case, a scroll to top button is utilized. Please note that the scroll to top button will not animate properly unless the demo is opened in a new page (outside the pattern-lab wrapper).',
         align: 'start',
       } only %}
     {% endset %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/floating-action-buttons/-05a-floating-action-buttons-demo.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/floating-action-buttons/-05a-floating-action-buttons-demo.twig
@@ -4,7 +4,7 @@
   {% set layout_items %}
     {% set banner %}
       {% include '@bolt-components-banner/banner.twig' with {
-        content: 'This demo shows the usage of basic floating action buttons. In this particular case, a scroll to top button is utilized.',
+        content: 'This demo shows the usage of basic floating action buttons. In this particular case, a scroll to top button is utilized. Please note that this button will not animate properly unless the demo is opened in a new page (outside the pattern-lab wrapper).',
         align: 'start',
       } only %}
     {% endset %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/floating-action-buttons/-10a-floating-action-buttons-demo-show-on-scroll-selector.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/floating-action-buttons/-10a-floating-action-buttons-demo-show-on-scroll-selector.twig
@@ -4,7 +4,7 @@
   {% set layout_items %}
     {% set banner %}
       {% include '@bolt-components-banner/banner.twig' with {
-        content: 'This demo shows individual floating action buttons to show on scroll. Once the user scrolls past Article Title, the buttons appear.',
+        content: 'This demo shows individual floating action buttons to show on scroll. Once the user scrolls past Article Title, the buttons appear. Please note that the scroll to top button will not animate properly unless the demo is opened in a new page (outside the pattern-lab wrapper).',
         align: 'start',
       } only %}
     {% endset %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/floating-action-buttons/-15a-floating-action-buttons-demo-toggle-button.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/floating-action-buttons/-15a-floating-action-buttons-demo-toggle-button.twig
@@ -4,7 +4,7 @@
   {% set layout_items %}
     {% set banner %}
       {% include '@bolt-components-banner/banner.twig' with {
-        content: 'This demo shows the usage of the toggle button. In this particular case, the toggle button is used to show more actions (a list of secondary action buttons).',
+        content: 'This demo shows the usage of the toggle button. In this particular case, the toggle button is used to show more actions (a list of secondary action buttons). Please note that the scroll to top button will not animate properly unless the demo is opened in a new page (outside the pattern-lab wrapper).',
         align: 'start',
       } only %}
     {% endset %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/floating-action-buttons/-999a-floating-action-buttons-demo-use-case-offsets.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/floating-action-buttons/-999a-floating-action-buttons-demo-use-case-offsets.twig
@@ -4,7 +4,7 @@
   {% set layout_items %}
     {% set banner %}
       {% include '@bolt-components-banner/banner.twig' with {
-        content: 'This demo shows using offsets to further adjust the placement of FAB.',
+        content: 'This demo shows using offsets to further adjust the placement of FAB. Please note that the scroll to top button will not animate properly unless the demo is opened in a new page (outside the pattern-lab wrapper).',
         align: 'start',
       } only %}
     {% endset %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/floating-action-buttons/05-floating-action-buttons.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/floating-action-buttons/05-floating-action-buttons.twig
@@ -5,7 +5,7 @@
 {% set notes %}
   <bolt-ol>
     <bolt-li>One or many action buttons can be used.</bolt-li>
-    <bolt-li>The most common use case is a &ldquo;back to top&rdquo; button. Please note that this button will not animate properly unless the demo is opened in a new page (outside the pattern-lab wrapper).</bolt-li>
+    <bolt-li>The most common use case is a &ldquo;back to top&rdquo; button. Please note that the scroll to top button will not animate properly unless the demo is opened in a new page (outside the pattern-lab wrapper).</bolt-li>
     <bolt-li>When using a <a href="link['viewall-elements-button']">Button element</a> as FAB, it is recommended to use an icon-only button with tooltip. Set <code>placement</code> of tooltip to <code>left</code> to avoid clashing with other buttons.</bolt-li>
   </bolt-ol>
 {% endset %}

--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/floating-action-buttons/05-floating-action-buttons.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/floating-action-buttons/05-floating-action-buttons.twig
@@ -5,7 +5,7 @@
 {% set notes %}
   <bolt-ol>
     <bolt-li>One or many action buttons can be used.</bolt-li>
-    <bolt-li>The most common use case is a &ldquo;back to top&rdquo; button.</bolt-li>
+    <bolt-li>The most common use case is a &ldquo;back to top&rdquo; button. Please note that this button will not animate properly unless the demo is opened in a new page (outside the pattern-lab wrapper).</bolt-li>
     <bolt-li>When using a <a href="link['viewall-elements-button']">Button element</a> as FAB, it is recommended to use an icon-only button with tooltip. Set <code>placement</code> of tooltip to <code>left</code> to avoid clashing with other buttons.</bolt-li>
   </bolt-ol>
 {% endset %}


### PR DESCRIPTION
## Jira

[https://pegadigitalit.atlassian.net/browse/DS-540](https://pegadigitalit.atlassian.net/browse/DS-540)

## Summary

Demo was added with #2423, this PR is to add a warning about pattern-lab.

## Details

Add a warning that the smooth animation does not work inside the pattern-lab wrapper and that it should be opened in a new tab.

## How to test

Read the demo text added in PR.
