### PR TITLE
DS-777 button element type validation

### DIFF
--- a/packages/elements/bolt-button/__tests__/__snapshots__/button.js.snap
+++ b/packages/elements/bolt-button/__tests__/__snapshots__/button.js.snap
@@ -143,3 +143,19 @@ exports[`Bolt button default 1`] = `
   This is a button
 </button>
 `;
+
+exports[`Button element missing type default 1`] = `
+<button type="button"
+        class="e-bolt-button"
+>
+  This is a button with missing type
+</button>
+`;
+
+exports[`Button element with href default 1`] = `
+<a href="example.com"
+   class="e-bolt-button"
+>
+  This is a button with an href attribute
+</a>
+`;

--- a/packages/elements/bolt-button/__tests__/button.js
+++ b/packages/elements/bolt-button/__tests__/button.js
@@ -49,6 +49,31 @@ describe('Bolt button', () => {
   });
 });
 
+describe('Button element missing type', () => {
+  test(`default`, async () => {
+    const results = await render('@bolt-elements-button/button.twig', {
+      content: 'This is a button with missing type',
+    });
+
+    await expect(results.ok).toBe(true);
+    await expect(results.html).toMatchSnapshot();
+  });
+});
+
+describe('Button element with href', () => {
+  test(`default`, async () => {
+    const results = await render('@bolt-elements-button/button.twig', {
+      content: 'This is a button with an href attribute',
+      attributes: {
+        href: 'example.com',
+      },
+    });
+
+    await expect(results.ok).toBe(true);
+    await expect(results.html).toMatchSnapshot();
+  });
+});
+
 describe('Bolt button Props', () => {
   test(`icon after`, async () => {
     const results = await render('@bolt-elements-button/button.twig', {

--- a/packages/elements/bolt-button/src/button.twig
+++ b/packages/elements/bolt-button/src/button.twig
@@ -8,7 +8,7 @@
  * Dev notes
  * 1. The markup is written in one line (combined with spaceless) to avoid any unwanted white-space.
  * 2. Zero width no-break space is passed to the icon container's :before and :after pseudo elements, combine that with nowrap white-space on the icon container, and it will make sure that an icon never wraps to the next line by itself, it will always wrap with the final word of the text. Do not remove the icon container spans. See: https://codepen.io/mikemai2awesome/pen/OJXbqwe?editors=0100
- * 3. If type is empty for a button, an error message will be shown in place of the button to remind the developer that type is required.  However, in a prod environment, we will set a default for them to try to recover.
+ * 3. If the type attribute is empty for a semantic <button>, an error message will be shown in place of the button to remind the developer that type is required. However, in a prod environment, we will set a default (type="button") for them to try to recover.
  */
 #}
 
@@ -18,11 +18,11 @@
   {{ validate_data_schema(schema, _self)|raw }}
 
   {% if attributes.href is empty and attributes.type is empty %}
-    {% set error_message = 'The type attribute is required for any button that is not a link'|t %}
+    {% set error_message = 'The type attribute is required for a semantic <button>, while the href attribute is required for a semantic <a>. Please pass one of those attributes.'|t %}
   {% endif %}
 
   {% if attributes.href and attributes.type %}
-    {% set error_message = 'The type attribute is not supported for buttons that are links'|t %}
+    {% set error_message = 'The type attribute should be used for a semantic <button>, while the href attribute should be used for a semantic <a>. If you have a reason for using both at the same time, please contact the core team.'|t %}
   {% endif %}
 {% endif %}
 
@@ -46,8 +46,14 @@
 ] %}
 
 {% if error_message %}
+  {% set message %}
+    {% include '@bolt-elements-icon/icon.twig' with {
+      name: 'close-circle',
+    } only %}
+    {{ error_message|e }}
+  {% endset %}
   {% include '@bolt-components-banner/banner.twig' with {
-    content: error_message,
+    content: message,
     status: 'error',
   } only %}
 {% else %}

--- a/packages/elements/bolt-button/src/button.twig
+++ b/packages/elements/bolt-button/src/button.twig
@@ -8,6 +8,7 @@
  * Dev notes
  * 1. The markup is written in one line (combined with spaceless) to avoid any unwanted white-space.
  * 2. Zero width no-break space is passed to the icon container's :before and :after pseudo elements, combine that with nowrap white-space on the icon container, and it will make sure that an icon never wraps to the next line by itself, it will always wrap with the final word of the text. Do not remove the icon container spans. See: https://codepen.io/mikemai2awesome/pen/OJXbqwe?editors=0100
+ * 3. If type is empty for a button, an error message will be shown in place of the button to remind the developer that type is required.  However, in a prod environment, we will set a default for them to try to recover.
  */
 #}
 
@@ -15,6 +16,14 @@
 {% set schema = bolt.data.components['@bolt-elements-button'].schema %}
 {% if enable_json_schema_validation %}
   {{ validate_data_schema(schema, _self)|raw }}
+
+  {% if attributes.href is empty and attributes.type is empty %}
+    {% set error_message = 'The type attribute is required for any button that is not a link'|t %}
+  {% endif %}
+
+  {% if attributes.href and attributes.type %}
+    {% set error_message = 'The type attribute is not supported for buttons that are links'|t %}
+  {% endif %}
 {% endif %}
 
 {# Variables #}
@@ -22,6 +31,7 @@
 {% set attributes = create_attribute(attributes|default({})) %}
 {% set tag = attributes.href ? 'a' : 'button' %}
 
+{# [3] #}
 {% if tag == 'button' and attributes.type is empty %}
   {% set attributes = attributes.setAttribute('type', 'button') %}
 {% endif %}
@@ -35,6 +45,13 @@
   icon_only ? 'e-bolt-button--icon-only',
 ] %}
 
+{% if error_message %}
+  {% include '@bolt-components-banner/banner.twig' with {
+    content: error_message,
+    status: 'error',
+  } only %}
+{% else %}
 {# Template #}
 {# [1], [2] #}
 {% spaceless %}<{{ tag }} {{ attributes.addClass(classes) }} {% if icon_only %}aria-label="{{ content|striptags|spaceless }}"{% endif %}>{% if icon_only %}<span class="e-bolt-button__icon-center" aria-hidden="true">{{ icon_only|spaceless }}</span>{% else %}{% if icon_before %}<span class="e-bolt-button__icon-before" aria-hidden="true">{{ icon_before|spaceless }}</span>{% endif %}{{ content|spaceless }}{% if icon_after %}<span class="e-bolt-button__icon-after" aria-hidden="true">{{ icon_after|spaceless }}</span>{% endif %}{% endif %}</{{ tag }}>{% endspaceless %}
+{% endif %}

--- a/packages/elements/bolt-button/src/button.twig
+++ b/packages/elements/bolt-button/src/button.twig
@@ -45,6 +45,9 @@
   icon_only ? 'e-bolt-button--icon-only',
 ] %}
 
+{# Template #}
+{# [1], [2] #}
+{% spaceless %}<{{ tag }} {{ attributes.addClass(classes) }} {% if icon_only %}aria-label="{{ content|striptags|spaceless }}"{% endif %}>{% if icon_only %}<span class="e-bolt-button__icon-center" aria-hidden="true">{{ icon_only|spaceless }}</span>{% else %}{% if icon_before %}<span class="e-bolt-button__icon-before" aria-hidden="true">{{ icon_before|spaceless }}</span>{% endif %}{{ content|spaceless }}{% if icon_after %}<span class="e-bolt-button__icon-after" aria-hidden="true">{{ icon_after|spaceless }}</span>{% endif %}{% endif %}</{{ tag }}>{% endspaceless %}
 {% if error_message %}
   {% set message %}
     {% include '@bolt-elements-icon/icon.twig' with {
@@ -56,8 +59,4 @@
     content: message,
     status: 'error',
   } only %}
-{% else %}
-{# Template #}
-{# [1], [2] #}
-{% spaceless %}<{{ tag }} {{ attributes.addClass(classes) }} {% if icon_only %}aria-label="{{ content|striptags|spaceless }}"{% endif %}>{% if icon_only %}<span class="e-bolt-button__icon-center" aria-hidden="true">{{ icon_only|spaceless }}</span>{% else %}{% if icon_before %}<span class="e-bolt-button__icon-before" aria-hidden="true">{{ icon_before|spaceless }}</span>{% endif %}{{ content|spaceless }}{% if icon_after %}<span class="e-bolt-button__icon-after" aria-hidden="true">{{ icon_after|spaceless }}</span>{% endif %}{% endif %}</{{ tag }}>{% endspaceless %}
 {% endif %}

--- a/packages/elements/bolt-button/src/button.twig
+++ b/packages/elements/bolt-button/src/button.twig
@@ -20,7 +20,11 @@
 {# Variables #}
 {% set this = init(schema) %}
 {% set attributes = create_attribute(attributes|default({})) %}
-{% set tag = attributes.type and not attributes.href ? 'button' : attributes.href and not attributes.type ? 'a' %}
+{% set tag = attributes.href ? 'a' : 'button' %}
+
+{% if tag == 'button' and attributes.type is empty %}
+  {% set attributes = attributes.setAttribute('type', 'button') %}
+{% endif %}
 
 {% set classes = [
   'e-bolt-button',

--- a/packages/twig-integration/twig-extensions-shared/src/TwigExtensions/BoltCore.php
+++ b/packages/twig-integration/twig-extensions-shared/src/TwigExtensions/BoltCore.php
@@ -11,6 +11,7 @@ use Twig\Extension\AbstractExtension;
 class BoltCore extends AbstractExtension implements InitRuntimeInterface, GlobalsInterface {
 
   public $data = [];
+  public $isDebug;
   public $version;
 
   function __construct() {
@@ -27,6 +28,7 @@ class BoltCore extends AbstractExtension implements InitRuntimeInterface, Global
       $fullManifestPath = TwigTools\Utils::resolveTwigPath($env, '@bolt-data/full-manifest.bolt.json');
       $dataDir = dirname($fullManifestPath);
       $this->data = Bolt\Utils::buildBoltData($dataDir);
+      $this->isDebug = $env->isDebug();
     } catch (\Exception $e) {
 
     }
@@ -37,7 +39,7 @@ class BoltCore extends AbstractExtension implements InitRuntimeInterface, Global
       'bolt' => [
         'data' => $this->data,
       ],
-      'enable_json_schema_validation' => true,
+      'enable_json_schema_validation' => $this->isDebug,
     ];
   }
 


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-777

## Summary

Pilots a new strategy for validation in button elements

## Details

* Previously, when button type and href were both missing, no tag would be set and the button would render with a missing tag (the following screenshot shows two valid buttons followed by a button that is missing the type attribute):
![Screen Shot 2022-05-03 at 12 17 20 PM](https://user-images.githubusercontent.com/677668/166805203-9333c2ad-ad6f-4530-9857-3144586b012c.png)
This PR adds a default type of `button` in that scenario.  If a button like this somehow makes it to prod, it will probably work as originally intended.
* However, to warn developers that they shouldn't omit the button type, if twig debugging is enabled (we use `enable_json_schema_validation` as a proxy), the button will be replaced with an error message telling them what's wrong.
![Screen Shot 2022-05-04 at 2 17 11 PM](https://user-images.githubusercontent.com/677668/166803654-8b819ddf-c25a-4252-8a28-c8ee58e53f05.png)

## How to test

1. Create a button with no type attribute in pattern lab:
```
{% include '@bolt-elements-button/button.twig' with {
    content: 'This is a button with no "type" attribute',
} only %}
```
2. Confirm that the button is replaced with a fat red error message as long as twig debugging is enabled (see screenshot in the `Details` section).

A similar warning should display if _both_ the `href` and `type` attributes are set.

If twig debugging is disabled (true in the case of the jest test snapshots added in this PR), the buttons should display normally, even though the data passed in is missing critical parts.

