### PR TITLE
CC-959: Cleanup Popover/Tooltip on disconnect

### DIFF
--- a/docs-site/src/index.js
+++ b/docs-site/src/index.js
@@ -101,3 +101,29 @@ const quickFiltersScrollEl = document.querySelector(
 if (quickFiltersScrollEl) {
   quickFiltersScroll(quickFiltersScrollEl);
 }
+
+// Popover/Tooltip disconnectedCallback test
+const setupPopoverCallbackTest = async () => {
+  const poppers = document.querySelectorAll(
+    '.js-test-tippy-disconnected bolt-popover, .js-test-tippy-disconnected bolt-tooltip',
+  );
+
+  // Wait for popovers to initialize
+  await Promise.all([[...poppers].map(el => el.updateComplete)]);
+
+  poppers.forEach(el => {
+    const container = el.closest('.js-test-tippy-disconnected');
+
+    el.addEventListener('click', () => {
+      [...container.children].forEach(el => el.remove());
+    });
+  });
+};
+
+Promise.all(
+  ['bolt-popover', 'bolt-tooltip'].map(name =>
+    customElements.whenDefined(name),
+  ),
+).then(() => {
+  setupPopoverCallbackTest();
+});

--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/popover/15-popover-disconnected-callback.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/popover/15-popover-disconnected-callback.twig
@@ -1,0 +1,47 @@
+<p>When you click on the Popover or the Tooltip custom JS will remove the component from the DOM. This test verifies that the disconnected callback fires on removal and the Popover/Tooltip disappears and is destroyed.</p>
+
+{% set trigger %}
+  {% include '@bolt-elements-button/button.twig' with {
+    content: 'This triggers a popover on hover',
+    size: 'small',
+    attributes: {
+      type: 'button'
+    }
+  } only %}
+{% endset %}
+{% set link %}
+  {% include '@bolt-elements-text-link/text-link.twig' with {
+    content: 'call to action',
+    attributes: {
+      href: 'https://google.com'
+    }
+  } only %}
+{% endset %}
+{% set content %}
+  This is the content of the popover with a {{ link }}.
+{% endset %}
+
+<div class="js-test-tippy-disconnected">
+  {% include '@bolt-components-popover/popover.twig' with {
+    trigger: trigger,
+    trigger_event: 'hover',
+    content: content,
+  } only %}
+</div>
+
+<div class="js-test-tippy-disconnected">
+  {% set check_icon %}
+    <span class="u-bolt-color-success">
+      {% include '@bolt-elements-icon/icon.twig' with {
+        name: 'check-solid',
+        attributes: {
+          'aria-label': 'Yay',
+        }
+      } only %}
+    </span>
+  {% endset %}
+  {% include '@bolt-components-tooltip/tooltip.twig' with {
+    trigger: check_icon,
+    content: 'Solved',
+  } only %}
+</div>

--- a/packages/components/bolt-popover/src/popover.js
+++ b/packages/components/bolt-popover/src/popover.js
@@ -25,6 +25,12 @@ class BoltPopover extends BoltElement {
     this.uuid = this.uuid || Math.floor(10000 + Math.random() * 90000);
   }
 
+  disconnectedCallback() {
+    super.disconnectedCallback && super.disconnectedCallback();
+
+    this.popover?.destroy();
+  }
+
   getPaddingTop() {
     const stickyPageHeader =
       document.querySelector('.c-bolt-page-header') ||

--- a/packages/components/bolt-tooltip/src/tooltip.js
+++ b/packages/components/bolt-tooltip/src/tooltip.js
@@ -23,6 +23,12 @@ class BoltTooltip extends BoltElement {
     this.uuid = this.uuid || Math.floor(10000 + Math.random() * 90000);
   }
 
+  disconnectedCallback() {
+    super.disconnectedCallback && super.disconnectedCallback();
+
+    this.popover?.destroy();
+  }
+
   getPaddingTop() {
     const stickyPageHeader =
       document.querySelector('.c-bolt-page-header') ||


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/CC-959

## Summary

When Popover/Tooltip is removed from DOM, be sure to destroy any related Tippy instances.

## Details

This fixes the bug where you replace a Popover on the page (via Drupal AJAX for example) and the old popover remains visible.

## How to test

- Review code
- See demo page to verify Popover/Tooltip is removed when node is deleted
