### PR TITLE
Docs page schema logic fix

### DIFF
--- a/docs-site/src/components/pattern-lab-utils/docs.twig
+++ b/docs-site/src/components/pattern-lab-utils/docs.twig
@@ -5,7 +5,11 @@
   {% set change_log_file = "@bolt-#{componentGroup}-#{componentName}/CHANGELOG.md" %}
   {% set pkg = get_data("@bolt-#{componentGroup}-#{componentName}/package.json") %}
   {# Handle multiple schemas #}
-  {% if data.components["@bolt-#{componentGroup}-#{componentName}"].schema["#{componentName}"] is defined %}
+  {# `has_single_schema` is mainly a workaround for the "Type" element. When we check for schema["type"] it could either be
+     the schema's "type": "oject" key/value pair or an array containing multiple schemas for the element "Type". We don't want
+     to restructure the Bolt data right now, so just adding this workaround. #}
+  {% set has_single_schema = data.components["@bolt-#{componentGroup}-#{componentName}"].schema["$schema"] is defined %}
+  {% if data.components["@bolt-#{componentGroup}-#{componentName}"].schema["#{componentName}"] is defined and not has_single_schema %}
     {% set component_schemas = data.components["@bolt-#{componentGroup}-#{componentName}"].schema %}
     {% set schema = component_schemas["#{componentName}"] %}
   {% else %}


### PR DESCRIPTION
## Jira

n/a

## Summary

Update logic in `docs.twig` to prevent a condition from unexpectedly returning true.

## Details

This only affects PL docs pages. There is [a line](https://github.com/boltdesignsystem/bolt/blob/master/docs-site/src/components/pattern-lab-utils/docs.twig#L8) that checks if a schema contains multiple schemas by seeing if a certain key exists. For example, if `schema["dialog"]` exists we know this component contains multiple schemas. If the component has only a single schema it is structured this way: `schema[...allTheSchemaProps]`. This went awry when we created a component called "Type", as `type` is a schema key name.

To avoid restructuring Bolt data (a big PITA), the simplest fix here is to add another check to just be sure that we're not mistaking a component name for a schema key. I'm doing this by checking to see if `schema["$schema"]` exists. If it does, we can be sure this actually contains a single schema, not multiple.

## How to test

- Review code changes.
- Verify other schemas continue to work as expected.
- See "Dialog" for an example of multiple schemas.