### PR TITLE
DS-459 Comment out esc key hijack in PL

### DIFF
--- a/packages/website-ui/uikit-workshop/src/scripts/components/pl-nav/pl-nav.iframe-helper.js
+++ b/packages/website-ui/uikit-workshop/src/scripts/components/pl-nav/pl-nav.iframe-helper.js
@@ -28,5 +28,7 @@ Mousetrap.bind('esc', function(e) {
     // @todo: how do we want to handle exceptions here?
   }
 
-  return false;
+  // IMPORTANT: commenting this out as it prevents escape key events from returning!
+  // Not sure if this is even a part of an active PL feature, but this cannot happen.
+  // return false;
 });


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-459

## Summary

Comment out PL JS that is preventing escape key event from firing.

## Details

This appears to be a part of the PL Search or navigation component. It captures escape keypress and prevents it from returning in certain cases. I don't believe we even have PL search anymore so I feel comfortable removing this. If it causes any minor escape-key regressions in PL I'm also fine with that as it's interfering with core component functionality (we need escape key to close dialog).

## How to test

- Review code