### PR TITLE
[6.x] DS-872 Add bundle analyzer to build

### DIFF
--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -10,6 +10,8 @@
   "license": "MIT",
   "main": "bolt.js",
   "scripts": {
+    "analyze": "bolt start --analyze",
+    "analyze:prod": "bolt build --prod --analyze",
     "build": "bolt build",
     "build:lang": "bolt build --i18n",
     "build:noisy": "bolt build --verbosity 5",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     ]
   },
   "scripts": {
+    "analyze": "cd docs-site && yarn run analyze",
+    "analyze:prod": "cd docs-site && yarn run analyze:prod",
     "build": "cd docs-site && yarn run build:prod",
     "cc": "yarn create:component",
     "ce": "yarn create:element",

--- a/packages/build-tools/cli.js
+++ b/packages/build-tools/cli.js
@@ -122,6 +122,11 @@ program
         config.watch =
           typeof options.watch === 'undefined' ? config.watch : options.watch;
 
+        config.analyze =
+          typeof options.analyze === 'undefined'
+            ? config.analyze
+            : options.analyze;
+
         config.prod =
           typeof program.prod === 'undefined' ? config.prod : program.prod;
 
@@ -178,6 +183,7 @@ Environment: ${config.prod ? 'Production' : 'Development'}
       )
       .option('-I, --i18n', configSchema.properties.i18n.description)
       .option('-Q, --quick', configSchema.properties.quick.description)
+      .option('--analyze', configSchema.properties.analyze.description)
       .action(async options => {
         log.info(
           `Starting build (${options.parallel ? 'parallel' : 'serial'})`,
@@ -240,6 +246,7 @@ Environment: ${config.prod ? 'Production' : 'Development'}
         configSchema.properties.webpackDevServer.description,
       )
       .option('--watch', configSchema.properties.watch.description)
+      .option('--analyze', configSchema.properties.analyze.description)
       .action(async options => {
         if (options.watch === undefined) {
           options.watch = true;

--- a/packages/build-tools/create-webpack-config.js
+++ b/packages/build-tools/create-webpack-config.js
@@ -10,6 +10,7 @@ const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const SpriteLoaderPlugin = require('svg-sprite-loader/plugin');
+const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const postcssDiscardDuplicates = require('postcss-discard-duplicates');
 const autoprefixer = require('autoprefixer');
 
@@ -266,7 +267,6 @@ async function createWebpackConfig(buildConfig) {
         },
       }),
       new webpack.ProgressPlugin(boltWebpackProgress), // Ties together the Bolt custom Webpack messages + % complete
-      new webpack.NoEmitOnErrorsPlugin(), // ?
     ],
   };
 
@@ -314,6 +314,10 @@ async function createWebpackConfig(buildConfig) {
 
   if (config.configureWebpack) {
     sharedWebpackConfig = merge(sharedWebpackConfig, config.configureWebpack);
+  }
+
+  if (config.analyze) {
+    sharedWebpackConfig.plugins.push(new BundleAnalyzerPlugin());
   }
 
   // Generate global JS data based on if the build is for ES Module-supporting browsers or not

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -92,6 +92,7 @@
     "ts-loader": "^6.2.1",
     "typescript": "^3.7.5",
     "webpack": "^5.74.0",
+    "webpack-bundle-analyzer": "^4.6.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-middleware": "^5.3.3",
     "webpack-manifest-plugin": "^5.0.0",

--- a/packages/build-tools/tasks/webpack-tasks.js
+++ b/packages/build-tools/tasks/webpack-tasks.js
@@ -34,6 +34,7 @@ async function compile(customWebpackConfig) {
   return new Promise((resolve, reject) => {
     const compiler = boltWebpackMessages(webpack(webpackConfig));
     compiler.run((err, stats) => {
+      compiler.close();
       if (err) {
         return reject(err);
       } else {

--- a/packages/build-tools/tasks/webpack-tasks.js
+++ b/packages/build-tools/tasks/webpack-tasks.js
@@ -34,7 +34,6 @@ async function compile(customWebpackConfig) {
   return new Promise((resolve, reject) => {
     const compiler = boltWebpackMessages(webpack(webpackConfig));
     compiler.run((err, stats) => {
-      compiler.close();
       if (err) {
         return reject(err);
       } else {

--- a/packages/build-tools/tasks/webpack-tasks.js
+++ b/packages/build-tools/tasks/webpack-tasks.js
@@ -34,6 +34,9 @@ async function compile(customWebpackConfig) {
   return new Promise((resolve, reject) => {
     const compiler = boltWebpackMessages(webpack(webpackConfig));
     compiler.run((err, stats) => {
+      // Don't forget to close the compiler
+      // @see https://webpack.js.org/api/node/#run
+      compiler.close();
       if (err) {
         return reject(err);
       } else {

--- a/packages/build-tools/utils/config-store.js
+++ b/packages/build-tools/utils/config-store.js
@@ -35,6 +35,7 @@ async function getDefaultConfig() {
     env: process.env.NODE_ENV,
     enableCache: configSchema.properties.enableCache.default,
     watch: configSchema.properties.watch.default,
+    analyze: configSchema.properties.analyze.default,
     sourceMaps: configSchema.properties.sourceMaps.default,
     i18n: configSchema.properties.i18n.default,
     renderingService: configSchema.properties.renderingService.default,

--- a/packages/build-tools/utils/config.schema.yml
+++ b/packages/build-tools/utils/config.schema.yml
@@ -28,6 +28,10 @@
       type: boolean
       description: Configures internal tasks to watch for changes vs exiting when finished.
       default: false
+    analyze:
+      type: boolean
+      description: If `true` enables webpack-bundle-analyzer on `bolt start`.
+      default: false
     sourceMaps:
       type: boolean
       description: When set to true, generates sourcemaps when CSS and JS files are compiled.

--- a/packages/build-tools/utils/config.schema.yml
+++ b/packages/build-tools/utils/config.schema.yml
@@ -30,7 +30,7 @@
       default: false
     analyze:
       type: boolean
-      description: If `true` enables webpack-bundle-analyzer on `bolt start`.
+      description: If `true` enables webpack-bundle-analyzer on `bolt start` and `bolt build`.
       default: false
     sourceMaps:
       type: boolean

--- a/yarn.lock
+++ b/yarn.lock
@@ -3290,6 +3290,11 @@
     send "0.16.2"
     serve-index "1.9.1"
 
+"@polka/url@^1.0.0-next.20":
+  version "1.0.0-next.21"
+  resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.21.tgz#5de5a2385a35309427f6011992b544514d559aa1"
+  integrity sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==
+
 "@popperjs/core@^2.8.3":
   version "2.9.1"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.1.tgz#7f554e7368c9ab679a11f4a042ca17149d70cf12"
@@ -3906,6 +3911,11 @@ acorn-walk@^6.0.1:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.2.0.tgz#123cb8f3b84c2171f1f7fb252615b1c78a6b1a8c"
 
+acorn-walk@^8.0.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
 acorn@^5.5.3:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
@@ -3918,7 +3928,7 @@ acorn@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.0.tgz#949d36f2c292535da602283586c2477c57eb2d6c"
 
-acorn@^8.5.0, acorn@^8.7.1:
+acorn@^8.0.4, acorn@^8.5.0, acorn@^8.7.1:
   version "8.8.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
   integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
@@ -7301,6 +7311,11 @@ duplexer@^0.1.1, duplexer@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
 
+duplexer@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
+  integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
+
 duplexify@^3.2.0, duplexify@^3.4.2, duplexify@^3.6.0:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.7.1.tgz#2a4df5317f6ccfd91f86d6fd25d8d8a103b88309"
@@ -9450,6 +9465,13 @@ gzip-size@^3.0.0:
   resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-3.0.0.tgz#546188e9bdc337f673772f81660464b389dce520"
   dependencies:
     duplexer "^0.1.1"
+
+gzip-size@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-6.0.0.tgz#065367fd50c239c0671cbcbad5be3e2eeb10e462"
+  integrity sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==
+  dependencies:
+    duplexer "^0.1.2"
 
 handlebars@^4.4.3, handlebars@^4.7.6:
   version "4.7.7"
@@ -12853,6 +12875,11 @@ move-concurrently@^1.0.1:
     rimraf "^2.5.4"
     run-queue "^1.0.3"
 
+mrmime@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mrmime/-/mrmime-1.0.1.tgz#5f90c825fad4bdd41dc914eff5d1a8cfdaf24f27"
+  integrity sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -13625,6 +13652,11 @@ open@^6.4.0:
 opencollective-postinstall@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz#5657f1bede69b6e33a45939b061eb53d3c6c3a89"
+
+opener@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
+  integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
 
 openurl@1.1.1:
   version "1.1.1"
@@ -16978,6 +17010,15 @@ simple-swizzle@^0.2.2:
   dependencies:
     is-arrayish "^0.3.1"
 
+sirv@^1.0.7:
+  version "1.0.19"
+  resolved "https://registry.yarnpkg.com/sirv/-/sirv-1.0.19.tgz#1d73979b38c7fe91fcba49c85280daa9c2363b49"
+  integrity sha512-JuLThK3TnZG1TAKDwNIqNq6QA2afLOCcm+iE8D1Kj3GA40pSPsxQjjJl0J8X3tsR7T+CP1GavpzLwYkgVLWrZQ==
+  dependencies:
+    "@polka/url" "^1.0.0-next.20"
+    mrmime "^1.0.0"
+    totalist "^1.0.0"
+
 sisteransi@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.4.tgz#386713f1ef688c7c0304dc4c0632898941cad2e3"
@@ -18427,6 +18468,11 @@ toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
 
+totalist@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/totalist/-/totalist-1.1.0.tgz#a4d65a3e546517701e3e5c37a47a70ac97fe56df"
+  integrity sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==
+
 tough-cookie@^2.3.3, tough-cookie@^2.3.4, tough-cookie@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
@@ -19236,6 +19282,21 @@ webidl-conversions@^6.1.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
   integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
 
+webpack-bundle-analyzer@^4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.6.1.tgz#bee2ee05f4ba4ed430e4831a319126bb4ed9f5a6"
+  integrity sha512-oKz9Oz9j3rUciLNfpGFjOb49/jEpXNmWdVH8Ls//zNcnLlQdTGXQQMsBbb/gR7Zl8WNLxVCq+0Hqbx3zv6twBw==
+  dependencies:
+    acorn "^8.0.4"
+    acorn-walk "^8.0.0"
+    chalk "^4.1.0"
+    commander "^7.2.0"
+    gzip-size "^6.0.0"
+    lodash "^4.17.20"
+    opener "^1.5.2"
+    sirv "^1.0.7"
+    ws "^7.3.1"
+
 webpack-cli@^4.10.0:
   version "4.10.0"
   resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-4.10.0.tgz#37c1d69c8d85214c5a65e589378f53aec64dab31"
@@ -19649,6 +19710,11 @@ ws@^6.1.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.1.tgz#442fdf0a47ed64f59b6a5d8ff130f4748ed524fb"
   dependencies:
     async-limiter "~1.0.0"
+
+ws@^7.3.1:
+  version "7.5.9"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
+  integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
 
 ws@~3.3.1:
   version "3.3.3"


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-872

## Summary

Add bundle analyzer to the build to monitor bundle sizes.

## Details

[Bundle analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer) shows bundle sizes of the build in a list view and as an interactive visual tree.

Bundle analyzer can run in both dev and prod modes. Prod is most useful because it shows us the actual bundle sizes we ship. Unfortunately I was unable to "watch" in prod mode due to some build issues I do not have time to debug. So for now you can only watch in "dev" mode and build in "prod" mode.

This PR also adds `compiler.close()` to `packages/build-tools/tasks/webpack-tasks.js`. This is [recommended in the docs](https://webpack.js.org/api/node/#run). I added it while attempting to watch in "prod" mode - that didn't work but closing the compiler is a good idea regardless.

## How to test

- Run `yarn` to install bundle analyzer.
- Run `yarn analyze` to watch the files in dev mode. Verify the Bundle analyzer window pops up.
- Run `yarn analyze:prod` to build the files in prod mode. Verify the same and that the bundles are smaller, as they should be in prod mode.

### Release Notes
- Adds `yarn analyze` and `yarn analyze:prod` commands to the build to enable [Webpack bundle analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer).