### PR TITLE
DS-839: Fix avatar edit button template

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/40-components/profile/15-profile-avatar-edit-button.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/40-components/profile/15-profile-avatar-edit-button.twig
@@ -3,6 +3,7 @@
     {% include '@bolt-components-profile/profile-avatar-edit-button.twig' with {
       content: 'Edit Text'|t,
       attributes: {
+        type: 'button',
         class: 'js-button-edit',
         'data-foo': 'bar'
       },
@@ -24,6 +25,7 @@
   {% include '@bolt-components-profile/profile-avatar-edit-button.twig' with {
     content: 'Edit Text'|t,
     attributes: {
+      type: 'button',
       class: 'js-button-edit',
       'data-foo': 'bar'
     },
@@ -40,9 +42,16 @@
 } only %}
 {% endverbatim %}{% endset %}
 
+{% set notes %}
+  <bolt-ol>
+    <bolt-li>Depending on if the <code>&lt;a&gt;</code> element or the <code>&lt;button&gt;</code> element is being used, the proper HTML attributes should be passed in via the edit button's <code>attributes</code> prop. See <a href="{{ link['elements-button-attributes'] }}" class="e-bolt-text-link">Button element docs</a> for more info.</bolt-li>
+  </bolt-ol>
+{% endset %}
+
 {% include '@utils/pattern-doc-page.twig' with {
   title: 'Profile with Avatar Edit Button',
   description: 'The avatar can display an edit button on hover and focus.',
+  notes: notes,
   demo: demo,
   twig_markup: twig_markup,
 } only %}

--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/profile/00-profile-edit.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/profile/00-profile-edit.twig
@@ -1,0 +1,29 @@
+{% set edit_button %}
+  {% include '@bolt-components-profile/profile-avatar-edit-button.twig' with {
+    content: 'Edit Text'|t,
+    type: 'button',
+    attributes: {
+      id: "pega-image-edit-button",
+      href: "#",
+      rel: "nofollow",
+      class: [
+        'use-ajax',
+        'js-pega-accounts-modal-open-button',
+        'pega-accounts-modal-open-button',
+      ],
+      'data-dialog-type': 'dialog',
+      'data-dialog-renderer': 'pega_accounts_modal',
+      'data-dialog-options': '[\"width\": \"auto\"]'
+    }
+  } only %}
+{% endset %}
+{% include '@bolt-components-profile/profile.twig' with {
+  name: {
+    content: '<strong>First Last</strong> (@username)',
+    tag: 'h2',
+  },
+  job_title: 'Lead System Architect',
+  location: 'United States',
+  avatar_edit_button: edit_button,
+} only %}
+

--- a/packages/components/bolt-profile/src/profile-avatar-edit-button.twig
+++ b/packages/components/bolt-profile/src/profile-avatar-edit-button.twig
@@ -6,12 +6,11 @@
 
 {# Variables #}
 {% set this = init(schema.properties.content) %}
-{% set _attributes = create_attribute(attributes|default({})) %}
+{% set attributes = create_attribute(attributes|default({})) %}
 
-{% set _attributes = _attributes|merge({
-  type: 'button',
-  class: 'c-bolt-profile__avatar-edit-button'
-}) %}
+{% set classes = [
+  'c-bolt-profile__avatar-edit-button',
+] %}
 
 {% set icon_pencil %}
   {% include '@bolt-elements-icon/icon.twig' with {
@@ -25,7 +24,7 @@
     border_radius: 'full',
     icon_only: icon_pencil,
     size: 'large',
-    attributes: _attributes
+    attributes: attributes.addClass(classes)
   } only %}
   <span class="c-bolt-profile__avatar-edit-background"></span>
 </div>


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-839

## Summary

Fixes bug where button `type` is hardcoded and user classes are overwritten.

## Details

There was a regression in the avatar edit button template where `type` became hardcoded and user provided classnames were overwritten by base classnames. This PR fixes both and adds a test page verifying the required Drupal Ajax attributes will work when passed into the component.

## How to test

- Review the code
- Review the Test page