### PR TITLE
DS-796: Delete ratio-object

### DIFF
--- a/packages/global/styles/05-objects/objects-ratio/ratio.js
+++ b/packages/global/styles/05-objects/objects-ratio/ratio.js
@@ -1,3 +1,0 @@
-// Moved to standalone package -- see ui/objects/bolt-ratio for original source code!
-
-import '@bolt/components-ratio';

--- a/packages/global/styles/05-objects/objects-ratio/ratio.scss
+++ b/packages/global/styles/05-objects/objects-ratio/ratio.scss
@@ -1,3 +1,0 @@
-// Moved to standalone package -- see components/bolt-ratio for original source code!
-
-@import '@bolt/components-ratio';

--- a/packages/global/styles/05-objects/objects-ratio/ratio.standalone.js
+++ b/packages/global/styles/05-objects/objects-ratio/ratio.standalone.js
@@ -1,3 +1,0 @@
-// Moved to standalone package -- see components/bolt-ratio for original source code!
-
-import '@bolt/components-ratio/src/ratio.js';

--- a/packages/global/styles/05-objects/objects-ratio/ratio.twig
+++ b/packages/global/styles/05-objects/objects-ratio/ratio.twig
@@ -1,3 +1,0 @@
-{# Moved to standalone package -- see ui/objects/bolt-ratio for original source code! #}
-
-{% extends "@bolt-components-ratio/ratio.twig" %}

--- a/packages/global/styles/index.js
+++ b/packages/global/styles/index.js
@@ -1,3 +1,2 @@
-// Calculate intrinsic ratio
-import './05-objects/objects-ratio/ratio';
+// Trigger animation on load
 import './06-animations/_999-animations-on-load-test';

--- a/packages/global/styles/index.scss
+++ b/packages/global/styles/index.scss
@@ -27,7 +27,6 @@
 @import '05-objects/objects-flag/_objects-flag';
 @import '05-objects/objects-grid/_objects-grid';
 @import '05-objects/objects-inline-list/_objects-inline-list';
-@import '05-objects/objects-ratio/ratio';
 @import '05-objects/objects-ui-list/_objects-ui-list';
 @import '05-objects/objects-wrapper/_objects-wrapper';
 


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-796

## Summary

Ratio object is removed from the global > styles > 05-objects folder.

## Details

Referring to the previously [research ticket](https://pegadigitalit.atlassian.net/browse/DS-652) we don't need the ratio object anymore.

**Note that this is a copy of [this old pull request](https://github.com/boltdesignsystem/bolt/pull/2501). I did it again because something went wrong** 

## How to test

Pull the branch. Check if there's no ratio object in the Bolt repository and usage of that.

## Release notes

The Ratio object has been removed. The [Ratio component](https://boltdesignsystem.com/pattern-lab/?p=viewall-components-ratio-deprecated) is deprecated. Use the [Ratio element](https://boltdesignsystem.com/pattern-lab/?p=viewall-elements-ratio) instead.