### PR TITLE
WWW-1591: Updated the modal's accessibility header headline

### DIFF
--- a/packages/components/bolt-modal/__tests__/__snapshots__/modal.js.snap
+++ b/packages/components/bolt-modal/__tests__/__snapshots__/modal.js.snap
@@ -116,7 +116,7 @@ exports[`<bolt-modal> Component Long content usage <bolt-modal> w/o Shadow DOM r
           >
             
                 
-            <h1
+            <h2
               class="c-bolt-modal__dialog-title"
               id="dialog-title-12345"
               style=""
@@ -124,7 +124,7 @@ exports[`<bolt-modal> Component Long content usage <bolt-modal> w/o Shadow DOM r
               
                   Dialog content
                 
-            </h1>
+            </h2>
             
                 
             <!---->
@@ -384,7 +384,7 @@ exports[`<bolt-modal> Component Simple usage <bolt-modal> w/o Shadow DOM renders
           >
             
                 
-            <h1
+            <h2
               class="c-bolt-modal__dialog-title"
               id="dialog-title-12345"
               style=""
@@ -392,7 +392,7 @@ exports[`<bolt-modal> Component Simple usage <bolt-modal> w/o Shadow DOM renders
               
                   Dialog content
                 
-            </h1>
+            </h2>
             
                 
             <!---->

--- a/packages/components/bolt-modal/src/modal.js
+++ b/packages/components/bolt-modal/src/modal.js
@@ -404,12 +404,12 @@ class BoltModal extends BoltElement {
                   `
                 : ''}
               <header class="${headerClasses}">
-                <h1
+                <h2
                   id="dialog-title-${uuid}"
                   class="c-bolt-modal__dialog-title"
                 >
                   Dialog content
-                </h1>
+                </h2>
                 ${this.slotify('header')}
               </header>
               <div class="c-bolt-modal__container-body">


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/WWW-1591

## Summary

Changed the modal's accessibility headline from a `h1` to a `h2`

## How to test

* Pull down the branch and run Patternlab
* Navigate to one of the Modal Component's PL page and tab through the page with Voice Over (cmd + F5 on a Mac)
* Confirm that the screen reader reads out the new modal `h2` headline

## Release notes

Changed the Modal Component's accessibility headline from a `h1` to a `h2`
