### PR TITLE
DS-774: Close Popover when inner action is clicked

### DIFF
--- a/docs-site/src/pages/pattern-lab/_patterns/999-tests/popover/20-popover-close-on-action.twig
+++ b/docs-site/src/pages/pattern-lab/_patterns/999-tests/popover/20-popover-close-on-action.twig
@@ -1,0 +1,36 @@
+{% set link %}
+  {% include '@bolt-elements-text-link/text-link.twig' with {
+    content: 'This is a link',
+    attributes: {
+      href: '#'
+    }
+  } only %}
+{% endset %}
+
+{% set button %}
+  {% include '@bolt-elements-button/button.twig' with {
+    content: 'This is a button',
+    attributes: {
+      type: 'submit'
+    }
+  } only %}
+{% endset %}
+
+{% set trigger %}
+  {% include '@bolt-elements-button/button.twig' with {
+  content: 'This triggers a popover',
+  attributes: {
+    type: 'button'
+  }
+} only %}
+{% endset %}
+
+{% include '@bolt-components-popover/popover.twig' with {
+  trigger: trigger,
+  content: link,
+} only %}
+
+{% include '@bolt-components-popover/popover.twig' with {
+  trigger: trigger,
+  content: button,
+} only %}

--- a/packages/components/bolt-popover/src/popover.js
+++ b/packages/components/bolt-popover/src/popover.js
@@ -170,6 +170,13 @@ class BoltPopover extends BoltElement {
     this.initTippy();
     this.setAttribute('ready', '');
 
+    // close popover when inner action is clicked
+    for (const innerAction of this.content.querySelectorAll('a, button')) {
+      innerAction.addEventListener('click', () => {
+        this.popover?.hide();
+      });
+    }
+
     // Call super and dispatch "ready" event _after_ Tippy is setup
     super.firstUpdated && super.firstUpdated();
   }


### PR DESCRIPTION
## Jira

[https://pegadigitalit.atlassian.net/browse/DS-774](https://pegadigitalit.atlassian.net/browse/DS-774)

## Summary

Add event listener to close popover on click for anchors and buttons.

## Details

Add event listener to close popover on click for anchors and buttons.

## How to test

Check the test page in browser and verify the popover closes when clicking on a link or a button.
