### PR TITLE
DS-834: Remove the medium animation duration 

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/animations/icon-test-fade-ins.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/animations/icon-test-fade-ins.twig
@@ -10,7 +10,6 @@
         'a-bolt-base',
         'a-bolt-in',
         'a-bolt-in--fade-up',
-        'a-bolt-duration-short',
         'a-bolt-cascade-fast',
       ]
     }

--- a/packages/global/styles/06-animations/_animations.scss
+++ b/packages/global/styles/06-animations/_animations.scss
@@ -5,13 +5,13 @@
 /**
  * Dev notes:
  * 1. Safari performance issue (elements flickers in random places after animation starts).
- * 2. Start animation one after another.
+ * 2. This is default animation duration which corresponds to 'short' (200ms).
  */
 
 .a-bolt-base {
   visibility: hidden; /* [1] */
   animation-delay: var(--bolt-animation-delay);
-  animation-duration: var(--bolt-animation-duration);
+  animation-duration: var(--bolt-animation-duration); /* [2] */
   animation-fill-mode: both;
   animation-play-state: paused;
 
@@ -40,16 +40,12 @@
   animation-duration: calc(var(--bolt-animation-duration) * 2.5);
 }
 
-.a-bolt-duration-short {
-  animation-duration: calc(var(--bolt-animation-duration) / 2);
-}
-
 .a-bolt-delay-long {
   --bolt-animation-delay: 500ms;
   animation-delay: var(--bolt-animation-delay);
 }
 
 .a-bolt-delay-short {
-  --bolt-animation-delay: 100ms;
+  --bolt-animation-delay: 200ms;
   animation-delay: var(--bolt-animation-delay);
 }


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-834

## Summary

We have two options for animation duration:

- short
- long

## Details

- short duration is now our default value which is _200ms_
- long remained the same - _500ms_
- delay animation **short** was updated from _100ms_ to _200ms_ to correspond with the default animation duration which is also _200ms_

## How to test

Check the `_animations.scss` and **Tests** folder with animations to confirm if elements appear as before.