### PR TITLE
Remove write-file-webpack-plugin package

### DIFF
--- a/packages/build-tools/create-webpack-config.js
+++ b/packages/build-tools/create-webpack-config.js
@@ -11,7 +11,6 @@ const fs = require('fs');
 const deepmerge = require('deepmerge');
 const resolve = require('resolve');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
-const WriteFilePlugin = require('write-file-webpack-plugin');
 const npmSass = require('npm-sass');
 const merge = require('webpack-merge');
 const SassDocPlugin = require('@bolt/sassdoc-webpack-plugin');
@@ -69,7 +68,7 @@ async function createWebpackConfig(buildConfig) {
     if (components.global) {
       entry[globalEntryName] = ['@bolt/core-v3.x/styles/main.scss'];
 
-      components.global.forEach((component) => {
+      components.global.forEach(component => {
         if (component.assets.style) {
           entry[globalEntryName].push(component.assets.style);
         }
@@ -81,7 +80,7 @@ async function createWebpackConfig(buildConfig) {
     }
 
     if (components.individual) {
-      components.individual.forEach((component) => {
+      components.individual.forEach(component => {
         const files = [];
         if (component.assets.style) files.push(component.assets.style);
         if (component.assets.main) files.push(component.assets.main);
@@ -108,13 +107,13 @@ async function createWebpackConfig(buildConfig) {
     // Merge together global Sass data overrides specified in a .boltrc config
     if (config.globalData.scss && config.globalData.scss.length !== 0) {
       const overrideItems = [];
-      config.globalData.scss.forEach((item) => {
+      config.globalData.scss.forEach(item => {
         try {
           const file = fs.readFileSync(item, 'utf8');
           file
             .split('\n')
-            .filter((x) => x)
-            .forEach((x) => overrideItems.push(x));
+            .filter(x => x)
+            .forEach(x => overrideItems.push(x));
         } catch (err) {
           log.errorAndExit(`Could not find ${item}`, err);
         }
@@ -249,7 +248,7 @@ async function createWebpackConfig(buildConfig) {
                 {
                   loader: 'svg-sprite-loader',
                   options: {
-                    spriteFilename: (svgPath) =>
+                    spriteFilename: svgPath =>
                       `bolt-svg-sprite${svgPath.substr(-4)}`,
                   },
                 },
@@ -399,7 +398,7 @@ async function createWebpackConfig(buildConfig) {
     // Merge together any global JS data overrides
     if (config.globalData.js && config.globalData.js.length !== 0) {
       const overrideJsItems = [];
-      config.globalData.js.forEach((item) => {
+      config.globalData.js.forEach(item => {
         try {
           const overrideFile = require(path.resolve(process.cwd(), item));
           overrideJsItems.push(overrideFile);
@@ -529,12 +528,12 @@ async function assignLangToWebpackConfig(config, lang) {
     langSpecificConfig,
   );
 
-  langSpecificWebpackConfigs.forEach((langSpecificWebpackConfig) => {
+  langSpecificWebpackConfigs.forEach(langSpecificWebpackConfig => {
     webpackConfigs.push(langSpecificWebpackConfig);
   });
 }
 
-module.exports = async function () {
+module.exports = async function() {
   const config = await getConfig();
 
   return new Promise(async (resolve, reject) => {

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -115,7 +115,6 @@
     "webpack-hot-middleware": "^2.25.0",
     "webpack-manifest-plugin": "^2.2.0",
     "webpack-merge": "^4.2.2",
-    "write-file-webpack-plugin": "^4.5.1",
     "yaml-loader": "^0.6.0",
     "yargs": "^15.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4773,7 +4773,7 @@ chalk@2.4.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.2, chalk@^2.4.0, chalk@^2.4.1, chalk@^2.4.2:
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.2, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   dependencies:
@@ -12760,10 +12760,6 @@ module-alias@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/module-alias/-/module-alias-2.2.2.tgz#151cdcecc24e25739ff0aa6e51e1c5716974c0e0"
 
-moment@^2.22.1:
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
-
 morgan@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.1.tgz#0a8d16734a1d9afbc824b99df87e738e58e2da59"
@@ -19634,7 +19630,7 @@ write-file-atomic@2.4.1:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
 
-write-file-atomic@^2.0.0, write-file-atomic@^2.3.0, write-file-atomic@^2.4.2:
+write-file-atomic@^2.0.0, write-file-atomic@^2.4.2:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.3.tgz#1fd2e9ae1df3e75b8d8c367443c692d4ca81f481"
   dependencies:
@@ -19668,18 +19664,6 @@ write-file-atomic@^4.0.1:
   dependencies:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
-
-write-file-webpack-plugin@^4.5.1:
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/write-file-webpack-plugin/-/write-file-webpack-plugin-4.5.1.tgz#aeeb68889194da5ec8a864667d46da9e00ee92d5"
-  dependencies:
-    chalk "^2.4.0"
-    debug "^3.1.0"
-    filesize "^3.6.1"
-    lodash "^4.17.13"
-    mkdirp "^0.5.1"
-    moment "^2.22.1"
-    write-file-atomic "^2.3.0"
 
 write-json-file@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
## Summary

Removed the `write-file-webpack-plugin` dependency since it is not being used anymore

## Details

Removed the `write-file-webpack-plugin` dependency from the build  tools, this is due to research because of the dependabot PR (https://github.com/boltdesignsystem/bolt/pull/2504). We will  be closing PR #2504 after this is merged.
