### PR TITLE
Update twig version requirement to not be hard-coded.

### DIFF
--- a/docs-site/composer.json
+++ b/docs-site/composer.json
@@ -87,7 +87,6 @@
       "patternlab-plugin"
     ]
   },
-  "minimum-stability": "dev",
   "config": {
     "allow-plugins": {
       "cweagans/composer-patches": true

--- a/docs-site/composer.json
+++ b/docs-site/composer.json
@@ -47,7 +47,7 @@
     "cebe/markdown": "^1.2",
     "hyn/frontmatter": "^1.1",
     "basaltinc/twig-tools": "dev-master as 1.4.3",
-    "twig/twig": "v2.14.6"
+    "twig/twig": "^2.14.6"
   },
   "autoload": {
     "psr-0": {

--- a/docs-site/composer.lock
+++ b/docs-site/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e6112b4a59ca095707662a21ba0b3ba2",
+    "content-hash": "f3b7397e7e9ddc7b7a5f6c7d5c22b115",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -108,11 +108,11 @@
         },
         {
             "name": "bolt-design-system/core-php",
-            "version": "5.2.3",
+            "version": "5.7.4",
             "dist": {
                 "type": "path",
                 "url": "../packages/twig-integration/twig-extensions-shared",
-                "reference": "ca6c9348a5ab82ba691b40726aaf5abe6d1cf25a"
+                "reference": "aeec1a9c8e8aac5789e03795bb679dad927eb7d6"
             },
             "require": {
                 "basaltinc/twig-tools": "dev-master as 1.4.3",
@@ -121,7 +121,7 @@
                 "michelf/php-markdown": "^1.8.0",
                 "nabil1337/case-helper": "^0.1.0",
                 "shudrum/array-finder": "^1.1",
-                "twig/twig": "v2.14.6",
+                "twig/twig": "^2.14.11",
                 "webmozart/path-util": "^2.3"
             },
             "require-dev": {
@@ -1406,29 +1406,31 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "dev-main",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6"
+                "reference": "9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9174a3d80210dca8daa7f31fec659150bbeabfc6",
-                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e",
+                "reference": "9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
             },
+            "provide": {
+                "ext-mbstring": "*"
+            },
             "suggest": {
                 "ext-mbstring": "For best performance"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -1436,12 +1438,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1467,7 +1469,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/main"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -1483,7 +1485,83 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-27T12:26:48+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php72",
+            "version": "v1.26.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php72.git",
+                "reference": "bf44a9fd41feaac72b074de600314a93e2ae78e2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/bf44a9fd41feaac72b074de600314a93e2ae78e2",
+                "reference": "bf44a9fd41feaac72b074de600314a93e2ae78e2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.26-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php72\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php72/tree/v1.26.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/process",
@@ -1595,31 +1673,32 @@
         },
         {
             "name": "twig/twig",
-            "version": "v2.14.6",
+            "version": "v2.15.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "27e5cf2b05e3744accf39d4c68a3235d9966d260"
+                "reference": "ab402673db8746cb3a4c46f3869d6253699f614a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/27e5cf2b05e3744accf39d4c68a3235d9966d260",
-                "reference": "27e5cf2b05e3744accf39d4c68a3235d9966d260",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/ab402673db8746cb3a4c46f3869d6253699f614a",
+                "reference": "ab402673db8746cb3a4c46f3869d6253699f614a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
+                "php": ">=7.1.3",
                 "symfony/polyfill-ctype": "^1.8",
-                "symfony/polyfill-mbstring": "^1.3"
+                "symfony/polyfill-mbstring": "^1.3",
+                "symfony/polyfill-php72": "^1.8"
             },
             "require-dev": {
                 "psr/container": "^1.0",
-                "symfony/phpunit-bridge": "^4.4.9|^5.0.9"
+                "symfony/phpunit-bridge": "^4.4.9|^5.0.9|^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.14-dev"
+                    "dev-master": "2.15-dev"
                 }
             },
             "autoload": {
@@ -1658,7 +1737,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v2.14.6"
+                "source": "https://github.com/twigphp/Twig/tree/v2.15.3"
             },
             "funding": [
                 {
@@ -1670,7 +1749,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-16T12:12:47+00:00"
+            "time": "2022-09-28T08:40:08+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -1830,7 +1909,7 @@
             "alias_normalized": "2.9.0.0"
         }
     ],
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "stability-flags": {
         "pattern-lab/core": 20,
         "pattern-lab/patternengine-twig": 20,

--- a/packages/twig-integration/twig-extensions-shared/composer.json
+++ b/packages/twig-integration/twig-extensions-shared/composer.json
@@ -47,6 +47,5 @@
       "@composer install --no-interaction --prefer-dist --no-progress",
       "vendor/bin/phpunit --colors=always tests"
     ]
-  },
-  "minimum-stability": "dev"
+  }
 }

--- a/packages/twig-integration/twig-extensions-shared/composer.json
+++ b/packages/twig-integration/twig-extensions-shared/composer.json
@@ -33,7 +33,7 @@
     "gregwar/image": "^2.0",
     "nabil1337/case-helper": "^0.1.0",
     "mexitek/phpcolors": "^0.4.0",
-    "twig/twig": "v2.14.11"
+    "twig/twig": "^2.14.11"
   },
   "require-dev": {
     "phpunit/phpunit": "^7"


### PR DESCRIPTION
## Jira

N/A

## Summary

Changes fixed twig version requirement to range

## Details

Drupal is currently unable to update to a new version of twig since Bolt has a fixed version requirement.  This PR updates the composer requirement to be a semver range so that versions can be updated separately (within the same major version).

## How to test

Within the `docs-site` directory, run `composer update twig/twig`.  Confirm that a version later than 2.14.11 is installed.