### PR TITLE
DS-839: Fix broken schema to fix full_bleed prop

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/profile/00-profile-edit.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/profile/00-profile-edit.twig
@@ -239,6 +239,7 @@
       href: '#!',
     },
   },
+  full_bleed: true,
   attributes: {
     class: [
       't-bolt-white',

--- a/packages/components/bolt-profile/src/profile.twig
+++ b/packages/components/bolt-profile/src/profile.twig
@@ -1,4 +1,4 @@
-{% set schema = bolt.data.components['@bolt-components-profile'].schema %}
+{% set schema = bolt.data.components['@bolt-components-profile'].schema['profile'] %}
 {% if enable_json_schema_validation %}
   {{ validate_data_schema(schema, _self)|raw }}
 {% endif %}


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-839

## Summary

Fix broken schema to fix `full_bleed` prop.

## Details

In `5.7.1` we added multiple schemas to Profile but did not update the original `profile.twig` file to reference the schema. It now points to the schema properly and the `full_bleed` prop works again.

## How to test

- Review code
- See Profile full bleed page and compare to [the latest version](https://boltdesignsystem.com/pattern-lab/?p=components-profile-full-bleed)