### PR TITLE
DS-802 Bare List Object Deprecation

### DIFF
--- a/docs-site/src/components/pattern-lab-demos/_bare-list-demo.scss
+++ b/docs-site/src/components/pattern-lab-demos/_bare-list-demo.scss
@@ -1,0 +1,5 @@
+.c-bds-docs__bare-list-demo {
+  color: var(--bolt-color-navy);
+  border: 2px dashed #545da6;
+  background: var(--bolt-color-navy-xlight);
+}

--- a/docs-site/src/components/pattern-lab-demos/pattern-lab-demos.scss
+++ b/docs-site/src/components/pattern-lab-demos/pattern-lab-demos.scss
@@ -1,5 +1,6 @@
 @import '@bolt/core-v3.x';
 @import '__shared-styles';
+@import '_bare-list-demo.scss';
 @import '_clearfix-demo.scss';
 @import '_color-demo.scss';
 @import '_display-demo.scss';

--- a/docs-site/src/pages/pattern-lab/_patterns/10-visual-styles/999-more-utilities/bare-list.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/10-visual-styles/999-more-utilities/bare-list.twig
@@ -1,0 +1,74 @@
+{% embed "@utils/utilities.twig" with {
+  utility_name: "Bare List"
+} only %}
+
+  {% block utility_description %}
+    <p>Add the utility class <code>.u-bolt-bare-list</code> to a <code>ul</code> or <code>ol</code> tag to get rid of the list styling (margins, padding, list-style).</p>
+  {% endblock %}
+
+  {% block utility_demo %}
+    {% set ul %}
+    <h4>Bare unordered list</h4>
+    <ul class="c-bds-docs__bare-list-demo u-bolt-bare-list u-bolt-margin-bottom-medium">
+      <li>First item</li>
+      <li>Second item</li>
+      <li>Third item</li>
+      <li>Fourth item</li>
+    </ul>
+    {% endset %}
+
+    {% set ol %}
+    <h4>Bare ordered list</h4>
+    <ol class="c-bds-docs__bare-list-demo u-bolt-margin-bottom-medium u-bolt-bare-list">
+      <li>First item</li>
+      <li>Second item</li>
+      <li>Third item</li>
+      <li>Fourth item</li>
+    </ol>
+    {% endset %}
+
+    {% set ul_nested %}
+    <h4>Unordered list with nested unordered bare list</h4>
+    <div class="e-bolt-article">
+      <ul class="c-bds-docs__bare-list-demo">
+        <li>First item</li>
+        <li>Second item
+          <ul class="u-bolt-bare-list">
+            <li>Nested item first level 1</li>
+            <li>Nested item first level 2
+              <ul class="u-bolt-bare-list">
+                <li>Nested item second level 1</li>
+                <li>Nested item second level 2</li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+        <li>Third item</li>
+        <li>Fourth item</li>
+      </ul>
+    </div>
+    {% endset %}
+
+    {% include '@bolt-components-grid/grid.twig' with {
+      gutter: 'medium',
+      items: [
+        {
+          column_start: '1',
+          column_span: '12 6@small',
+          content: ul,
+        },
+        {
+          column_start: '1 7@small',
+          column_span: '12 6@small',
+          content: ol,
+        },
+        {
+          column_start: '1',
+          column_span: '12',
+          content: ul_nested,
+        },
+      ]
+    } only %}
+  {% endblock %}
+
+{% endembed %}

--- a/docs-site/src/pages/pattern-lab/_patterns/10-visual-styles/999-more-utilities/bare-list.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/10-visual-styles/999-more-utilities/bare-list.twig
@@ -1,5 +1,5 @@
 {% embed "@utils/utilities.twig" with {
-  utility_name: "Bare List"
+  utility_name: "Bolt Bare List"
 } only %}
 
   {% block utility_description %}

--- a/packages/global/styles/07-utilities/_utilities-bare-list.scss
+++ b/packages/global/styles/07-utilities/_utilities-bare-list.scss
@@ -1,0 +1,19 @@
+/* ------------------------------------ *\
+   #BARE LIST UTILITY
+\* ------------------------------------ */
+
+/**
+ *
+ * Dev notes:
+ * 1. Prevent spaces inconsistency of nested list when an ancestor is an article -> .e-bolt-article.
+ */
+
+.u-bolt-bare-list {
+  margin: 0 !important;
+  padding: 0 !important;
+  list-style: none !important;
+}
+
+.u-bolt-bare-list li {
+  margin-bottom: 0 !important; /* [1] */
+}

--- a/packages/global/styles/07-utilities/_utilities-bare-list.scss
+++ b/packages/global/styles/07-utilities/_utilities-bare-list.scss
@@ -5,7 +5,7 @@
 /**
  *
  * Dev notes:
- * 1. Prevent spaces inconsistency of nested list when an ancestor is an article -> .e-bolt-article.
+ * 1. Prevent space inconsistencies of nested lists when within an article (.e-bolt-article).
  */
 
 .u-bolt-bare-list {

--- a/packages/global/styles/index.scss
+++ b/packages/global/styles/index.scss
@@ -39,6 +39,7 @@
 @import '06-animations/_animations-bounce-in';
 @import '06-animations/_animations-bounce-out';
 
+@import '07-utilities/_utilities-bare-list';
 @import '07-utilities/_utilities-border-radius';
 @import '07-utilities/_utilities-clearfix';
 @import '07-utilities/_utilities-colors';


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-802

## Summary

A new utility class was created to achieve the same effect as the `bare-list-object` class.

## Details

A new `.u-bolt-bare-list` utility class is In the `More Utilities` folder. This class gets rid of **margin**, **padding** and **list-style-type** when added to the unordered list `<ul>` or ordered list `<ol>`.

## How to test

Check if the new utility class behaves the same as the `o-bolt-bare-list` object.

## Release notes

The `bare-list` object is deprecated. Please use the utility class `u-bolt-bare-list`.
