### PR TITLE
DS-733: make tabs show-more button invisble by default

### DIFF
--- a/packages/components/bolt-tabs/src/tabs.js
+++ b/packages/components/bolt-tabs/src/tabs.js
@@ -240,13 +240,12 @@ class BoltTabs extends withContext(BoltElement) {
     // If button is hidden, we need to show it before we get the width.
     // Explicitly check for 'is-hidden', as we'll be re-adding the class when we're done.
     if (this.showMoreItem.classList.contains('is-hidden')) {
+      this.showMoreItem.classList.add('is-invisible');
       this.showMoreItem.classList.remove('is-hidden');
       width = this.dropdownButton.offsetWidth;
       this.showMoreItem.classList.add('is-hidden');
+      this.showMoreItem.classList.remove('is-invisible');
     }
-
-    // remove default invisibility that prevents unstyled flash
-    this.showMoreItem.classList.remove('is-invisible');
 
     return width;
   }
@@ -598,7 +597,7 @@ class BoltTabs extends withContext(BoltElement) {
           class="${cx(
             'c-bolt-tabs__item',
             'c-bolt-tabs__show-more',
-            'is-invisible',
+            'is-hidden',
           )}"
         >
           <button

--- a/packages/components/bolt-tabs/src/tabs.js
+++ b/packages/components/bolt-tabs/src/tabs.js
@@ -240,12 +240,13 @@ class BoltTabs extends withContext(BoltElement) {
     // If button is hidden, we need to show it before we get the width.
     // Explicitly check for 'is-hidden', as we'll be re-adding the class when we're done.
     if (this.showMoreItem.classList.contains('is-hidden')) {
-      this.showMoreItem.classList.add('is-invisible');
       this.showMoreItem.classList.remove('is-hidden');
       width = this.dropdownButton.offsetWidth;
       this.showMoreItem.classList.add('is-hidden');
-      this.showMoreItem.classList.remove('is-invisible');
     }
+
+    // remove default invisibility that prevents unstyled flash
+    this.showMoreItem.classList.remove('is-invisible');
 
     return width;
   }
@@ -593,7 +594,13 @@ class BoltTabs extends withContext(BoltElement) {
 
     const dropdown = () => {
       return html`
-        <div class="${cx('c-bolt-tabs__item', 'c-bolt-tabs__show-more')}">
+        <div
+          class="${cx(
+            'c-bolt-tabs__item',
+            'c-bolt-tabs__show-more',
+            'is-invisible',
+          )}"
+        >
           <button
             type="button"
             aria-haspopup="true"


### PR DESCRIPTION
## Jira

[https://pegadigitalit.atlassian.net/browse/DS-733](https://pegadigitalit.atlassian.net/browse/DS-733)

## Summary

Make the tabs show-more button invisble on page-load to prevent an unstyled flash

## Details

Make the tabs show-more button invisble on page-load to prevent an unstyled flash

## How to test

refresh a page with tabs on it, confirm that you are no longer seeing the more button flash before hiding again.
