### PR TITLE
DS-423: Typeahead Button only Clickable When Menu is Open

### DIFF
--- a/packages/components/bolt-page-header/src/_page-header-desktop.scss
+++ b/packages/components/bolt-page-header/src/_page-header-desktop.scss
@@ -79,6 +79,11 @@
       pointer-events: all;
     }
 
+    @at-root .c-bolt-page-header__action-trigger--search[aria-expanded='false']
+        ~ #{&} {
+      pointer-events: none;
+    }
+
     &:before {
       content: '';
       opacity: 0.8;

--- a/packages/components/bolt-page-header/src/_page-header-desktop.scss
+++ b/packages/components/bolt-page-header/src/_page-header-desktop.scss
@@ -79,11 +79,6 @@
       pointer-events: all;
     }
 
-    @at-root .c-bolt-page-header__action-trigger--search[aria-expanded='false']
-        ~ #{&} {
-      pointer-events: none;
-    }
-
     &:before {
       content: '';
       opacity: 0.8;

--- a/packages/components/bolt-page-header/src/_page-header-desktop.scss
+++ b/packages/components/bolt-page-header/src/_page-header-desktop.scss
@@ -70,13 +70,13 @@
     z-index: 1;
     padding-right: calc(var(--bolt-page-padding-x) + 8vw);
     padding-left: calc(var(--bolt-page-padding-x) + 8vw);
-    pointer-events: all;
     transition: opacity var(--bolt-transition),
       visibility var(--bolt-transition), transform var(--bolt-transition);
 
     @at-root .c-bolt-page-header__action-trigger--search[aria-expanded='true']
         ~ #{&} {
       opacity: 1;
+      pointer-events: all;
     }
 
     &:before {

--- a/packages/components/bolt-typeahead/typeahead.scoped.scss
+++ b/packages/components/bolt-typeahead/typeahead.scoped.scss
@@ -203,7 +203,7 @@ bolt-autosuggest {
 }
 
 .c-bolt-typeahead__button--clear {
-  visibility: hidden;
+  display: none;
   right: 0;
 }
 
@@ -217,5 +217,5 @@ bolt-autosuggest {
 
 .c-bolt-typeahead__input[required]:valid ~ .c-bolt-typeahead__button--clear,
 .c-bolt-typeahead__button--clear.is-visible {
-  visibility: visible;
+  display: block;
 }

--- a/packages/components/bolt-typeahead/typeahead.scoped.scss
+++ b/packages/components/bolt-typeahead/typeahead.scoped.scss
@@ -212,7 +212,9 @@ bolt-autosuggest {
 }
 
 .c-bolt-typeahead__button.e-bolt-button--transparent {
-  --e-bolt-button-text-color: var(--bolt-color-navy-light); // Typeahead is not compatible with color themes. This overrides the Button element to not change with parent's color theme.
+  --e-bolt-button-text-color: var(
+    --bolt-color-navy-light
+  ); // Typeahead is not compatible with color themes. This overrides the Button element to not change with parent's color theme.
 }
 
 .c-bolt-typeahead__input[required]:valid ~ .c-bolt-typeahead__button--clear,


### PR DESCRIPTION
## Jira

[https://pegadigitalit.atlassian.net/browse/DS-769](https://pegadigitalit.atlassian.net/browse/DS-769)

## Summary

This PR is to fix the typeahead button still being clickable even when the menu is closed.

## Details

The submit button was still clickable even when the menu was closed. This moves the `pointer-events: all;` line to only be applicable when the menu is open.

## How to test

Follow the steps-to-reproduce shown in the ticket.
