### PR TITLE
Update card media deprecation to check both src and attributes.src

### DIFF
--- a/packages/components/bolt-card-replacement/src/card-replacement-media/_card-replacement-media.twig
+++ b/packages/components/bolt-card-replacement/src/card-replacement-media/_card-replacement-media.twig
@@ -12,7 +12,7 @@
       <ssr-keep for="bolt-card-replacement-media" class="c-bolt-card_replacement__media">
         {% if _card_replacement_image %}
           {# DEPRECATED. Pass a renderable image for media.image instead of structured data.  #}
-          {% if _card_replacement_image is iterable and  _card_replacement_image.src %}
+          {% if _card_replacement_image is iterable and (_card_replacement_image.src or _card_replacement_image.attributes.src) %}
             {% if horizontal and _card_replacement_image %}
               {% set _card_replacement_image = _card_replacement_image|merge({
                 ratio: false,


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-903

## Summary

Fixes deprecation logic for image in cards

## Details

https://github.com/boltdesignsystem/bolt/pull/2520 introduced [a check](https://github.com/boltdesignsystem/bolt/blob/9e9619db775cc2f229aefa1bd51e4fbcb23a844f/packages/components/bolt-card-replacement/src/card-replacement-media/_card-replacement-media.twig#L15) for usage of the deprecated image component.

The check didn't take into account the possibility that a `src` prop could be passed either directly or as `attributes.src`.  In the later case, the logic incorrectly assumed that a render array was being passed rather than structured data.

Ultimately, this should be fixed on the Drupal side, but this update fixes the break.

## How to test

On a local Drupal site, find a page that has cards with images and is exhibiting the above error after updating to Bolt 5.8.0. 
 Manually copy the change in this PR to the docroot/bolt/twig/packages/components/bolt-card-replacement/src/card-replacement-media/_card-replacement-media.twig.  Clear caches, reload the page, and confirm errors are gone and card images display as expected.
