### PR TITLE
DS-722 Listing Teaser design updates

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/listing-teaser/listing-teaser.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/listing-teaser/listing-teaser.twig
@@ -1,0 +1,104 @@
+<h2>Listing teaser with eyebrows separated with dash symbol and breadcrumbs separeted with chevron-right symbol.</h2>
+<br>
+{% set eyebrow_1 %}
+  {% include '@bolt-components-headline/eyebrow.twig' with {
+    text: 'Eyebrow 1',
+  } only %}
+{% endset %}
+{% set eyebrow_2 %}
+  {% include '@bolt-components-headline/eyebrow.twig' with {
+    text: 'Eyebrow 2',
+  } only %}
+{% endset %}
+{% set description %}
+  {% include '@bolt-components-headline/text.twig' with {
+    text: 'This is the description.',
+    size: 'medium',
+  } only %}
+{% endset %}
+{% set book %}
+  {% set icon_documentation %}
+    {% include '@bolt-elements-icon/icon.twig' with {
+      name: 'documentation',
+    } only %}
+  {% endset %}
+  {% include '@bolt-elements-text-link/text-link.twig' with {
+    content: 'Book name',
+    icon_before: icon_documentation,
+    reversed_underline: true,
+    attributes: {
+      href: 'https://google.com',
+    }
+  } only %}
+{% endset %}
+{% set chapter %}
+  {% include '@bolt-elements-text-link/text-link.twig' with {
+    content: 'Next level',
+    reversed_underline: true,
+    attributes: {
+      href: 'https://google.com',
+    }
+  } only %}
+{% endset %}
+{% set last %}
+  {% include '@bolt-elements-text-link/text-link.twig' with {
+    content: 'Last level',
+    reversed_underline: true,
+    attributes: {
+      href: 'https://google.com',
+    }
+  } only %}
+{% endset %}
+{% set breadcrumbs %}
+  {% include '@bolt-components-breadcrumb/breadcrumb.twig' with {
+    contentItems: [
+      book,
+      chapter,
+      '&hellip;',
+      last
+    ]
+  } only %}
+{% endset %}
+{% include '@bolt-components-listing-teaser/listing-teaser.twig' with {
+  eyebrow_items: [
+    eyebrow_1,
+    eyebrow_2,
+  ],
+  headline: {
+    text: 'This listing has a large headline',
+    tag: 'h3',
+    size: 'large',
+    link_attributes: {
+      href: 'https://google.com'
+    },
+  },
+  meta_items: [
+    breadcrumbs
+  ],
+  description: description,
+} only %}
+<hr>
+<h2>Listing teaser with eyebrows separated with dash symbol, breadcrumbs separeted with chevron-right symbol and meta items separated with pipeline symbol.</h2>
+<p>Here below is a long description which is truncated to 3 lines on screens above medium break-point and 2 lines for screens below medium break-point.</p>
+<br>
+{% include '@bolt-components-listing-teaser/listing-teaser.twig' with {
+  eyebrow_items: [
+    eyebrow_1,
+    eyebrow_2,
+  ],
+  headline: {
+    text: 'This listing has a large headline',
+    tag: 'h3',
+    size: 'large',
+    link_attributes: {
+      href: 'https://google.com'
+    },
+  },
+  meta_items: [
+    'meta list item 1',
+    'meta list item 2',
+    'meta list item 3',
+    'meta list item 4',
+  ],
+  description: 'Lorem ipsum dolor, sit amet consectetur adipisicing elit. At nemo beatae voluptate temporibus expedita fuga fugit dolore voluptatibus ad voluptates suscipit modi neque saepe eos nisi, impedit recusandae, sunt possimus. Lorem ipsum dolor, sit amet consectetur adipisicing elit. At nemo beatae voluptate temporibus expedita fuga fugit dolore voluptatibus ad voluptates suscipit modi neque saepe eos nisi, impedit recusandae, sunt possimus.',
+} only %}

--- a/packages/components/bolt-listing-teaser/src/listing-teaser.scss
+++ b/packages/components/bolt-listing-teaser/src/listing-teaser.scss
@@ -85,6 +85,14 @@
   margin-bottom: var(--bolt-spacing-y-xxsmall);
   pointer-events: none;
   grid-area: eyebrow;
+
+  .c-bolt-listing-teaser__meta {
+    > .c-bolt-listing-teaser__meta__item {
+      &:not(:last-child):after {
+        content: '\2012';
+      }
+    }
+  }
 }
 
 .c-bolt-listing-teaser__flag-heading {
@@ -181,6 +189,17 @@
     .e-bolt-icon {
       transform: translateY(0.1em);
     }
+  }
+}
+
+.c-bolt-listing-teaser__flag-content__item:not(.c-bolt-listing-teaser__flag-content__item--reply) {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+
+  @include bolt-mq($from: medium) {
+    -webkit-line-clamp: 2;
   }
 }
 

--- a/packages/components/bolt-listing-teaser/src/listing-teaser.scss
+++ b/packages/components/bolt-listing-teaser/src/listing-teaser.scss
@@ -192,7 +192,7 @@
   }
 }
 
-.c-bolt-listing-teaser__flag-content__item:not(.c-bolt-listing-teaser__flag-content__item--reply) {
+.c-bolt-listing-teaser__flag-content__item:not(.c-bolt-listing-teaser__flag-content__item--reply):not(.c-bolt-listing-teaser__flag-content__item--warning) {
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-772

## Summary

Listing Teaser design was updated to display new specific separators and truncate long descriptions on specific breakpoints.

## Details

- The separator between eyebrows should be a dash `-`.
- The separator between ordinary meta items should be a pipe `|`.
- The separator between breadcrumbs should be a chevron symbol `>`, and there should be three dots symbol `...` when the next location isn’t the next level down.
- The description text is truncated to 2 lines on screens above than medium breakpoint and 3 lines on screens below the medium breakpoint
- Test page was created.

## How to test

Pull the branch. Check if there's no regression on the Listing Teaser component. Go to test page `/pattern-lab/?p=tests-listing-teaser` in the Tests folder, and check if provided markup behaves as expected.

## Release notes

- The separator between eyebrows is now a dash symbol `-`.
- The separator between breadcrumbs is now a chevron symbol `>`
- Text in the description is truncated to 2 or 3 lines depending on the breakpoint

### Visual changes

- The separator between eyebrows is now a dash symbol `-`.
- The separator between breadcrumbs is now a chevron symbol `>`
- Text in the description is truncated to 2 or 3 lines depending on the breakpoint
