### PR TITLE
CC-959: Hide instead of destroy Tippy instance on disconnect

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/popover/15-popover-disconnected-callback.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/popover/15-popover-disconnected-callback.twig
@@ -1,5 +1,3 @@
-<p>When you click on the Popover or the Tooltip custom JS will remove the component from the DOM. This test verifies that the disconnected callback fires on removal and the Popover/Tooltip disappears and is destroyed.</p>
-
 {% set trigger %}
   {% include '@bolt-elements-button/button.twig' with {
     content: 'This triggers a popover on hover',
@@ -21,27 +19,60 @@
   This is the content of the popover with a {{ link }}.
 {% endset %}
 
-<div class="js-test-tippy-disconnected">
+{% set popover %}
   {% include '@bolt-components-popover/popover.twig' with {
     trigger: trigger,
     trigger_event: 'hover',
     content: content,
   } only %}
-</div>
+{% endset %}
 
-<div class="js-test-tippy-disconnected">
-  {% set check_icon %}
-    <span class="u-bolt-color-success">
-      {% include '@bolt-elements-icon/icon.twig' with {
-        name: 'check-solid',
-        attributes: {
-          'aria-label': 'Yay',
-        }
-      } only %}
-    </span>
-  {% endset %}
+{% set check_icon %}
+  <span class="u-bolt-color-success">
+    {% include '@bolt-elements-icon/icon.twig' with {
+      name: 'check-solid',
+      attributes: {
+        'aria-label': 'Yay',
+      }
+    } only %}
+  </span>
+{% endset %}
+
+{% set tooltip %}
   {% include '@bolt-components-tooltip/tooltip.twig' with {
     trigger: check_icon,
     content: 'Solved',
   } only %}
-</div>
+{% endset %}
+
+<bolt-stack>
+  <p>When you click on the Popover or the Tooltip custom JS will remove the component from the DOM. This test verifies that the disconnected callback fires on removal and the Popover/Tooltip disappears and is destroyed.</p>
+
+  <div class="js-test-tippy-disconnected">
+    {{ popover }}
+  </div>
+
+  <div class="js-test-tippy-disconnected">
+    {{ tooltip }}
+  </div>
+</bolt-stack>
+
+<bolt-stack>
+  <p>This example shows a popover and a tooltip inside another web component which may trigger disconnectedCallback if the outer component loads last.</p>
+
+  <div class="js-test-tippy-disconnected">
+    {% include '@bolt-components-list/list.twig' with {
+      items: [
+        popover
+      ]
+    } only %}
+  </div>
+
+  <div class="js-test-tippy-disconnected">
+    {% include '@bolt-components-list/list.twig' with {
+      items: [
+        tooltip
+      ]
+    } only %}
+  </div>
+</bolt-stack>

--- a/packages/components/bolt-popover/src/popover.js
+++ b/packages/components/bolt-popover/src/popover.js
@@ -28,7 +28,7 @@ class BoltPopover extends BoltElement {
   disconnectedCallback() {
     super.disconnectedCallback && super.disconnectedCallback();
 
-    this.popover?.destroy();
+    this.popover?.hide();
   }
 
   getPaddingTop() {

--- a/packages/components/bolt-tooltip/src/tooltip.js
+++ b/packages/components/bolt-tooltip/src/tooltip.js
@@ -26,7 +26,7 @@ class BoltTooltip extends BoltElement {
   disconnectedCallback() {
     super.disconnectedCallback && super.disconnectedCallback();
 
-    this.popover?.destroy();
+    this.popover?.hide();
   }
 
   getPaddingTop() {


### PR DESCRIPTION
## Jira

- https://pegadigitalit.atlassian.net/browse/DS-817
- https://pegadigitalit.atlassian.net/browse/CC-959

## Summary

Fixes a rare bug where a Popover/Tooltip inside of a Bolt List (or any other web component) fails to open.

## Details

When a Popover/Tooltip is inside another Bolt web component, and that other web component renders _after_ the Popover/Tooltip has rendered, it will trigger the Popover/Tooltip to disconnect. We are currently destroying the Tippy instance on disconnect. When the Popover/Tooltip reconnects, I expected it would reinitialize the Tippy instance, but it does not because the component's `firstUpdated()` lifecycle event only fires on the initial creation.

Instead of destroying the Tippy instance I am now just hiding it, which solves the original problem we sought to fix in https://github.com/boltdesignsystem/bolt/pull/2513, without creating this other bug.

## How to test
- Review code
- Open test page in PL: `/pattern-lab/?p=tests-popover-disconnected-callback`
- Replace the main Bolt List component JS file (`packages/components/bolt-list/index.js`) with this:
```
import { lazyQueue } from '@bolt/lazy-queue';

lazyQueue(['bolt-list'], async () => {
  // This forces the race condition to happen every time (for testing only!)
  setTimeout(async () => {
    await import(/*  webpackChunkName: 'bolt-list' */ './main');
  }, 100);
});
```
- Verify the Popover/Tooltip still works on the test page.