### PR TITLE
DS-821 WWW: Button Icon Size Bug

### DIFF
--- a/packages/elements/bolt-button/src/button.scss
+++ b/packages/elements/bolt-button/src/button.scss
@@ -195,7 +195,13 @@ $_bolt-button-hierarchy: primary, secondary, tertiary, transparent;
         --e-bolt-button-padding-x: var(--bolt-spacing-x-#{$size-name});
       }
 
-      @if $size-name == xsmall or $size-name == small {
+      @if $size-name == small {
+        --e-bolt-button-font-size: var(--bolt-type-font-size-small);
+        --e-bolt-button-line-height: var(--bolt-type-line-height-small);
+        --e-bolt-button-icon-only-size: 1.1em;
+      }
+
+      @if $size-name == xsmall {
         --e-bolt-button-font-size: var(--bolt-type-font-size-xsmall);
         --e-bolt-button-line-height: var(--bolt-type-line-height-xsmall);
         --e-bolt-button-icon-only-size: 1.1em;


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-821

## Summary

Font size variable `--e-bolt-button-font-size` is adapted to the helper button class -> `.e-bolt-button--*SIZE* `

## Details

- The `.e-bolt-button--small` has small font size (`--e-bolt-button-font-size: var(--bolt-type-font-size-small)`)
- The `.e-bolt-button--xsmall` has xsmall font size (`--e-bolt-button-font-size: var(--bolt-type-font-size-xsmall)`)
- The only-icon buttons have the same `--e-bolt-button-icon-only-size: 1.1em` both in the case of `.e-bolt-button--small` and `.e-bolt-button--xsmall`

## How to test

Pull the branch. 

- Go to `/pattern-lab/?p=elements-button-size`.
:point_right: Check if the small button and the xsmall button have appropriate sizes of the font. The small button should have a small font-size and the xsmall button should have xsmall font-size.

- Go to `/pattern-lab/?p=elements-button-with-icon-only`
:point_right: If you add to the only-icon button a helper class `.e-bolt-button--small` or `.e-bolt-button--xsmall` both cases should have the same `--e-bolt-button-icon-only-size: 1.1em`

### Visual changes

Buttons xsmall and small have adjusted font-size variables (**small** button - **small** font size, **xsmall** button - **xsmall** font size)
