### PR TITLE
[6.x] DS-909 Minify CSS in JS

### DIFF
--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -47,6 +47,7 @@
     "cosmiconfig": "^5.2.1",
     "css-loader": "^6.7.1",
     "css-minimizer-webpack-plugin": "^4.2.2",
+    "cssnano": "^5.1.14",
     "deepmerge": "^4.2.2",
     "del": "^5.1.0",
     "ejs": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6625,7 +6625,7 @@ cssnano-utils@^3.1.0:
   resolved "https://registry.yarnpkg.com/cssnano-utils/-/cssnano-utils-3.1.0.tgz#95684d08c91511edfc70d2636338ca37ef3a6861"
   integrity sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==
 
-cssnano@^5.1.8:
+cssnano@^5.1.14, cssnano@^5.1.8:
   version "5.1.14"
   resolved "https://registry.yarnpkg.com/cssnano/-/cssnano-5.1.14.tgz#07b0af6da73641276fe5a6d45757702ebae2eb05"
   integrity sha512-Oou7ihiTocbKqi0J1bB+TRJIQX5RMR3JghA8hcWSw9mjBLQ5Y3RWqEDoYG3sRNlAbCIXpqMoZGbq5KDR3vdzgw==


### PR DESCRIPTION
## Jira

https://pegadigitalit.atlassian.net/browse/DS-909
https://pegadigitalit.atlassian.net/browse/DS-910

## Summary

Minify CSS that is loaded by JS, e.g. by our web components.

## Details

This step was unintentionally removed in the Webpack 5 upgrade. I've added it back with a comment so that we don't remove it again - unless it is no longer necessary.

## How to test

1. Review code
2. Reproduce the issue
  - Checkout `release/6.x`
  - Delete `www/build` to remove any old build artifacts
  - Open `packages/components/bolt-card-replacement/src/card-replacement/card-replacement.scss` and replace the entire file with: 
```
/* ------------------------------------ *\
   Comment test 12345
\* ------------------------------------ */

.foo {
  border: 1px solid red;
}
```
  - Run `yarn build`
  - Open `www/build/bolt-card-replacement-bundle-HASH-GOES-HERE.js` and search for `12345`
  - You should see the comment
3. Verify the fix
 - Repeat step 2 on this feature branch (`feature/DS-909-cleanup-build-code`).
 - Be sure to run `yarn setup` to get the `cssnano` dependency.
 - You should not see the comment in the JS bundle. Search instead for `.foo`. You'll see only minified CSS.
